### PR TITLE
Removing load facets and paginations methods from Circulation Manager

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -101,6 +101,9 @@ class CirculationManagerAnnotator(Annotator):
         return self.cdn_url_for(
             "acquisition_groups", lane_name=lane_name, languages=languages, _external=True)
 
+    def default_lane_url(self):
+        return self.groups_url(None)
+
     def feed_url(self, lane, facets, pagination):
         lane_name, languages = self._lane_name_and_languages
         kwargs = dict(facets.items())

--- a/problem_details.py
+++ b/problem_details.py
@@ -1,4 +1,5 @@
 from core.util.problem_detail import ProblemDetail as pd
+from core.problem_details import *
 
 REMOTE_INTEGRATION_FAILED = pd(
       "http://librarysimplified.org/terms/problem/remote-integration-failed",
@@ -117,13 +118,6 @@ COULD_NOT_MIRROR_TO_REMOTE = pd(
       500,
       "Cannot mirror local state to remote.",
       "Could not convince a third party to accept the change you made. It's likely to show up again soon.",
-)
-
-INVALID_INPUT = pd(
-      "http://librarysimplified.org/terms/problem/invalid-input",
-      400,
-      "Invalid input.",
-      "You provided invalid or unrecognized input.",
 )
 
 NO_SUCH_LANE = pd(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -139,40 +139,6 @@ class TestBaseController(ControllerTest):
         no_such_lane = self.controller.load_lane('eng', 'No such lane')
         eq_("No such lane: No such lane", no_such_lane.detail)
 
-    def test_load_facets_from_request(self):
-        with self.app.test_request_context('/?order=%s' % Facets.ORDER_TITLE):
-            facets = self.controller.load_facets_from_request()
-            eq_(Facets.ORDER_TITLE, facets.order)
-
-        with self.app.test_request_context('/?order=bad_facet'):
-            problemdetail = self.controller.load_facets_from_request()
-            eq_(INVALID_INPUT.uri, problemdetail.uri)
-
-    def test_load_pagination_from_request(self):
-        with self.app.test_request_context('/?size=50&after=10'):
-            pagination = self.controller.load_pagination_from_request()
-            eq_(50, pagination.size)
-            eq_(10, pagination.offset)
-
-        with self.app.test_request_context('/'):
-            pagination = self.controller.load_pagination_from_request()
-            eq_(Pagination.DEFAULT_SIZE, pagination.size)
-            eq_(0, pagination.offset)
-
-        with self.app.test_request_context('/?size=string'):
-            pagination = self.controller.load_pagination_from_request()
-            eq_(INVALID_INPUT.uri, pagination.uri)
-            eq_("Invalid size: string", pagination.detail)
-
-        with self.app.test_request_context('/?after=string'):
-            pagination = self.controller.load_pagination_from_request()
-            eq_(INVALID_INPUT.uri, pagination.uri)
-            eq_("Invalid offset: string", pagination.detail)
-
-        with self.app.test_request_context('/?size=5000'):
-            pagination = self.controller.load_pagination_from_request()
-            eq_(100, pagination.size)
-
     def test_load_licensepool(self):
         licensepool = self._licensepool(edition=None)
         loaded_licensepool = self.controller.load_licensepool(


### PR DESCRIPTION
Refactors load_facets & load_paginations methods out of the Circulation Manager, instead depending on the server core ([this PR](https://github.com/NYPL/Simplified-server-core/pull/5))
