### PR TITLE
Workaround for "Resource temporarily unavailable" error

### DIFF
--- a/app.py
+++ b/app.py
@@ -210,6 +210,13 @@ if __name__ == '__main__':
     else:
         host = netloc
         port = 80
+
+    # Workaround for a "Resource temporarily unavailable" error when
+    # running in debug mode with the global socket timeout set by isbnlib
+    if debug:
+        import socket
+        socket.setdefaulttimeout(None)
+
     app.manager.log.info("Starting app on %s:%s", host, port)
     app.run(debug=debug, host=host, port=port)
 


### PR DESCRIPTION
This replaces https://github.com/NYPL/Simplified-server-core/pull/8

This sets the global socket timeout back to None when running in debug mode. The other apps may need the same change.
