### PR TITLE
Add patron to loans feed

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -479,9 +479,9 @@ class CirculationManagerAnnotator(Annotator):
     def add_patron(self, feed_obj):
         patron_details = {}
         if self.patron.username:
-            patron_details['username'] = self.patron.username
+            patron_details["{%s}username" % simplified_ns] = self.patron.username
         if self.patron.authorization_identifier:
-            patron_details['authorization_identifier'] = self.patron.authorization_identifier
+            patron_details["{%s}authorizationIdentifier" % simplified_ns] = self.patron.authorization_identifier
 
         patron_tag = E._makeelement("{%s}patron" % simplified_ns, patron_details)
         feed_obj.feed.append(patron_tag)

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -159,8 +159,10 @@ class TestOPDS(DatabaseTest):
         raw = unicode(feed_obj)
         feed_details = feedparser.parse(raw)['feed']
 
-        eq_(patron.username, feed_details['simplified_patron']['username'])
-        eq_(u'987654321', feed_details['simplified_patron']['authorization_identifier'])
+        assert "simplified:authorizationIdentifier" in raw
+        assert "simplified:username" in raw
+        eq_(patron.username, feed_details['simplified_patron']['simplified:username'])
+        eq_(u'987654321', feed_details['simplified_patron']['simplified:authorizationidentifier'])
 
     def test_acquisition_feed_includes_license_information(self):
         work = self._work(with_open_access_download=True)


### PR DESCRIPTION
Makes basic patron details available in the /loans OPDS feed, specifically patron username and authorization_identifier (currently the library card barcode).

Fixes #8.
