### PR TITLE
Remove pylru

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,16 +12,17 @@ nose
 python-dateutil
 uwsgi
 loggly-python-handler
-numpy
+
+# In circ, feedparser is only used in tests.
+feedparser
 
 # TODO: This is only used for summary evaluation, which I think should
 # only happen in the metadata wrangler, so it should be possible to move
 # it out of core.
 textblob
 
-# Requirements for circulation
-# feedparser is only used in tests.
-feedparser
+# Used only by circulation
+numpy
 
 # A NYPL-specific requirement
 newrelic


### PR DESCRIPTION
- Removes the GPL-licensed pylru library. Related to #44.
- Rearranges the `requirements.txt` file slightly to separate-out circulation-only dependencies.
