### PR TITLE
Dont show licensepools with no edition #55

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -499,31 +499,16 @@ class CirculationManagerAnnotator(Annotator):
 class CirculationManagerLoanAndHoldAnnotator(CirculationManagerAnnotator):
 
     @classmethod
-    def work_for(cls, loan_or_hold):
-        """Given a loan or hold, try to find the corresponding work."""
-        if not loan_or_hold:
-            return None
-
-        license_pool = loan_or_hold.license_pool
-        if not license_pool:
-            return None
-        if license_pool.work:
-            return license_pool.work
-        if license_pool.edition and license_pool.edition.work:
-            return license_pool.edition.work
-        return None        
-
-    @classmethod
     def active_loans_for(cls, circulation, patron, test_mode=False):
         db = Session.object_session(patron)
         active_loans_by_work = {}
         for loan in patron.loans:
-            work = cls.work_for(loan)
+            work = loan.work
             if work:
                 active_loans_by_work[work] = loan
         active_holds_by_work = {}
         for hold in patron.holds:
-            work = cls.work_for(hold)
+            work = loan.work
             if work:
                 active_holds_by_work[hold.license_pool.work] = hold
 

--- a/opds.py
+++ b/opds.py
@@ -508,9 +508,9 @@ class CirculationManagerLoanAndHoldAnnotator(CirculationManagerAnnotator):
                 active_loans_by_work[work] = loan
         active_holds_by_work = {}
         for hold in patron.holds:
-            work = loan.work
+            work = hold.work
             if work:
-                active_holds_by_work[hold.license_pool.work] = hold
+                active_holds_by_work[work] = hold
 
         annotator = cls(
             circulation, None, patron, active_loans_by_work, active_holds_by_work,

--- a/opds.py
+++ b/opds.py
@@ -499,16 +499,31 @@ class CirculationManagerAnnotator(Annotator):
 class CirculationManagerLoanAndHoldAnnotator(CirculationManagerAnnotator):
 
     @classmethod
+    def work_for(cls, loan_or_hold):
+        """Given a loan or hold, try to find the corresponding work."""
+        if not loan_or_hold:
+            return None
+
+        license_pool = loan_or_hold.license_pool
+        if not license_pool:
+            return None
+        if license_pool.work:
+            return license_pool.work
+        if license_pool.edition and license_pool.edition.work:
+            return license_pool.edition.work
+        return None        
+
+    @classmethod
     def active_loans_for(cls, circulation, patron, test_mode=False):
         db = Session.object_session(patron)
         active_loans_by_work = {}
         for loan in patron.loans:
-            work = loan.license_pool.work or loan.license_pool.edition.work
+            work = cls.work_for(loan)
             if work:
                 active_loans_by_work[work] = loan
         active_holds_by_work = {}
         for hold in patron.holds:
-            work = hold.license_pool.work or hold.license_pool.edition.work
+            work = cls.work_for(hold)
             if work:
                 active_holds_by_work[hold.license_pool.work] = hold
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -91,34 +91,6 @@ class TestOPDS(DatabaseTest):
         borrow_rels = [x['rel'] for x in borrow_links]
         assert OPDSFeed.BORROW_REL in borrow_rels
 
-    def test_derive_work(self):
-        """Test the helper method that turns a Loan or Hold into a Work."""
-        patron = self.default_patron
-
-        m = CirculationManagerLoanAndHoldAnnotator.work_for
-
-        # The easy cases.
-        eq_(None, m(None))
-
-        work = self._work(with_license_pool=True)
-        pool = work.license_pools[0]
-
-        loan, is_new = pool.loan_to(patron)
-        eq_(work, m(loan))
-
-        loan.license_pool = None
-        eq_(None, m(loan))
-
-        # If pool.work is None but pool.edition.work is valid, we 
-        # use that.
-        loan.license_pool = pool
-        pool.work = None
-        eq_(pool.edition.work, m(loan))
-
-        # If that's also None, we're helpless.
-        pool.edition.work = None
-        eq_(None, m(loan))
-
     def test_active_loan_feed(self):
         patron = self.default_patron
         raw = CirculationManagerLoanAndHoldAnnotator.active_loans_for(

--- a/threem.py
+++ b/threem.py
@@ -30,6 +30,11 @@ from core.model import (
     Session,
 )
 
+from core.metadata_layer import (
+    CirculationData,
+    Metadata,
+)
+
 from core.monitor import (
     Monitor,
     IdentifierSweepMonitor,
@@ -79,7 +84,9 @@ class ThreeMAPI(BaseThreeMAPI, BaseCirculationAPI):
         return events
 
     def get_circulation_for(self, identifiers):
-        """Return circulation objects for the selected identifiers."""
+        """Return (Metadata, CirculationData) 2-tuples for the 
+        selected identifiers.
+        """
         url = "/circulation/items/" + ",".join(identifiers)
         response = self.request(url)
         if response.status_code == 404:
@@ -87,9 +94,11 @@ class ThreeMAPI(BaseThreeMAPI, BaseCirculationAPI):
         if response.status_code != 200:
             raise IOError("Server gave status code %s: %s" % (
                 response.status_code, response.content))
-        for circ in CirculationParser().process_all(response.content):
-            if circ:
-                yield circ
+
+        for m, c in CirculationParser().process_all(response.content):
+            if m and c:
+                yield (m, c)
+        
 
     def patron_activity(self, patron, pin):
         patron_id = patron.authorization_identifier
@@ -257,10 +266,11 @@ class CirculationParser(XMLParser):
             yield i
 
     def process_one(self, tag, namespaces):
+        """Return: a list of 2-tuples (Metadata, CirculationData)"""
         if not tag.xpath("ItemId"):
             # This happens for events associated with books
             # no longer in our collection.
-            return None
+            return None, None
 
         def value(key):
             return self.text_of_subtag(tag, key)
@@ -268,34 +278,56 @@ class CirculationParser(XMLParser):
         def intvalue(key):
             return self.int_of_subtag(tag, key)
 
-        identifiers = {}
-        item = { Identifier : identifiers }
+        # First create a basic Metadata object so we know which book
+        # we're talking about.
+        threem_identifier = IdentifierData(
+            type=Identifier.THREEM_ID, identifier=value("ItemId")
+        )
 
-        identifiers[Identifier.THREEM_ID] = value("ItemId")
-        identifiers[Identifier.ISBN] = value("ISBN13")
-        
-        item[LicensePool.licenses_owned] = intvalue("TotalCopies")
+        isbn_identifier = IdentifierData(
+            type=Identifier.ISBN, identifier=value("ISBN13")
+        )
+
+        metadata = Metadata(
+            data_source=DataSource.THREEM,
+            license_data_source=DataSource.THREEM,
+            primary_identifier=threem_identifier,
+            identifiers=[isbn_identifier]
+        )
+
+        # Then create a CirculationData object.
+        licenses_owned = intvalue("TotalCopies")
+        licenses_available = 0
         try:
-            item[LicensePool.licenses_available] = intvalue("AvailableCopies")
+            licenses_available = intvalue("AvailableCopies")
         except IndexError:
             logging.warn("No information on available copies for %s",
                          identifiers[Identifier.THREEM_ID]
                      )
 
-        # Counts of patrons who have the book in a certain state.
-        for threem_key, simplified_key in [
-                ("Holds", LicensePool.patrons_in_hold_queue),
-                ("Reserves", LicensePool.licenses_reserved)
-        ]:
-            t = tag.xpath(threem_key)
+        def _patron_count(key):
+            "Count patrons who have the book in a certain state."
+            t = tag.xpath(key)
             if t:
                 t = t[0]
                 value = int(t.xpath("count(Patron)"))
-                item[simplified_key] = value
+                return value
             else:
                 logging.warn("No circulation information provided for %s %s",
-                             identifiers[Identifier.THREEM_ID], threem_key)
-        return item
+                             threem_id, key)
+                return 0
+
+        licenses_reserved = _patron_count("Reserves")
+        patrons_in_hold_queue = _patron_count("Holds")
+
+        circulation = CirculationData(
+            licenses_owned=licenses_owned,
+            licenses_available=licenses_available, 
+            licenses_reserved=licenses_reserved,
+            patrons_in_hold_queue=patrons_in_hold_queue,
+        )
+
+        return metadata, circulation
 
 class ThreeMException(Exception):
     pass
@@ -529,26 +561,22 @@ class ThreeMCirculationSweep(IdentifierSweepMonitor):
             identifiers_by_threem_id[identifier.identifier] = identifier
 
         identifiers_not_mentioned_by_threem = set(identifiers)
-        now = datetime.datetime.utcnow()
-        for circ in self.api.get_circulation_for(threem_ids):
+
+        for metadata, circ in self.api.get_circulation_for(threem_ids):
             if not circ:
                 continue
-            threem_id = circ[Identifier][Identifier.THREEM_ID]
+            threem_id = metadata.primary_identifier.identifier
             identifier = identifiers_by_threem_id[threem_id]
             identifiers_not_mentioned_by_threem.remove(identifier)
 
             pool = identifier.licensed_through
+            pool_is_new = False
             if not pool:
                 # We don't have a license pool for this work. That
                 # shouldn't happen--how did we know about the
                 # identifier?--but it shouldn't be a big deal to
                 # create one.
-                pool, ignore = LicensePool.for_foreign_id(
-                    self._db, self.data_source, identifier.type,
-                    identifier.identifier)
-                CirculationEvent.log(
-                    self._db, pool, CirculationEvent.TITLE_ADD,
-                    None, None, start=now)
+                pool, pool_is_new = metadata.license_pool(self._db)
 
             if pool.edition:
                 self.log.info("Updating %s (%s)", pool.edition.title,
@@ -557,13 +585,7 @@ class ThreeMCirculationSweep(IdentifierSweepMonitor):
                 self.log.info(
                     "Updating unknown work %s", identifier.identifier
                 )
-            # Update availability and send out notifications.
-            pool.update_availability(
-                circ.get(LicensePool.licenses_owned, 0),
-                circ.get(LicensePool.licenses_available, 0),
-                circ.get(LicensePool.licenses_reserved, 0),
-                circ.get(LicensePool.patrons_in_hold_queue, 0))
-
+            circulation.update(pool, pool_is_new)
 
         # At this point there may be some license pools left over
         # that 3M doesn't know about.  This is a pretty reliable
@@ -581,19 +603,20 @@ class ThreeMCirculationSweep(IdentifierSweepMonitor):
                     "Removing unknown work %s from circulation.",
                     identifier.identifier
                 )
-            pool.licenses_owned = 0
-            pool.licenses_available = 0
-            pool.licenses_reserved = 0
-            pool.patrons_in_hold_queue = 0
-            pool.last_checked = now
-
+            circulation = CirculationData(
+                licenses_owned=0,
+                licenses_available=0, 
+                licenses_reserved=0,
+                patrons_in_hold_queue=0,
+            )
+            circulation.update(pool, False)
 
 class ThreeMEventMonitor(Monitor):
 
     """Register CirculationEvents for 3M titles.
 
     When a new book comes on the scene, we find out about it here and
-    we create a LicensePool.  But the bibliographic data isn't
+    we create a LicensePool. But the bibliographic data isn't
     inserted into those LicensePools until the
     ThreeMBibliographicMonitor runs. And the circulation data isn't
     associated with it until the ThreeMCirculationMonitor runs.
@@ -744,17 +767,8 @@ class ThreeMCirculationMonitor(Monitor):
         for p in pools:
             pool_for_identifier[p.identifier.identifier] = p
             identifiers.append(p.identifier.identifier)
-        for item in self.api.get_circulation_for(identifiers):
-            identifier = item[Identifier][Identifier.THREEM_ID]
-            pool = pool_for_identifier[identifier]
-            self.process_pool(_db, pool, item)
+        for metadata, circulation in self.api.get_circulation_for(identifiers):
+            pool, pool_is_new = metadata.license_pool(_db)
+            circulation.update(pool, pool_is_new)
         _db.commit()
         return most_recent_timestamp
-        
-    def process_pool(self, _db, pool, item):
-        pool.update_availability(
-            item[LicensePool.licenses_owned],
-            item[LicensePool.licenses_available],
-            item[LicensePool.licenses_reserved],
-            item[LicensePool.patrons_in_hold_queue])
-        self.log.info("%r: %d owned, %d available, %d reserved, %d queued", pool.edition(), pool.licenses_owned, pool.licenses_available, pool.licenses_reserved, pool.patrons_in_hold_queue)


### PR DESCRIPTION
I defined a helper method that takes a loan or hold and figures out which Work to use. In an edge situation like a loan with no license pool, a loan with no edition, or a loan with a license pool that has no work, etc. etc., it returns None and the book doesn't show up.