### PR TITLE
Coverage scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
-bin/
 build/
 develop-eggs/
 dist/

--- a/axis.py
+++ b/axis.py
@@ -522,8 +522,9 @@ class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):
 
     def __init__(self, _db):
         self.parser = BibliographicParser()
-        super(Axis360BibliographicCoverageProvider, self).__init__(_db,
-                Axis360API(_db), DataSource.AXIS_360)
+        super(Axis360BibliographicCoverageProvider, self).__init__(
+            _db, Axis360API(_db), DataSource.AXIS_360
+        )
 
     def process_batch(self, identifiers):
         identifier_strings = self.api.create_identifier_strings(identifiers)

--- a/bin/bibliographic_coverage_3m
+++ b/bin/bibliographic_coverage_3m
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Gather basic bibliographic information from 3M."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from threem import ThreeMBibliographicCoverageProvider
+from core.scripts import RunCoverageProviderScript
+RunCoverageProviderScript(ThreeMBibliographicCoverageProvider).run()

--- a/bin/bibliographic_coverage_overdrive
+++ b/bin/bibliographic_coverage_overdrive
@@ -5,6 +5,6 @@ import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
-from core.overdrive import OverdriveBibliographicCoverageProvider
+from overdrive import OverdriveBibliographicCoverageProvider
 from core.scripts import RunCoverageProviderScript
 RunCoverageProviderScript(OverdriveBibliographicCoverageProvider).run()

--- a/bin/bibliographic_coverage_overdrive
+++ b/bin/bibliographic_coverage_overdrive
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Gather basic bibliographic information from Overdrive."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.overdrive import OverdriveBibliographicCoverageProvider
+from core.scripts import RunCoverageProviderScript
+RunCoverageProviderScript(OverdriveBibliographicCoverageProvider).run()

--- a/coverage.py
+++ b/coverage.py
@@ -83,8 +83,8 @@ class MetadataWranglerCoverageProvider(OPDSImportCoverageProvider):
         )
 
     @property
-    def editions_that_need_coverage(self):
-        """Returns identifiers (not editions) that need coverage."""
+    def items_that_need_coverage(self):
+        """Returns identifiers that need coverage."""
         q = Identifier.missing_coverage_from(
             self._db, self.input_sources, self.coverage_source)
         return q
@@ -125,7 +125,7 @@ class MetadataWranglerCoverageProvider(OPDSImportCoverageProvider):
 
         for edition in imported:
             self.finalize_import(edition)
-            results.append(edition)
+            results.append(edition.primary_identifier)
 
         for failure in self.handle_import_messages(messages_by_id):
             results.append(failure)
@@ -189,7 +189,7 @@ class OpenAccessDownloadURLCoverageProvider(OPDSImportCoverageProvider):
         )
 
     @property
-    def editions_that_need_coverage(self):
+    def items_that_need_coverage(self):
         """Returns Editions associated with an open-access LicensePool but
         with no open-access download URL.
         """
@@ -202,8 +202,8 @@ class OpenAccessDownloadURLCoverageProvider(OPDSImportCoverageProvider):
         )
         return q
 
-    def process_batch(self, editions):
-        identifiers = [x.primary_identifier for x in editions]
+    def process_batch(self, items):
+        identifiers = [x.primary_identifier for x in items]
         response = self.content_lookup.lookup(identifiers)
         importer = OPDSImporter(self._db, DataSource.OA_CONTENT_SERVER)
         imported, messages_by_id, next_links = importer.import_from_feed(
@@ -219,7 +219,7 @@ class OpenAccessDownloadURLCoverageProvider(OPDSImportCoverageProvider):
                     "Successfully located open access download ID for %r: %s", 
                     edition, edition.open_access_download_url
                 )
-                results.append(edition)
+                results.append(edition.primary_identifier)
             else:
                 exception = "Open access content server acknowledged book but gave no open-access download URL."
                 failure = CoverageFailure(

--- a/overdrive.py
+++ b/overdrive.py
@@ -14,6 +14,7 @@ from circulation import (
 from core.overdrive import (
     OverdriveAPI as BaseOverdriveAPI,
     OverdriveRepresentationExtractor,
+    OverdriveBibliographicCoverageProvider as BaseOverdriveBibliographicCoverageProvider,
 )
 
 from core.model import (
@@ -707,4 +708,20 @@ class RecentOverdriveCollectionMonitor(OverdriveCirculationMonitor):
         super(RecentOverdriveCollectionMonitor, self).__init__(
             _db, "Reverse Chronological Overdrive Collection Monitor",
             interval_seconds, maximum_consecutive_unchanged_books)
+
+
+class OverdriveBibliographicCoverageProvider(BaseOverdriveBibliographicCoverageProvider):
+
+    """Fill in bibliographic metadata for Overdrive records.
+    
+    Then mark the works as presentation-ready.
+    """
+    def process_batch(self, identifiers):
+        results = []
+        for result in super(OverdriveBibliographicCoverageProvider, self).process_batch(identifiers):
+            # Mark every successful result as presentation-ready.
+            if isinstance(result, Identifier):
+                result = self.set_presentation_ready(result)
+            results.append(result)
+        return results
 


### PR DESCRIPTION
This branch adds three scripts that create CoverageRecords between all commercially licensed books and the licensing authority. So the Overdrive script looks up books on Overdrive, sets their metadata, and makes them presentation ready (even though we still need to ask the metadata wrangler about them to finalize the presentation and get the book cover). Similarly for the 3M script and the Axis 360 script.

