### PR TITLE
Fix bug 60 - 'alternate' link for book is wrong

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -95,8 +95,10 @@ class CirculationManagerAnnotator(Annotator):
     def permalink_for(self, work, license_pool, identifier):
         if isinstance(identifier, Identifier):
             identifier = identifier.identifier
-        return self.url_for('work', data_source=license_pool.data_source.name,
-                       identifier=identifier, _external=True)
+        return self.url_for(
+            'permalink', data_source=license_pool.data_source.name,
+            identifier=identifier, _external=True
+        )
 
     def groups_url(self, lane):
         lane_name, languages = self._lane_name_and_languages
@@ -193,6 +195,7 @@ class CirculationManagerAnnotator(Annotator):
         feed.add_link_to_entry(
             entry, 
             rel='alternate',
+            type=OPDSFeed.ENTRY_TYPE,
             href=self.permalink_for(
                 work, active_license_pool, identifier_identifier
             )

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -55,9 +55,15 @@ class TestOPDS(DatabaseTest):
         [entry] = feed['entries']
         eq_(entry['id'], pool.identifier.urn)
 
-        [alternate] = [x['href'] for x in entry['links'] if x['rel'] == 'alternate']
+
+        [(alternate, type)] = [(x['href'], x['type']) for x in entry['links'] if x['rel'] == 'alternate']
         permalink = annotator.permalink_for(w1, pool, pool.identifier)
         eq_(alternate, permalink)
+        eq_(OPDSFeed.ENTRY_TYPE, type)
+
+        # Make sure we are using the 'permalink' controller -- we were using
+        # 'work' and that was wrong.
+        assert '/host/permalink' in permalink
 
     def test_acquisition_feed_includes_problem_reporting_link(self):
         w1 = self._work(with_open_access_download=True)


### PR DESCRIPTION
This branch fixes bug 60, in which the 'alternate' link for a book used the 'work' controller instead of the 'permalink' controller.