### PR TITLE
It doesn't matter what Overdrive says the patron's position is--if th…

### DIFF
--- a/overdrive.py
+++ b/overdrive.py
@@ -377,9 +377,10 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
             position = hold.get('holdListPosition')
             if position is not None:
                 position = int(position)
-            if position == 1 and 'checkout' in hold.get('actions', {}):
+            if 'checkout' in hold.get('actions', {}):
                 # This patron needs to decide whether to check the
-                # book out. By our reckoning, their position is 0, not 1.
+                # book out. By our reckoning, the patron's position is
+                # 0, not whatever position Overdrive had for them.
                 position = 0
             yield HoldInfo(
                 Identifier.OVERDRIVE_ID,


### PR DESCRIPTION
…ere is a checkout action on a hold, we consider their position to be zero.

This branch relaxes an assumption that if you have an Overdrive book on hold but ready to check out, your hold queue position will be 1. Actually, your hold queue position can be any number. The important thing is not the hold queue position but the presence of a 'checkout' option.

This fixes bug #65.