### PR TITLE
About link

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -251,6 +251,7 @@ class CirculationManager(object):
                 ("terms-of-service", Configuration.terms_of_service_url()),
                 ("privacy-policy", Configuration.privacy_policy_url()),
                 ("copyright", Configuration.acknowledgements_url()),
+                ("about", Configuration.about_url()),
         ):
             if value:
                 links[rel] = dict(href=value, type="text/html")

--- a/opds.py
+++ b/opds.py
@@ -266,6 +266,7 @@ class CirculationManagerAnnotator(Annotator):
                 ("terms-of-service", Configuration.terms_of_service_url()),
                 ("privacy-policy", Configuration.privacy_policy_url()),
                 ("copyright", Configuration.acknowledgements_url()),
+                ("about", Configuration.about_url()),
         ):
             if value:
                 d = dict(href=value, type="text/html", rel=rel)

--- a/threem.py
+++ b/threem.py
@@ -776,3 +776,7 @@ class ThreeMBibliographicCoverageProvider(BaseThreeMBibliographicCoverageProvide
                 result = self.set_presentation_ready(result)
             results.append(result)
         return results
+
+    def process_item(self, identifier):
+        results = self.process_batch([identifier])
+        return results[0]


### PR DESCRIPTION
This branch works on https://github.com/NYPL-Simplified/android/issues/190 by making the 'about' link defined by https://github.com/NYPL-Simplified/server_core/pull/66 actually show up in OPDS feeds. I added a previously missing test which verifies that all these links show up if they're configured. 

This branch also includes a totally miscellaneous implementation of process_item() for the 3M coverage provider--I noticed it was missing when I needed to call ensure_coverage() on a 3M book for a one-off script I wrote.