### PR TITLE
Open-access books are not subject to a site policy that prohibits holdds, since you never need to put one on hold.

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -384,6 +384,7 @@ class CirculationManagerController(object):
             )
 
         if (license_pool.licenses_available == 0 and
+            not license_pool.open_access and
             Configuration.hold_policy() !=
             Configuration.HOLD_POLICY_ALLOW
         ):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -180,6 +180,20 @@ class TestBaseController(ControllerTest):
             work = self._work(with_license_pool=True)
             [pool] = work.license_pools
             pool.licenses_available = 0
+            
+            # This is an open-access work, so there's no problem.
+            eq_(True, pool.open_access)
+
+            # Open-access books still be borrowed even if they have no
+            # 'licenses' available.
+            problem = self.controller.apply_borrowing_policy(
+                patron, pool
+            )
+            eq_(None, problem)
+
+            # But if it weren't an open-access work, there'd be a big
+            # problem.
+            pool.open_access = False
             problem = self.controller.apply_borrowing_policy(
                 patron, pool
             )


### PR DESCRIPTION
The test for this one is a little unusual. The case being tested previously shouldn't have worked, since works created in tests are open-access by default. I changed the case previously tested to give the right behavior, and added another test that verifies what I _thought_ I was testing before--you can't put a hold on a non-open-access book.