### PR TITLE
Google config

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,7 +76,7 @@ def returns_problem_detail(f):
 def requires_admin(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        admin = app.manager.admin_controller.authenticated_admin_from_request()
+        admin = app.manager.admin_controller.authenticated_admin_from_request(**kwargs)
         if isinstance(admin, ProblemDetail):
             return admin.response
         elif isinstance(admin, Response):
@@ -200,10 +200,11 @@ def google_auth_callback():
     return app.manager.admin_controller.signin(flask.request.args)
 
 @app.route('/admin')
+@app.route('/admin/<access_token>')
 @requires_admin
 @returns_problem_detail
-def admin():
-    return app.manager.admin_controller.admin_info()
+def admin(access_token=None):
+    return app.manager.admin_controller.admin_info(access_token=access_token)
 
 # Controllers used for operations purposes
 @app.route('/heartbeat')

--- a/app.py
+++ b/app.py
@@ -79,13 +79,12 @@ def returns_problem_detail(f):
 def requires_admin(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        admin = app.manager.admin_controller.authenticated_admin_from_request(**kwargs)
+        admin = app.manager.admin_controller.authenticated_admin_from_request()
         if isinstance(admin, ProblemDetail):
-            return admin.response
+            return app.manager.admin_controller.error_response(admin)
         elif isinstance(admin, Response):
             return admin
-        else:
-            return f(*args, **kwargs)
+        return f(*args, **kwargs)
     return decorated
 
 @app.route('/')
@@ -203,7 +202,6 @@ def google_auth_callback():
     return app.manager.admin_controller.redirect_after_signin()
 
 @app.route('/admin')
-@requires_admin
 @returns_problem_detail
 def admin():
     return app.manager.admin_controller.signin()

--- a/app.py
+++ b/app.py
@@ -10,7 +10,6 @@ from flask import (
     Response,
     redirect,
 )
-from werkzeug.wrappers import Response as RedirectResponse
 
 from config import Configuration
 from core.app_server import (
@@ -80,9 +79,7 @@ def requires_admin(f):
         admin = app.manager.admin_controller.authenticated_admin_from_request()
         if isinstance(admin, ProblemDetail):
             return admin.response
-        elif isinstance(admin, RedirectResponse):
-            # A returned redirect uses the werkzeug.wrappers base class to
-            # create a response here.
+        elif isinstance(admin, Response):
             return admin
         else:
             return f(*args, **kwargs)

--- a/app.py
+++ b/app.py
@@ -207,11 +207,6 @@ def loadstorm_verify(code):
     else:
         return Response("", 404)
 
-# @app.route('/force_error/<string>')
-# def force_error(string):
-#     raise Exception("Forced error: %s" % string)
-#     # return problem(None, "Forced error: %s" % string, 500)
-
 if __name__ == '__main__':
     debug = True
     url = Configuration.integration_url(

--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ app.config['DEBUG'] = debug
 app.debug = debug
 
 # The secret key is used for signing cookies for admin login
-app.secret_key = os.urandom(24)
+app.secret_key = Configuration.get(Configuration.SECRET_KEY)
 
 if os.environ.get('AUTOINITIALIZE') == "False":
     pass

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import flask
 from flask import (
     Flask, 
     Response,
+    redirect,
 )
 
 from config import Configuration
@@ -180,6 +181,12 @@ def adobe_vendor_id_accountinfo():
 @returns_problem_detail
 def adobe_vendor_id_status():
     return app.manager.adobe_vendor_id.status_handler()
+
+@app.route('/GoogleAuth/signin')
+@returns_problem_detail
+def google_auth_signin():
+    return app.manager.google().signin(flask.request.args)
+
 # Controllers used for operations purposes
 @app.route('/heartbeat')
 @returns_problem_detail

--- a/app.py
+++ b/app.py
@@ -31,6 +31,9 @@ logging.getLogger().info("Application debug mode==%r" % debug)
 app.config['DEBUG'] = debug
 app.debug = debug
 
+# The secret key is used for signing cookies for admin login
+app.secret_key = os.urandom(24)
+
 if os.environ.get('AUTOINITIALIZE') == "False":
     pass
     # It's the responsibility of the importing code to set app.manager
@@ -197,14 +200,13 @@ def adobe_vendor_id_status():
 @app.route('/GoogleAuth/callback')
 @returns_problem_detail
 def google_auth_callback():
-    return app.manager.admin_controller.signin(flask.request.args)
+    return app.manager.admin_controller.redirect_after_signin()
 
 @app.route('/admin')
-@app.route('/admin/<access_token>')
 @requires_admin
 @returns_problem_detail
-def admin(access_token=None):
-    return app.manager.admin_controller.admin_info(access_token=access_token)
+def admin():
+    return app.manager.admin_controller.signin()
 
 # Controllers used for operations purposes
 @app.route('/heartbeat')

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from flask import (
     Response,
     redirect,
 )
+from werkzeug.wrappers import Response as RedirectResponse
 
 from config import Configuration
 from core.app_server import (
@@ -79,8 +80,10 @@ def requires_admin(f):
         admin = app.manager.admin_controller.authenticated_admin_from_request()
         if isinstance(admin, ProblemDetail):
             return admin.response
-        elif admin.startswith('https://'):
-            return redirect(admin)
+        elif isinstance(admin, RedirectResponse):
+            # A returned redirect uses the werkzeug.wrappers base class to
+            # create a response here.
+            return admin
         else:
             return f(*args, **kwargs)
     return decorated
@@ -194,9 +197,9 @@ def adobe_vendor_id_accountinfo():
 def adobe_vendor_id_status():
     return app.manager.adobe_vendor_id.status_handler()
 
-@app.route('/GoogleAuth/signin')
+@app.route('/GoogleAuth/callback')
 @returns_problem_detail
-def google_auth_signin():
+def google_auth_callback():
     return app.manager.admin_controller.signin(flask.request.args)
 
 @app.route('/admin')

--- a/app.py
+++ b/app.py
@@ -72,7 +72,19 @@ def returns_problem_detail(f):
             return v.response
         return v
     return decorated
-        
+
+def requires_admin(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        admin = app.manager.admin_controller.authenticated_admin_from_request()
+        if isinstance(admin, ProblemDetail):
+            return admin.response
+        elif admin.startswith('https://'):
+            return redirect(admin)
+        else:
+            return f(*args, **kwargs)
+    return decorated
+
 @app.route('/')
 @returns_problem_detail
 def index():
@@ -185,7 +197,13 @@ def adobe_vendor_id_status():
 @app.route('/GoogleAuth/signin')
 @returns_problem_detail
 def google_auth_signin():
-    return app.manager.google().signin(flask.request.args)
+    return app.manager.admin_controller.signin(flask.request.args)
+
+@app.route('/admin')
+@requires_admin
+@returns_problem_detail
+def admin():
+    return app.manager.admin_controller.admin_info()
 
 # Controllers used for operations purposes
 @app.route('/heartbeat')

--- a/config.json.sample
+++ b/config.json.sample
@@ -12,6 +12,10 @@
     	},
         
     	"S3" : {
-    	}
+        },
+
+        "Google OAuth": {
+            "client_json_file": "/path/to/client/json/file.json"
+        }
     }
 }

--- a/config.json.sample
+++ b/config.json.sample
@@ -1,6 +1,7 @@
 {
     "gutenberg_illustrated_binary_path" : "",
     "data_directory" : "",
+    "secret_key" : "use this: import os; os.urandom(24).encode('hex')",
     "policies" : {
     },
     "integrations" : {

--- a/config.py
+++ b/config.py
@@ -16,6 +16,7 @@ class Configuration(CoreConfiguration):
     LANGUAGE_FORCE = "force"
     LARGE_COLLECTION_LANGUAGES = "large_collections"
     SMALL_COLLECTION_LANGUAGES = "small_collections"
+    ADMIN_AUTH_DOMAIN = "admin_authentication_domain"
 
     LANES_POLICY = "lanes"
     DEFAULT_OPDS_FORMAT = "simple_opds_entry"
@@ -35,6 +36,9 @@ class Configuration(CoreConfiguration):
 
     MILLENIUM_INTEGRATION = "Millenium"
     STAFF_PICKS_INTEGRATION = "Staff Picks"
+
+    GOOGLE_OAUTH_INTEGRATION = "Google OAuth"
+    GOOGLE_OAUTH_CLIENT_JSON = "client_json_file"
 
     LIST_FIELDS = "fields"
    

--- a/config.py
+++ b/config.py
@@ -37,6 +37,7 @@ class Configuration(CoreConfiguration):
     MILLENIUM_INTEGRATION = "Millenium"
     STAFF_PICKS_INTEGRATION = "Staff Picks"
 
+    SECRET_KEY = "secret_key"
     GOOGLE_OAUTH_INTEGRATION = "Google OAuth"
     GOOGLE_OAUTH_CLIENT_JSON = "client_json_file"
 

--- a/controller.py
+++ b/controller.py
@@ -456,6 +456,9 @@ class AdminController(CirculationManagerController):
             return redirect(admin_url, Response=Response)
 
     def staff_email(self, email):
+        """Checks the domain of an email address against the admin-authorized
+        domain"""
+
         staff_domain = Configuration.policy(
             Configuration.ADMIN_AUTH_DOMAIN, required=True
         )

--- a/controller.py
+++ b/controller.py
@@ -80,6 +80,7 @@ from config import (
 from lanes import make_lanes
 
 from adobe_vendor_id import AdobeVendorIDController
+from oauth import GoogleAuthService
 from axis import (
     Axis360API,
 )
@@ -227,6 +228,8 @@ class CirculationManager(object):
             self.log.warn("Adobe Vendor ID controller is disabled due to missing or incomplete configuration.")
             self.adobe_vendor_id = None
 
+    def google(self):
+        return GoogleAuthService(self._db, self.url_for('google_auth_signin'))
 
     def annotator(self, lane, *args, **kwargs):
         """Create an appropriate OPDS annotator for the given lane."""

--- a/controller.py
+++ b/controller.py
@@ -14,7 +14,6 @@ import flask
 from flask import (
     Response,
     redirect,
-
 )
 
 from core.app_server import (
@@ -400,7 +399,7 @@ class AdminController(CirculationManagerController):
     @property
     def google(self):
         return GoogleAuthService(
-            self._db, self.url_for('google_auth_signin'),
+            self._db, self.url_for('google_auth_callback'),
             test_mode=self.manager.testing
         )
 
@@ -410,7 +409,7 @@ class AdminController(CirculationManagerController):
             admin = get_one(self._db, Admin, access_token=authorization[7:])
             if admin and self.google.active_credentials(admin):
                 return admin
-        return self.google.auth_uri
+        return redirect(self.google.auth_uri)
 
     def authenticated_admin(self, credentials):
         """Creates or updates an admin with the given credentials"""
@@ -438,7 +437,6 @@ class AdminController(CirculationManagerController):
         else:
             admin = self.authenticated_admin(credentials)
             return self.admin_info(admin)
-
 
 
 class IndexController(CirculationManagerController):

--- a/controller.py
+++ b/controller.py
@@ -406,13 +406,10 @@ class AdminController(CirculationManagerController):
 
     def authenticated_admin_from_request(self):
         authorization = flask.request.environ.get('HTTP_AUTHORIZATION')
-        if not authorization:
-            return self.google.auth_uri
-
-        admin = get_one(self._db, Admin, access_token=authorization[7:])
-        if admin and self.google.active_credentials(admin):
-            return admin
-
+        if authorization:
+            admin = get_one(self._db, Admin, access_token=authorization[7:])
+            if admin and self.google.active_credentials(admin):
+                return admin
         return self.google.auth_uri
 
     def authenticated_admin(self, credentials):

--- a/controller.py
+++ b/controller.py
@@ -410,10 +410,11 @@ class AdminController(CirculationManagerController):
             admin = get_one(self._db, Admin, access_token=authorization[7:])
             if admin and self.google.active_credentials(admin):
                 return admin
-        return redirect(self.google.auth_uri)
+        return redirect(self.google.auth_uri, Response=Response)
 
     def authenticated_admin(self, admin_details):
         """Creates or updates an admin with the given details"""
+
         admin, ignore = get_one_or_create(
             self._db, Admin, email=admin_details['email']
         )

--- a/controller.py
+++ b/controller.py
@@ -417,10 +417,7 @@ class AdminController(CirculationManagerController):
 
     def authenticated_admin(self, credentials):
         """Creates or updates an admin with the given credentials"""
-        admin, is_new = get_one_or_create(
-            self._db, Admin,
-            authorization_identifier=credentials['email'],
-        )
+        admin = Admin(email=credentials['email'])
         admin.update_credentials(
             self._db, credentials['access_token'], credentials['credentials']
         )
@@ -429,9 +426,8 @@ class AdminController(CirculationManagerController):
     def admin_info(self, admin=None):
         if not admin:
             admin = self.authenticated_admin_from_request()
-        set_trace()
         return json.dumps(dict(
-            email=admin.authorization_identifier,
+            email=admin.email,
             access_token=admin.access_token
         ))
 

--- a/oauth.py
+++ b/oauth.py
@@ -1,7 +1,7 @@
 import json
 from nose.tools import set_trace
 
-from core.util.problem_detail import ProblemDetail as pd
+from problem_details import GOOGLE_OAUTH_FAILURE
 from config import Configuration
 from oauth2client import client as GoogleClient
 
@@ -47,13 +47,8 @@ class GoogleAuthService(object):
             ), redirect_url
 
     def google_error_problem_detail(self, error):
-        detail = "There was an error connecting with Google OAuth: %s" % error
-        return pd(
-            "http://librarysimplified.org/terms/problem/google-oauth-error",
-            400,
-            "Google OAuth Error",
-            detail,
-        )
+        error_detail = GOOGLE_OAUTH_FAILURE.detail + " Error: " + error
+        return GOOGLE_OAUTH_FAILURE.detailed(error_detail)
 
     def active_credentials(self, admin):
         """Check that existing credentials aren't expired"""

--- a/oauth.py
+++ b/oauth.py
@@ -1,15 +1,6 @@
-import re
 import json
-import datetime
-from flask import url_for, redirect
 from nose.tools import set_trace
 
-# from core.config import Configuration
-from core.model import (
-    get_one,
-    get_one_or_create,
-    Admin,
-)
 from core.util.problem_detail import ProblemDetail as pd
 from oauth2client import client as GoogleClient
 
@@ -61,8 +52,7 @@ class GoogleAuthService(object):
         """Check that existing credentials aren't expired"""
 
         if admin.credential:
-            credentials = json.loads(admin.credential)
-            oauth_credentials = GoogleClient.OAuth2Credentials.from_json(credentials)
+            oauth_credentials = self.client.OAuth2Credentials.from_json(admin.credential)
             return not oauth_credentials.access_token_expired
         return False
 

--- a/oauth.py
+++ b/oauth.py
@@ -42,8 +42,8 @@ class GoogleAuthService(object):
         if auth_code:
             credentials = self.client.step2_exchange(auth_code)
             return dict(
-                domain=credentials.id_token.get('email'),
                 email_domain=credentials.id_token.get('hd'),
+                email=credentials.id_token.get('email'),
                 access_token=credentials.get_access_token()[0],
                 credentials=json.dumps(credentials.to_json()),
             )

--- a/oauth.py
+++ b/oauth.py
@@ -87,6 +87,9 @@ class DummyGoogleClient(object):
         def from_json(self, credentials):
             return self
 
+        def get_access_token(self):
+            return ["opensesame"]
+
     def __init__(self, email='example@nypl.org'):
         self.credentials = self.Credentials(email=email)
         self.Oauth2Credentials = self.credentials
@@ -96,3 +99,6 @@ class DummyGoogleClient(object):
 
     def step2_exchange(self, auth_code):
         return self.credentials
+
+    def step1_get_authorize_url(self):
+        return "GOOGLE REDIRECT"

--- a/oauth.py
+++ b/oauth.py
@@ -73,13 +73,10 @@ class GoogleAuthService(object):
         """Check for existing credentials"""
 
         admin = get_one(self._db, Admin, authorization_identifier=email)
-        set_trace()
         credentials = admin.credential_for_source(self.datasource)
         if credentials:
             # Use the credentials if they're not expired.
-            # set_trace()
             credentials = self._build_oauth_credentials(credentials)
-            # set_trace()
             return credentials.access_token_expired == False
         return False
 

--- a/oauth.py
+++ b/oauth.py
@@ -23,14 +23,15 @@ class GoogleAuthService(object):
     </oauthResponse>
     """
 
-    def __init__(self, _db, redirect_uri):
+    def __init__(self, _db, redirect_uri, test_mode=False):
         self._db = _db
         self.datasource = DataSource.lookup(self._db, DataSource.GOOGLE)
-        self.client = GoogleClient.flow_from_clientsecrets(
-            '../nypl_config/client_secret.json',
-            scope='https://www.googleapis.com/auth/userinfo.email',
-            redirect_uri=redirect_uri
-        )
+        if not test_mode:
+            self.client = GoogleClient.flow_from_clientsecrets(
+                '../nypl_config/client_secret.json',
+                scope='https://www.googleapis.com/auth/userinfo.email',
+                redirect_uri=redirect_uri
+            )
 
     def signin(self, request):
         """Google Oauth sign-in flow"""

--- a/oauth.py
+++ b/oauth.py
@@ -32,12 +32,12 @@ class GoogleAuthService(object):
 
     def callback(self, request={}):
         """Google Oauth sign-in flow"""
+
         # The Google Oauth client sometimes hits the callback with an error.
         # These will be returned as a problem detail.
         error = request.get('error')
         if error:
-            return google_error_problem_detail(error)
-
+            return self.google_error_problem_detail(error)
         auth_code = request.get('code')
         if auth_code:
             credentials = self.client.step2_exchange(auth_code)

--- a/oauth.py
+++ b/oauth.py
@@ -17,10 +17,8 @@ class GoogleAuthService(object):
                 redirect_uri=redirect_uri
             )
 
-
-    @property
-    def auth_uri(self):
-        return self.client.step1_get_authorize_url()
+    def auth_uri(self, redirect_url):
+        return self.client.step1_get_authorize_url(state=redirect_url)
 
     @classmethod
     def from_environment(cls, redirect_uri, test_mode=False):
@@ -40,12 +38,13 @@ class GoogleAuthService(object):
             return self.google_error_problem_detail(error)
         auth_code = request.get('code')
         if auth_code:
+            redirect_url = request.get("state")
             credentials = self.client.step2_exchange(auth_code)
             return dict(
                 email=credentials.id_token.get('email'),
                 access_token=credentials.get_access_token()[0],
                 credentials=credentials.to_json(),
-            )
+            ), redirect_url
 
     def google_error_problem_detail(self, error):
         detail = "There was an error connecting with Google OAuth: %s" % error
@@ -98,5 +97,5 @@ class DummyGoogleClient(object):
     def step2_exchange(self, auth_code):
         return self.credentials
 
-    def step1_get_authorize_url(self):
+    def step1_get_authorize_url(self, state):
         return "GOOGLE REDIRECT"

--- a/oauth.py
+++ b/oauth.py
@@ -52,7 +52,7 @@ class GoogleAuthService(object):
         """Check that existing credentials aren't expired"""
 
         if admin.credential:
-            oauth_credentials = self.client.OAuth2Credentials.from_json(admin.credential)
+            oauth_credentials = GoogleClient.OAuth2Credentials.from_json(admin.credential)
             return not oauth_credentials.access_token_expired
         return False
 

--- a/oauth.py
+++ b/oauth.py
@@ -17,6 +17,7 @@ class GoogleAuthService(object):
                 redirect_uri=redirect_uri
             )
 
+
     @property
     def auth_uri(self):
         return self.client.step1_get_authorize_url()
@@ -24,7 +25,7 @@ class GoogleAuthService(object):
     @classmethod
     def from_environment(cls, redirect_uri, test_mode=False):
         config = Configuration.integration(
-            Configuration.GOOGLE_OAUTH_INTEGRATION, required=True
+            Configuration.GOOGLE_OAUTH_INTEGRATION
         )
         client_json_file = config[Configuration.GOOGLE_OAUTH_CLIENT_JSON]
         return cls(client_json_file, redirect_uri, test_mode)

--- a/oauth.py
+++ b/oauth.py
@@ -43,7 +43,7 @@ class GoogleAuthService(object):
             return dict(
                 email=credentials.id_token.get('email'),
                 access_token=credentials.get_access_token()[0],
-                credentials=json.dumps(credentials.to_json()),
+                credentials=credentials.to_json(),
             )
 
     def google_error_problem_detail(self, error):

--- a/oauth.py
+++ b/oauth.py
@@ -12,7 +12,7 @@ class GoogleAuthService(object):
             self.client = DummyGoogleClient()
         else:
             self.client = GoogleClient.flow_from_clientsecrets(
-                '../nypl_config/client_secret.json',
+                client_json_file,
                 scope='https://www.googleapis.com/auth/userinfo.email',
                 redirect_uri=redirect_uri
             )

--- a/oauth.py
+++ b/oauth.py
@@ -11,84 +11,88 @@ from core.model import (
     Admin,
 )
 from core.util.problem_detail import ProblemDetail as pd
-from problem_details import INVALID_ADMIN_CREDENTIALS
 from oauth2client import client as GoogleClient
 
 class GoogleAuthService(object):
 
-    AUTHENTICATION_RESPONSE_TEMPLATE = """
-    <oauthResponse xmlns="http://librarysimplified.org/terms">
-        <authorizationIdentifier>%(auth_id)s</authorizationIdentifier>
-    </oauthResponse>
-    """
-
     def __init__(self, _db, redirect_uri, test_mode=False):
         self._db = _db
-        if not test_mode:
+        if test_mode:
+            self.client = DummyGoogleClient()
+        else:
             self.client = GoogleClient.flow_from_clientsecrets(
                 '../nypl_config/client_secret.json',
                 scope='https://www.googleapis.com/auth/userinfo.email',
                 redirect_uri=redirect_uri
             )
 
-    def signin(self, request):
-        """Google Oauth sign-in flow"""
+    @property
+    def auth_uri(self):
+        return self.client.step1_get_authorize_url()
 
+    def callback(self, request={}):
+        """Google Oauth sign-in flow"""
         # The Google Oauth client sometimes hits the callback with an error.
         # These will be returned as a problem detail.
         error = request.get('error')
         if error:
-            return pd(
-                "http://librarysimplified.org/terms/problem/google-oauth-error",
-                400,
-                "Google Oauth Error",
-                "There was an error connecting with Google Oauth: %s" % error,
-            )
-
-        # If the client sends an authorization id to us, we can check to
-        # confirm we already have details for that user.
-        email = request.get('auth_id')
-        if email:
-            if self.existing_credentials(email):
-                return self.AUTHENTICATION_RESPONSE_TEMPLATE % dict(
-                    auth_id = email
-                )
+            return google_error_problem_detail(error)
 
         auth_code = request.get('code')
         if auth_code:
             credentials = self.client.step2_exchange(auth_code)
-            email_domain = credentials.id_token.get('hd')
-            if email_domain and email_domain == "nypl.org":
-                admin = self.create_admin(credentials)
-                return self.AUTHENTICATION_RESPONSE_TEMPLATE % dict(
-                    auth_id = admin.authorization_identifier
-                )
-            else:
-                return INVALID_ADMIN_CREDENTIALS
+            return dict(
+                domain=credentials.id_token.get('email'),
+                email_domain=credentials.id_token.get('hd'),
+                access_token=credentials.get_access_token()[0],
+                credentials=json.dumps(credentials.to_json()),
+            )
 
-        return redirect(self.client.step1_get_authorize_url())
+    def google_error_problem_detail(self, error):
+        detail = "There was an error connecting with Google Oauth: %s" % error
+        return pd(
+            "http://librarysimplified.org/terms/problem/google-oauth-error",
+            400,
+            "Google Oauth Error",
+            detail,
+        )
 
-    def existing_credentials(self, email):
-        """Check for existing credentials"""
+    def active_credentials(self, admin):
+        """Check that existing credentials aren't expired"""
 
-        admin = get_one(self._db, Admin, authorization_identifier=email)
-        if admin and admin.credentials:
-            # Use the credentials if they're not expired.
-            oauth_credentials = self._build_oauth_credentials(admin.credentials)
-            return oauth_credentials.access_token_expired == False
+        if admin.credential:
+            credentials = json.loads(admin.credential)
+            oauth_credentials = self.client.Oauth2Credentials.from_json(credentials)
+            return not oauth_credentials.access_token_expired
         return False
 
-    def _build_oauth_credentials(self, credentials):
-        """Builds our saved credentials into a Oauth2Credentials object"""
-        credentials = json.loads(credentials.as_json)
-        return self.client.Oauth2Credentials.from_json(credentials)
 
-    def create_admin(self, credentials):
-        credentials_str = json.dumps(credentials.to_json())
-        admin, ignore = get_one_or_create(
-            self._db, Admin,
-            authorization_identifier=credentials.id_token.get('email'),
-            credential=credentials_str,
-        )
-        return admin
+class DummyGoogleClient(object):
+    """Mock Google Oauth client for testing"""
 
+    expired = False
+
+    class Credentials(object):
+        """Mock Oauth2Credentials object for testing"""
+
+        access_token_expired = False
+
+        def __init__(self, email):
+            domain = email[email.index('@')+1:]
+            self.id_token = {"hd" : domain, "email" : email}
+
+        def to_json(self):
+            return json.loads('{"id_token" : %s }' % json.dumps(self.id_token))
+
+        def from_json(self, credentials):
+            return self
+
+    def __init__(self, email='example@nypl.org'):
+        self.credentials = self.Credentials(email=email)
+        self.Oauth2Credentials = self.credentials
+
+    def flow_from_client_secrets(self, config, scope=None, redirect_uri=None):
+        return self
+
+    def step2_exchange(self, auth_code):
+        return self.credentials

--- a/oauth.py
+++ b/oauth.py
@@ -1,0 +1,98 @@
+import re
+import json
+import datetime
+from flask import url_for, redirect
+from nose.tools import set_trace
+
+# from core.config import Configuration
+from core.model import (
+    get_one,
+    get_one_or_create,
+    Admin,
+    DataSource,
+)
+from core.util.problem_detail import ProblemDetail as pd
+from problem_details import INVALID_ADMIN_CREDENTIALS
+from oauth2client import client as GoogleClient
+
+class GoogleAuthService(object):
+
+    AUTHENTICATION_RESPONSE_TEMPLATE = """
+    <oauthResponse xmlns="http://librarysimplified.org/terms">
+        <authorizationIdentifier>%(auth_id)s</authorizationIdentifier>
+    </oauthResponse>
+    """
+
+    def __init__(self, _db, redirect_uri):
+        self._db = _db
+        self.datasource = DataSource.lookup(self._db, DataSource.GOOGLE)
+        self.client = GoogleClient.flow_from_clientsecrets(
+            '../nypl_config/client_secret.json',
+            scope='https://www.googleapis.com/auth/userinfo.email',
+            redirect_uri=redirect_uri
+        )
+
+    def signin(self, request):
+        """Google Oauth sign-in flow"""
+
+        # The Google Oauth client sometimes hits the callback with an error.
+        # These will be returned as a problem detail.
+        error = request.get('error')
+        if error:
+            return pd(
+                "http://librarysimplified.org/terms/problem/google-oauth-error",
+                400,
+                "Google Oauth Error",
+                "There was an error connecting with Google Oauth: %s" % error,
+            )
+
+        # If the client sends an authorization id to us, we can check to
+        # confirm we already have details for that user.
+        email = request.get('auth_id')
+        if email:
+            if self.existing_credentials(email):
+                return self.AUTHENTICATION_RESPONSE_TEMPLATE % dict(
+                    auth_id = email
+                )
+
+        auth_code = request.get('code')
+        if auth_code:
+            credentials = self.client.step2_exchange(auth_code)
+            email_domain = credentials.id_token.get('hd')
+            if email_domain and email_domain == "nypl.org":
+                admin = self.create_admin_with_credentials(credentials)
+                return self.AUTHENTICATION_RESPONSE_TEMPLATE % dict(
+                    auth_id = admin.authorization_identifier
+                )
+            else:
+                return INVALID_ADMIN_CREDENTIALS
+
+        return redirect(self.client.step1_get_authorize_url())
+
+    def existing_credentials(self, email):
+        """Check for existing credentials"""
+
+        admin = get_one(self._db, Admin, authorization_identifier=email)
+        set_trace()
+        credentials = admin.credential_for_source(self.datasource)
+        if credentials:
+            # Use the credentials if they're not expired.
+            # set_trace()
+            credentials = self._build_oauth_credentials(credentials)
+            # set_trace()
+            return credentials.access_token_expired == False
+        return False
+
+    def _build_oauth_credentials(self, credentials):
+        """Builds our saved OauthCredentials into a Oauth2Credentials object"""
+        credentials = json.loads(credentials.as_json)
+        return self.client.Oauth2Credentials.from_json(credentials)
+
+    def create_admin_with_credentials(self, credentials):
+        admin, is_new = get_one_or_create(
+            self._db, Admin,
+            authorization_identifier=credentials.id_token.get('email')
+        )
+        admin.add_authentication(self._db, self.datasource, credentials.to_json())
+        return admin
+

--- a/oauth.py
+++ b/oauth.py
@@ -31,9 +31,9 @@ class GoogleAuthService(object):
         return self.client.step1_get_authorize_url()
 
     def callback(self, request={}):
-        """Google Oauth sign-in flow"""
+        """Google OAuth sign-in flow"""
 
-        # The Google Oauth client sometimes hits the callback with an error.
+        # The Google OAuth client sometimes hits the callback with an error.
         # These will be returned as a problem detail.
         error = request.get('error')
         if error:
@@ -49,11 +49,11 @@ class GoogleAuthService(object):
             )
 
     def google_error_problem_detail(self, error):
-        detail = "There was an error connecting with Google Oauth: %s" % error
+        detail = "There was an error connecting with Google OAuth: %s" % error
         return pd(
             "http://librarysimplified.org/terms/problem/google-oauth-error",
             400,
-            "Google Oauth Error",
+            "Google OAuth Error",
             detail,
         )
 
@@ -62,18 +62,18 @@ class GoogleAuthService(object):
 
         if admin.credential:
             credentials = json.loads(admin.credential)
-            oauth_credentials = self.client.Oauth2Credentials.from_json(credentials)
+            oauth_credentials = GoogleClient.OAuth2Credentials.from_json(credentials)
             return not oauth_credentials.access_token_expired
         return False
 
 
 class DummyGoogleClient(object):
-    """Mock Google Oauth client for testing"""
+    """Mock Google OAuth client for testing"""
 
     expired = False
 
     class Credentials(object):
-        """Mock Oauth2Credentials object for testing"""
+        """Mock OAuth2Credentials object for testing"""
 
         access_token_expired = False
 
@@ -92,7 +92,7 @@ class DummyGoogleClient(object):
 
     def __init__(self, email='example@nypl.org'):
         self.credentials = self.Credentials(email=email)
-        self.Oauth2Credentials = self.credentials
+        self.OAuth2Credentials = self.credentials
 
     def flow_from_client_secrets(self, config, scope=None, redirect_uri=None):
         return self

--- a/problem_details.py
+++ b/problem_details.py
@@ -168,3 +168,10 @@ CANNOT_RELEASE_HOLD = pd(
     "Could not release hold.",
     "Could not release hold."
 )
+
+INVALID_ADMIN_CREDENTIALS = pd(
+      "http://librarysimplified.org/terms/problem/admin-credentials-invalid",
+      401,
+      "Invalid admin credentials",
+      "A valid library staff email is required.",
+)

--- a/problem_details.py
+++ b/problem_details.py
@@ -175,3 +175,10 @@ INVALID_ADMIN_CREDENTIALS = pd(
       "Invalid admin credentials",
       "A valid library staff email is required.",
 )
+
+GOOGLE_OAUTH_FAILURE = pd(
+      "http://librarysimplified.org/terms/problem/google-oauth-failure",
+      400,
+      "Google OAuth Error",
+      "There was an error connecting with Google OAuth.",
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ textblob
 
 # Used only by circulation
 numpy
+oauth2client
 
 # A NYPL-specific requirement
 newrelic

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -267,18 +267,24 @@ class TestAdminController(ControllerTest):
         super(TestAdminController, self).setup()
         self.admin, ignore = create(
             self._db, Admin, email=u'example@nypl.org', access_token=u'abc123',
-            credential=json.dumps({u'abc':123})
+            credential=json.dumps({
+                u'access_token': u'abc123',
+                u'client_id': u'', u'client_secret': u'',
+                u'refresh_token': u'', u'token_expiry': u'', u'token_uri': u'',
+                u'user_agent': u'', u'invalid': u''
+            })
         )
 
     def test_authenticated_admin_from_request(self):
-        # Sends you an admin if you send their access token in the headers.
+        # Sends you an admin if you send their access token.
         with self.app.test_request_context(
             '/admin', headers=dict(Authorization="Bearer "+self.admin.access_token)
         ):
             response = self.manager.admin_controller.authenticated_admin_from_request()
             eq_(self.admin, response)
 
-        # Redirects to Google OAuth flow if you don't
+        # Redirects to Google OAuth flow if you don't pass an access token in
+        # the header or uri.
         with temp_config() as config:
             config[Configuration.GOOGLE_OAUTH_INTEGRATION] = {
                 Configuration.GOOGLE_OAUTH_CLIENT_JSON : "/path"
@@ -355,8 +361,8 @@ class TestAccountController(ControllerTest):
             account_info = json.loads(self.manager.accounts.account())
             eq_("alice", account_info.get('username'))
             eq_("0", account_info.get('barcode'))
-        
-        
+
+
 class TestLoanController(ControllerTest):
     def setup(self):
         super(TestLoanController, self).setup()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -278,7 +278,7 @@ class TestAdminController(ControllerTest):
             response = self.manager.admin_controller.authenticated_admin_from_request()
             eq_(self.admin, response)
 
-        # Redirects to Google Oauth flow if you don't
+        # Redirects to Google OAuth flow if you don't.
         with self.app.test_request_context('/admin'):
             response = self.manager.admin_controller.authenticated_admin_from_request()
             eq_(302, response.status_code)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -308,7 +308,9 @@ class TestAdminController(ControllerTest):
     def test_admin_info(self):
         # Will give you admin details if you pass it an admin.
         # This allows the Google callback flow to return something.
-        passed_admin_info = self.manager.admin_controller.admin_info(admin=self.admin)
+        passed_admin_info = self.manager.admin_controller.admin_info(
+            access_token=self.admin.access_token
+        )
         passed_admin_info = json.loads(passed_admin_info)
         eq_(self.admin.email, passed_admin_info.get('email'))
         eq_(self.admin.access_token, passed_admin_info.get('access_token'))
@@ -320,6 +322,7 @@ class TestAdminController(ControllerTest):
             admin_info = json.loads(self.manager.admin_controller.admin_info())
             eq_(self.admin.email, admin_info.get('email'))
             eq_(self.admin.access_token, admin_info.get('access_token'))
+
 
 class TestAccountController(ControllerTest):
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -281,7 +281,8 @@ class TestAdminController(ControllerTest):
         # Redirects to Google Oauth flow if you don't
         with self.app.test_request_context('/admin'):
             response = self.manager.admin_controller.authenticated_admin_from_request()
-            eq_("GOOGLE REDIRECT", response)
+            eq_(302, response.status_code)
+            eq_(u"GOOGLE REDIRECT", response.headers['Location'])
 
     def test_admin_info(self):
         # Will give you admin details if you pass it an admin.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -284,6 +284,27 @@ class TestAdminController(ControllerTest):
             eq_(302, response.status_code)
             eq_(u"GOOGLE REDIRECT", response.headers['Location'])
 
+    def test_authenticated_admin(self):
+        # Creates a new admin with fresh details.
+        new_admin_details = {
+            'email' : u'admin@nypl.org', 'email_domain' : u'nypl.org',
+            'access_token' : u'tubular', 'credentials' : u'gnarly'
+        }
+        admin = self.manager.admin_controller.authenticated_admin(new_admin_details)
+        eq_('admin@nypl.org', admin.email)
+        eq_('tubular', admin.access_token)
+        eq_('gnarly', admin.credential)
+
+        # Or overwrites credentials for an existing admin.
+        existing_admin_details = {
+            'email' : u'example@nypl.org', 'email_domain' : u'nypl.org',
+            'access_token' : u'bananas', 'credentials' : u'b-a-n-a-n-a-s',
+        }
+        admin = self.manager.admin_controller.authenticated_admin(existing_admin_details)
+        eq_(self.admin.id, admin.id)
+        eq_('bananas', self.admin.access_token)
+        eq_('b-a-n-a-n-a-s', self.admin.credential)
+
     def test_admin_info(self):
         # Will give you admin details if you pass it an admin.
         # This allows the Google callback flow to return something.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -281,16 +281,16 @@ class TestAdminController(ControllerTest):
             response = self.manager.admin_controller.authenticated_admin_from_request()
             eq_(self.admin, response)
 
-        # Redirects to Google OAuth flow if you don't pass an access token in
-        # the header or uri.
+        # Returns an error if you aren't authenticated.
         with temp_config() as config:
             config[Configuration.GOOGLE_OAUTH_INTEGRATION] = {
                 Configuration.GOOGLE_OAUTH_CLIENT_JSON : "/path"
             }
             with self.app.test_request_context('/admin'):
+                # You get back a problem detail when you're not authenticated.
                 response = self.manager.admin_controller.authenticated_admin_from_request()
-                eq_(302, response.status_code)
-                eq_(u"GOOGLE REDIRECT", response.headers['Location'])
+                eq_(401, response.status_code)
+                eq_(INVALID_ADMIN_CREDENTIALS.detail, response.detail)
 
     def test_authenticated_admin(self):
         # Creates a new admin with fresh details.

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,83 @@
+import json
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+
+from . import DatabaseTest
+from ..core.model import (
+    Admin,
+    OauthCredential,
+)
+from ..core.util.problem_detail import ProblemDetail
+
+from ..oauth import GoogleAuthService
+
+
+class DummyGoogleClient(object):
+    """Mock Google Oauth client for testing"""
+
+    class Credentials(object):
+        """Mock Oauth2Credentials object for testing"""
+
+        def __init__(self, email):
+            domain = email[email.index('@')+1:]
+            self.id_token = {"hd" : domain, "email" : email }
+
+        def access_token_expired(expired=False):
+            self.expired = expired
+            return self.expired
+
+        def to_json(self):
+            return json.loads('{"id_token" : %s }' % json.dumps(self.id_token))
+
+        def from_json(self, json):
+            self
+
+    def __init__(self, email='example@nypl.org'):
+        self.credentials = self.Credentials(email=email)
+        self.Oauth2Credentials = self.credentials
+
+    def flow_from_client_secrets(self, config, scope=None, redirect_uri=None):
+        return self
+
+    def step2_exchange(self, auth_code):
+        return self.credentials
+
+class TestGoogleAuthService(DatabaseTest):
+    def setup(self):
+        super(TestGoogleAuthService, self).setup()
+        self.google = GoogleAuthService(self._db, "http://example.com/callback")
+        self.google.client = DummyGoogleClient()
+
+    def test_signin(self):
+        # There are no admins or credentials in the database.
+        admins = self._db.query(Admin)
+        credentials = self._db.query(OauthCredential)
+        eq_(0, len(admins.all()))
+        eq_(0, len(credentials.all()))
+
+        # Returns a problem detail when an email doesn't have authorization.
+        self.google.client = DummyGoogleClient(email='broken@example.com')
+        invalid_response = self.google.signin({'code' : 'abc'})
+        eq_(0, len(admins.all()))
+        eq_(True, isinstance(invalid_response, ProblemDetail))
+        eq_(401, invalid_response.status_code)
+        eq_("Invalid administrative credentials", invalid_response.title)
+
+        # Returns a problem detail when Google returns an error.
+        self.google.client = DummyGoogleClient()
+        error_response = self.google.signin({'error' : 'access_denied'})
+        eq_(0, len(admins.all()))
+        eq_(True, isinstance(error_response, ProblemDetail))
+        eq_(400, error_response.status_code)
+        eq_(True, error_response.detail.endswith('access_denied'))
+
+        # Successful case creates and admin with credentials
+        success_response = self.google.signin({'code' : 'abc'})
+        eq_(1, len(admins.all()))
+        eq_(1, len(credentials.all()))
+        credentials_belong_to_admin = admins.all()[0].credentials == credentials.all()
+        eq_(True, credentials_belong_to_admin)
+        assert "<authorizationIdentifier>" in success_response
+        assert "example@nypl.org" in success_response

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -27,7 +27,6 @@ class TestGoogleAuthService(DatabaseTest):
 
         # Successful case creates a dict of admin details
         success = self.google.callback({'code' : 'abc'})
-        eq_('nypl.org', success['email_domain'])
         eq_('example@nypl.org', success['email'])
         eq_('opensesame', success['access_token'])
         default_credentials = json.dumps({"id_token": {"email": "example@nypl.org", "hd": "nypl.org"}})

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -5,10 +5,7 @@ from nose.tools import (
 )
 
 from . import DatabaseTest
-from ..core.model import (
-    Admin,
-    OauthCredential,
-)
+from ..core.model import Admin
 from ..core.util.problem_detail import ProblemDetail
 
 from ..oauth import GoogleAuthService
@@ -22,11 +19,7 @@ class DummyGoogleClient(object):
 
         def __init__(self, email):
             domain = email[email.index('@')+1:]
-            self.id_token = {"hd" : domain, "email" : email }
-
-        def access_token_expired(expired=False):
-            self.expired = expired
-            return self.expired
+            self.id_token = {"hd" : domain, "email" : email}
 
         def to_json(self):
             return json.loads('{"id_token" : %s }' % json.dumps(self.id_token))
@@ -53,9 +46,7 @@ class TestGoogleAuthService(DatabaseTest):
     def test_signin(self):
         # There are no admins or credentials in the database.
         admins = self._db.query(Admin)
-        credentials = self._db.query(OauthCredential)
         eq_(0, len(admins.all()))
-        eq_(0, len(credentials.all()))
 
         # Returns a problem detail when an email doesn't have authorization.
         self.google.client = DummyGoogleClient(email='broken@example.com')
@@ -76,8 +67,6 @@ class TestGoogleAuthService(DatabaseTest):
         # Successful case creates and admin with credentials
         success_response = self.google.signin({'code' : 'abc'})
         eq_(1, len(admins.all()))
-        eq_(1, len(credentials.all()))
-        credentials_belong_to_admin = admins.all()[0].credentials == credentials.all()
-        eq_(True, credentials_belong_to_admin)
+        assert "example@nypl.org" in admins.all()[0].credential
         assert "<authorizationIdentifier>" in success_response
         assert "example@nypl.org" in success_response

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -24,9 +24,6 @@ class DummyGoogleClient(object):
         def to_json(self):
             return json.loads('{"id_token" : %s }' % json.dumps(self.id_token))
 
-        def from_json(self, json):
-            self
-
     def __init__(self, email='example@nypl.org'):
         self.credentials = self.Credentials(email=email)
         self.Oauth2Credentials = self.credentials

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -5,65 +5,30 @@ from nose.tools import (
 )
 
 from . import DatabaseTest
-from ..core.model import Admin
 from ..core.util.problem_detail import ProblemDetail
 
-from ..oauth import GoogleAuthService
-
-
-class DummyGoogleClient(object):
-    """Mock Google Oauth client for testing"""
-
-    class Credentials(object):
-        """Mock Oauth2Credentials object for testing"""
-
-        def __init__(self, email):
-            domain = email[email.index('@')+1:]
-            self.id_token = {"hd" : domain, "email" : email}
-
-        def to_json(self):
-            return json.loads('{"id_token" : %s }' % json.dumps(self.id_token))
-
-    def __init__(self, email='example@nypl.org'):
-        self.credentials = self.Credentials(email=email)
-        self.Oauth2Credentials = self.credentials
-
-    def flow_from_client_secrets(self, config, scope=None, redirect_uri=None):
-        return self
-
-    def step2_exchange(self, auth_code):
-        return self.credentials
+from ..oauth import (
+    GoogleAuthService,
+    DummyGoogleClient,
+)
 
 class TestGoogleAuthService(DatabaseTest):
-    def setup(self):
+
+    def test_callback(self):
         super(TestGoogleAuthService, self).setup()
         self.google = GoogleAuthService(self._db, "", test_mode=True)
-        self.google.client = DummyGoogleClient()
-
-    def test_signin(self):
-        # There are no admins or credentials in the database.
-        admins = self._db.query(Admin)
-        eq_(0, len(admins.all()))
-
-        # Returns a problem detail when an email doesn't have authorization.
-        self.google.client = DummyGoogleClient(email='broken@example.com')
-        invalid_response = self.google.signin({'code' : 'abc'})
-        eq_(0, len(admins.all()))
-        eq_(True, isinstance(invalid_response, ProblemDetail))
-        eq_(401, invalid_response.status_code)
-        eq_("Invalid administrative credentials", invalid_response.title)
 
         # Returns a problem detail when Google returns an error.
         self.google.client = DummyGoogleClient()
-        error_response = self.google.signin({'error' : 'access_denied'})
-        eq_(0, len(admins.all()))
+        error_response = self.google.callback({'error' : 'access_denied'})
         eq_(True, isinstance(error_response, ProblemDetail))
         eq_(400, error_response.status_code)
         eq_(True, error_response.detail.endswith('access_denied'))
 
-        # Successful case creates and admin with credentials
-        success_response = self.google.signin({'code' : 'abc'})
-        eq_(1, len(admins.all()))
-        assert "example@nypl.org" in admins.all()[0].credential
-        assert "<authorizationIdentifier>" in success_response
-        assert "example@nypl.org" in success_response
+        # Successful case creates a dict of admin details
+        success = self.google.callback({'code' : 'abc'})
+        eq_('nypl.org', success['email_domain'])
+        eq_('example@nypl.org', success['email'])
+        eq_('opensesame', success['access_token'])
+        default_credentials = json.dumps({"id_token": {"email": "example@nypl.org", "hd": "nypl.org"}})
+        eq_(default_credentials, success['credentials'])

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -29,5 +29,5 @@ class TestGoogleAuthService(DatabaseTest):
         success = self.google.callback({'code' : 'abc'})
         eq_('example@nypl.org', success['email'])
         eq_('opensesame', success['access_token'])
-        default_credentials = json.dumps({"id_token": {"email": "example@nypl.org", "hd": "nypl.org"}})
+        default_credentials = {"id_token": {"email": "example@nypl.org", "hd": "nypl.org"}}
         eq_(default_credentials, success['credentials'])

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -26,7 +26,7 @@ class TestGoogleAuthService(DatabaseTest):
         eq_(True, error_response.detail.endswith('access_denied'))
 
         # Successful case creates a dict of admin details
-        success = self.google.callback({'code' : 'abc'})
+        success, redirect = self.google.callback({'code' : 'abc'})
         eq_('example@nypl.org', success['email'])
         eq_('opensesame', success['access_token'])
         default_credentials = {"id_token": {"email": "example@nypl.org", "hd": "nypl.org"}}

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -47,7 +47,7 @@ class DummyGoogleClient(object):
 class TestGoogleAuthService(DatabaseTest):
     def setup(self):
         super(TestGoogleAuthService, self).setup()
-        self.google = GoogleAuthService(self._db, "http://example.com/callback")
+        self.google = GoogleAuthService(self._db, "", test_mode=True)
         self.google.client = DummyGoogleClient()
 
     def test_signin(self):


### PR DESCRIPTION
Fixes #74 & #81. Creates admins. Uses Google OAuth to authenticate them. Handles callbacks. Holds onto access codes. Allows for library-specific configuration. Tests it. Creates peace & love on earth. Remains *very* commit-ted.

Replaces/includes #80.