### PR TITLE
Sync only finds current patrons loans

### DIFF
--- a/circulation.py
+++ b/circulation.py
@@ -456,9 +456,15 @@ class CirculationAPI(object):
         # Get our internal view of the patron's current state.
         __transaction = self._db.begin_nested()
         local_loans = self._db.query(Loan).join(Loan.license_pool).filter(
-            LicensePool.data_source_id.in_(self.data_source_ids_for_sync))
+            LicensePool.data_source_id.in_(self.data_source_ids_for_sync)
+        ).filter(
+            Loan.patron==patron
+        )
         local_holds = self._db.query(Hold).join(Hold.license_pool).filter(
-            LicensePool.data_source_id.in_(self.data_source_ids_for_sync))
+            LicensePool.data_source_id.in_(self.data_source_ids_for_sync)
+        ).filter(
+            Hold.patron==patron
+        )
 
         now = datetime.datetime.utcnow()
         local_loans_by_identifier = {}

--- a/circulation.py
+++ b/circulation.py
@@ -265,6 +265,7 @@ class CirculationAPI(object):
             hold_info.hold_position
         )
         if existing_loan:
+            logging.info("In borrow(), deleting loan #%d." % existing_loan.id)
             self._db.delete(existing_loan)
         __transaction.commit()
         return None, hold, is_new
@@ -365,6 +366,7 @@ class CirculationAPI(object):
         )
         if loan:
             __transaction = self._db.begin_nested()
+            logging.info("In revoke_loan(), deleting loan #%d" % loan.id)
             self._db.delete(loan)
             __transaction.commit()
         if not licensepool.open_access:
@@ -514,6 +516,7 @@ class CirculationAPI(object):
         # and we should get rid of it.
         for loan in local_loans_by_identifier.values():
             if loan.license_pool.data_source in self.data_sources_for_sync:
+                logging.info("In sync_bookshelf for patron %s, deleting loan %d (patron %s)" % (patron.authorization_identifier, loan.id, loan.patron.authorization_identifier))
                 self._db.delete(loan)
 
         # Every hold remaining in holds_by_identifier is a hold that


### PR DESCRIPTION
This branch was originally designed to diagnose a problem on an active site, and I've still got the debugging code in place, but while writing it I think I found the problem.

sync_bookshelf() starts with a set of `local_loans` and `local_holds` for the given patron. It asks the external data sources about the list of loans _they_ have for the given patron, and any loans not on the remote list get removed locally.

...except... it doesn't limit the `local_loans` and `local_holds` to the given patron. It gets _all_ the active loans and holds. So every time someone syncs their bookshelf they're destroying the local records of every other patron's loans, but not their own.

This branch fixes that stupid bug.