### PR TITLE
Admin metadata refresh

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -210,7 +210,4 @@ class WorkController(CirculationManagerController):
             # Otherwise, it just doesn't know anything.
             return METADATA_REFRESH_FAILURE
 
-        return redirect(
-            url_for('permalink', data_source=data_source, identifier=identifier),
-            Response=Response
-        )
+        return Response("", 200)

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -202,9 +202,10 @@ class WorkController(CirculationManagerController):
 
         if record.exception:
             # There was a coverage failure.
-            if isinstance(record.exception, int) and record.exception == 201:
-                # A 201 error means it's never looked up this work before
-                # so it's started the resolution process.
+            if (isinstance(record.exception, int)
+                and record.exception in [201, 202]):
+                # A 201/202 error means it's never looked up this work before
+                # so it's started the resolution process or looking for sources.
                 return METADATA_REFRESH_PENDING
             # Otherwise, it just doesn't know anything.
             return METADATA_REFRESH_FAILURE

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -26,10 +26,10 @@ from config import (
 from oauth import GoogleAuthService
 
 from api.controller import CirculationManagerController
+from api.coverage import MetadataWranglerCoverageProvider
 from core.app_server import entry_response
 from core.opds import AcquisitionFeed
 from opds import AdminAnnotator
-
 
 def setup_admin_controllers(manager):
     """Set up all the controllers that will be used by the admin parts of the web app."""

--- a/api/admin/opds.py
+++ b/api/admin/opds.py
@@ -20,6 +20,13 @@ class AdminAnnotator(CirculationManagerAnnotator):
             identifier_identifier = identifier.identifier
             data_source_name = active_license_pool.data_source.name
 
+        feed.add_link_to_entry(
+            entry,
+            rel="http://librarysimplified.org/terms/rel/refresh",
+            href=self.url_for(
+                "refresh", data_source=data_source_name,
+                identifier=identifier_identifier, _external=True)
+        )
 
         if active_license_pool.suppressed:
             feed.add_link_to_entry(

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -76,6 +76,12 @@ def suppress(data_source, identifier):
 def unsuppress(data_source, identifier):
     return app.manager.admin_work_controller.unsuppress(data_source, identifier)
 
+@app.route('/works/<data_source>/<identifier>/refresh')
+@returns_problem_detail
+@requires_csrf_token
+@requires_admin
+def refresh(data_source, identifier):
+    return app.manager.work_controller.refresh_metadata(data_source, identifier)
 
 @app.route('/admin')
 @app.route('/admin/')

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -76,12 +76,12 @@ def suppress(data_source, identifier):
 def unsuppress(data_source, identifier):
     return app.manager.admin_work_controller.unsuppress(data_source, identifier)
 
-@app.route('/works/<data_source>/<identifier>/refresh')
+@app.route('/works/<data_source>/<identifier>/refresh', methods=['POST'])
 @returns_problem_detail
 @requires_csrf_token
 @requires_admin
 def refresh(data_source, identifier):
-    return app.manager.work_controller.refresh_metadata(data_source, identifier)
+    return app.manager.admin_work_controller.refresh_metadata(data_source, identifier)
 
 @app.route('/admin')
 @app.route('/admin/')

--- a/api/controller.py
+++ b/api/controller.py
@@ -42,6 +42,7 @@ from core.lane import (
 from core.model import (
     get_one,
     get_one_or_create,
+    Admin,
     Complaint,
     DataSource,
     Hold,
@@ -49,7 +50,6 @@ from core.model import (
     Loan,
     LicensePoolDeliveryMechanism,
     production_session,
-    Admin,
 )
 from core.opds import (
     E,
@@ -92,7 +92,6 @@ from threem import (
     ThreeMAPI,
     DummyThreeMAPI,
 )
-
 from circulation import (
     CirculationAPI,
     DummyCirculationAPI,
@@ -149,8 +148,6 @@ class CirculationManager(object):
             self.hold_notification_email_address = Configuration.default_notification_email_address()
 
         self.opds_authentication_document = self.create_authentication_document()
-        #self.log.debug("Lane layout:")
-        #self.log_lanes()
 
     def cdn_url_for(self, view, *args, **kwargs):
         return cdn_url_for(view, *args, **kwargs)
@@ -288,7 +285,6 @@ class CirculationManagerController(object):
         else:
             flask.request.patron = patron
             return patron
-        
 
     def authenticated_patron(self, barcode, pin):
         """Look up the patron authenticated by the given barcode/pin.
@@ -421,7 +417,6 @@ class IndexController(CirculationManagerController):
         else:
             lang_key, name = lane_info
             return self.load_lane(lang_key, name)
-        
 
     def appropriate_index_for_patron_type(self):
         root_lane = self.authenticated_patron_root_lane()

--- a/api/controller.py
+++ b/api/controller.py
@@ -84,7 +84,6 @@ from adobe_vendor_id import AdobeVendorIDController
 from axis import (
     Axis360API,
 )
-from coverage import MetadataWranglerCoverageProvider
 from overdrive import (
     OverdriveAPI,
     DummyOverdriveAPI,

--- a/api/controller.py
+++ b/api/controller.py
@@ -84,6 +84,7 @@ from adobe_vendor_id import AdobeVendorIDController
 from axis import (
     Axis360API,
 )
+from coverage import MetadataWranglerCoverageProvider
 from overdrive import (
     OverdriveAPI,
     DummyOverdriveAPI,
@@ -700,7 +701,6 @@ class LoanController(CirculationManagerController):
         if fulfillment.content_type:
             headers['Content-Type'] = fulfillment.content_type
         return Response(fulfillment.content, status_code, headers)
-    
 
     def revoke(self, data_source, identifier):
         patron = flask.request.patron

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -27,6 +27,10 @@ from core.opds_import import (
     OPDSImporter,
 )
 
+class HTTPIntegrationException(Exception):
+    pass
+
+
 class OPDSImportCoverageProvider(CoverageProvider):
 
     def handle_import_messages(self, messages_by_id):

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -122,14 +122,18 @@ class MetadataWranglerCoverageProvider(OPDSImportCoverageProvider):
         )
 
         for edition in imported:
-            self.finalize_import(edition)
+            self.finalize_batch(edition)
             results.append(edition.primary_identifier)
 
         for failure in self.handle_import_messages(messages_by_id):
             results.append(failure)
         return results
 
-    def finalize_import(self, edition):
+    def process_item(self, identifier):
+        [result] = self.process_batch([identifier])
+        return result
+
+    def finalize_batch(self, edition):
         """Now that an OPDS entry has been imported into an Edition, make sure
         there's a Work associated with the edition, and mark the Work
         as presentation-ready.

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -8,7 +8,6 @@ from core.coverage import (
 from sqlalchemy import (
     and_,
 )
-from monitor import HTTPIntegrationException
 from core.model import (
     CoverageRecord,
     DataSource,

--- a/api/monitor.py
+++ b/api/monitor.py
@@ -28,9 +28,6 @@ from core.external_search import (
     ExternalSearchIndex,
 )
 
-class HTTPIntegrationException(Exception):
-    pass
-
 class SearchIndexUpdateMonitor(WorkSweepMonitor):
     """Make sure the search index is up-to-date for every work.
     """

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -198,7 +198,7 @@ METADATA_REFRESH_PENDING = pd(
 )
 
 METADATA_REFRESH_FAILURE = pd(
-      "http://librarysimplified.org/terms/problem/metadata-refresh-pending",
+      "http://librarysimplified.org/terms/problem/metadata-refresh-failure",
       400,
       "Metadata could not be refreshed.",
       "Metadata could not be refreshed.",

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -189,3 +189,17 @@ INVALID_CSRF_TOKEN = pd(
       "Invalid CSRF token",
       "There was an error saving your changes.",
 )
+
+METADATA_REFRESH_PENDING = pd(
+      "http://librarysimplified.org/terms/problem/metadata-refresh-pending",
+      201,
+      "Metadata refresh pending.",
+      "The Metadata Wrangler is looking for new data. Check back later.",
+)
+
+METADATA_REFRESH_FAILURE = pd(
+      "http://librarysimplified.org/terms/problem/metadata-refresh-pending",
+      400,
+      "Metadata could not be refreshed.",
+      "Metadata could not be refreshed.",
+)

--- a/scripts.py
+++ b/scripts.py
@@ -424,7 +424,7 @@ class UpdateMetadata(Script):
         identifiers = [x.primary_identifier for x in editions]
         client = SimplifiedOPDSLookup.from_config()
         feed = client.lookup(identifiers).content
-        importer = DetailedOPDSImporter(self._db, feed)
+        importer = OPDSImporter(self._db, feed)
         results = importer.import_from_feed()
         self._db.commit()
 

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -81,10 +81,7 @@ class TestWorkController(AdminControllerTest):
             eq_(False, lp.suppressed)
 
     def test_refresh_metadata(self):
-        [lp] = self.english_1.license_pools
-        datasource = lp.data_source.name
-        identifier = lp.identifier.identifier
-        permalink_route = '/works/' + datasource + '/' + identifier
+        permalink_route = '/works/' + self.datasource + '/' + self.identifier
 
         success_provider = AlwaysSuccessfulCoverageProvider(
             "Always successful", [Identifier.GUTENBERG_ID],
@@ -99,18 +96,17 @@ class TestWorkController(AdminControllerTest):
             # A successful response from the metadata wrangler returns user to
             # the permalink.
             response = self.manager.work_controller.refresh_metadata(
-                datasource, identifier, provider=success_provider
+                self.datasource, self.identifier, provider=success_provider
             )
             eq_(302, response.status_code)
             eq_(permalink_route, response.headers['Location'])
 
 
             response = self.manager.work_controller.refresh_metadata(
-                datasource, identifier, provider=failure_provider
+                self.datasource, self.identifier, provider=failure_provider
             )
             eq_(METADATA_REFRESH_FAILURE.status_code, response.status_code)
             eq_(METADATA_REFRESH_FAILURE.detail, response.detail)
-
 
 class TestSigninController(AdminControllerTest):
 


### PR DESCRIPTION
- A new route for refreshing a book's metadata, included in its Admin-annotated OPDS entry
- Metadata Wrangler-related problem details
- A test refactoring that made more sense before, but is now just *here*.
- Annoying whitespace changes to make reviewing more difficult!!