### PR TITLE
Allow 3M Monitor to accept a default start date

### DIFF
--- a/api/threem.py
+++ b/api/threem.py
@@ -5,7 +5,6 @@ import datetime
 import os
 import re
 import logging
-import sys
 
 from nose.tools import set_trace
 
@@ -605,34 +604,32 @@ class ThreeMEventMonitor(Monitor):
     """
 
     TWO_YEARS_AGO = datetime.timedelta(365*2)
-    name = "3M Event Monitor"
 
     def __init__(self, _db, default_start_time=None,
-                 account_id=None, library_id=None, account_key=None):
+                 account_id=None, library_id=None, account_key=None,
+                 cli_date=None):
+        self.service_name = "3M Event Monitor"
         if not default_start_time:
-            default_start_time = self.create_default_start_time(sys.argv[1:])
-
+            default_start_time = self.create_default_start_time(cli_date)
         super(ThreeMEventMonitor, self).__init__(
-            _db, self.name, default_start_time=default_start_time)
+            _db, self.service_name, default_start_time=default_start_time)
         self.api = ThreeMAPI(self._db, account_id, library_id, account_key)
 
-    @classmethod
-    def create_default_start_time(cls, date_args=None):
+    def create_default_start_time(self, cli_date):
         """Sets the default start time if it's passed as an argument.
 
         The command line date argument should have the format YYYY-MM-DD.
         """
-        if date_args:
-            date = date_args[0]
+        if cli_date:
             try:
-                year, month, day = [int(digit) for digit in date.split('-')]
-                return datetime.datetime(year, month, day)
-            except ValueError:
+                date = cli_date[0]
+                return datetime.datetime.strptime(date, "%Y-%m-%d")
+            except ValueError as e:
                 # Date argument wasn't in the proper format.
-                two_years_ago = datetime.datetime.utcnow() - cls.TWO_YEARS_AGO
-                logging.getLogger(cls.name).warn(
-                    "Couldn't parse date value. Using default instead: %s",
-                    two_years_ago.strftime('%B %d, %Y')
+                two_years_ago = datetime.datetime.utcnow() - self.TWO_YEARS_AGO
+                self.log.warn(
+                    "%s. Using default date instead: %s.", e,
+                    two_years_ago.strftime("%B %d, %Y")
                 )
                 return two_years_ago
         return None

--- a/api/threem.py
+++ b/api/threem.py
@@ -513,12 +513,11 @@ class ThreeMCirculationSweep(IdentifierSweepMonitor):
     count the same event.  However it will greatly improve our current
     view of our 3M circulation, which is more important.
     """
-    def __init__(self, _db, account_id=None, library_id=None, account_key=None):
+    def __init__(self, _db, testing=False):
         super(ThreeMCirculationSweep, self).__init__(
             _db, "3M Circulation Sweep", batch_size=25)
         self._db = _db
-        self.api = ThreeMAPI(self._db, account_id, library_id,
-                             account_key)
+        self.api = ThreeMAPI(self._db, testing=testing)
         self.data_source = DataSource.lookup(self._db, DataSource.THREEM)
 
     def identifier_query(self):
@@ -607,13 +606,13 @@ class ThreeMEventMonitor(Monitor):
 
     def __init__(self, _db, default_start_time=None,
                  account_id=None, library_id=None, account_key=None,
-                 cli_date=None):
+                 cli_date=None, testing=False):
         self.service_name = "3M Event Monitor"
         if not default_start_time:
             default_start_time = self.create_default_start_time(cli_date)
         super(ThreeMEventMonitor, self).__init__(
             _db, self.service_name, default_start_time=default_start_time)
-        self.api = ThreeMAPI(self._db, account_id, library_id, account_key)
+        self.api = ThreeMAPI(self._db, testing=testing)
 
     def create_default_start_time(self, cli_date):
         """Sets the default start time if it's passed as an argument.

--- a/api/threem.py
+++ b/api/threem.py
@@ -627,7 +627,7 @@ class ThreeMEventMonitor(Monitor):
                 # Date argument wasn't in the proper format.
                 two_years_ago = datetime.datetime.utcnow() - self.TWO_YEARS_AGO
                 self.log.warn(
-                    "%s. Using default date instead: %s.", e,
+                    "%r. Using default date instead: %s.", e,
                     two_years_ago.strftime("%B %d, %Y")
                 )
                 return two_years_ago

--- a/bin/threem_monitor
+++ b/bin/threem_monitor
@@ -7,4 +7,4 @@ package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
 from core.scripts import RunMonitorScript
 from api.threem import ThreeMEventMonitor
-RunMonitorScript(ThreeMEventMonitor).run()
+RunMonitorScript(ThreeMEventMonitor, cli_date=sys.argv[1:2]).run()

--- a/tests/test_3m.py
+++ b/tests/test_3m.py
@@ -16,6 +16,7 @@ from core.model import (
     Identifier,
     Edition,
 )
+from . import DatabaseTest
 from api.circulation_exceptions import *
 
 class Test3MEventParser(object):
@@ -204,21 +205,22 @@ class TestErrorParser(object):
         assert isinstance(error, CannotHold)
 
 
-class TestThreeMEventMonitor(object):
+class TestThreeMEventMonitor(DatabaseTest):
 
   def test_default_start_time(self):
+    monitor = ThreeMEventMonitor(self._db)
     no_args = []
-    eq_(None, ThreeMEventMonitor.create_default_start_time(no_args))
+    eq_(None, monitor.create_default_start_time(no_args))
 
     not_date_args = ['initialize']
     too_many_args = ['2013', '04', '02']
     for args in [not_date_args, too_many_args]:
-      two_years_ago = datetime.datetime.utcnow() - ThreeMEventMonitor.TWO_YEARS_AGO
-      default_start_time = ThreeMEventMonitor.create_default_start_time(args)
+      two_years_ago = datetime.datetime.utcnow() - monitor.TWO_YEARS_AGO
+      default_start_time = monitor.create_default_start_time(args)
 
       eq_(True, isinstance(default_start_time, datetime.datetime))
       assert (two_years_ago - default_start_time).total_seconds() <= 2
 
     proper_args = ['2013-04-02']
-    default_start_time = ThreeMEventMonitor.create_default_start_time(proper_args)
+    default_start_time = monitor.create_default_start_time(proper_args)
     eq_(datetime.datetime(2013, 4, 2), default_start_time)

--- a/tests/test_3m.py
+++ b/tests/test_3m.py
@@ -208,7 +208,8 @@ class TestErrorParser(object):
 class TestThreeMEventMonitor(DatabaseTest):
 
   def test_default_start_time(self):
-    monitor = ThreeMEventMonitor(self._db)
+    monitor = ThreeMEventMonitor(self._db, testing=True)
+
     no_args = []
     eq_(None, monitor.create_default_start_time(no_args))
 

--- a/tests/test_3m.py
+++ b/tests/test_3m.py
@@ -5,6 +5,7 @@ from api.threem import (
     CirculationParser,
     EventParser,
     ErrorParser,
+    ThreeMEventMonitor,
 )
 from core.model import (
     CirculationEvent,
@@ -201,3 +202,23 @@ class TestErrorParser(object):
         # exception for it.
         error = parser.process_all(self.TRIED_TO_HOLD_BOOK_ON_LOAN)
         assert isinstance(error, CannotHold)
+
+
+class TestThreeMEventMonitor(object):
+
+  def test_default_start_time(self):
+    no_args = []
+    eq_(None, ThreeMEventMonitor.create_default_start_time(no_args))
+
+    not_date_args = ['initialize']
+    too_many_args = ['2013', '04', '02']
+    for args in [not_date_args, too_many_args]:
+      two_years_ago = datetime.datetime.utcnow() - ThreeMEventMonitor.TWO_YEARS_AGO
+      default_start_time = ThreeMEventMonitor.create_default_start_time(args)
+
+      eq_(True, isinstance(default_start_time, datetime.datetime))
+      assert (two_years_ago - default_start_time).total_seconds() <= 2
+
+    proper_args = ['2013-04-02']
+    default_start_time = ThreeMEventMonitor.create_default_start_time(proper_args)
+    eq_(datetime.datetime(2013, 4, 2), default_start_time)


### PR DESCRIPTION
Because the ThreeMEventMonitor is also how we keep track of ThreeM circulation overall, it needs to be able to be initialized to gather all data possible given a particular start date. This update allows an administrator to pass in a date and begin gathering circulation events (and create `licensepools` & `identifiers`) from that date until now.