### PR TITLE
Use collection_token instead of the no-longer-available collection_name.

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -477,7 +477,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         if isinstance(book, basestring):
             book_id = book
             circulation_link = self.AVAILABILITY_ENDPOINT % dict(
-                collection_name=self.collection_name,
+                collection_token=self.collection_token,
                 product_id=book_id
             )
             book = dict(id=book_id)


### PR DESCRIPTION
As per https://github.com/NYPL-Simplified/server_core/pull/113, this branch changes the circ manager to use collection_token instead of collection_name, which has been removed.