### PR TITLE
Use open-access CDN when fulfilling patron's request for an open-access book

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -14,6 +14,7 @@ from core.model import (
     Loan,
     Hold,
 )
+from core.util.cdn import cdnify
 from config import Configuration
 
 class CirculationInfo(object):
@@ -349,7 +350,8 @@ class CirculationAPI(object):
             raise NoOpenAccessDownload()
 
         rep = fulfillment.resource.representation
-        content_link = rep.url
+        cdn_host = Configuration.cdn_host(Configuration.CDN_OPEN_ACCESS_CONTENT)
+        content_link = cdnify(rep.url, cdn_host)
         media_type = rep.media_type
         return FulfillmentInfo(
             identifier_type=licensepool.identifier.type,


### PR DESCRIPTION
My previous branch on this topic changed the `open-access` link in an open-access book's OPDS feed to use the open-access CDN, if one was configured. But that's not how most patrons actually download these books; they use the `fulfill` controller, which calls `CirculationAPI.fulfill_open_access`, which didn't use the open-access CDN. This branch fixes that problem.

I don't have any tests for CirculationAPI because it's really difficult to test :(, but I have tested this manually and verified that it works properly.