### PR TITLE
Remove numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ feedparser
 textblob
 
 # Used only by circulation
-numpy
 oauth2client
 
 # A NYPL-specific requirement


### PR DESCRIPTION
No longer necessary with `core/util/median.py` in full effect.