### PR TITLE
Commit changes made during startup

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -43,7 +43,7 @@ def run():
         import socket
         socket.setdefaulttimeout(None)
 
-    app.manager.log.info("Starting app on %s:%s", host, port)
+    logging.info("Starting app on %s:%s", host, port)
     app.run(debug=debug, host=host, port=port)
 
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -193,6 +193,9 @@ class CirculationManager(object):
                 overdrive=self.overdrive,
                 axis=self.axis
             )
+        # Make sure that any changes to the database (as might happen
+        # on initial setup) are committed before continuing.
+        self._db.commit()
 
     def setup_controllers(self):
         """Set up all the controllers that will be used by the web app."""

--- a/api/controller.py
+++ b/api/controller.py
@@ -193,9 +193,6 @@ class CirculationManager(object):
                 overdrive=self.overdrive,
                 axis=self.axis
             )
-        # Make sure that any changes to the database (as might happen
-        # on initial setup) are committed before continuing.
-        self._db.commit()
 
     def setup_controllers(self):
         """Set up all the controllers that will be used by the web app."""

--- a/api/routes.py
+++ b/api/routes.py
@@ -21,13 +21,18 @@ from opds import (
 from controller import CirculationManager
 
 
-if os.environ.get('AUTOINITIALIZE') == "False":
-    pass
-    # It's the responsibility of the importing code to set app.manager
-    # appropriately.
-else:
-    if getattr(app, 'manager', None) is None:
-        app.manager = CirculationManager()
+@app.before_first_request
+def initialize_circulation_manager():
+    if os.environ.get('AUTOINITIALIZE') == "False":
+        pass
+        # It's the responsibility of the importing code to set app.manager
+        # appropriately.
+    else:
+        if getattr(app, 'manager', None) is None:
+            app.manager = CirculationManager()
+            # Make sure that any changes to the database (as might happen
+            # on initial setup) are committed before continuing.
+            app.manager._db.commit()
 
 
 


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/server_core/issues/154 by making sure that a)  `CirculationManager` is not initialized more than once when running with the reloader turned on, b) the database session is committed after `CirculationManager` is initialized, ensuring that documents like the Overdrive list of library collections only ever have to be obtained once.

As a bonus, this cuts startup time in half (from 6 seconds to 3 seconds on my computer).