### PR TITLE
Stop unconfigured services from logging errors

### DIFF
--- a/api/services.py
+++ b/api/services.py
@@ -47,19 +47,17 @@ class ServiceStatus(object):
             return status
         patron = patrons[0]
 
-        apis = { 'Overdrive': self.overdrive,
-                 '3M': self.threem,
-                 'Axis': self.axis }
-
-        for name, api in apis.items():
+        for api in [self.overdrive, self.threem, self.axis]:
             if not api:
                 continue
+            name = api.source.name
             service = "%s patron account" % name
             def do_patron_activity(api, name, patron):
                 return api.patron_activity(patron, password)
 
             self._add_timing(
-                status, service, do_patron_activity, api, name, patron
+                status, service, do_patron_activity,
+                api, name, patron
             )
 
         if response:

--- a/api/services.py
+++ b/api/services.py
@@ -52,10 +52,10 @@ class ServiceStatus(object):
                  'Axis': self.axis }
 
         for name, api in apis.items():
+            if not api:
+                continue
             service = "%s patron account" % name
             def do_patron_activity(api, name, patron):
-                if not api:
-                    raise ValueError("%s not configured" % name)
                 return api.patron_activity(patron, password)
 
             self._add_timing(
@@ -87,7 +87,7 @@ class ServiceStatus(object):
             delivery_mechanism = license_pool.delivery_mechanisms[0]
         loans = []
 
-        service = "Checkout IDENTIFIER:%r" % identifier
+        service = "Checkout IDENTIFIER: %r" % identifier
         def do_checkout():
             loan, hold, is_new = api.borrow(
                 patron, password, license_pool, delivery_mechanism,
@@ -102,7 +102,7 @@ class ServiceStatus(object):
             self.log_status(status)
             return
 
-        service = "Fulfill IDENTIFIER:%r" % identifier
+        service = "Fulfill IDENTIFIER: %r" % identifier
         def do_fulfillment():
             api.fulfill(
                 patron, password, license_pool, delivery_mechanism


### PR DESCRIPTION
Unconfigured APIs were turning up as errors in the logs, which distracts from the work the script is actually doing. This branch ignores unconfigured APIs completely. Who needs em??!

It also uses an API's Data Source name, instead of whatever higgledy-piggledy was hard-coded there before (i.e. I called it "Axis" instead of "Axis 360" 😑 ).