### PR TITLE
Stop using configuration in test versions of the Google Oauth service

### DIFF
--- a/api/admin/oauth.py
+++ b/api/admin/oauth.py
@@ -22,6 +22,8 @@ class GoogleAuthService(object):
 
     @classmethod
     def from_environment(cls, redirect_uri, test_mode=False):
+        if test_mode:
+            return cls('/path', '/callback', test_mode)
         config = Configuration.integration(
             Configuration.GOOGLE_OAUTH_INTEGRATION
         )

--- a/config.json.sample
+++ b/config.json.sample
@@ -14,10 +14,6 @@
     	},
         
     	"S3" : {
-        },
-
-        "Google OAuth": {
-            "client_json_file": "/path/to/client/json/file.json"
         }
     }
 }

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -236,15 +236,11 @@ class TestSignInController(AdminControllerTest):
             eq_(self.admin, response)
 
         # Returns an error if you aren't authenticated.
-        with temp_config() as config:
-            config[Configuration.GOOGLE_OAUTH_INTEGRATION] = {
-                Configuration.GOOGLE_OAUTH_CLIENT_JSON : "/path"
-            }
-            with self.app.test_request_context('/admin'):
-                # You get back a problem detail when you're not authenticated.
-                response = self.manager.admin_sign_in_controller.authenticated_admin_from_request()
-                eq_(401, response.status_code)
-                eq_(INVALID_ADMIN_CREDENTIALS.detail, response.detail)
+        with self.app.test_request_context('/admin'):
+            # You get back a problem detail when you're not authenticated.
+            response = self.manager.admin_sign_in_controller.authenticated_admin_from_request()
+            eq_(401, response.status_code)
+            eq_(INVALID_ADMIN_CREDENTIALS.detail, response.detail)
 
     def test_authenticated_admin(self):
         # Creates a new admin with fresh details.


### PR DESCRIPTION
This will fix the two test errors that pop up with configuration files that don't have Google Oauth set up; it bypasses environmental configuration entirely, instead using knowledge of the test environment to build a test-friendly Google Oauth "Client".