### PR TITLE
Admin edit summary

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -230,10 +230,24 @@ class WorkController(CirculationManagerController):
 
         new_summary = flask.request.form.get("summary")
         if new_summary != work.summary_text:
-            (link, is_new) =  work.primary_edition.primary_identifier.add_link(
-                Hyperlink.DESCRIPTION, None, 
-                staff_data_source, content=new_summary)
-            work.set_summary(link.resource)
+            old_summary = None
+            if work.summary and work.summary.data_source == staff_data_source:
+                old_summary = work.summary
+
+            if new_summary:
+                (link, is_new) =  work.primary_edition.primary_identifier.add_link(
+                    Hyperlink.DESCRIPTION, None, 
+                    staff_data_source, content=new_summary)
+                work.set_summary(link.resource)
+            else:
+                work.set_summary(None)
+
+            # Delete previous staff summary
+            if old_summary:
+                for link in old_summary.links:
+                    self._db.delete(link)
+                self._db.delete(old_summary)
+
             changed = True
 
         if changed:

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -228,19 +228,16 @@ class WorkController(CirculationManagerController):
             )
             changed = True
 
-        new_summary = flask.request.form.get("summary")
+        new_summary = flask.request.form.get("summary") or ""
         if new_summary != work.summary_text:
             old_summary = None
             if work.summary and work.summary.data_source == staff_data_source:
                 old_summary = work.summary
 
-            if new_summary:
-                (link, is_new) =  work.primary_edition.primary_identifier.add_link(
-                    Hyperlink.DESCRIPTION, None, 
-                    staff_data_source, content=new_summary)
-                work.set_summary(link.resource)
-            else:
-                work.set_summary(None)
+            (link, is_new) =  work.primary_edition.primary_identifier.add_link(
+                Hyperlink.DESCRIPTION, None, 
+                staff_data_source, content=new_summary)
+            work.set_summary(link.resource)
 
             # Delete previous staff summary
             if old_summary:

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -39,7 +39,6 @@ class AdminControllerTest(ControllerTest):
 
             setup_admin_controllers(self.manager)
 
-
 class TestWorkController(AdminControllerTest):
 
     def test_details(self):
@@ -99,10 +98,34 @@ class TestWorkController(AdminControllerTest):
                 ("summary", "<p>New summary</p>")
             ])
             response = self.manager.admin_work_controller.edit(lp.data_source.name, lp.identifier.identifier)
+            eq_(200, response.status_code)
             eq_("Young Adult", self.english_1.audience)
             assert 'Young Adult' in self.english_1.simple_opds_entry
             assert 'Adults Only' not in self.english_1.simple_opds_entry
 
+        with self.app.test_request_context("/"):
+            # Change the summary again
+            flask.request.form = ImmutableMultiDict([
+                ("title", "New title"),
+                ("audience", "Young Adult"),
+                ("summary", "abcd")
+            ])
+            response = self.manager.admin_work_controller.edit(lp.data_source.name, lp.identifier.identifier)
+            eq_(200, response.status_code)
+            eq_("abcd", self.english_1.summary_text)
+            assert 'New summary' not in self.english_1.simple_opds_entry
+
+        with self.app.test_request_context("/"):
+            # Now delete the summary entirely
+            flask.request.form = ImmutableMultiDict([
+                ("title", "New title"),
+                ("audience", "Young Adult"),
+                ("summary", "")
+            ])
+            response = self.manager.admin_work_controller.edit(lp.data_source.name, lp.identifier.identifier)
+            eq_(200, response.status_code)
+            eq_("", self.english_1.summary_text)
+            assert 'abcd' not in self.english_1.simple_opds_entry
 
     def test_suppress(self):
         [lp] = self.english_1.license_pools

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -72,6 +72,15 @@ class ControllerTest(DatabaseTest):
         os.environ['AUTOINITIALIZE'] = "False"
         from api.app import app
         del os.environ['AUTOINITIALIZE']
+
+        # PRESERVE_CONTEXT_ON_EXCEPTION needs to be off in tests
+        # to prevent one test failure from breaking later tests as well.
+        # When used with flask's test_request_context, exceptions
+        # from previous tests wuold cause flask to roll back the db
+        # when you entered a new request context, deleting rows that
+        # were created in the test setup.
+        app.config['PRESERVE_CONTEXT_ON_EXCEPTION'] = False
+
         self.app = app
 
         # Create two English books and a French book.


### PR DESCRIPTION
This uses https://github.com/NYPL-Simplified/server_core/pull/189

This fixes #146, and also a bug where staff couldn't edit the summary multiple times.

I also fixed the problem where a bunch of the admin tests would fail any time an earlier test had failed.