### PR TITLE
Add py-bcrypt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ uwsgi
 loggly-python-handler
 mock
 cairosvg
+py-bcrypt
 
 # In circ, feedparser is only used in tests.
 feedparser


### PR DESCRIPTION
This is a new dependency introduced to core in NYPL-Simplified/server_core#183.