### PR TITLE
Scoped session

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,4 +1,5 @@
 from nose.tools import set_trace
+import os
 import logging
 import urlparse
 
@@ -14,7 +15,9 @@ from core.model import SessionManager
 
 app = Flask(__name__)
 
-session_factory = SessionManager.sessionmaker()
+testing = 'TESTING' in os.environ
+db_url = Configuration.database_url(testing)
+session_factory = SessionManager.sessionmaker(db_url)
 _db = flask_scoped_session(session_factory, app)
 
 import routes

--- a/api/app.py
+++ b/api/app.py
@@ -8,11 +8,14 @@ from flask import (
     Response,
     redirect,
 )
-
+from flask_sqlalchemy_session import flask_scoped_session
 from config import Configuration
-
+from core.model import SessionManager
 
 app = Flask(__name__)
+
+session_factory = SessionManager.sessionmaker()
+_db = flask_scoped_session(session_factory, app)
 
 import routes
 if Configuration.get(Configuration.INCLUDE_ADMIN_INTERFACE):

--- a/api/routes.py
+++ b/api/routes.py
@@ -8,7 +8,7 @@ from flask import (
     redirect,
 )
 
-from app import app
+from app import app, _db
 
 from config import Configuration
 from core.app_server import (
@@ -20,7 +20,6 @@ from opds import (
 )
 from controller import CirculationManager
 
-
 @app.before_first_request
 def initialize_circulation_manager():
     if os.environ.get('AUTOINITIALIZE') == "False":
@@ -29,7 +28,7 @@ def initialize_circulation_manager():
         # appropriately.
     else:
         if getattr(app, 'manager', None) is None:
-            app.manager = CirculationManager()
+            app.manager = CirculationManager(_db=_db)
             # Make sure that any changes to the database (as might happen
             # on initial setup) are committed before continuing.
             app.manager._db.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pillow
 psycopg2
 requests
 sqlalchemy==1.0.6
+flask-sqlalchemy-session
 lxml
 flask
 isbnlib


### PR DESCRIPTION
This branch initializes the CirculationManager object with a scoped session (http://flask-sqlalchemy-session.readthedocs.org/en/v1.1/) which creates a new database session per Flask request. 

This will allow us to configure uwsgi to spawn multiple threads inside a single worker process. The advantage of that is explained here:

http://stackoverflow.com/questions/20058464/whats-the-advantage-of-running-multiple-threads-per-uwsgi-process

This won't help us handle more simultaneous requests (only more workers will do that), EXCEPT in the case when a request gets bogged down in a long-running IO-bound task (such as checking out a book from a slow provider). If that happens, multithreading allows that worker to handle another request while it waits for the IO-bound task to complete.

This is a low-cost solution to the problem of long-running IO-bound tasks eating up all the worker processes. The highest-performance solution is to make the circulation manager asynchronous, but after doing a lot of research I think this is incompatible with our use of the SQLAlchemy ORM. 

The next best-performing solution is to put all the big network-bound patron tasks--checking out books, fulfilling them, putting them on hold, etc. into a database table and fulfil them asynchronously with a Monitor. I think this is a good idea but it's a lot more work than this, and even once that's done this will make the app server more scalable.