### PR TITLE
added "up" links to complaints and suppressed feeds

### DIFF
--- a/api/admin/opds.py
+++ b/api/admin/opds.py
@@ -96,9 +96,12 @@ class AdminFeed(AcquisitionFeed):
         feed = cls(_db, title, url, works, annotator)
 
         # Render a 'start' link
-        top_level_title = "Collection Home"
+        top_level_title = annotator.top_level_title()
         start_uri = annotator.groups_url(None)
         feed.add_link(href=start_uri, rel="start", title=top_level_title)
+
+        # Render an 'up' link, same as the 'start' link to indicate top-level feed
+        feed.add_link(href=start_uri, rel="up", title=top_level_title)
 
         if len(works) > 0:
             # There are works in this list. Add a 'next' link.
@@ -125,9 +128,12 @@ class AdminFeed(AcquisitionFeed):
         feed = cls(_db, title, url, works, annotator)
 
         # Render a 'start' link
-        top_level_title = "Collection Home"
+        top_level_title = annotator.top_level_title()
         start_uri = annotator.groups_url(None)
         feed.add_link(href=start_uri, rel="start", title=top_level_title)
+
+        # Render an 'up' link, same as the 'start' link to indicate top-level feed
+        feed.add_link(href=start_uri, rel="up", title=top_level_title)
 
         if len(works) > 0:
             # There are works in this list. Add a 'next' link.

--- a/tests/admin/test_opds.py
+++ b/tests/admin/test_opds.py
@@ -126,6 +126,11 @@ class TestOPDS(DatabaseTest):
         # Make sure the links are in place.
         [start] = self.links(parsed, 'start')
         eq_(annotator.groups_url(None), start['href'])
+        eq_(annotator.top_level_title(), start['title'])
+
+        [up] = self.links(parsed, 'up')
+        eq_(annotator.groups_url(None), up['href'])
+        eq_(annotator.top_level_title(), up['title'])
 
         [next_link] = self.links(parsed, 'next')
         eq_(annotator.complaints_url(facets, pagination.next_page), next_link['href'])
@@ -169,6 +174,11 @@ class TestOPDS(DatabaseTest):
         # Make sure the links are in place.
         [start] = self.links(parsed, 'start')
         eq_(annotator.groups_url(None), start['href'])
+        eq_(annotator.top_level_title(), start['title'])
+
+        [up] = self.links(parsed, 'up')
+        eq_(annotator.groups_url(None), up['href'])
+        eq_(annotator.top_level_title(), up['title'])
 
         [next_link] = self.links(parsed, 'next')
         eq_(annotator.suppressed_url(pagination.next_page), next_link['href'])


### PR DESCRIPTION
This branch adds "up" links (with the same url and title as "start" links) to admin complaints and suppressed feeds.