### PR TITLE
Scope the database session

### DIFF
--- a/api/admin/opds.py
+++ b/api/admin/opds.py
@@ -121,7 +121,10 @@ class AdminFeed(AcquisitionFeed):
     def suppressed(cls, _db, title, url, annotator, pagination=None):
         pagination = pagination or Pagination.default()
 
-        q = _db.query(LicensePool).filter(LicensePool.suppressed == True)
+        q = _db.query(LicensePool).filter(
+            LicensePool.suppressed == True).order_by(
+                LicensePool.id
+            )
         pools = pagination.apply(q).all()
 
         works = [pool.work for pool in pools]

--- a/api/app.py
+++ b/api/app.py
@@ -15,6 +15,7 @@ from core.model import SessionManager
 
 app = Flask(__name__)
 
+
 testing = 'TESTING' in os.environ
 db_url = Configuration.database_url(testing)
 SessionManager.initialize(db_url)

--- a/api/app.py
+++ b/api/app.py
@@ -9,9 +9,16 @@ from flask import (
     Response,
     redirect,
 )
+from flask_sqlalchemy_session import flask_scoped_session
 from config import Configuration
+from core.model import SessionManager
 
 app = Flask(__name__)
+
+testing = 'TESTING' in os.environ
+db_url = Configuration.database_url(testing)
+session_factory = SessionManager.sessionmaker(db_url)
+_db = flask_scoped_session(session_factory, app)
 
 import routes
 if Configuration.get(Configuration.INCLUDE_ADMIN_INTERFACE):

--- a/api/app.py
+++ b/api/app.py
@@ -20,6 +20,7 @@ db_url = Configuration.database_url(testing)
 SessionManager.initialize(db_url)
 session_factory = SessionManager.sessionmaker(db_url)
 _db = flask_scoped_session(session_factory, app)
+SessionManager.initialize_data(_db)
 
 import routes
 if Configuration.get(Configuration.INCLUDE_ADMIN_INTERFACE):

--- a/api/app.py
+++ b/api/app.py
@@ -17,6 +17,7 @@ app = Flask(__name__)
 
 testing = 'TESTING' in os.environ
 db_url = Configuration.database_url(testing)
+SessionManager.initialize(db_url)
 session_factory = SessionManager.sessionmaker(db_url)
 _db = flask_scoped_session(session_factory, app)
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -144,7 +144,6 @@ class CirculationManager(object):
             self.hold_notification_email_address = Configuration.default_notification_email_address()
 
         self.opds_authentication_document = self.create_authentication_document()
-        self._db.expunge_all()
 
     def cdn_url_for(self, view, *args, **kwargs):
         return cdn_url_for(view, *args, **kwargs)

--- a/api/controller.py
+++ b/api/controller.py
@@ -108,7 +108,7 @@ class CirculationManager(object):
     parent = None
     language_key = ""
 
-    def __init__(self, _db=None, lanes=None, testing=False):
+    def __init__(self, _db, lanes=None, testing=False):
 
         self.log = logging.getLogger("Circulation manager web app")
 
@@ -118,9 +118,6 @@ class CirculationManager(object):
             except CannotLoadConfiguration, e:
                 self.log.error("Could not load configuration file: %s" % e)
                 sys.exit()
-
-        if _db is None and not testing:
-            _db = production_session()
         self._db = _db
 
         self.testing = testing
@@ -147,6 +144,7 @@ class CirculationManager(object):
             self.hold_notification_email_address = Configuration.default_notification_email_address()
 
         self.opds_authentication_document = self.create_authentication_document()
+        self._db.expunge_all()
 
     def cdn_url_for(self, view, *args, **kwargs):
         return cdn_url_for(view, *args, **kwargs)

--- a/api/routes.py
+++ b/api/routes.py
@@ -8,7 +8,7 @@ from flask import (
     redirect,
 )
 
-from app import app
+from app import app, _db
 
 from config import Configuration
 from core.app_server import (
@@ -28,7 +28,7 @@ def initialize_circulation_manager():
         # appropriately.
     else:
         if getattr(app, 'manager', None) is None:
-            app.manager = CirculationManager()
+            app.manager = CirculationManager(_db)
             # Make sure that any changes to the database (as might happen
             # on initial setup) are committed before continuing.
             app.manager._db.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ loggly-python-handler
 mock
 cairosvg
 py-bcrypt
-flask-sqlalchemy-session
 
 # In circ, feedparser is only used in tests.
 feedparser

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ loggly-python-handler
 mock
 cairosvg
 py-bcrypt
+flask-sqlalchemy-session
 
 # In circ, feedparser is only used in tests.
 feedparser

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,20 +3,7 @@ from nose.tools import set_trace
 
 from core.testing import (
     DatabaseTest,
-    _setup,
-    _teardown,
+    package_setup,
 )
 
-class CirculationDBInfo(object):
-    connection = None
-    engine = None
-    transaction = None
-
-DatabaseTest.DBInfo = CirculationDBInfo
-
-def setup():
-    _setup(CirculationDBInfo)
-
-def teardown():
-    _teardown(CirculationDBInfo)
-
+package_setup()

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -7,7 +7,7 @@ import json
 import feedparser
 from werkzeug import ImmutableMultiDict
 
-from ..test_controller import ControllerTest
+from ..test_controller import CirculationControllerTest
 from api.admin.controller import setup_admin_controllers
 from api.problem_details import *
 from api.admin.config import (
@@ -28,7 +28,7 @@ from core.testing import (
     NeverSuccessfulCoverageProvider,
 )
 
-class AdminControllerTest(ControllerTest):
+class AdminControllerTest(CirculationControllerTest):
 
     def setup(self):
         with temp_config() as config:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -122,7 +122,6 @@ class CirculationControllerTest(ControllerTest):
             "Quite British", "John Bull", language="eng", fiction=True,
             with_open_access_download=True
         )
-        print self.english_1.license_pools
         self.english_2 = self._work(
             "Totally American", "Uncle Sam", language="eng", fiction=False,
             with_open_access_download=True

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -856,10 +856,10 @@ class TestScopedSession(ControllerTest):
 
             # But if we were to use flask_scoped_session to create a
             # brand new session, it would not see the Identifier,
-            # because it's running in a new request-specific.
+            # because it's running in a new request-specific
+            # transaction.
             new_session = self.app.manager._db.session_factory()
             eq_([], new_session.query(Identifier).all())
-
 
         # Once we exit the context of the Flask request, the session is
         # committed and the Identifier shows up everywhere.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -762,6 +762,15 @@ class TestFeedController(CirculationControllerTest):
                 eq_(1, counter['Other Languages'])
 
     def test_search(self):
+
+        # Put two works into the search index
+        self.english_1.update_external_index(self.manager.external_search)
+        self.english_2.update_external_index(self.manager.external_search)
+
+        # Update the materialized view to make sure the works show up.
+        SessionManager.refresh_materialized_views(self._db)
+
+        # Execute a search query designed to find the second one.
         with self.app.test_request_context("/?q=t&size=1&after=1"):
             response = self.manager.opds_feeds.search(None, None)
             feed = feedparser.parse(response.data)
@@ -770,7 +779,7 @@ class TestFeedController(CirculationControllerTest):
             eq_(1, len(entries))
             entry = entries[0]
 
-            eq_("Uncle Sam", entry.author)
+            eq_(self.english_2.author, entry.author)
 
             assert 'links' in entry
             assert len(entry.links) > 0

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -848,16 +848,15 @@ class TestScopedSession(ControllerTest):
             eq_([], self._db.query(Identifier).all())
 
             # It shows up in the flask_scoped_session object that
-            # created the request-scoped session, (I think) because it
-            # is running the parent of the request-specific
-            # transaction.
+            # created the request-scoped session, because within the
+            # context of a request, running database queries on that object
+            # actually runs them against your request-scoped session.
             [identifier] = self.app.manager._db.query(Identifier).all()
             eq_("1024", identifier.identifier)
 
             # But if we were to use flask_scoped_session to create a
             # brand new session, it would not see the Identifier,
-            # because it's running in a new request-specific
-            # transaction.
+            # because it's running in a different database session.
             new_session = self.app.manager._db.session_factory()
             eq_([], new_session.query(Identifier).all())
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -68,15 +68,8 @@ class TestCirculationManager(CirculationManager):
 class ControllerTest(DatabaseTest):
 
     app = None
-
-    @classmethod
-    def setup_class(cls):
-        """Set up the app server and create a database session scoped to its
-        requests.
-        """
-        DatabaseTest.setup_class()
-        cls.valid_auth = 'Basic ' + base64.b64encode('200:2222')
-        cls.invalid_auth = 'Basic ' + base64.b64encode('200:2221')
+    valid_auth = 'Basic ' + base64.b64encode('200:2222')
+    invalid_auth = 'Basic ' + base64.b64encode('200:2221')
 
     def setup(self):
         """Create a CirculationManager that uses the database connection

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -82,8 +82,6 @@ class ControllerTest(DatabaseTest):
         self.app = app
         del os.environ['AUTOINITIALIZE']
 
-        app.secret_key = 'test'
-
         # PRESERVE_CONTEXT_ON_EXCEPTION needs to be off in tests
         # to prevent one test failure from breaking later tests as well.
         # When used with flask's test_request_context, exceptions


### PR DESCRIPTION
This branch makes `_db` a mandatory argument to the `CirculationManager` constructor. In the tests, we use the same database session we were using before. But in the actual app, we use a `flask_scoped_session` that creates a new database session for every request.

I made changes to bring the test setup and teardown up-to-date with my recent core branch.

I also make some changes designed to make tests pass more reliably. I had a couple cases where lists were in a semi-random order and occasionally I'd get the wrong order and the test would fail.

This is not ready to merge yet because I need to add at least some kind of test of the `flask_scoped_session`. My plan to use it for all the controller tests has fallen through but I should be able to do a basic test that two different requests use different sessions.