### PR TITLE
Use client details for wrangler

### DIFF
--- a/api/admin/opds.py
+++ b/api/admin/opds.py
@@ -121,7 +121,8 @@ class AdminFeed(AcquisitionFeed):
     def suppressed(cls, _db, title, url, annotator, pagination=None):
         pagination = pagination or Pagination.default()
 
-        q = _db.query(LicensePool).filter(LicensePool.suppressed == True)
+        q = _db.query(LicensePool).filter(LicensePool.suppressed == True).\
+            order_by(LicensePool.id)
         pools = pagination.apply(q).all()
 
         works = [pool.work for pool in pools]

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -11,8 +11,7 @@ from api.app import app
 from config import Configuration
 
 from core.util.problem_detail import ProblemDetail
-
-from api.routes import returns_problem_detail
+from core.app_server import returns_problem_detail
 
 from controller import setup_admin_controllers
 from templates import (

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -76,10 +76,7 @@ class MetadataWranglerCoverageProvider(OPDSImportCoverageProvider):
         )
 
         if not metadata_lookup:
-            url = Configuration.integration_url(
-                Configuration.METADATA_WRANGLER_INTEGRATION
-            )
-            metadata_lookup = SimplifiedOPDSLookup(url)
+            metadata_lookup = SimplifiedOPDSLookup.from_config()
         self.lookup = metadata_lookup
 
         super(MetadataWranglerCoverageProvider, self).__init__(

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -45,6 +45,8 @@ class OPDSImportCoverageProvider(CoverageProvider):
             # book.
             if not message.success:
                 exception = str(message.status_code)
+                if message.message:
+                    exception += ": %s" % message.message
                 transient = message.transient
                 identifier_obj, ignore = Identifier.parse_urn(self._db, identifier)
                 yield CoverageFailure(self, identifier_obj, exception, transient)

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -100,8 +100,9 @@ class MetadataWranglerCoverageProvider(OPDSImportCoverageProvider):
                 join(Identifier.coverage_records).\
                 filter(CoverageRecord.data_source==reaper_source)
         # TODO: Add a check for reapered and relicensed Identifiers.
-        # relicensed = reaper_covered.join(Identifier.license_pool).
-        return uncovered.except_(reaper_covered)
+        relicensed = reaper_covered.join(Identifier.licensed_through).\
+                filter(LicensePool.licenses_owned > 0)
+        return uncovered.except_(reaper_covered).union(relicensed)
 
     def create_id_mapping(self, batch):
         mapping = dict()

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -471,7 +471,6 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         circulation information.
         """
         # Retrieve current circulation information about this book
-        # print "Update for %s" % book
         orig_book = book
         book_id = None
         if isinstance(book, basestring):
@@ -567,6 +566,7 @@ class DummyOverdriveResponse(object):
 
     def json(self):
         return json.loads(self.content)
+
 
 class DummyOverdriveAPI(OverdriveAPI):
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -13,6 +13,7 @@ from app import app
 from config import Configuration
 from core.app_server import (
     ErrorHandler,
+    returns_problem_detail,
 )
 from core.util.problem_detail import ProblemDetail
 from opds import (
@@ -60,16 +61,6 @@ def requires_auth(f):
         else:
             return f(*args, **kwargs)
     return decorated
-
-def returns_problem_detail(f):
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        v = f(*args, **kwargs)
-        if isinstance(v, ProblemDetail):
-            return v.response
-        return v
-    return decorated
-
 
 @app.route('/')
 @returns_problem_detail

--- a/bin/metadata_wrangler_collection_reaper
+++ b/bin/metadata_wrangler_collection_reaper
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Remove unlicensed items from the metadata wrangler collection."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from api.coverage import MetadataWranglerCollectionReaper
+from core.scripts import RunCoverageProviderScript
+RunCoverageProviderScript(MetadataWranglerCollectionReaper).run()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,20 +3,8 @@ from nose.tools import set_trace
 
 from core.testing import (
     DatabaseTest,
-    _setup,
-    _teardown,
+    package_setup,
 )
 
-class CirculationDBInfo(object):
-    connection = None
-    engine = None
-    transaction = None
-
-DatabaseTest.DBInfo = CirculationDBInfo
-
-def setup():
-    _setup(CirculationDBInfo)
-
-def teardown():
-    _teardown(CirculationDBInfo)
+package_setup()
 

--- a/tests/admin/test_opds.py
+++ b/tests/admin/test_opds.py
@@ -158,6 +158,7 @@ class TestOPDS(DatabaseTest):
 
         pagination = Pagination(size=1)
         annotator = TestAnnotator()
+        titles = [work1.title, work2.title]
 
         def make_page(pagination):
             return AdminFeed.suppressed(
@@ -169,7 +170,9 @@ class TestOPDS(DatabaseTest):
         first_page = make_page(pagination)
         parsed = feedparser.parse(unicode(first_page))
         eq_(1, len(parsed['entries']))
-        eq_(work1.title, parsed['entries'][0].title)
+        assert parsed['entries'][0].title in titles
+        titles.remove(parsed['entries'][0].title)
+        [remaining_title] = titles
 
         # Make sure the links are in place.
         [start] = self.links(parsed, 'start')
@@ -192,7 +195,7 @@ class TestOPDS(DatabaseTest):
         [previous] = self.links(parsed, 'previous')
         eq_(annotator.suppressed_url(pagination), previous['href'])
         eq_(1, len(parsed['entries']))
-        eq_(work2.title, parsed['entries'][0]['title'])
+        eq_(remaining_title, parsed['entries'][0]['title'])
 
 class TestAnnotator(AdminAnnotator):
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -25,10 +25,12 @@ from core.model import (
     Loan,
     Hold,
     DataSource,
+    Edition,
     Identifier,
     Complaint,
     SessionManager,
     CachedFeed,
+    Work,
     get_one,
     create,
 )
@@ -734,15 +736,13 @@ class TestFeedController(ControllerTest):
             response = self.manager.opds_feeds.search(None, None)
             feed = feedparser.parse(response.data)
             entries = feed['entries']
-
             eq_(1, len(entries))
             entry = entries[0]
-
-            eq_("Uncle Sam", entry.author)
+            assert entry.author in [self.english_1.author, self.english_2.author]
 
             assert 'links' in entry
             assert len(entry.links) > 0
-            
+
             borrow_links = [link for link in entry.links if link.rel == 'http://opds-spec.org/acquisition/borrow']
             eq_(1, len(borrow_links))
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -80,6 +80,9 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
         items = provider.items_that_need_coverage.all()
         assert reaper_cr.identifier not in items
         eq_([cr.identifier, relicensed_lp.identifier], items)
+        # The Wrangler Reaper coverage record has been removed from the
+        # relicensed identifier.
+        eq_([], relicensed_lp.identifier.coverage_records)
 
 
 class TestMetadataWranglerCollectionReaper(DatabaseTest):

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -79,7 +79,8 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
             provider = MetadataWranglerCoverageProvider(self._db)
         items = provider.items_that_need_coverage.all()
         assert reaper_cr.identifier not in items
-        eq_([cr.identifier, relicensed_lp.identifier], items)
+        eq_(2, len(items))
+        eq_([relicensed_lp.identifier, cr.identifier], sorted(items))
         # The Wrangler Reaper coverage record has been removed from the
         # relicensed identifier.
         eq_([], relicensed_lp.identifier.coverage_records)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -66,12 +66,14 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
         other_source = DataSource.lookup(self._db, DataSource.OVERDRIVE)
         cr = self._coverage_record(self._edition(), other_source)
         reaper_cr = self._coverage_record(self._edition(), reaper_source)
+        relicensed, relicensed_lp = self._edition(with_license_pool=True)
+        self._coverage_record(relicensed, reaper_source)
+        relicensed_lp.update_availability(1, 0, 0, 0)
 
         provider = MetadataWranglerCoverageProvider(self._db)
         items = provider.items_that_need_coverage.all()
         assert reaper_cr.identifier not in items
-        eq_([cr.identifier], items)
-        pass
+        eq_([cr.identifier, relicensed_lp.identifier], items)
 
 
 class TestMetadataWranglerCollectionReaper(DatabaseTest):
@@ -118,4 +120,3 @@ class TestMetadataWranglerCollectionReaper(DatabaseTest):
         remaining_records = self._db.query(CoverageRecord).all()
         assert doubly_wrangler not in remaining_records
         eq_([cr_wrangler, cr_reaper, doubly_reaper], remaining_records)
-        pass

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -80,7 +80,8 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
         items = provider.items_that_need_coverage.all()
         assert reaper_cr.identifier not in items
         eq_(2, len(items))
-        eq_([relicensed_lp.identifier, cr.identifier], sorted(items))
+        assert relicensed_lp.identifier in items
+        assert cr.identifier in items
         # The Wrangler Reaper coverage record has been removed from the
         # relicensed identifier.
         eq_([], relicensed_lp.identifier.coverage_records)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -7,17 +7,19 @@ from . import (
     DatabaseTest,
 )
 
+from core.config import (
+    Configuration,
+    temp_config,
+)
 from core.model import (
     CoverageRecord,
     DataSource,
     Identifier,
 )
-
-from core.opds_import import(
+from core.opds_import import (
     StatusMessage,
 )
-
-from core.coverage import(
+from core.coverage import (
     CoverageFailure,
 )
 
@@ -70,7 +72,11 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
         self._coverage_record(relicensed, reaper_source)
         relicensed_lp.update_availability(1, 0, 0, 0)
 
-        provider = MetadataWranglerCoverageProvider(self._db)
+        with temp_config() as config:
+            config[Configuration.INTEGRATIONS][Configuration.METADATA_WRANGLER_INTEGRATION] = {
+                Configuration.URL : "http://url.gov"
+            }
+            provider = MetadataWranglerCoverageProvider(self._db)
         items = provider.items_that_need_coverage.all()
         assert reaper_cr.identifier not in items
         eq_([cr.identifier, relicensed_lp.identifier], items)
@@ -83,7 +89,12 @@ class TestMetadataWranglerCollectionReaper(DatabaseTest):
         self.wrangler_source = DataSource.lookup(
             self._db, DataSource.METADATA_WRANGLER
         )
-        self.reaper = MetadataWranglerCollectionReaper(self._db)
+
+        with temp_config() as config:
+            config[Configuration.INTEGRATIONS][Configuration.METADATA_WRANGLER_INTEGRATION] = {
+                Configuration.URL : "http://url.gov"
+            }
+            self.reaper = MetadataWranglerCollectionReaper(self._db)
 
     def test_items_that_need_coverage(self):
         covered_unlicensed_lp = self._licensepool(None, open_access=False)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -46,9 +46,9 @@ class TestOPDSImportCoverageProvider(DatabaseTest):
         [f1, f2] = sorted(list(provider.handle_import_messages(messages_by_id)),
                           key=lambda x: x.exception)
         eq_(identifier, f1.obj)
-        eq_("201", f1.exception)
+        eq_("201: try again later", f1.exception)
         eq_(True, f1.transient)
 
         eq_(identifier2, f2.obj)
-        eq_("404", f2.exception)
+        eq_("404: we're doomed", f2.exception)
         eq_(False, f2.transient)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -62,14 +62,20 @@ class TestOPDSImportCoverageProvider(DatabaseTest):
 class TestMetadataWranglerCoverageProvider(DatabaseTest):
 
     def test_items_that_need_coverage(self):
-        reaper_source = DataSource.lookup(
-            self._db, DataSource.METADATA_WRANGLER_COLLECTION
-        )
+        source = DataSource.lookup(self._db, DataSource.METADATA_WRANGLER)
         other_source = DataSource.lookup(self._db, DataSource.OVERDRIVE)
+        # An item that hasn't been covered by the provider yet
         cr = self._coverage_record(self._edition(), other_source)
-        reaper_cr = self._coverage_record(self._edition(), reaper_source)
+        # An item that has been covered by the reaper operation already
+        reaper_cr = self._coverage_record(
+            self._edition(), source, operation=CoverageRecord.REAP_OPERATION
+        )
+        # An item that has been covered by the reaper operation, but has
+        # had its license repurchased.
         relicensed, relicensed_lp = self._edition(with_license_pool=True)
-        self._coverage_record(relicensed, reaper_source)
+        self._coverage_record(
+            relicensed, source, operation=CoverageRecord.REAP_OPERATION
+        )
         relicensed_lp.update_availability(1, 0, 0, 0)
 
         with temp_config() as config:
@@ -78,12 +84,17 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
             }
             provider = MetadataWranglerCoverageProvider(self._db)
         items = provider.items_that_need_coverage.all()
+        # Provider ignores anything that has been reaped and doesn't have
+        # licenses.
         assert reaper_cr.identifier not in items
+        # But it picks up anything that hasn't been covered at all and anything
+        # that's been licensed anew even if its already been reaped.
         eq_(2, len(items))
         assert relicensed_lp.identifier in items
         assert cr.identifier in items
-        # The Wrangler Reaper coverage record has been removed from the
-        # relicensed identifier.
+        # The Wrangler Reaper coverage record is removed from the db
+        # when it's committed.
+        self._db.commit()
         eq_([], relicensed_lp.identifier.coverage_records)
 
 
@@ -91,10 +102,7 @@ class TestMetadataWranglerCollectionReaper(DatabaseTest):
 
     def setup(self):
         super(TestMetadataWranglerCollectionReaper, self).setup()
-        self.wrangler_source = DataSource.lookup(
-            self._db, DataSource.METADATA_WRANGLER
-        )
-
+        self.source = DataSource.lookup(self._db, DataSource.METADATA_WRANGLER)
         with temp_config() as config:
             config[Configuration.INTEGRATIONS][Configuration.METADATA_WRANGLER_INTEGRATION] = {
                 Configuration.URL : "http://url.gov"
@@ -102,37 +110,60 @@ class TestMetadataWranglerCollectionReaper(DatabaseTest):
             self.reaper = MetadataWranglerCollectionReaper(self._db)
 
     def test_items_that_need_coverage(self):
+        """The reaper only returns identifiers with unlicensed license_pools
+        that have been synced with the Metadata Wrangler.
+        """
+        # A Wrangler-synced item that doesn't have any owned licenses
         covered_unlicensed_lp = self._licensepool(None, open_access=False)
         covered_unlicensed_lp.update_availability(0, 0, 0, 0)
-        self._coverage_record(covered_unlicensed_lp.edition, self.wrangler_source)
-
-        # Identifiers that haven't been looked up on the Metadata Wrangler
-        # are ignored, even if they don't have licenses.
+        self._coverage_record(
+            covered_unlicensed_lp.edition, self.source,
+            operation=CoverageRecord.SYNC_OPERATION
+        )
+        # An unsynced item that doesn't have any licenses
         uncovered_unlicensed_lp = self._licensepool(None, open_access=False)
         uncovered_unlicensed_lp.update_availability(0, 0, 0, 0)
-        # Identifiers that have owned licenses are ignored.
         licensed_lp = self._licensepool(None, open_access=False)
-        # Identifiers that represent open access identifiers are ignored.
+        # An open access license pool
         open_access_lp = self._licensepool(None)
 
         items = self.reaper.items_that_need_coverage.all()
         eq_(1, len(items))
+        # Items that are licensed are ignored.
         assert licensed_lp.identifier not in items
+        # Items with open access license pools are ignored.
         assert open_access_lp.identifier not in items
+        # Items that haven't been synced with the Metadata Wrangler are
+        # ignored, even if they don't have licenses.
         assert uncovered_unlicensed_lp.identifier not in items
+        # Only synced items without owned licenses are returned.
         eq_([covered_unlicensed_lp.identifier], items)
 
     def test_finalize_batch(self):
-        reaper_source = DataSource.lookup(self._db, DataSource.METADATA_WRANGLER_COLLECTION)
-        cr_wrangler = self._coverage_record(self._edition(), self.wrangler_source)
-        cr_reaper = self._coverage_record(self._edition(), reaper_source)
+        """Metadata Wrangler sync coverage records are deleted from the db
+        when the the batch is finalized if the item has been reaped.
+        """
+        # Create two identifiers that have been either synced or reaped.
+        sync_cr = self._coverage_record(
+            self._edition(), self.source, operation=CoverageRecord.SYNC_OPERATION
+        )
+        reaped_cr = self._coverage_record(
+            self._edition(), self.source, operation=CoverageRecord.REAP_OPERATION
+        )
 
-        # Create coverage records for an Identifier that is double-covered.
+        # Create coverage records for an Identifier that has been both synced
+        # and reaped.
         doubly_covered = self._edition()
-        doubly_wrangler = self._coverage_record(doubly_covered, self.wrangler_source)
-        doubly_reaper = self._coverage_record(doubly_covered, reaper_source)
+        doubly_sync_record = self._coverage_record(
+            doubly_covered, self.source, operation=CoverageRecord.SYNC_OPERATION
+        )
+        doubly_reap_record = self._coverage_record(
+            doubly_covered, self.source, operation=CoverageRecord.REAP_OPERATION
+        )
 
         self.reaper.finalize_batch()
         remaining_records = self._db.query(CoverageRecord).all()
-        assert doubly_wrangler not in remaining_records
-        eq_([cr_wrangler, cr_reaper, doubly_reaper], remaining_records)
+
+        # The syncing record has been deleted from the database
+        assert doubly_sync_record not in remaining_records
+        eq_([sync_cr, reaped_cr, doubly_reap_record], remaining_records)


### PR DESCRIPTION
Some changes included in this branch:

- Update circ to use new test setup from core
- Fix a couple tests broken due to changing database ordering
- Includes exception messages in CoverageFailures - not just the status code integer
- Adds a Coverage Provider-type reaper to remove newly-unlicensed works from an authenticated collection on the Metadata Wrangler (MW)
- Adjusts the existing MW Coverage Provider to re-run relicensed works.

The CoverageRecords created by these two providers work as a sort of in-collection/out-of-collection toggle. In collection, the Metadata Wrangler creates a record when works are added to the circ manager or when they're relicensed (even if the reaper has already removed them). When items exit the collection and no licenses are owned, the reaper deletes that record and adds a its own record.

One particular area of uncertainty is the name of the Metadata Wrangler Collection Reaper `data_source`. It needs to have a DataSource in order to create CoverageRecords, but it seems odd to have a whole separate source for this one particular action. Ideas in this (or any other) regard are welcome.

Fixes #156.