### PR TITLE
Dont store data model objects in CirculationAPI

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -530,7 +530,7 @@ class CirculationAPI(object):
         # the provider doesn't know about, which means it's expired
         # and we should get rid of it.
         for loan in local_loans_by_identifier.values():
-            if loan.license_pool.data_source.id in data_source_ids_for_sync:
+            if loan.license_pool.data_source.id in self.data_source_ids_for_sync:
                 logging.info("In sync_bookshelf for patron %s, deleting loan %d (patron %s)" % (patron.authorization_identifier, loan.id, loan.patron.authorization_identifier))
                 self._db.delete(loan)
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -176,20 +176,16 @@ class CirculationManager(object):
     def setup_circulation(self):
         """Set up distributor APIs and a the Circulation object."""
         if self.testing:
-
-            self.overdrive = DummyOverdriveAPI(self._db)
-            self.threem = DummyThreeMAPI(self._db)
-            self.axis = None
             self.circulation = DummyCirculationAPI(self._db)
         else:
-            self.overdrive = OverdriveAPI.from_environment(self._db)
-            self.threem = ThreeMAPI.from_environment(self._db)
-            self.axis = Axis360API.from_environment(self._db)
+            overdrive = OverdriveAPI.from_environment(self._db)
+            threem = ThreeMAPI.from_environment(self._db)
+            axis = Axis360API.from_environment(self._db)
             self.circulation = CirculationAPI(
                 _db=self._db, 
-                threem=self.threem, 
-                overdrive=self.overdrive,
-                axis=self.axis
+                threem=threem, 
+                overdrive=overdrive,
+                axis=axis
             )
 
     def setup_controllers(self):


### PR DESCRIPTION
This branch fixes a problem where data model objects (DataSource objects) were being used after the database session that created them went out of scope. This caused bookshelf sync to fail silently.

The app server creates a single CirculationAPI object and uses it to manage all circulation-type interaction with external APIs. Previous to this branch, the CirculationAPI constructor looked up some DataSource objects and stored them in instance variables. But when an actual request came in, it was assigned a new database connection, and those DataSource objects were no longer usable.

This branch changes the CirculationAPI constructor so that it stores database names instead of DataSource objects. The DataSource objects are looked up as necessary using DataSource.lookup(). This hurts performance, but circulation transactions are relatively rare, so I'm not too worried about a number of redundant DataSource lookups, and this is something I think we can optimize in a later branch.

The tests in test_overdrive.py verify that the code still works as before, but I can't think of a way to test the specific case where the database connection that creates the CirculationAPI object goes out of scope.