### PR TITLE
 Don't roll back database session if database session hasn't been created yet 

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -27,6 +27,9 @@ SessionManager.initialize_data(_db)
 import routes
 if Configuration.get(Configuration.INCLUDE_ADMIN_INTERFACE):
     import admin.routes
+
+# TODO: See note in routes.py about calling this manually instead of
+# using @app.before_first_request().
 routes.initialize_circulation_manager()
 
 debug = Configuration.logging_policy().get("level") == 'DEBUG'

--- a/api/app.py
+++ b/api/app.py
@@ -30,7 +30,7 @@ if Configuration.get(Configuration.INCLUDE_ADMIN_INTERFACE):
 
 # TODO: See note in routes.py about calling this manually instead of
 # using @app.before_first_request().
-routes.initialize_circulation_manager()
+# routes.initialize_circulation_manager()
 
 debug = Configuration.logging_policy().get("level") == 'DEBUG'
 logging.getLogger().info("Application debug mode==%r" % debug)

--- a/api/app.py
+++ b/api/app.py
@@ -27,6 +27,7 @@ SessionManager.initialize_data(_db)
 import routes
 if Configuration.get(Configuration.INCLUDE_ADMIN_INTERFACE):
     import admin.routes
+routes.initialize_circulation_manager()
 
 debug = Configuration.logging_policy().get("level") == 'DEBUG'
 logging.getLogger().info("Application debug mode==%r" % debug)

--- a/api/app.py
+++ b/api/app.py
@@ -28,10 +28,6 @@ import routes
 if Configuration.get(Configuration.INCLUDE_ADMIN_INTERFACE):
     import admin.routes
 
-# TODO: See note in routes.py about calling this manually instead of
-# using @app.before_first_request().
-# routes.initialize_circulation_manager()
-
 debug = Configuration.logging_policy().get("level") == 'DEBUG'
 logging.getLogger().info("Application debug mode==%r" % debug)
 app.config['DEBUG'] = debug

--- a/api/controller.py
+++ b/api/controller.py
@@ -271,7 +271,9 @@ class CirculationManagerController(object):
         try:
             patron = self.authenticated_patron(header.username, header.password)
         except RemoteInitiatedServerError,e:
-            return problem(REMOTE_INTEGRATION_FAILED, e.message, 503)
+            return REMOTE_INTEGRATION_FAILED.detailed(
+                "Error in authentication service"
+            )
         if isinstance(patron, ProblemDetail):
             flask.request.patron = None
             return patron

--- a/api/routes.py
+++ b/api/routes.py
@@ -21,8 +21,8 @@ from opds import (
 )
 from controller import CirculationManager
 
-@app.before_first_request
-def initialize_circulation_manager():
+#@app.before_first_request
+def initialize_circulation_manager(): 
     if os.environ.get('AUTOINITIALIZE') == "False":
         pass
         # It's the responsibility of the importing code to set app.manager

--- a/api/routes.py
+++ b/api/routes.py
@@ -21,9 +21,9 @@ from opds import (
 )
 from controller import CirculationManager
 
-# TODO: We can't use before_first_request here because Flask continues to
-# process requests while before_first_request is running. Those requests
-# will fail.
+# TODO: Without the monkeypatch below, Flask continues to process
+# requests while before_first_request is running. Those requests will
+# fail, since the app isn't completely set up yet.
 #
 # This is fixed in Flask 0.10.2, which is currently unreleased:
 #  https://github.com/pallets/flask/issues/879

--- a/api/routes.py
+++ b/api/routes.py
@@ -21,19 +21,25 @@ from opds import (
 )
 from controller import CirculationManager
 
+# TODO: We can't use before_first_request here because Flask continues to
+# process requests while before_first_request is running. Those requests
+# will fail.
+#
+# This is fixed in Flask 0.10.2, which is currently unreleased:
+#  https://github.com/pallets/flask/issues/879
+#
 #@app.before_first_request
 def initialize_circulation_manager(): 
     if os.environ.get('AUTOINITIALIZE') == "False":
-        pass
         # It's the responsibility of the importing code to set app.manager
         # appropriately.
+        pass
     else:
         if getattr(app, 'manager', None) is None:
             app.manager = CirculationManager(_db)
             # Make sure that any changes to the database (as might happen
             # on initial setup) are committed before continuing.
             app.manager._db.commit()
-
 
 
 h = ErrorHandler(app, app.config['DEBUG'])

--- a/api/routes.py
+++ b/api/routes.py
@@ -43,7 +43,10 @@ def exception_handler(exception):
 
 @app.teardown_request
 def shutdown_session(exception):
-    if app.manager._db:
+    if (hasattr(app, 'manager') 
+        and hasattr(app.manager, '_db') 
+        and app.manager._db
+    ):
         if exception:
             app.manager._db.rollback()
         else:

--- a/api/routes.py
+++ b/api/routes.py
@@ -30,7 +30,6 @@ from controller import CirculationManager
 #
 @app.before_first_request
 def initialize_circulation_manager(): 
-    set_trace()
     if os.environ.get('AUTOINITIALIZE') == "False":
         # It's the responsibility of the importing code to set app.manager
         # appropriately.
@@ -56,7 +55,7 @@ def monkeypatch_try_trigger_before_first_request_functions(self):
         if self._got_first_request:
             return
         for func in self.before_first_request_funcs:
-            func()
+            func() 
         self._got_first_request = True
 
 from flask import Flask


### PR DESCRIPTION
This branch fixes the display of errors that happen early on in the startup process, by removing code that can mask that error with another, more stupid error--the attempt to roll back a database session that hasn't been initialized yet.

I also added a monkeypatch taken from an unreleased version of Flask, which stops Flask from handling requests while the @app.before_first_request functions are running. 