### PR TITLE
Upgrade command line arguments

### DIFF
--- a/api/coverage.py
+++ b/api/coverage.py
@@ -198,8 +198,8 @@ class MetadataWranglerCollectionReaper(MetadataWranglerCoverageProvider):
 
     service_name = "Metadata Wrangler Reaper"
 
-    def __init__(self, _db):
-        super(MetadataWranglerCollectionReaper, self).__init__(_db)
+    def __init__(self, _db, *args, **kwargs):
+        super(MetadataWranglerCollectionReaper, self).__init__(_db, *args, **kwargs)
         self.operation = CoverageRecord.REAP_OPERATION
 
     @property

--- a/scripts.py
+++ b/scripts.py
@@ -443,8 +443,8 @@ class AvailabilityRefreshScript(IdentifierInputScript):
     license source.
     """
     def do_run(self):
-        identifiers = self.parse_identifiers()
-        if not identifiers:
+        args = self.parse_command_line(self._db)
+        if not args.identifiers:
             raise Exception(
                 "You must specify at least one identifier to refresh."
             )
@@ -453,8 +453,8 @@ class AvailabilityRefreshScript(IdentifierInputScript):
         # always safe.
         start = 0
         size = 10
-        while start < len(identifiers):
-            batch = identifiers[start:start+size]
+        while start < len(args.identifiers):
+            batch = args.identifiers[start:start+size]
             self.refresh_availability(batch)
             self._db.commit()
             start += size


### PR DESCRIPTION
This branch makes minor changes and improvements that go along with https://github.com/NYPL-Simplified/server_core/pull/223.

* The `MetadataWranglerCollectionReaper` constructor needs to take the same arguments as other `CoverageProvider` constructors, because the `RunCoverageProviderScript` passes in those arguments when it instantiates the `CoverageProvider`.

* The `AvailabilityRefreshScript` no longer needs to call `parse_identifiers()`; it just needs to call `parse_command_line(self._db)` and the identifiers will be properly loaded from the database.