### PR TITLE
Dont prestore data source

### DIFF
--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -203,12 +203,15 @@ class AdobeVendorIDModel(object):
                  temporary_token_duration=None):
         self._db = _db
         self.authenticator = authenticator
-        self.data_source = DataSource.lookup(_db, DataSource.ADOBE)
         self.temporary_token_duration = (
             temporary_token_duration or datetime.timedelta(minutes=10))
         if isinstance(node_value, basestring):
             node_value = int(node_value, 16)
         self.node_value = node_value
+
+    @property
+    def data_source(self):
+        return DataSource.lookup(self._db, DataSource.ADOBE)
 
     def uuid_and_label(self, patron):
         """Create or retrieve a Vendor ID UUID and human-readable Vendor ID


### PR DESCRIPTION
This fixes a serious issue that prevents new Adobe vendor IDs from being registered. There was one more piece of code that was keeping a database object: the Adobe controller. In a multithreaded environment you can't hold on to this information outside of a request context. I changed it to look up the DataSource every time.