### PR TITLE
3M books are never open access. Record this fact.

### DIFF
--- a/api/threem.py
+++ b/api/threem.py
@@ -581,6 +581,9 @@ class ThreeMCirculationSweep(IdentifierSweepMonitor):
                 pool, ignore = LicensePool.for_foreign_id(
                     self._db, self.data_source, identifier.type,
                     identifier.identifier)
+
+                # 3M books are never open-access.
+                pool.open_access = False
                 CirculationEvent.log(
                     self._db, pool, CirculationEvent.TITLE_ADD,
                     None, None, start=now)
@@ -608,14 +611,15 @@ class ThreeMCirculationSweep(IdentifierSweepMonitor):
             pool = identifier.licensed_through
             if not pool:
                 continue
-            if pool.edition:
-                self.log.warn("Removing %s (%s) from circulation",
-                              pool.edition.title, pool.edition.author)
-            else:
-                self.log.warn(
-                    "Removing unknown work %s from circulation.",
-                    identifier.identifier
-                )
+            if pool.licenses_owned > 0:
+                if pool.edition:
+                    self.log.warn("Removing %s (%s) from circulation",
+                                  pool.edition.title, pool.edition.author)
+                else:
+                    self.log.warn(
+                        "Removing unknown work %s from circulation.",
+                        identifier.identifier
+                    )
             pool.licenses_owned = 0
             pool.licenses_available = 0
             pool.licenses_reserved = 0

--- a/migration/20160513-3m-books-are-never-open-access.sql
+++ b/migration/20160513-3m-books-are-never-open-access.sql
@@ -1,0 +1,1 @@
+update licensepools set open_access=false where open_access is null and data_source_id=(select id from datasources where name='3M');


### PR DESCRIPTION
This branch makes sure that newly created 3M LicensePools are marked as non-open-access. (Their .open_access was being left blank.)

Also, don't record a work as being 'removed' when its `.licenses_owned` was already set to zero on the local side--it was already removed and you're filling the log with redundant junk.