### PR TITLE
Bring back bibliographic coverage scripts

### DIFF
--- a/bin/3m_bibliographic_coverage
+++ b/bin/3m_bibliographic_coverage
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Make sure all 3M books have bibliographic coverage."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.scripts import RunCoverageProviderScript
+from core.threem import ThreeMBibliographicCoverageProvider
+RunCoverageProviderScript(ThreeMBibliographicCoverageProvider).run()

--- a/bin/axis_bibliographic_coverage
+++ b/bin/axis_bibliographic_coverage
@@ -3,7 +3,7 @@
 import os
 import sys
 bin_dir = os.path.split(__file__)[0]
-package_dir = os.path.join(bin_dir, "..", "..")
+package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
 from core.scripts import RunCoverageProviderScript
 from core.axis import Axis360BibliographicCoverageProvider

--- a/bin/overdrive_bibliographic_coverage
+++ b/bin/overdrive_bibliographic_coverage
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Make sure all Overdrive books have bibliographic coverage."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.scripts import RunCoverageProviderScript
+from core.overdrive import OverdriveBibliographicCoverageProvider
+RunCoverageProviderScript(OverdriveBibliographicCoverageProvider).run()


### PR DESCRIPTION
This branch brings back bibliographic coverage scripts for each licensed book source. Previously I thought these were not necessary in normal operation and could be treated as repair scripts, but they totally are necessary. The bibliographic coverage scripts are how we find out about format availability--information that the licensed book sources make available but that is not captured by the metadata wrangler.