### PR TITLE
Fix work lookup 500

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -206,6 +206,8 @@ class CirculationManagerAnnotator(Annotator):
             identifier_identifier = work.identifier
             data_source_name = work.name
         else:
+            if not active_license_pool:
+                active_license_pool = identifier.licensed_through
             identifier_identifier = identifier.identifier
             data_source_name = active_license_pool.data_source.name
 

--- a/bin/repair/work_consolidation
+++ b/bin/repair/work_consolidation
@@ -6,4 +6,4 @@ bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 from core.scripts import WorkConsolidationScript
-WorkConsolidationScript(force=True).run()
+WorkConsolidationScript(force=False).run()

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -119,6 +119,24 @@ class TestCirculationManagerAnnotator(DatabaseTest):
         feed_url = self.annotator.lane_url(fantasy_lane_without_sublanes)
         eq_(feed_url, self.annotator.feed_url(fantasy_lane_without_sublanes))
 
+    def test_single_entry_no_active_license_pool(self):
+        work = self._work(with_open_access_download=True)
+        pool = work.license_pools[0]
+
+        # Create an <entry> tag for this work and its LicensePool.
+        feed1 = AcquisitionFeed.single_entry(
+            self._db, work, self.annotator, pool
+        )
+
+        # If we don't pass in the license pool, it makes a guess to
+        # figure out which license pool we're talking about.
+        feed2 = AcquisitionFeed.single_entry(
+            self._db, work, self.annotator, None
+        )
+
+        # Both entries are identical.
+        eq_(etree.tostring(feed1), etree.tostring(feed2))
+
 
 class TestOPDS(DatabaseTest):
 
@@ -335,4 +353,3 @@ class TestOPDS(DatabaseTest):
 
         copies_re = re.compile('<opds:copies[^>]+total="100"', re.S)
         assert copies_re.search(u) is not None
-


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/circulation/issues/186 by making `CirculationManagerAnnotator.annotate_work_entry` a little more robust. It's not the worst error but the fact that it causes 500 errors creates noise that can mask other, more serious errors in our reports.