### PR TITLE
3M's internal problems handled as 502 errors

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -57,6 +57,8 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI):
 
     SET_DELIVERY_MECHANISM_AT = BaseCirculationAPI.BORROW_STEP
 
+    SERVICE_NAME = "Axis 360"
+
     # Create a lookup table between common DeliveryMechanism identifiers
     # and Overdrive format types.
     epub = Representation.EPUB_MEDIA_TYPE
@@ -82,7 +84,9 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI):
         try:
             return CheckoutResponseParser().process_all(response.content)
         except etree.XMLSyntaxError, e:
-            raise InternalServerError(response.content)
+            raise RemoteInitiatedServerError(
+                response.content, self.SERVICE_NAME
+            )
 
     def fulfill(self, patron, pin, licensepool, format_type):
         """Fulfill a patron's request for a specific book.

--- a/api/circulation_exceptions.py
+++ b/api/circulation_exceptions.py
@@ -1,3 +1,8 @@
+from core.problem_details import (
+    INTEGRATION_ERROR,
+    INTERNAL_SERVER_ERROR,
+)
+
 class CirculationException(Exception):
     """An exception occured when carrying out a circulation operation.
 
@@ -8,14 +13,24 @@ class CirculationException(Exception):
 class InternalServerError(Exception):
     status_code = 500
 
+    @property
+    def as_problem_detail_document(self):
+        """Return a suitable problem detail document."""
+        return INTERNAL_SERVER_ERROR
+
 class RemoteInitiatedServerError(InternalServerError):
     """One of the servers we communicate with had an internal error."""
+    status_code = 502
 
     def __init__(self, message, service_name):
         super(RemoteInitiatedServerError, self).__init__(message)
         self.service_name = service_name
 
-    status_code = 502
+    @property
+    def as_problem_detail_document(self):
+        """Return a suitable problem detail document."""
+        msg = "Integration error communicating with %s" % self.service_name
+        return INTEGRATION_ERROR.detailed(msg)
 
 class NoOpenAccessDownload(CirculationException):
     """We expected a book to have an open-access download, but it didn't."""

--- a/api/circulation_exceptions.py
+++ b/api/circulation_exceptions.py
@@ -10,6 +10,11 @@ class InternalServerError(Exception):
 
 class RemoteInitiatedServerError(InternalServerError):
     """One of the servers we communicate with had an internal error."""
+
+    def __init__(self, message, service_name):
+        super(RemoteInitiatedServerError, self).__init__(message)
+        self.service_name = service_name
+
     status_code = 502
 
 class NoOpenAccessDownload(CirculationException):

--- a/api/circulation_exceptions.py
+++ b/api/circulation_exceptions.py
@@ -10,6 +10,7 @@ class InternalServerError(Exception):
 
 class RemoteInitiatedServerError(InternalServerError):
     """One of the servers we communicate with had an internal error."""
+    status_code = 502
 
 class NoOpenAccessDownload(CirculationException):
     """We expected a book to have an open-access download, but it didn't."""

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -955,3 +955,12 @@ class TestScopedSession(ControllerTest):
         # which is the same as self._db, the unscoped database session
         # used by most other unit tests.
         assert session1 != session2
+
+
+class TestRemoteErrorHandling(ControllerTest):
+    """Ensure that errors on the remote side are handled as 502 errors
+    so they don't look like internal server errors.
+    """
+
+    def test_threem_remote_error(self):
+

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -955,12 +955,3 @@ class TestScopedSession(ControllerTest):
         # which is the same as self._db, the unscoped database session
         # used by most other unit tests.
         assert session1 != session2
-
-
-class TestRemoteErrorHandling(ControllerTest):
-    """Ensure that errors on the remote side are handled as 502 errors
-    so they don't look like internal server errors.
-    """
-
-    def test_threem_remote_error(self):
-

--- a/tests/test_threem.py
+++ b/tests/test_threem.py
@@ -162,11 +162,11 @@ class TestErrorParser(TestThreeMAPI):
         eq_(msg, error.message)
 
     def test_malformed_error_message_becomes_remote_initiated_server_error(self):
-        msg = """<Error xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">This error doesn't follow the formula.</Error>"""
+        msg = """<weird>This error does not follow the standard set out by 3M.</weird>"""
         error = ErrorParser().process_all(msg)
         assert isinstance(error, RemoteInitiatedServerError)
         eq_(ThreeMAPI.SERVICE_NAME, error.service_name)
-        eq_(msg, error.message)
+        eq_("Unknown error", error.message)
 
     def test_blank_error_message_becomes_remote_initiated_server_error(self):
         msg = """<Error xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Message/></Error>"""

--- a/tests/test_threem.py
+++ b/tests/test_threem.py
@@ -157,6 +157,7 @@ class TestErrorParser(TestThreeMAPI):
         msg = "The server has encountered an error"
         error = ErrorParser().process_all(msg)
         assert isinstance(error, RemoteInitiatedServerError)
+        eq_(ThreeMAPI.SERVICE_NAME, error.service_name)
         eq_(502, error.status_code)
         eq_(msg, error.message)
 
@@ -164,10 +165,12 @@ class TestErrorParser(TestThreeMAPI):
         msg = """<Error xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">This error doesn't follow the formula.</Error>"""
         error = ErrorParser().process_all(msg)
         assert isinstance(error, RemoteInitiatedServerError)
+        eq_(ThreeMAPI.SERVICE_NAME, error.service_name)
         eq_(msg, error.message)
 
     def test_blank_error_message_becomes_remote_initiated_server_error(self):
         msg = """<Error xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Message/></Error>"""
         error = ErrorParser().process_all(msg)
         assert isinstance(error, RemoteInitiatedServerError)
+        eq_(ThreeMAPI.SERVICE_NAME, error.service_name)
         eq_("Unknown error", error.message)


### PR DESCRIPTION
This branch builds on https://github.com/NYPL-Simplified/server_core/pull/259. It changes RemoteInitiatedServerError and InternalServerError so that the core ErrorHandler turns them into problem detail documents.

The rationale is that these errors are really, really serious errors. We don't know when they might happen, and they stop a client request in its tracks. The request can't be completed. So normal "catch the exception and turn it into a nice problem detail" code isn't going to work. 

At the same time, we want to handle RemoteInitiatedServerError (a problem with some external service we called) differently from InternalServerError (a problem with the web app itself). We want the clients to be able to render a RemoteInitiatedServerError to the patron so when they call tech support they'll be able to say which service caused the problem, and that measn problem detail documents.

As a proof of concept, this branch also changes the 3M ErrorParser to return RemoteInitiatedServerError whenever the server returns a document that can't be parsed as a normal error document. (Generally because the app server is down.) I've simulated this error in a running web app and verified that it's handled correctly, when combined with the code in the core branch.