### PR TITLE
Test circulation API

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -221,8 +221,6 @@ class CirculationAPI(object):
                 on_multiple='interchangeable'
             )
 
-        loan_info = None
-        hold_info = None
         try:
             loan_info = api.checkout(
                 patron, pin, licensepool, internal_format

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -215,13 +215,13 @@ class CirculationAPI(object):
             # certain error conditions (like NoAvailableCopies) mean
             # something different if you already have a confirmed
             # active loan.
+            set_trace()
             self.sync_bookshelf(patron, pin)
             existing_loan = get_one(
                 self._db, Loan, patron=patron, license_pool=licensepool,
                 on_multiple='interchangeable'
             )
 
-        # There is no existing loan. Try to check out the book.
         loan_info = None
         hold_info = None
         try:
@@ -244,11 +244,14 @@ class CirculationAPI(object):
                 licensepool.identifier.type, licensepool.identifier.identifier,
                 None, None, None
             )
-        except (NoAvailableCopies, CannotRenew):
+        except NoAvailableCopies:
             if existing_loan:
-                # That's fine, we already have an active loan so we'll
-                # just use that.
-                return existing_loan, None, False
+                # The patron tried to renew a loan but there are
+                # people waiting in line for them to return the book,
+                # so renewals are not allowed.
+                raise CannotRenew(
+                    "You cannot renew a loan if other patrons have the work on hold."
+                )
             else:
                 # That's fine, we'll just (try to) place a hold.
                 pass
@@ -507,6 +510,20 @@ class CirculationAPI(object):
         self.log.debug("Full sync took %.2f sec", after-before)
         return loans, holds
 
+    def local_loans(self, patron):
+        return self._db.query(Loan).join(Loan.license_pool).filter(
+            LicensePool.data_source_id.in_(self.data_source_ids_for_sync)
+        ).filter(
+            Loan.patron==patron
+        )
+
+    def local_holds(self, patron):
+        return self._db.query(Hold).join(Hold.license_pool).filter(
+            LicensePool.data_source_id.in_(self.data_source_ids_for_sync)
+        ).filter(
+            Hold.patron==patron
+        )
+
     def sync_bookshelf(self, patron, pin):
 
         # Get the external view of the patron's current state.
@@ -514,16 +531,8 @@ class CirculationAPI(object):
 
         # Get our internal view of the patron's current state.
         __transaction = self._db.begin_nested()
-        local_loans = self._db.query(Loan).join(Loan.license_pool).filter(
-            LicensePool.data_source_id.in_(self.data_source_ids_for_sync)
-        ).filter(
-            Loan.patron==patron
-        )
-        local_holds = self._db.query(Hold).join(Hold.license_pool).filter(
-            LicensePool.data_source_id.in_(self.data_source_ids_for_sync)
-        ).filter(
-            Hold.patron==patron
-        )
+        local_loans = self.local_loans(patron)
+        local_holds = self.local_holds(patron)
 
         now = datetime.datetime.utcnow()
         local_loans_by_identifier = {}
@@ -599,98 +608,6 @@ class CirculationAPI(object):
         __transaction.commit()
         return active_loans, active_holds
 
-
-class DummyCirculationAPI(CirculationAPI):
-
-    def __init__(self, db):
-        super(DummyCirculationAPI, self).__init__(db)
-        self.responses = defaultdict(list)
-        self.active_loans = []
-        self.active_holds = []
-        self.identifier_type_to_data_source_name = {
-            Identifier.GUTENBERG_ID: DataSource.GUTENBERG,
-            Identifier.OVERDRIVE_ID: DataSource.OVERDRIVE,
-            Identifier.THREEM_ID: DataSource.THREEM,
-            Identifier.AXIS_360_ID: DataSource.AXIS_360,
-        }
-
-    def queue_checkout(self, response):
-        self._queue('checkout', response)
-
-    def queue_hold(self, response):
-        self._queue('hold', response)
-
-    def queue_fulfill(self, response):
-        self._queue('fulfill', response)
-
-    def queue_checkin(self, response):
-        self._queue('checkin', response)
-
-    def queue_release_hold(self, response):
-        self._queue('release_hold', response)
-
-    def _queue(self, k, v):
-        self.responses[k].append(v)
-
-    def set_patron_activity(self, loans, holds):
-        self.active_loans = loans
-        self.active_holds = holds
-
-    def patron_activity(self, patron, pin):
-        # Should be a 2-tuple containing a list of LoanInfo and a
-        # list of HoldInfo.
-        return self.active_loans, self.active_holds
-
-    def _return_or_raise(self, k):
-        logging.debug(k)
-        l = self.responses[k]
-        v = l.pop()
-        if isinstance(v, Exception):
-            raise v
-        return v
-
-    class FakeAPI(object):
-        def __init__(self, set_delivery_mechanism_at, can_revoke_hold_when_reserved, dummy):
-            self.SET_DELIVERY_MECHANISM_AT = set_delivery_mechanism_at
-            self.CAN_REVOKE_HOLD_WHEN_RESERVED = can_revoke_hold_when_reserved
-            self.dummy = dummy
-
-        def checkout(
-                self, patron_obj, patron_password, licensepool, 
-                delivery_mechanism
-        ):
-            # Should be a LoanInfo.
-            return self.dummy._return_or_raise('checkout')
-                
-        def place_hold(self, patron, pin, licensepool, 
-                       hold_notification_email=None):
-            # Should be a HoldInfo.
-            return self.dummy._return_or_raise('hold')
-
-        def fulfill(self, patron, password, pool, delivery_mechanism):
-            # Should be a FulfillmentInfo.
-            return self.dummy._return_or_raise('fulfill')
-
-        def checkin(self, patron, pin, licensepool):
-            # Return value is not checked.
-            return self.dummy._return_or_raise('checkin')
-
-        def release_hold(self, patron, pin, licensepool):
-            # Return value is not checked.
-            return self.dummy._return_or_raise('release_hold')
-
-        def internal_format(self, delivery_mechanism):
-            return delivery_mechanism
-
-    def api_for_license_pool(self, licensepool):
-        set_delivery_mechanism_at = BaseCirculationAPI.FULFILL_STEP
-        can_revoke_hold_when_reserved = True
-        if licensepool.data_source.name == DataSource.AXIS_360:
-            set_delivery_mechanism_at = BaseCirculationAPI.BORROW_STEP
-        if licensepool.data_source.name == DataSource.THREEM:
-            can_revoke_hold_when_reserved = False
-        
-        return self.FakeAPI(set_delivery_mechanism_at, can_revoke_hold_when_reserved, self)
 
 class BaseCirculationAPI(object):
     """Encapsulates logic common to all circulation APIs."""

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -215,7 +215,6 @@ class CirculationAPI(object):
             # certain error conditions (like NoAvailableCopies) mean
             # something different if you already have a confirmed
             # active loan.
-            set_trace()
             self.sync_bookshelf(patron, pin)
             existing_loan = get_one(
                 self._db, Loan, patron=patron, license_pool=licensepool,

--- a/api/controller.py
+++ b/api/controller.py
@@ -94,8 +94,8 @@ from threem import (
 )
 from circulation import (
     CirculationAPI,
-    DummyCirculationAPI,
 )
+from testing import MockCirculationAPI
 from services import ServiceStatus
 
 class CirculationManager(object):
@@ -175,7 +175,7 @@ class CirculationManager(object):
     def setup_circulation(self):
         """Set up distributor APIs and a the Circulation object."""
         if self.testing:
-            self.circulation = DummyCirculationAPI(self._db)
+            self.circulation = MockCirculationAPI(self._db)
         else:
             overdrive = OverdriveAPI.from_environment(self._db)
             threem = ThreeMAPI.from_environment(self._db)

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -3,7 +3,7 @@ from core.problem_details import *
 
 REMOTE_INTEGRATION_FAILED = pd(
       "http://librarysimplified.org/terms/problem/remote-integration-failed",
-      500,
+      502,
       "Third-party service failed.",
       "The library could not complete your request because a third-party service has failed.",
 )
@@ -73,21 +73,21 @@ OUTSTANDING_FINES = pd(
 
 CHECKOUT_FAILED = pd(
       "http://librarysimplified.org/terms/problem/cannot-issue-loan",
-      500,
+      502,
       "Could not issue loan.",
       "Could not issue loan (reason unknown).",
 )
 
 HOLD_FAILED = pd(
       "http://librarysimplified.org/terms/problem/cannot-place-hold",
-      500,
+      502,
       "Could not place hold.",
       "Could not place hold (reason unknown).",
 )
 
 RENEW_FAILED = pd(
       "http://librarysimplified.org/terms/problem/cannot-renew-loan",
-      500,
+      400,
       "Could not renew loan.",
       "Could not renew loan (reason unknown).",
 )
@@ -122,7 +122,7 @@ NO_ACTIVE_LOAN_OR_HOLD = pd(
 
 COULD_NOT_MIRROR_TO_REMOTE = pd(
       "http://librarysimplified.org/terms/problem/cannot-mirror-to-remote",
-      500,
+      502,
       "Could not mirror local state to remote.",
       "Could not convince a third party to accept the change you made. It's likely to show up again soon.",
 )

--- a/api/testing.py
+++ b/api/testing.py
@@ -1,0 +1,145 @@
+import logging
+from collections import defaultdict
+from core.testing import DatabaseTest
+from core.model import (
+    DataSource,
+    Identifier,
+    Loan,
+    Hold,
+)
+from api.circulation import (
+    BaseCirculationAPI,
+    CirculationAPI,
+    LoanInfo,
+    HoldInfo,
+)
+
+
+class MockRemoteAPI(object):
+    def __init__(self, set_delivery_mechanism_at, can_revoke_hold_when_reserved):
+        self.SET_DELIVERY_MECHANISM_AT = set_delivery_mechanism_at
+        self.CAN_REVOKE_HOLD_WHEN_RESERVED = can_revoke_hold_when_reserved
+        self.responses = defaultdict(list)
+        self.log = logging.getLogger("Mock remote API")
+
+    def checkout(
+            self, patron_obj, patron_password, licensepool, 
+            delivery_mechanism
+    ):
+        # Should be a LoanInfo.
+        return self._return_or_raise('checkout')
+                
+    def place_hold(self, patron, pin, licensepool, 
+                   hold_notification_email=None):
+        # Should be a HoldInfo.
+        return self._return_or_raise('hold')
+
+    def fulfill(self, patron, password, pool, delivery_mechanism):
+        # Should be a FulfillmentInfo.
+        return self._return_or_raise('fulfill')
+
+    def checkin(self, patron, pin, licensepool):
+        # Return value is not checked.
+        return self._return_or_raise('checkin')
+
+    def release_hold(self, patron, pin, licensepool):
+        # Return value is not checked.
+        return self.return_or_raise('release_hold')
+
+    def internal_format(self, delivery_mechanism):
+        return delivery_mechanism
+
+    def queue_checkout(self, response):
+        self._queue('checkout', response)
+
+    def queue_hold(self, response):
+        self._queue('hold', response)
+
+    def queue_fulfill(self, response):
+        self._queue('fulfill', response)
+
+    def queue_checkin(self, response):
+        self._queue('checkin', response)
+
+    def queue_release_hold(self, response):
+        self._queue('release_hold', response)
+
+    def _queue(self, k, v):
+        self.responses[k].append(v)
+
+    def _return_or_raise(self, k):
+        self.log.debug(k)
+        l = self.responses[k]
+        v = l.pop()
+        if isinstance(v, Exception):
+            raise v
+        return v
+
+class MockCirculationAPI(CirculationAPI):
+
+    def __init__(self, _db):
+        super(MockCirculationAPI, self).__init__(_db)
+        self.responses = defaultdict(list)
+        self.remote_loans = []
+        self.remote_holds = []
+        self.identifier_type_to_data_source_name = {
+            Identifier.GUTENBERG_ID: DataSource.GUTENBERG,
+            Identifier.OVERDRIVE_ID: DataSource.OVERDRIVE,
+            Identifier.THREEM_ID: DataSource.THREEM,
+            Identifier.AXIS_360_ID: DataSource.AXIS_360,
+        }
+        self.data_source_ids_for_sync = [
+            DataSource.lookup(self._db, name).id for name in 
+            self.identifier_type_to_data_source_name.values()
+        ]
+        self.remotes = {}
+
+    def local_loans(self, patron):
+        return self._db.query(Loan).filter(Loan.patron==patron)
+
+    def local_holds(self, patron):
+        return self._db.query(Hold).filter(Loan.patron==patron)
+
+    def add_remote_loan(self, *args, **kwargs):
+        self.remote_loans.append(LoanInfo(*args, **kwargs))
+
+    def add_remote_hold(self, *args, **kwargs):
+        self.remote_holds.append(HoldInfo(*args, **kwargs))
+
+    def patron_activity(self, patron, pin):
+        """Return a 2-tuple (loans, holds)."""
+        return self.remote_loans, self.remote_holds
+
+    def queue_checkout(self, licensepool, response):
+        self._queue('checkout', licensepool, response)
+
+    def queue_hold(self, licensepool, response):
+        self._queue('hold', licensepool, response)
+
+    def queue_fulfill(self, licensepool, response):
+        self._queue('fulfill', licensepool, response)
+
+    def queue_checkin(self, licensepool, response):
+        self._queue('checkin', licensepool, response)
+
+    def queue_release_hold(self, licensepool, response):
+        self._queue('release_hold', licensepool, response)
+
+    def _queue(self, method, licensepool, response):
+        mock = self.api_for_license_pool(licensepool)
+        return mock._queue(method, response)
+
+    def api_for_license_pool(self, licensepool):
+        source = licensepool.data_source.name
+        if source not in self.remotes:
+            set_delivery_mechanism_at = BaseCirculationAPI.FULFILL_STEP
+            can_revoke_hold_when_reserved = True
+            if source == DataSource.AXIS_360:
+                set_delivery_mechanism_at = BaseCirculationAPI.BORROW_STEP
+            if source == DataSource.THREEM:
+                can_revoke_hold_when_reserved = False
+            remote = MockRemoteAPI(
+                set_delivery_mechanism_at, can_revoke_hold_when_reserved
+            )
+            self.remotes[source] = remote
+        return self.remotes[source]

--- a/api/testing.py
+++ b/api/testing.py
@@ -1,6 +1,5 @@
 import logging
 from collections import defaultdict
-from core.testing import DatabaseTest
 from core.model import (
     DataSource,
     Identifier,

--- a/api/testing.py
+++ b/api/testing.py
@@ -97,7 +97,7 @@ class MockCirculationAPI(CirculationAPI):
         return self._db.query(Loan).filter(Loan.patron==patron)
 
     def local_holds(self, patron):
-        return self._db.query(Hold).filter(Loan.patron==patron)
+        return self._db.query(Hold).filter(Hold.patron==patron)
 
     def add_remote_loan(self, *args, **kwargs):
         self.remote_loans.append(LoanInfo(*args, **kwargs))

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -24,7 +24,7 @@ from core.model import (
 )
 
 from . import DatabaseTest
-from testing import MockCirculationAPI
+from api.testing import MockCirculationAPI
 
 
 class TestCirculationAPI(DatabaseTest):

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -162,7 +162,7 @@ class TestCirculationAPI(DatabaseTest):
         )
 
         # This is the expected behavior in most cases--you tried to
-        # renew the loan and failed.
+        # renew the loan and failed because it's not time yet.
         self.remote.queue_response(CannotRenew())
         new_loan, hold, is_new = self.borrow()
 
@@ -171,8 +171,8 @@ class TestCirculationAPI(DatabaseTest):
         eq_(None, hold)
         eq_(False, is_new)
 
-        # This is what Overdrive does when you fail to renew the loan
-        # and there are no available copies.
+        # NoAvailableCopies can happen if renewals are prohibited when
+        # there are already people waiting in line for the book.
         self.remote.queue_response(NoAvailableCopies())
         new_loan, hold, is_new = self.borrow()
 

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -1,4 +1,6 @@
 """Test the CirculationAPI."""
+import logging
+from collections import defaultdict
 from nose.tools import (
     assert_raises_regexp,
     set_trace,
@@ -28,51 +30,38 @@ from core.model import (
 from . import DatabaseTest
 
 class MockRemoteAPI(object):
-    def __init__(self, set_delivery_mechanism_at, can_revoke_hold_when_reserved, dummy):
+    def __init__(self, set_delivery_mechanism_at, can_revoke_hold_when_reserved):
         self.SET_DELIVERY_MECHANISM_AT = set_delivery_mechanism_at
         self.CAN_REVOKE_HOLD_WHEN_RESERVED = can_revoke_hold_when_reserved
-        self.dummy = dummy
+        self.responses = defaultdict(list)
+        self.log = logging.getLogger("Mock remote API")
 
     def checkout(
             self, patron_obj, patron_password, licensepool, 
             delivery_mechanism
     ):
         # Should be a LoanInfo.
-        return self.dummy._return_or_raise('checkout')
+        return self._return_or_raise('checkout')
                 
     def place_hold(self, patron, pin, licensepool, 
                    hold_notification_email=None):
         # Should be a HoldInfo.
-        return self.dummy._return_or_raise('hold')
+        return self._return_or_raise('hold')
 
     def fulfill(self, patron, password, pool, delivery_mechanism):
         # Should be a FulfillmentInfo.
-        return self.dummy._return_or_raise('fulfill')
+        return self._return_or_raise('fulfill')
 
     def checkin(self, patron, pin, licensepool):
         # Return value is not checked.
-        return self.dummy._return_or_raise('checkin')
+        return self._return_or_raise('checkin')
 
     def release_hold(self, patron, pin, licensepool):
         # Return value is not checked.
-        return self.dummy._return_or_raise('release_hold')
+        return self.return_or_raise('release_hold')
 
     def internal_format(self, delivery_mechanism):
         return delivery_mechanism
-
-class MockCirculationAPI(CirculationAPI):
-
-    def __init__(self, db):
-        super(MockCirculationAPI, self).__init__(db)
-        self.responses = defaultdict(list)
-        self.active_loans = []
-        self.active_holds = []
-        self.identifier_type_to_data_source_name = {
-            Identifier.GUTENBERG_ID: DataSource.GUTENBERG,
-            Identifier.OVERDRIVE_ID: DataSource.OVERDRIVE,
-            Identifier.THREEM_ID: DataSource.THREEM,
-            Identifier.AXIS_360_ID: DataSource.AXIS_360,
-        }
 
     def queue_checkout(self, response):
         self._queue('checkout', response)
@@ -92,94 +81,63 @@ class MockCirculationAPI(CirculationAPI):
     def _queue(self, k, v):
         self.responses[k].append(v)
 
-    def set_patron_activity(self, loans, holds):
-        self.active_loans = loans
-        self.active_holds = holds
-
-    def patron_activity(self, patron, pin):
-        # Should be a 2-tuple containing a list of LoanInfo and a
-        # list of HoldInfo.
-        return self.active_loans, self.active_holds
-
     def _return_or_raise(self, k):
-        logging.debug(k)
+        self.log.debug(k)
         l = self.responses[k]
         v = l.pop()
         if isinstance(v, Exception):
             raise v
         return v
 
-    def api_for_license_pool(self, licensepool):
-        set_delivery_mechanism_at = BaseCirculationAPI.FULFILL_STEP
-        can_revoke_hold_when_reserved = True
-        if licensepool.data_source.name == DataSource.AXIS_360:
-            set_delivery_mechanism_at = BaseCirculationAPI.BORROW_STEP
-        if licensepool.data_source.name == DataSource.THREEM:
-            can_revoke_hold_when_reserved = False
-        
-        return MockRemoteAPI(set_delivery_mechanism_at, can_revoke_hold_when_reserved, self)
-
-
-class DummyRemoteAPI(object):
-
-    """The equivalent of the OverdriveAPI or ThreeMAPI, rigged for testing."""
-
-    SET_DELIVERY_MECHANISM_AT = BaseCirculationAPI.FULFILL_STEP
-
-    def __init__(self):
-        self.loans = []
-        self.holds = []
-        self.responses = []
-
-    def internal_format(self, delivery_mechanism):
-        return "doesn't matter"
-
-    def queue_response(self, response):
-        self.responses.insert(0, response)
-
-    def patron_activity(self, patron, pin):
-        return self.loans + self.holds
-
-    def respond(self, *args, **kwargs):
-        set_trace()
-        response = self.responses.pop()
-        if isinstance(response, Exception):
-            raise response
-        else:
-            return response
-
-    checkout = respond
-    place_hold = respond
-
-
-class DummyCirculationAPI(CirculationAPI):
-
-    """A testable superclass of CirculationAPI that sends requests to
-    DummyRemoteAPI instead of to real APIs.
-    """
+class MockCirculationAPI(CirculationAPI):
 
     def __init__(self, _db):
-        super(DummyCirculationAPI, self).__init__(_db)
-        self.remote = DummyRemoteAPI()
-        self.apis = [self.remote]
-        self.data_source_ids_for_sync = [x.id for x in _db.query(DataSource)]
-
-    def api_for_license_pool(self, licensepool):
-        return self.remote
-
-    def add_remote_loan(self, *args, **kwargs):
-        loaninfo = LoanInfo(*args, **kwargs)
-        self.remote.loans.append(loaninfo)
-
-    def add_remote_hold(self, *args, **kwargs):
-        loaninfo = HoldInfo(*args, **kwargs)
-        self.remote.holds.append(loaninfo)
+        super(MockCirculationAPI, self).__init__(_db)
+        self.responses = defaultdict(list)
+        self.remote_loans = []
+        self.remote_holds = []
+        self.identifier_type_to_data_source_name = {
+            Identifier.GUTENBERG_ID: DataSource.GUTENBERG,
+            Identifier.OVERDRIVE_ID: DataSource.OVERDRIVE,
+            Identifier.THREEM_ID: DataSource.THREEM,
+            Identifier.AXIS_360_ID: DataSource.AXIS_360,
+        }
+        self.data_source_ids_for_sync = [
+            DataSource.lookup(self._db, name).id for name in 
+            self.identifier_type_to_data_source_name.values()
+        ]
+        self.remotes = {}
 
     def local_loans(self, patron):
         return self._db.query(Loan).filter(Loan.patron==patron)
 
     def local_holds(self, patron):
-        return self._db.query(Hold).filter(Hold.patron==patron)
+        return self._db.query(Hold).filter(Loan.patron==patron)
+
+    def add_remote_loan(self, *args, **kwargs):
+        self.remote_loans.append(LoanInfo(*args, **kwargs))
+
+    def add_remote_hold(self, *args, **kwargs):
+        self.remote_loans.append(LoanInfo(*args, **kwargs))
+
+    def patron_activity(self, patron, pin):
+        """Return a 2-tuple (loans, holds)."""
+        return self.remote_loans, self.remote_holds
+
+    def api_for_license_pool(self, licensepool):
+        source = licensepool.data_source.name
+        if source not in self.remotes:
+            set_delivery_mechanism_at = BaseCirculationAPI.FULFILL_STEP
+            can_revoke_hold_when_reserved = True
+            if source == DataSource.AXIS_360:
+                set_delivery_mechanism_at = BaseCirculationAPI.BORROW_STEP
+            if source == DataSource.THREEM:
+                can_revoke_hold_when_reserved = False
+            remote = MockRemoteAPI(
+                set_delivery_mechanism_at, can_revoke_hold_when_reserved
+            )
+            self.remotes[source] = remote
+        return self.remotes[source]
 
 
 class TestCirculationAPI(DatabaseTest):
@@ -194,8 +152,8 @@ class TestCirculationAPI(DatabaseTest):
         self.identifier = self.pool.identifier
         [self.delivery_mechanism] = self.pool.delivery_mechanisms
         self.patron = self.default_patron
-        self.circulation = DummyCirculationAPI(self._db)
-        self.remote = self.circulation.remote
+        self.circulation = MockCirculationAPI(self._db)
+        self.remote = self.circulation.api_for_license_pool(self.pool)
         self.email = 'foo@example.com'
 
     def borrow(self):
@@ -214,7 +172,7 @@ class TestCirculationAPI(DatabaseTest):
             self.IN_TWO_WEEKS
         )
 
-        self.remote.queue_response(AlreadyCheckedOut())
+        self.remote.queue_checkout(AlreadyCheckedOut())
         now = datetime.utcnow()
         loan, hold, is_new = self.borrow()
 
@@ -242,7 +200,7 @@ class TestCirculationAPI(DatabaseTest):
             self.IN_TWO_WEEKS, 10
         )
 
-        self.remote.queue_response(AlreadyOnHold())
+        self.remote.queue_checkout(AlreadyOnHold())
         now = datetime.utcnow()
         loan, hold, is_new = self.borrow()
 
@@ -276,7 +234,7 @@ class TestCirculationAPI(DatabaseTest):
 
         # This is the expected behavior in most cases--you tried to
         # renew the loan and failed because it's not time yet.
-        self.remote.queue_response(CannotRenew())
+        self.remote.queue_checkout(CannotRenew())
         assert_raises_regexp(CannotRenew, '^$', self.borrow)
 
     def test_attempt_renew_with_local_loan_and_no_available_copies(self):
@@ -298,7 +256,7 @@ class TestCirculationAPI(DatabaseTest):
         #
         # Contrast with the way NoAvailableCopies is handled in 
         # test_loan_becomes_hold_if_no_available_copies.
-        self.remote.queue_response(NoAvailableCopies())
+        self.remote.queue_checkout(NoAvailableCopies())
         assert_raises_regexp(
             CannotRenew, 
             "You cannot renew a loan if other patrons have the work on hold.",
@@ -306,13 +264,29 @@ class TestCirculationAPI(DatabaseTest):
         )
 
     def test_loan_becomes_hold_if_no_available_copies(self):
+        # We want to borrow this book but there are no copies.
+        self.remote.queue_checkout(NoAvailableCopies())
+        self.remote.queue_hold(
+            HoldInfo(self.identifier.type, self.identifier.identifier,
+                     None, None, 10)
+        )
+
+        # As such, an attempt to renew our loan results in us actually
+        # placing a hold on the book.
+        loan, hold, is_new = self.borrow()
+        eq_(None, loan)
+        eq_(True, is_new)
+        eq_(self.pool, hold.license_pool)
+        eq_(self.patron, hold.patron)
+
+    def test_loan_becomes_hold_if_no_available_copies_and_preexisting_loan(self):
         # Once upon a time, we had a loan for this book.
         loan, ignore = self.pool.loan_to(self.patron)        
 
         # But no longer! What's more, other patrons have taken all the
         # copies!
-        self.remote.queue_response(NoAvailableCopies())
-        self.remote.queue_response(
+        self.remote.queue_checkout(NoAvailableCopies())
+        self.remote.queue_hold(
             HoldInfo(self.identifier.type, self.identifier.identifier,
                      None, None, 10)
         )

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -1,0 +1,184 @@
+"""Test the CirculationAPI."""
+from nose.tools import (
+    set_trace,
+    eq_,
+)
+
+from datetime import (
+    datetime, 
+    timedelta,
+)
+
+from api.circulation_exceptions import *
+from api.circulation import (
+    BaseCirculationAPI,
+    CirculationAPI,
+    LoanInfo,
+    HoldInfo,
+)
+
+from . import DatabaseTest
+
+class DummyRemoteAPI(object):
+
+    """The equivalent of the OverdriveAPI or ThreeMAPI, rigged for testing."""
+
+    SET_DELIVERY_MECHANISM_AT = BaseCirculationAPI.FULFILL_STEP
+
+    def __init__(self):
+        self.loans = []
+        self.holds = []
+        self.responses = []
+
+    def internal_format(self, delivery_mechanism):
+        return "doesn't matter"
+
+    def queue_response(self, response):
+        self.responses.insert(0, response)
+
+    def respond(self, *args, **kwargs):
+        response = self.responses.pop()
+        if isinstance(response, Exception):
+            raise response
+        else:
+            return response
+
+    checkout = respond
+        
+
+class DummyCirculationAPI(CirculationAPI):
+
+    """A testable superclass of CirculationAPI that sends requests to
+    DummyRemoteAPI instead of to real APIs.
+    """
+
+    def __init__(self, _db):
+        super(DummyCirculationAPI, self).__init__(_db)
+        self.remote = DummyRemoteAPI()
+        self.apis = [self.remote]
+
+    def api_for_license_pool(self, licensepool):
+        return self.remote
+
+    def add_remote_loan(self, *args, **kwargs):
+        loaninfo = LoanInfo(*args, **kwargs)
+        self.remote.loans.append(loaninfo)
+
+    def add_remote_hold(self, *args, **kwargs):
+        loaninfo = HoldInfo(*args, **kwargs)
+        self.remote.holds.append(loaninfo)
+
+
+class TestCirculationAPI(DatabaseTest):
+
+    YESTERDAY = datetime.utcnow() - timedelta(days=1) 
+    IN_TWO_WEEKS = datetime.utcnow() + timedelta(days=14) 
+
+    def setup(self):
+        super(TestCirculationAPI, self).setup()
+        edition, self.pool = self._edition(with_license_pool=True)
+        self.pool.open_access = False
+        self.identifier = self.pool.identifier
+        [self.delivery_mechanism] = self.pool.delivery_mechanisms
+        self.patron = self.default_patron
+        self.circulation = DummyCirculationAPI(self._db)
+        self.remote = self.circulation.remote
+        self.email = 'foo@example.com'
+
+    def borrow(self):
+        return self.circulation.borrow(
+            self.patron, '1234', self.pool, self.delivery_mechanism, self.email
+        )
+
+    def test_attempt_borrow_with_existing_remote_loan(self):
+        """The patron has a remote loan that the circ manager doesn't know
+        about, and they just tried to borrow a book they already have
+        a loan for.
+        """
+        # Remote loan.
+        self.circulation.add_remote_loan(
+            self.identifier.type, self.identifier.identifier, self.YESTERDAY,
+            self.IN_TWO_WEEKS
+        )
+
+        self.remote.queue_response(AlreadyCheckedOut())
+        now = datetime.utcnow()
+        loan, hold, is_new = self.borrow()
+
+        # There is now a new local loan representing the remote loan.
+        eq_(True, is_new)
+        eq_(self.pool, loan.license_pool)
+        eq_(self.patron, loan.patron)
+        eq_(None, hold)
+
+        # The server told us 'there's already a loan for this book'
+        # but didn't give us any useful information on when that loan
+        # was created. We've faked it with values that should be okay
+        # until the next sync.
+        assert abs((loan.start-now).seconds) < 2
+        eq_(3600, (loan.end-loan.start).seconds)
+
+    def test_attempt_borrow_with_existing_remote_hold(self):
+        """The patron has a remote hold that the circ manager doesn't know
+        about, and they just tried to borrow a book they already have
+        on hold.
+        """
+        # Remote hold.
+        self.circulation.add_remote_hold(
+            self.identifier.type, self.identifier.identifier, self.YESTERDAY,
+            self.IN_TWO_WEEKS, 10
+        )
+
+        self.remote.queue_response(AlreadyOnHold())
+        now = datetime.utcnow()
+        loan, hold, is_new = self.borrow()
+
+        # There is now a new local hold representing the remote hold.
+        eq_(True, is_new)
+        eq_(None, loan)
+        eq_(self.pool, hold.license_pool)
+        eq_(self.patron, hold.patron)
+
+        # The server told us 'you already have this book on hold' but
+        # didn't give us any useful information on when that hold was
+        # created. We've set the hold start time to the time we found
+        # out about it. We'll get the real information the next time
+        # we do a sync.
+        assert abs((hold.start-now).seconds) < 2
+        eq_(None, hold.end)
+        eq_(None, hold.position)
+        
+    def test_attempt_renew_with_local_loan(self):
+        """We have a local loan and a remote loan but the patron tried to
+        borrow again -- probably to renew their loan.
+        """
+        # Local loan.
+        loan, ignore = self.pool.loan_to(self.patron)        
+
+        # Remote loan.
+        self.circulation.add_remote_loan(
+            self.identifier.type, self.identifier.identifier, self.YESTERDAY,
+            self.IN_TWO_WEEKS
+        )
+
+        # This is the expected behavior in most cases--you tried to
+        # renew the loan and failed.
+        self.remote.queue_response(CannotRenew())
+        new_loan, hold, is_new = self.borrow()
+
+        # We get our preexisting local loan back.
+        eq_(loan, new_loan)
+        eq_(None, hold)
+        eq_(False, is_new)
+
+        # This is what Overdrive does when you fail to renew the loan
+        # and there are no available copies.
+        self.remote.queue_response(NoAvailableCopies())
+        new_loan, hold, is_new = self.borrow()
+
+        # Again, we get our preexisting local loan back.
+        eq_(loan, new_loan)
+        eq_(None, hold)
+        eq_(False, is_new)
+
+

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -1,6 +1,4 @@
 """Test the CirculationAPI."""
-import logging
-from collections import defaultdict
 from nose.tools import (
     assert_raises_regexp,
     set_trace,
@@ -14,8 +12,6 @@ from datetime import (
 
 from api.circulation_exceptions import *
 from api.circulation import (
-    BaseCirculationAPI,
-    CirculationAPI,
     LoanInfo,
     HoldInfo,
 )
@@ -28,116 +24,7 @@ from core.model import (
 )
 
 from . import DatabaseTest
-
-class MockRemoteAPI(object):
-    def __init__(self, set_delivery_mechanism_at, can_revoke_hold_when_reserved):
-        self.SET_DELIVERY_MECHANISM_AT = set_delivery_mechanism_at
-        self.CAN_REVOKE_HOLD_WHEN_RESERVED = can_revoke_hold_when_reserved
-        self.responses = defaultdict(list)
-        self.log = logging.getLogger("Mock remote API")
-
-    def checkout(
-            self, patron_obj, patron_password, licensepool, 
-            delivery_mechanism
-    ):
-        # Should be a LoanInfo.
-        return self._return_or_raise('checkout')
-                
-    def place_hold(self, patron, pin, licensepool, 
-                   hold_notification_email=None):
-        # Should be a HoldInfo.
-        return self._return_or_raise('hold')
-
-    def fulfill(self, patron, password, pool, delivery_mechanism):
-        # Should be a FulfillmentInfo.
-        return self._return_or_raise('fulfill')
-
-    def checkin(self, patron, pin, licensepool):
-        # Return value is not checked.
-        return self._return_or_raise('checkin')
-
-    def release_hold(self, patron, pin, licensepool):
-        # Return value is not checked.
-        return self.return_or_raise('release_hold')
-
-    def internal_format(self, delivery_mechanism):
-        return delivery_mechanism
-
-    def queue_checkout(self, response):
-        self._queue('checkout', response)
-
-    def queue_hold(self, response):
-        self._queue('hold', response)
-
-    def queue_fulfill(self, response):
-        self._queue('fulfill', response)
-
-    def queue_checkin(self, response):
-        self._queue('checkin', response)
-
-    def queue_release_hold(self, response):
-        self._queue('release_hold', response)
-
-    def _queue(self, k, v):
-        self.responses[k].append(v)
-
-    def _return_or_raise(self, k):
-        self.log.debug(k)
-        l = self.responses[k]
-        v = l.pop()
-        if isinstance(v, Exception):
-            raise v
-        return v
-
-class MockCirculationAPI(CirculationAPI):
-
-    def __init__(self, _db):
-        super(MockCirculationAPI, self).__init__(_db)
-        self.responses = defaultdict(list)
-        self.remote_loans = []
-        self.remote_holds = []
-        self.identifier_type_to_data_source_name = {
-            Identifier.GUTENBERG_ID: DataSource.GUTENBERG,
-            Identifier.OVERDRIVE_ID: DataSource.OVERDRIVE,
-            Identifier.THREEM_ID: DataSource.THREEM,
-            Identifier.AXIS_360_ID: DataSource.AXIS_360,
-        }
-        self.data_source_ids_for_sync = [
-            DataSource.lookup(self._db, name).id for name in 
-            self.identifier_type_to_data_source_name.values()
-        ]
-        self.remotes = {}
-
-    def local_loans(self, patron):
-        return self._db.query(Loan).filter(Loan.patron==patron)
-
-    def local_holds(self, patron):
-        return self._db.query(Hold).filter(Loan.patron==patron)
-
-    def add_remote_loan(self, *args, **kwargs):
-        self.remote_loans.append(LoanInfo(*args, **kwargs))
-
-    def add_remote_hold(self, *args, **kwargs):
-        self.remote_loans.append(LoanInfo(*args, **kwargs))
-
-    def patron_activity(self, patron, pin):
-        """Return a 2-tuple (loans, holds)."""
-        return self.remote_loans, self.remote_holds
-
-    def api_for_license_pool(self, licensepool):
-        source = licensepool.data_source.name
-        if source not in self.remotes:
-            set_delivery_mechanism_at = BaseCirculationAPI.FULFILL_STEP
-            can_revoke_hold_when_reserved = True
-            if source == DataSource.AXIS_360:
-                set_delivery_mechanism_at = BaseCirculationAPI.BORROW_STEP
-            if source == DataSource.THREEM:
-                can_revoke_hold_when_reserved = False
-            remote = MockRemoteAPI(
-                set_delivery_mechanism_at, can_revoke_hold_when_reserved
-            )
-            self.remotes[source] = remote
-        return self.remotes[source]
+from testing import MockCirculationAPI
 
 
 class TestCirculationAPI(DatabaseTest):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -419,14 +419,19 @@ class TestLoanController(CirculationControllerTest):
         with self.app.test_request_context(
                 "/", headers=dict(Authorization=self.valid_auth)):
             self.manager.loans.authenticated_patron_from_request()
-            self.manager.circulation.queue_checkout(NoAvailableCopies())
-            self.manager.circulation.queue_hold(HoldInfo(
-                pool.identifier.type,
-                pool.identifier.identifier,
-                datetime.datetime.utcnow(),
-                datetime.datetime.utcnow() + datetime.timedelta(seconds=3600),
-                1,
-            ))
+            self.manager.circulation.queue_checkout(
+                pool, NoAvailableCopies()
+            )
+            self.manager.circulation.queue_hold(
+                pool,
+                HoldInfo(
+                    pool.identifier.type,
+                    pool.identifier.identifier,
+                    datetime.datetime.utcnow(),
+                    datetime.datetime.utcnow() + datetime.timedelta(seconds=3600),
+                    1,
+                )
+            )
             response = self.manager.loans.borrow(
                 DataSource.THREEM, pool.identifier.identifier)
             eq_(201, response.status_code)
@@ -454,14 +459,18 @@ class TestLoanController(CirculationControllerTest):
         with self.app.test_request_context(
                 "/", headers=dict(Authorization=self.valid_auth)):
             self.manager.loans.authenticated_patron_from_request()
-            self.manager.circulation.queue_checkout(AlreadyOnHold())
-            self.manager.circulation.queue_hold(HoldInfo(
-                pool.identifier.type,
-                pool.identifier.identifier,
-                datetime.datetime.utcnow(),
-                datetime.datetime.utcnow() + datetime.timedelta(seconds=3600),
-                1,
-            ))
+            self.manager.circulation.queue_checkout(
+                pool, AlreadyOnHold()
+            )
+            self.manager.circulation.queue_hold(
+                pool, HoldInfo(
+                    pool.identifier.type,
+                    pool.identifier.identifier,
+                    datetime.datetime.utcnow(),
+                    datetime.datetime.utcnow() + datetime.timedelta(seconds=3600),
+                    1,
+                )
+            )
             response = self.manager.loans.borrow(
                 DataSource.THREEM, pool.identifier.identifier)
             eq_(201, response.status_code)
@@ -486,7 +495,9 @@ class TestLoanController(CirculationControllerTest):
          with self.app.test_request_context(
                  "/", headers=dict(Authorization=self.valid_auth)):
              self.manager.loans.authenticated_patron_from_request()
-             self.manager.circulation.queue_checkout(NotFoundOnRemote())
+             self.manager.circulation.queue_checkout(
+                 pool, NotFoundOnRemote()
+             )
              response = self.manager.loans.borrow(
                  DataSource.THREEM, pool.identifier.identifier)
              eq_(404, response.status_code)
@@ -498,7 +509,7 @@ class TestLoanController(CirculationControllerTest):
              patron = self.manager.loans.authenticated_patron_from_request()
              loan, newly_created = self.pool.loan_to(patron)
 
-             self.manager.circulation.queue_checkin(True)
+             self.manager.circulation.queue_checkin(self.pool, True)
 
              response = self.manager.loans.revoke(self.pool.data_source.name, self.pool.identifier.identifier)
 
@@ -510,7 +521,7 @@ class TestLoanController(CirculationControllerTest):
              patron = self.manager.loans.authenticated_patron_from_request()
              hold, newly_created = self.pool.on_hold_to(patron, position=0)
 
-             self.manager.circulation.queue_release_hold(True)
+             self.manager.circulation.queue_release_hold(self.pool, True)
 
              response = self.manager.loans.revoke(self.pool.data_source.name, self.pool.identifier.identifier)
 
@@ -565,12 +576,16 @@ class TestLoanController(CirculationControllerTest):
             with self.app.test_request_context(
                     "/", headers=dict(Authorization=auth)):
                 self.manager.loans.authenticated_patron_from_request()
-                self.manager.circulation.queue_checkout(LoanInfo(
-                    pool.identifier.type,
-                    pool.identifier.identifier,
-                    datetime.datetime.utcnow(),
-                    datetime.datetime.utcnow() + datetime.timedelta(seconds=3600),
-                ))
+
+                self.manager.circulation.queue_checkout(
+                    pool,
+                    LoanInfo(
+                        pool.identifier.type,
+                        pool.identifier.identifier,
+                        datetime.datetime.utcnow(),
+                        datetime.datetime.utcnow() + datetime.timedelta(seconds=3600),
+                    )
+                )
                 response = self.manager.loans.borrow(
                     DataSource.THREEM, pool.identifier.identifier)
                 
@@ -628,20 +643,19 @@ class TestLoanController(CirculationControllerTest):
         threem_pool.licenses_available = 0
         threem_pool.open_access = False
         
-        loan = LoanInfo(
+        self.manager.circulation.add_remote_loan(
             overdrive_pool.identifier.type,
             overdrive_pool.identifier.identifier,
             datetime.datetime.utcnow(),
-            datetime.datetime.utcnow() + datetime.timedelta(seconds=3600),
+            datetime.datetime.utcnow() + datetime.timedelta(seconds=3600)
         )
-        hold = HoldInfo(
+        self.manager.circulation.add_remote_hold(
             threem_pool.identifier.type,
             threem_pool.identifier.identifier,
             datetime.datetime.utcnow(),
             datetime.datetime.utcnow() + datetime.timedelta(seconds=3600),
             0,
         )
-        self.manager.circulation.set_patron_activity([loan], [hold])
 
         with self.app.test_request_context(
                 "/", headers=dict(Authorization=self.valid_auth)):


### PR DESCRIPTION
This branch fixes an edge case in renewals. Overdrive (and possibly other distributors) prohibits renewing a loan if there are people waiting in line for the book. If you try, the `OverdriveAPI` raises `NoAvailableCopies`. In `CirculationAPI` weren't prepared for this--we only prepared for `CannotRenew`, which is raised if there _are_ available copies but your loan isn't near enough to its expiry date for renewal to be an option.

This real improvement in this branch is `test_circulationapi.py`, which contains the first tests of the troublesome `CirculationAPI` class. I had put this off because properly testing the code requires two levels of mock objects--a mock `CirculationAPI` that calls mock remote API objects--but this is so important to the circ manager and there are so many weird edge cases that I finally had to do it. I've added tests for all the `borrow()` cases that end with an active loan for the book. There are a lot more tests to be written and I'll get to them as I can.