### PR TITLE
Immediately update a book's availability if exception indicates our data is out-of-date

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -153,6 +153,13 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI):
         return list(AvailabilityResponseParser().process_all(
             availability.content))
 
+    def update_availability(self, licensepool):
+        """Update the availability information for a single LicensePool.
+
+        Part of the CirculationAPI interface.
+        """
+        self.update_licensepools_for_identifiers([licensepool.identifier])
+
     def update_licensepools_for_identifiers(self, identifiers):
         """Update availability information for a list of books.
 

--- a/api/axis.py
+++ b/api/axis.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import contains_eager
 from lxml import etree
 from core.axis import (
     Axis360API as BaseAxis360API,
+    MockAxis360API as BaseMockAxis360API,
     Axis360Parser,
     BibliographicParser,
     Axis360BibliographicCoverageProvider
@@ -275,6 +276,8 @@ class Axis360CirculationMonitor(Monitor):
         availability.update(license_pool, new_license_pool)
         return edition, license_pool
 
+class MockAxis360API(BaseMockAxis360API, Axis360API):
+    pass
 
 class AxisCollectionReaper(IdentifierSweepMonitor):
     """Check for books that are in the local collection but have left our

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -221,6 +221,7 @@ class CirculationAPI(object):
                 on_multiple='interchangeable'
             )
 
+        needs_update = False
         try:
             loan_info = api.checkout(
                 patron, pin, licensepool, internal_format
@@ -251,7 +252,17 @@ class CirculationAPI(object):
                 )
             else:
                 # That's fine, we'll just (try to) place a hold.
-                pass
+                #
+                # Since the patron incorrectly believed there were
+                # copies available, update availability information
+                # immediately.
+                api.update_availability(licensepool)
+        except NoLicenses, e:
+            # Since the patron incorrectly believed there were
+            # licenses available, update availability information
+            # immediately.
+            api.update_availability(licensepool)
+            raise e
 
         if loan_info:
             # We successfuly secured a loan.  Now create it in our

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -221,7 +221,6 @@ class CirculationAPI(object):
                 on_multiple='interchangeable'
             )
 
-        needs_update = False
         try:
             loan_info = api.checkout(
                 patron, pin, licensepool, internal_format

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -525,6 +525,10 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
             book, license_pool, is_new
         )
 
+    # Alias for the CirculationAPI interface
+    def update_availability(self, licensepool):
+        return self.update_licensepool(licensepool.identifier.identifier)
+
     def update_licensepool_with_book_info(self, book, license_pool, is_new_pool):
         """Update a book's LicensePool with information from a JSON
         representation of its circulation info.

--- a/api/testing.py
+++ b/api/testing.py
@@ -20,6 +20,7 @@ class MockRemoteAPI(object):
         self.CAN_REVOKE_HOLD_WHEN_RESERVED = can_revoke_hold_when_reserved
         self.responses = defaultdict(list)
         self.log = logging.getLogger("Mock remote API")
+        self.availability_updated_for = []
 
     def checkout(
             self, patron_obj, patron_password, licensepool, 
@@ -27,6 +28,10 @@ class MockRemoteAPI(object):
     ):
         # Should be a LoanInfo.
         return self._return_or_raise('checkout')
+
+    def update_availability(self, licensepool):
+        """Simply record the fact that update_availability was called."""
+        self.availability_updated_for.append(licensepool)
                 
     def place_hold(self, patron, pin, licensepool, 
                    hold_notification_email=None):

--- a/api/threem.py
+++ b/api/threem.py
@@ -267,7 +267,26 @@ class DummyThreeMAPIResponse(object):
         self.content = content
 
 class MockThreeMAPI(BaseMockThreeMAPI, ThreeMAPI):
-    pass
+
+    def queue_response(self, status_code, headers={}, content=None):
+        from testing import MockRequestsResponse
+        self.responses.insert(
+            0, MockRequestsResponse(status_code, headers, content)
+        )
+
+    def __init__(self, _db, *args, **kwargs):
+        self.responses = []
+        self.requests = []
+
+        with temp_config() as config:
+            config[Configuration.INTEGRATIONS]['3M'] = {
+                'library_id' : 'a',
+                'account_id' : 'b',
+                'account_key' : 'c',
+            }
+            super(MockThreeMAPI, self).__init__(
+                _db, *args, base_url="http://3m.test", **kwargs
+            )
 
 
 class ThreeMParser(XMLParser):

--- a/api/threem.py
+++ b/api/threem.py
@@ -267,26 +267,7 @@ class DummyThreeMAPIResponse(object):
         self.content = content
 
 class MockThreeMAPI(BaseMockThreeMAPI, ThreeMAPI):
-
-    def queue_response(self, status_code, headers={}, content=None):
-        from testing import MockRequestsResponse
-        self.responses.insert(
-            0, MockRequestsResponse(status_code, headers, content)
-        )
-
-    def __init__(self, _db, *args, **kwargs):
-        self.responses = []
-        self.requests = []
-
-        with temp_config() as config:
-            config[Configuration.INTEGRATIONS]['3M'] = {
-                'library_id' : 'a',
-                'account_id' : 'b',
-                'account_key' : 'c',
-            }
-            super(MockThreeMAPI, self).__init__(
-                _db, *args, base_url="http://3m.test", **kwargs
-            )
+    pass
 
 
 class ThreeMParser(XMLParser):

--- a/api/threem.py
+++ b/api/threem.py
@@ -99,6 +99,13 @@ class ThreeMAPI(BaseThreeMAPI, BaseCirculationAPI):
             if circ:
                 yield circ
 
+    def update_availability(self, licensepool):
+        """Update the availability information for a single LicensePool."""
+        for circ in self.get_circulation_for([licensepool.identifier]):
+            self.apply_circulation_information_to_licensepool(
+                circ, licensepool
+            )
+
     def patron_activity(self, patron, pin):
         patron_id = patron.authorization_identifier
         path = "circulation/patron/%s" % patron_id
@@ -225,6 +232,29 @@ class ThreeMAPI(BaseThreeMAPI, BaseCirculationAPI):
             return True
         else:
             raise CannotReleaseHold()
+
+    def apply_circulation_information_to_licensepool(self, circ, pool):
+        """Apply the output of CirculationParser.process_one() to a
+        LicensePool.
+        
+        TODO: It should be possible to have CirculationParser yield 
+        CirculationData objects instead and to replace this code with
+        CirculationData.apply(pool)
+        """
+        if pool.presentation_edition:
+            e = pool.presentation_edition
+            self.log.info("Updating %s (%s)", e.title, e.author)
+        else:
+            self.log.info(
+                "Updating unknown work %s", identifier.identifier
+            )
+        # Update availability and send out notifications.
+        pool.update_availability(
+            circ.get(LicensePool.licenses_owned, 0),
+            circ.get(LicensePool.licenses_available, 0),
+            circ.get(LicensePool.licenses_reserved, 0),
+            circ.get(LicensePool.patrons_in_hold_queue, 0)
+        )
 
 
 class DummyThreeMAPIResponse(object):
@@ -591,20 +621,7 @@ class ThreeMCirculationSweep(IdentifierSweepMonitor):
                     self._db, pool, CirculationEvent.TITLE_ADD,
                     None, None, start=now)
 
-            if pool.presentation_edition:
-                e = pool.presentation_edition
-                self.log.info("Updating %s (%s)", e.title, e.author)
-            else:
-                self.log.info(
-                    "Updating unknown work %s", identifier.identifier
-                )
-            # Update availability and send out notifications.
-            pool.update_availability(
-                circ.get(LicensePool.licenses_owned, 0),
-                circ.get(LicensePool.licenses_available, 0),
-                circ.get(LicensePool.licenses_reserved, 0),
-                circ.get(LicensePool.patrons_in_hold_queue, 0))
-
+            self.api.apply_circulation_data_to_licensepool(pool)
 
         # At this point there may be some license pools left over
         # that 3M doesn't know about.  This is a pretty reliable

--- a/api/threem.py
+++ b/api/threem.py
@@ -101,7 +101,9 @@ class ThreeMAPI(BaseThreeMAPI, BaseCirculationAPI):
 
     def update_availability(self, licensepool):
         """Update the availability information for a single LicensePool."""
-        for circ in self.get_circulation_for([licensepool.identifier]):
+        for circ in self.get_circulation_for(
+                [licensepool.identifier.identifier]
+        ):
             self.apply_circulation_information_to_licensepool(
                 circ, licensepool
             )
@@ -416,7 +418,7 @@ class ErrorParser(ThreeMParser):
         actual, expected = m.groups()
         expected = expected.split(",")
 
-        if actual == 'CAN_WISH' and actual == 'CAN_HOLD':
+        if actual == 'CAN_WISH':
             return NoLicenses(message)
 
         if 'CAN_LOAN' in expected and actual == 'CAN_HOLD':

--- a/tests/files/threem/circulation_information.xml
+++ b/tests/files/threem/circulation_information.xml
@@ -1,1 +1,0 @@
-<ArrayOfItemCirculation xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ItemCirculation><ItemId>d5rf89</ItemId><ItemLibraryId>a4tmf</ItemLibraryId><ISBN13>9781101190623</ISBN13><TotalCopies>1</TotalCopies></ItemCirculation></ArrayOfItemCirculation>

--- a/tests/files/threem/circulation_information.xml
+++ b/tests/files/threem/circulation_information.xml
@@ -1,0 +1,1 @@
+<ArrayOfItemCirculation xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ItemCirculation><ItemId>d5rf89</ItemId><ItemLibraryId>a4tmf</ItemLibraryId><ISBN13>9781101190623</ISBN13><TotalCopies>1</TotalCopies></ItemCirculation></ArrayOfItemCirculation>

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -50,10 +50,11 @@ class TestOverdriveAPI(DatabaseTest):
         )
 
         # We have never checked the circulation information for this
-        # LicensePool, and its information is the default for a 
-        # LicensePool created with _edition().
-        eq_(1, pool.licenses_owned)
-        eq_(1, pool.licenses_available)
+        # LicensePool. Put some random junk in the pool to make sure
+        # it gets replaced.
+        pool.licenses_owned = 10
+        pool.licenses_available = 4
+        pool.patrons_in_hold_queue = 3
         eq_(None, pool.last_checked)
 
         # Prepare availability information.
@@ -81,6 +82,7 @@ class TestOverdriveAPI(DatabaseTest):
         # date the availability information was last checked.
         eq_(5, pool.licenses_owned)
         eq_(5, pool.licenses_available)
+        eq_(0, pool.patrons_in_hold_queue)
         assert pool.last_checked is not None
 
     def test_update_licensepool_provides_bibliographic_coverage(self):


### PR DESCRIPTION
If you try to borrow a book and get a NoAvailableCopies or NoLicenses exception, this branch immediately asks the license provider for up-to-date licensing information, to reduce the amount of time our licensing information is out of date.

This branch adds a new method, `update_availability(self, licensepool)` to the contract implemented by all the APIs used by `CirculationAPI`. Its job is to update the licensing information for a single `LicensePool`. I implemented and tested all three cases (Overdrive, 3M, Axis 360), and it's always a wrapper around a little bit of preexisting code.

This is useful code to have around, so I finished the branch even though this sort of race condition isn't currently the major problem driving `NoAvailableCopies` and `NoLicenses` exceptions: see https://github.com/NYPL-Simplified/circulation/issues/213