### PR TITLE
Institute a single code path for updating the circulation information for 3M books

### DIFF
--- a/tests/files/threem/item_circulation_single.xml
+++ b/tests/files/threem/item_circulation_single.xml
@@ -1,0 +1,1 @@
+<ArrayOfItemCirculation xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ItemCirculation><ItemId>d5rf89</ItemId><ItemLibraryId>a4tmf</ItemLibraryId><ISBN13>9781101190623</ISBN13><TotalCopies>1</TotalCopies><AvailableCopies>1</AvailableCopies><Checkouts /><Holds /><Reserves /></ItemCirculation></ArrayOfItemCirculation>


### PR DESCRIPTION
This branch changes the implementation of ThreeMAPI.update_availability so that it checks the status of a single LicensePool by instantiating a ThreeMCirculationSweep and calling its `process_batch()` method on a single identifier. This may seem like overkill, and the code should certainly be refactored, but it solves two pretty bad problems:

1. My previous branch introduced a typo into ThreeMCirculationSweep.process_batch() which I didn't catch because that method isn't tested. It is tested now, albeit only accidentally.

2. The whole point of my previous branch is that if a book leaves the collection and then someone tries to check it out, we find out that the book is gone. In my previous branch, that didn't happen, because the essential code doesn't run. The essential code compares the list of identifiers we sent 3M against the list of identifiers we got back, and deduces that any identifier not mentioned in the list must have left our collection. That code is currently in ThreeMCirculationSweep.