### PR TITLE
Patron oauth

### DIFF
--- a/api/admin/config.py
+++ b/api/admin/config.py
@@ -10,7 +10,6 @@ import contextlib
 class Configuration(CirculationManagerConfiguration):
 
     ADMIN_AUTH_DOMAIN = "admin_authentication_domain"
-    SECRET_KEY = "secret_key"
     GOOGLE_OAUTH_INTEGRATION = "Google OAuth"
     GOOGLE_OAUTH_CLIENT_JSON = "client_json_file"
 

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -89,9 +89,7 @@ class AdobeVendorIDRequestHandler(object):
             return self.error_document(
                 self.AUTH_ERROR_TYPE, "No method specified")
         if data['method'] == parser.STANDARD:
-            username = data['username']
-            password = data['password']
-            user_id, label = standard_lookup(username, password)
+            user_id, label = standard_lookup(data)
             failure = self.AUTHENTICATION_FAILURE
         elif data['method'] == parser.AUTH_DATA:
             authdata = data[parser.AUTH_DATA]
@@ -246,13 +244,13 @@ class AdobeVendorIDModel(object):
             patron, self.temporary_token_duration)
         return credential
 
-    def standard_lookup(self, username, password):       
-        """Look up a patron by username and password. Return their Vendor ID
+    def standard_lookup(self, authorization_data):
+        """Look up a patron by authorization header. Return their Vendor ID
         UUID and their human-readable label, creating a Credential
         object to hold the UUID if necessary.
         """
         patron = self.authenticator.authenticated_patron(
-            self._db, username, password)
+            self._db, authorization_data)
         return self.uuid_and_label(patron)
 
     def authdata_lookup(self, authdata):

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1,7 +1,16 @@
+from nose.tools import set_trace
 from config import (
     Configuration,
     CannotLoadConfiguration,
 )
+from core.util.opds_authentication_document import OPDSAuthenticationDocument
+
+import urlparse
+import uuid
+import json
+import jwt
+from flask import Response
+
 
 class Authenticator(object):
 
@@ -11,26 +20,40 @@ class Authenticator(object):
             from millenium_patron import (
                 DummyMilleniumPatronAPI,
             )
-            return DummyMilleniumPatronAPI()
+            return cls(DummyMilleniumPatronAPI(), [])
 
-        provider = Configuration.policy("authentication")
-        if not provider:
+        providers = Configuration.policy("authentication")
+        if not providers:
             raise CannotLoadConfiguration(
                 "No authentication policy given."
             )
-        if provider == 'Millenium':
+        if isinstance(providers, basestring):
+            providers = [providers]
+        basic_auth_provider = None
+        oauth_providers = []
+        if 'Millenium' in providers:
             from millenium_patron import (
                 MilleniumPatronAPI,
             )
-            api = MilleniumPatronAPI.from_environment()
-        elif provider == 'First Book':
+            basic_auth_provider = MilleniumPatronAPI.from_environment()
+        elif 'First Book' in providers:
             from firstbook import FirstBookAuthenticationAPI
-            api = FirstBookAuthenticationAPI.from_config()
-        else:
+            basic_auth_provider = FirstBookAuthenticationAPI.from_config()
+
+        if 'Clever' in providers:
+            from clever import CleverAuthenticationAPI
+            oauth_providers.append(CleverAuthenticationAPI.from_config())
+
+        if not basic_auth_provider and not oauth_providers:
             raise CannotLoadConfiguration(
                 "Unrecognized authentication provider: %s" % provider
             )
-        return api
+        return cls(basic_auth_provider, oauth_providers)
+
+    def __init__(self, basic_auth_provider=None, oauth_providers=None):
+        self.basic_auth_provider = basic_auth_provider
+        self.oauth_providers = oauth_providers or []
+        self.secret_key = Configuration.get(Configuration.SECRET_KEY)
 
     def server_side_validation(self, identifier, password):
         if not hasattr(self, 'identifier_re'):
@@ -49,5 +72,100 @@ class Authenticator(object):
             valid = valid and (self.password_re.match(password) is not None)
         return valid
 
-    def authenticated_patron(self, _db, identifier, password):
-        pass
+    def decode_token(self, token):
+        """Extract auth provider name and access token from JSON web token."""
+        decoded = jwt.decode(token, self.secret_key, algorithms=['HS256'])
+        provider_name = decoded['iss']
+        token = decoded['token']
+        return (provider_name, token)
+
+    def create_token(self, provider_name, provider_token):
+        """Create a JSON web token with the provider name and access token."""
+        payload = dict(
+            token=provider_token,
+            # I'm not sure this is the correct way to use an
+            # Issuer claim (https://tools.ietf.org/html/rfc7519#section-4.1.1).
+            # Maybe we should use something custom instead.
+            iss=provider_name,
+        )
+        return jwt.encode(payload, self.secret_key, algorithm='HS256')
+
+    def authenticated_patron(self, _db, header):
+        if self.basic_auth_provider and 'password' in header:
+            return self.basic_auth_provider.authenticated_patron(_db, header)
+        elif self.oauth_providers and 'bearer' in header.lower():
+            simplified_token = header.split(' ')[1]
+            provider_name, provider_token = self.decode_token(simplified_token)
+            for provider in self.oauth_providers:
+                if provider_name == provider.NAME:
+                    return provider.authenticated_patron(_db, provider_token)
+        return None
+
+    def oauth_callback(self, _db, params):
+        if self.oauth_providers and params.get('code') and params.get('state'):
+            for provider in self.oauth_providers:
+                if params.get('state') == provider.NAME:
+                    provider_token = provider.oauth_callback(_db, params)
+                    # Create an access token for our app that includes the provider
+                    # as well as the provider's token.
+                    simplified_token = self.create_token(provider.NAME, provider_token)
+
+                    # TODO: should we have a mobile redirect?
+                    # In a web application, this is where we'd redirect the client to the
+                    # page they came from. A WebView in a mobile app doesn't need that,
+                    # but we might want to redirect from a browser back to the app.
+                    return Response(json.dumps(dict(access_token=simplified_token)), 200, {"Content-Type": "application/json"})
+
+    def patron_info(self, header):
+        if self.basic_auth_provider and 'password' in header:
+            return self.basic_auth_provider.patron_info(header.get('username'))
+        elif self.oauth_providers and 'bearer' in header.lower():
+            simplified_token = header.split(' ')[1]
+            provider_name, provider_token = self.decode_token(simplified_token)
+            for provider in self.oauth_providers:
+                if provider_name == provider.NAME:
+                    return provider.patron_info(provider_token)
+        return {}
+            
+
+    def create_authentication_document(self):
+        """Create the OPDS authentication document to be used when
+        there's a 401 error.
+        """
+        base_opds_document = Configuration.base_opds_authentication_document()
+        auth_type = [OPDSAuthenticationDocument.BASIC_AUTH_FLOW]
+
+        custom_auth_types = {}
+        for provider in self.oauth_providers:
+            type = "http://librarysimplified.org/authtype/%s" % provider.NAME
+            custom_auth_types[type] = provider
+            auth_type.append(type)
+
+        circulation_manager_url = Configuration.integration_url(
+            Configuration.CIRCULATION_MANAGER_INTEGRATION, required=True)
+        scheme, netloc, path, parameters, query, fragment = (
+            urlparse.urlparse(circulation_manager_url))
+        opds_id = str(uuid.uuid3(uuid.NAMESPACE_DNS, str(netloc)))
+
+        links = {}
+        for rel, value in (
+                ("terms-of-service", Configuration.terms_of_service_url()),
+                ("privacy-policy", Configuration.privacy_policy_url()),
+                ("copyright", Configuration.acknowledgements_url()),
+                ("about", Configuration.about_url()),
+        ):
+            if value:
+                links[rel] = dict(href=value, type="text/html")
+
+        doc = OPDSAuthenticationDocument.fill_in(
+            base_opds_document, auth_type, "Library", opds_id, None, "Barcode",
+            "PIN", links=links
+            )
+
+        for type, provider in custom_auth_types.items():
+            provider_info = dict(
+                authenticate=provider.authenticate_url(),
+            )
+            doc[type] = provider_info
+
+        return json.dumps(doc)

--- a/api/clever.py
+++ b/api/clever.py
@@ -1,0 +1,107 @@
+from nose.tools import set_trace
+import logging
+import base64
+import json
+import requests
+from flask import url_for
+from authenticator import Authenticator
+from config import Configuration
+from core.model import (
+    get_one,
+    get_one_or_create,
+    Patron,
+)
+from problem_details import *
+
+class CleverAuthenticationAPI(Authenticator):
+
+    NAME = 'Clever'
+
+    CLEVER_OAUTH_URL = "https://clever.com/oauth/authorize?response_type=code&client_id=%s&redirect_uri=%s&state=Clever"
+    CLEVER_TOKEN_URL = "https://clever.com/oauth/tokens"
+    CLEVER_API_BASE_URL = "https://api.clever.com"
+
+    log = logging.getLogger('Clever authentication API')
+
+    def __init__(self, client_id, client_secret):
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    @classmethod
+    def from_config(cls):
+        config = Configuration.integration(cls.NAME, required=True)
+        client_id = config.get(Configuration.OAUTH_CLIENT_ID)
+        client_secret = config.get(Configuration.OAUTH_CLIENT_SECRET)
+        return cls(client_id, client_secret)
+
+    def authenticate_url(self):
+        redirect_uri = url_for('oauth_callback', _external=True)
+        return self.CLEVER_OAUTH_URL % (self.client_id, redirect_uri)
+
+    def authenticated_patron(self, _db, token):
+        bearer_headers = {
+            'Authorization': 'Bearer %s' % token
+        }
+
+        result = requests.get(self.CLEVER_API_BASE_URL + '/me', headers=bearer_headers).json()
+        data = result['data']
+
+        identifier = data['id']
+
+        patron = get_one(_db, Patron, authorization_identifier=identifier)
+        return patron
+
+
+    def oauth_callback(self, _db, params):
+        code = params.get('code')
+        payload = dict(
+            code=code,
+            grant_type='authorization_code',
+            redirect_uri=url_for('oauth_callback', _external=True),
+        )
+        headers = {
+            'Authorization': 'Basic %s' % base64.b64encode(self.client_id + ":" + self.client_secret),
+            'Content-Type': 'application/json',
+        }
+
+        response = requests.post(self.CLEVER_TOKEN_URL, data=json.dumps(payload), headers=headers).json()
+        token = response['access_token']
+
+        bearer_headers = {
+            'Authorization': 'Bearer %s' % token
+        }
+        result = requests.get(self.CLEVER_API_BASE_URL + '/me', headers=bearer_headers).json()
+        data = result['data']
+
+        # TODO: which teachers and admins should have access?
+        if result['type'] != 'student':
+            return INVALID_CREDENTIALS
+
+        identifier = data['id']
+        student = requests.get(self.CLEVER_API_BASE_URL + '/v1.1/students/%s' % identifier, headers=bearer_headers).json()
+
+        # TODO: check student free and reduced lunch status and/or school's NCES ID
+
+        student_data = student['data']
+        school_id = student_data['school']
+        school = requests.get(self.CLEVER_API_BASE_URL + '/v1.1/schools/%s' % school_id, headers=bearer_headers).json()
+
+        grade = student_data.get('grade')
+        external_type = None
+        if grade in ["Kindergarten", "1", "2", "3"]:
+            external_type = "E"
+        elif grade in ["4", "5", "6", "7", "8"]:
+            external_type = "M"
+        elif grade in ["9", "10", "11", "12"]:
+            external_type = "H"
+
+        patron, is_new = get_one_or_create(
+            _db, Patron, external_identifier=identifier,
+            authorization_identifier=identifier,
+        )
+        patron._external_type = external_type
+
+        return token
+
+    def patron_info(self, identifier):
+        return {}

--- a/api/clever.py
+++ b/api/clever.py
@@ -15,6 +15,7 @@ from problem_details import *
 
 class CleverAuthenticationAPI(Authenticator):
 
+    TYPE = Authenticator.OAUTH
     NAME = 'Clever'
 
     CLEVER_OAUTH_URL = "https://clever.com/oauth/authorize?response_type=code&client_id=%s&redirect_uri=%s&state=Clever"
@@ -35,6 +36,7 @@ class CleverAuthenticationAPI(Authenticator):
         return cls(client_id, client_secret)
 
     def authenticate_url(self):
+        """URL to direct patrons to for authentication with the provider."""
         redirect_uri = url_for('oauth_callback', _external=True)
         return self.CLEVER_OAUTH_URL % (self.client_id, redirect_uri)
 
@@ -105,3 +107,5 @@ class CleverAuthenticationAPI(Authenticator):
 
     def patron_info(self, identifier):
         return {}
+
+AuthenticationAPI = CleverAuthenticationAPI

--- a/api/config.py
+++ b/api/config.py
@@ -36,6 +36,10 @@ class Configuration(CoreConfiguration):
     AUTHENTICATION_TEST_USERNAME = "test_username"
     AUTHENTICATION_TEST_PASSWORD = "test_password"
 
+    OAUTH_CLIENT_ID = 'client_id'
+    OAUTH_CLIENT_SECRET = 'client_secret'
+    SECRET_KEY = "secret_key"
+
     MILLENIUM_INTEGRATION = "Millenium"
     STAFF_PICKS_INTEGRATION = "Staff Picks"
 

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -13,10 +13,12 @@ from core.model import (
 
 class FirstBookAuthenticationAPI(Authenticator):
 
+    TYPE = Authenticator.BASIC_AUTH
+    NAME = 'First Book'
+
     SUCCESS_MESSAGE = 'Valid Code Pin Pair'
 
     SECRET_KEY = 'key'
-    FIRSTBOOK = 'First Book'
 
     log = logging.getLogger("First Book authentication API")
 
@@ -29,7 +31,7 @@ class FirstBookAuthenticationAPI(Authenticator):
 
     @classmethod
     def from_config(cls):
-        config = Configuration.integration(cls.FIRSTBOOK, required=True)
+        config = Configuration.integration(cls.NAME, required=True)
         host = config.get(Configuration.URL)
         key = config.get(cls.SECRET_KEY)
         if not host:
@@ -115,3 +117,4 @@ class DummyFirstBookAuthentationAPI(FirstBookAuthenticationAPI):
                 return DummyFirstBookResponse(200, self.FAILURE)
 
 
+AuthenticationAPI = FirstBookAuthenticationAPI

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -63,7 +63,10 @@ class FirstBookAuthenticationAPI(Authenticator):
             return True
         return False
 
-    def authenticated_patron(self, _db, identifier, password):
+    def authenticated_patron(self, _db, header):
+        identifier = header.get('username')
+        password = header.get('password')
+
         # If they fail basic validation, there is no authenticated patron.
         if not self.server_side_validation(identifier, password):
             return None

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -117,7 +117,10 @@ class MilleniumPatronAPI(Authenticator, XMLParser):
             username = dump.get(self.USERNAME_FIELD),
         )
         
-    def authenticated_patron(self, db, identifier, password):
+    def authenticated_patron(self, db, header):
+        identifier = header.get('username')
+        password = header.get('password')
+
         # If they fail basic validation, there is no authenticated patron.
         if not self.server_side_validation(identifier, password):
             return None

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -19,6 +19,9 @@ from core.model import (
 
 class MilleniumPatronAPI(Authenticator, XMLParser):
 
+    TYPE = Authenticator.BASIC_AUTH
+    NAME = "Millenium"
+
     RECORD_NUMBER_FIELD = 'RECORD #[p81]'
     PATRON_TYPE_FIELD = 'P TYPE[p47]'
     EXPIRATION_FIELD = 'EXP DATE[p43]'
@@ -44,7 +47,7 @@ class MilleniumPatronAPI(Authenticator, XMLParser):
         self.parser = etree.HTMLParser()
 
     @classmethod
-    def from_environment(cls):
+    def from_config(cls):
         config = Configuration.integration(
             Configuration.MILLENIUM_INTEGRATION, required=True)
         host = config.get(Configuration.URL)
@@ -272,3 +275,5 @@ class DummyMilleniumPatronAPI(MilleniumPatronAPI):
         u['P BARCODE[pb]'] = barcode
         u['RECORD #[p81]'] = "200" + barcode
         return u
+
+AuthenticationAPI = MilleniumPatronAPI

--- a/api/routes.py
+++ b/api/routes.py
@@ -203,6 +203,12 @@ def adobe_vendor_id_accountinfo():
 def adobe_vendor_id_status():
     return app.manager.adobe_vendor_id.status_handler()
 
+# Redirect URI for OAuth providers, eg. Clever
+@app.route('/oauth_callback')
+@returns_problem_detail
+def oauth_callback():
+    return app.manager.auth.oauth_callback(app.manager._db, flask.request.args)
+
 
 # Controllers used for operations purposes
 @app.route('/heartbeat')

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ textblob
 
 # Used only by circulation
 oauth2client
+pyjwt
 
 # A NYPL-specific requirement
 newrelic

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -34,7 +34,7 @@ class TestVendorIDModel(DatabaseTest):
         # Normally this test patron doesn't have an authorization identifier.
         # Let's make sure there is one so it'll show up as the label.
         self.bob_patron = self.authenticator.authenticated_patron(
-            self._db, "5", "5555")
+            self._db, dict(username="5", password="5555"))
         self.bob_patron.authorization_identifier = "5"
 
     def test_uuid(self):
@@ -61,7 +61,7 @@ class TestVendorIDModel(DatabaseTest):
         eq_(credential.credential, bob_authdata.credential)
 
     def test_standard_lookup_success(self):
-        urn, label = self.model.standard_lookup("5", "5555")
+        urn, label = self.model.standard_lookup(dict(username="5", password="5555"))
 
         # There is now a UUID associated with Bob's patron account,
         # and that's the UUID returned by standard_lookup().
@@ -107,7 +107,7 @@ class TestVendorIDModel(DatabaseTest):
         eq_(None, label)
 
     def test_urn_to_label_success(self):
-        urn, label = self.model.standard_lookup("5", "5555")
+        urn, label = self.model.standard_lookup(dict(username="5", password="5555"))
         label2 = self.model.urn_to_label(urn)
         eq_(label, label2)
         eq_("Card number 5", label)
@@ -117,7 +117,7 @@ class TestVendorIDModel(DatabaseTest):
         eq_(None, label)
 
     def test_urn_to_label_failure_incorrect_urn(self):
-        urn, label = self.model.standard_lookup("5", "5555")
+        urn, label = self.model.standard_lookup(dict(username="5", password="5555"))
         label = self.model.urn_to_label("bad urn")
         eq_(None, label)
 
@@ -191,9 +191,9 @@ class TestVendorIDRequestHandler(object):
             self.TEST_VENDOR_ID)
 
     @classmethod
-    def _standard_login(cls, username, password):
+    def _standard_login(cls, data):
         return cls.username_password_lookup.get(
-            (username, password), (None, None))
+            (data.get('username'), data.get('password')), (None, None))
 
     @classmethod
     def _authdata_login(cls, authdata):

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1,0 +1,202 @@
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+import json
+from api.config import (
+    Configuration,
+    temp_config,
+)
+from api.authenticator import Authenticator
+from api.millenium_patron import MilleniumPatronAPI
+from api.firstbook import FirstBookAuthenticationAPI
+from api.clever import CleverAuthenticationAPI
+from . import DatabaseTest
+
+class DummyAuthAPI(Authenticator):
+    """ An Auth API that keeps track of how many times it's called."""
+    def __init__(self):
+        self.count = 0
+
+    def authenticated_patron(self, _db, header):
+        self.count = self.count + 1
+        return True
+
+    def patron_info(self, header):
+        self.count = self.count + 1
+        return True
+
+    def oauth_callback(self, _db, params):
+        self.count = self.count + 1
+        return "token"
+
+class TestAuthenticator(DatabaseTest):
+
+    def test_initialize(self):
+        # Only a basic auth provider.
+        with temp_config() as config:
+            config[Configuration.POLICIES] = {
+                Configuration.AUTHENTICATION_POLICY: 'Millenium'
+            }
+            
+            auth = Authenticator.initialize(self._db)
+
+            assert auth.basic_auth_provider != None
+            assert isinstance(auth.basic_auth_provider, MilleniumPatronAPI)
+
+            eq_(0, len(auth.oauth_providers))
+
+        # A basic auth provider and an oauth provider.
+        with temp_config() as config:
+            config[Configuration.POLICIES] = {
+                Configuration.AUTHENTICATION_POLICY: ['First Book', 'Clever']
+            }
+            config[Configuration.INTEGRATIONS] = {
+                FirstBookAuthenticationAPI.FIRSTBOOK: {
+                    Configuration.URL: "http://url",
+                    FirstBookAuthenticationAPI.SECRET_KEY: "secret",
+                },
+                CleverAuthenticationAPI.NAME: {
+                    Configuration.OAUTH_CLIENT_ID: 'client_id',
+                    Configuration.OAUTH_CLIENT_SECRET: 'client_secret',
+                }
+            }
+
+            auth = Authenticator.initialize(self._db)
+
+            assert auth.basic_auth_provider != None
+            assert isinstance(auth.basic_auth_provider, FirstBookAuthenticationAPI)
+
+            eq_(1, len(auth.oauth_providers))
+            assert isinstance(auth.oauth_providers[0], CleverAuthenticationAPI)
+
+        # Only an oauth provider
+        with temp_config() as config:
+            config[Configuration.POLICIES] = {
+                Configuration.AUTHENTICATION_POLICY: 'Clever'
+            }
+
+            auth = Authenticator.initialize(self._db)
+            eq_(None, auth.basic_auth_provider)
+
+            eq_(1, len(auth.oauth_providers))
+            assert isinstance(auth.oauth_providers[0], CleverAuthenticationAPI)
+
+    def test_create_decode_token(self):
+        auth = Authenticator.initialize(self._db)
+        token = auth.create_token("Provider name", "Provider token")
+
+        decoded_name, decoded_token = auth.decode_token(token)
+
+        eq_("Provider name", decoded_name)
+        eq_("Provider token", decoded_token)
+
+    def test_authenticated_patron(self):
+
+        # Check that the correct auth provider is called.
+        basic_auth = DummyAuthAPI()
+        oauth1 = DummyAuthAPI()
+        oauth1.NAME = "oauth1"
+        oauth2 = DummyAuthAPI()
+        oauth2.NAME = "oauth2"
+
+        auth = Authenticator.initialize(self._db, test=True)
+        auth.basic_auth_provider = basic_auth
+        auth.oauth_providers = [oauth1, oauth2]
+        
+        # Basic auth
+        header = dict(username="foo", password="bar")
+        auth.authenticated_patron(self._db, header)
+        eq_(1, basic_auth.count)
+        eq_(0, oauth1.count)
+        eq_(0, oauth2.count)
+
+        # Oauth 1
+        token = auth.create_token("oauth1", "token")
+        header = "Bearer: %s" % token
+        auth.authenticated_patron(self._db, header)
+        eq_(1, basic_auth.count)
+        eq_(1, oauth1.count)
+        eq_(0, oauth2.count)
+
+        # Oauth 2
+        token = auth.create_token("oauth2", "token")
+        header = "Bearer: %s" % token
+        auth.authenticated_patron(self._db, header)
+        eq_(1, basic_auth.count)
+        eq_(1, oauth1.count)
+        eq_(1, oauth2.count)
+
+    def test_oauth_callback(self):
+
+        # Check that the correct auth provider is called.
+        basic_auth = DummyAuthAPI()
+        oauth1 = DummyAuthAPI()
+        oauth1.NAME = "oauth1"
+        oauth2 = DummyAuthAPI()
+        oauth2.NAME = "oauth2"
+
+        auth = Authenticator.initialize(self._db, test=True)
+        auth.basic_auth_provider = basic_auth
+        auth.oauth_providers = [oauth1, oauth2]
+        
+        # Oauth 1
+        params = dict(code="foo", state="oauth1")
+        response = auth.oauth_callback(self._db, params)
+        eq_(0, basic_auth.count)
+        eq_(1, oauth1.count)
+        eq_(0, oauth2.count)
+        eq_(200, response.status_code)
+        token = json.loads(response.data).get("access_token")
+        provider_name, provider_token = auth.decode_token(token)
+        eq_("oauth1", provider_name)
+        eq_("token", provider_token)
+        
+        # Oauth 2
+        params = dict(code="foo", state="oauth2")
+        response = auth.oauth_callback(self._db, params)
+        eq_(0, basic_auth.count)
+        eq_(1, oauth1.count)
+        eq_(1, oauth2.count)
+        eq_(200, response.status_code)
+        token = json.loads(response.data).get("access_token")
+        provider_name, provider_token = auth.decode_token(token)
+        eq_("oauth2", provider_name)
+        eq_("token", provider_token)
+
+    def test_patron_info(self):
+
+        # Check that the correct auth provider is called.
+        basic_auth = DummyAuthAPI()
+        oauth1 = DummyAuthAPI()
+        oauth1.NAME = "oauth1"
+        oauth2 = DummyAuthAPI()
+        oauth2.NAME = "oauth2"
+
+        auth = Authenticator.initialize(self._db, test=True)
+        auth.basic_auth_provider = basic_auth
+        auth.oauth_providers = [oauth1, oauth2]
+        
+        # Basic auth
+        header = dict(username="foo", password="bar")
+        auth.patron_info(header)
+        eq_(1, basic_auth.count)
+        eq_(0, oauth1.count)
+        eq_(0, oauth2.count)
+
+        # Oauth 1
+        token = auth.create_token("oauth1", "token")
+        header = "Bearer: %s" % token
+        auth.patron_info(header)
+        eq_(1, basic_auth.count)
+        eq_(1, oauth1.count)
+        eq_(0, oauth2.count)
+
+        # Oauth 2
+        token = auth.create_token("oauth2", "token")
+        header = "Bearer: %s" % token
+        auth.patron_info(header)
+        eq_(1, basic_auth.count)
+        eq_(1, oauth1.count)
+        eq_(1, oauth2.count)
+

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -36,7 +36,7 @@ class TestAuthenticator(DatabaseTest):
         # Only a basic auth provider.
         with temp_config() as config:
             config[Configuration.POLICIES] = {
-                Configuration.AUTHENTICATION_POLICY: 'Millenium'
+                Configuration.AUTHENTICATION_POLICY: 'api.millenium_patron'
             }
             
             auth = Authenticator.initialize(self._db)
@@ -49,10 +49,10 @@ class TestAuthenticator(DatabaseTest):
         # A basic auth provider and an oauth provider.
         with temp_config() as config:
             config[Configuration.POLICIES] = {
-                Configuration.AUTHENTICATION_POLICY: ['First Book', 'Clever']
+                Configuration.AUTHENTICATION_POLICY: ['api.firstbook', 'api.clever']
             }
             config[Configuration.INTEGRATIONS] = {
-                FirstBookAuthenticationAPI.FIRSTBOOK: {
+                FirstBookAuthenticationAPI.NAME: {
                     Configuration.URL: "http://url",
                     FirstBookAuthenticationAPI.SECRET_KEY: "secret",
                 },
@@ -73,7 +73,7 @@ class TestAuthenticator(DatabaseTest):
         # Only an oauth provider
         with temp_config() as config:
             config[Configuration.POLICIES] = {
-                Configuration.AUTHENTICATION_POLICY: 'Clever'
+                Configuration.AUTHENTICATION_POLICY: 'api.clever'
             }
 
             auth = Authenticator.initialize(self._db)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -38,6 +38,11 @@ class TestAuthenticator(DatabaseTest):
             config[Configuration.POLICIES] = {
                 Configuration.AUTHENTICATION_POLICY: 'api.millenium_patron'
             }
+            config[Configuration.INTEGRATIONS] = {
+                MilleniumPatronAPI.NAME: {
+                    Configuration.URL: "http://url"
+                }
+            }
             
             auth = Authenticator.initialize(self._db)
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -80,6 +80,12 @@ class TestAuthenticator(DatabaseTest):
             config[Configuration.POLICIES] = {
                 Configuration.AUTHENTICATION_POLICY: 'api.clever'
             }
+            config[Configuration.INTEGRATIONS] = {
+                CleverAuthenticationAPI.NAME: {
+                    Configuration.OAUTH_CLIENT_ID: 'client_id',
+                    Configuration.OAUTH_CLIENT_SECRET: 'client_secret',
+                }
+            }
 
             auth = Authenticator.initialize(self._db)
             eq_(None, auth.basic_auth_provider)
@@ -88,7 +94,7 @@ class TestAuthenticator(DatabaseTest):
             assert isinstance(auth.oauth_providers[0], CleverAuthenticationAPI)
 
     def test_create_decode_token(self):
-        auth = Authenticator.initialize(self._db)
+        auth = Authenticator.initialize(self._db, test=True)
         token = auth.create_token("Provider name", "Provider token")
 
         decoded_name, decoded_token = auth.decode_token(token)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -153,15 +153,15 @@ class TestBaseController(CirculationControllerTest):
             eq_(self.app.manager._db, self._db)
 
     def test_authenticated_patron_invalid_credentials(self):
-        value = self.controller.authenticated_patron("5", "1234")
+        value = self.controller.authenticated_patron(dict(username="5", password="1234"))
         eq_(value, INVALID_CREDENTIALS)
 
     def test_authenticated_patron_expired_credentials(self):
-        value = self.controller.authenticated_patron("0", "0000")
+        value = self.controller.authenticated_patron(dict(username="0", password="0000"))
         eq_(value, EXPIRED_CREDENTIALS)
 
     def test_authenticated_patron_correct_credentials(self):
-        value = self.controller.authenticated_patron("5", "5555")
+        value = self.controller.authenticated_patron(dict(username="5", password="5555"))
         assert isinstance(value, Patron)
 
     def test_load_lane(self):
@@ -218,7 +218,7 @@ class TestBaseController(CirculationControllerTest):
 
     def test_apply_borrowing_policy_when_holds_prohibited(self):
         
-        patron = self.controller.authenticated_patron("5", "5555")
+        patron = self.controller.authenticated_patron(dict(username="5", password="5555"))
         with temp_config() as config:
             config[Configuration.POLICIES] = {
                 Configuration.HOLD_POLICY : Configuration.HOLD_POLICY_HIDE
@@ -247,7 +247,7 @@ class TestBaseController(CirculationControllerTest):
 
     def test_apply_borrowing_policy_for_audience_restriction(self):
 
-        patron = self.controller.authenticated_patron("5", "5555")
+        patron = self.controller.authenticated_patron(dict(username="5", password="5555"))
         work = self._work(with_license_pool=True)
         [pool] = work.license_pools
 

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -87,19 +87,19 @@ class TestMilleniumPatronAPI(DatabaseTest):
         # Patron is valid, but not in our database yet
         self.api.enqueue("dump.success.html")
         self.api.enqueue("pintest.good.html")
-        alice = self.api.authenticated_patron(self._db, "alice", "4444")
+        alice = self.api.authenticated_patron(self._db, dict(username="alice", password="4444"))
         eq_("44444444444447", alice.authorization_identifier)
         eq_("alice", alice.username)
 
         # Patron is in the db, now authenticate with barcode
         self.api.enqueue("pintest.good.html")
-        alice = self.api.authenticated_patron(self._db, "44444444444447", "4444")
+        alice = self.api.authenticated_patron(self._db, dict(username="44444444444447", password="4444"))
         eq_("44444444444447", alice.authorization_identifier)
         eq_("alice", alice.username)
 
         # Authenticate with username again
         self.api.enqueue("pintest.good.html")
-        alice = self.api.authenticated_patron(self._db, "alice", "4444")
+        alice = self.api.authenticated_patron(self._db, dict(username="alice", password="4444"))
         eq_("44444444444447", alice.authorization_identifier)
         eq_("alice", alice.username)
 


### PR DESCRIPTION
This branch adds support for OAuth authentication providers. A circulation manager can support multiple OAuth providers and one basic auth provider.

The first OAuth provider is Clever - this branch has an initial implementation but it needs more work once we know the requirements.

Providers are now configured by module name in the config file, eg `['api.firstbook', 'api.clever']` - and this requires changing the existing config files. In the future we could move the auth provider modules to a different package or repo.