### PR TITLE
'Other Language' sublanes

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -17,6 +17,7 @@ class Configuration(CoreConfiguration):
     LANGUAGE_FORCE = "force"
     LARGE_COLLECTION_LANGUAGES = "large_collections"
     SMALL_COLLECTION_LANGUAGES = "small_collections"
+    TINY_COLLECTION_LANGUAGES = "tiny_collections"
 
     LANES_POLICY = "lanes"
     DEFAULT_OPDS_FORMAT = "simple_opds_entry"
@@ -78,6 +79,19 @@ class Configuration(CoreConfiguration):
         value = cls.language_policy().get(cls.SMALL_COLLECTION_LANGUAGES, '')
         logging.info("Language policy: %r" % cls.language_policy())
         logging.info("Small collections: %r" % value)
+        if not value:
+            return []
+        if isinstance(value, list):
+            return value
+        return [[x] for x in value.split(',')]
+
+    @classmethod
+    def tiny_collection_languages(cls):
+        import logging
+        logging.info("In tiny_collection_languages.")
+        value = cls.language_policy().get(cls.TINY_COLLECTION_LANGUAGES, '')
+        logging.info("Language policy: %r" % cls.language_policy())
+        logging.info("Tiny collections: %r" % value)
         if not value:
             return []
         if isinstance(value, list):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -42,14 +42,14 @@ def make_lanes_default(_db):
     # Fiction", "Adult Nonfiction", and "Children/YA" sublanes.
     #
     # Finally the top-level LaneList includes an "Other Languages" sublane
-    # which covers all other languages. This lane contains "Adult Fiction",
-    # "Adult Nonfiction", and "Children/YA" sublanes.
+    # which covers all other languages. This lane contains sublanes for each
+    # of the tiny-collection languages in the configuration.
     seen_languages = set()
 
     top_level_lanes = []
 
     def language_list(x):
-        if isinstance(language_set, basestring):
+        if isinstance(x, basestring):
             return x.split(',')
         return x
 
@@ -339,44 +339,27 @@ def lane_for_small_collection(_db, languages):
 def lane_for_other_languages(_db, exclude_languages):
     """Make a lane for all books not in one of the given languages."""
 
-    YA = Classifier.AUDIENCE_YOUNG_ADULT
-    CHILDREN = Classifier.AUDIENCE_CHILDREN
+    language_lanes = []
+    other_languages = Configuration.tiny_collection_languages()
 
-    common_args = dict(
-        exclude_languages=exclude_languages,
-        genres=None,
-    )
-
-    adult_fiction = Lane(
-        _db, 
-        full_name="Adult Fiction",
-        display_name="Fiction",
-        fiction=True, 
-        audiences=Classifier.AUDIENCES_ADULT,
-        **common_args
-    )
-    adult_nonfiction = Lane(
-        _db, full_name="Adult Nonfiction", 
-        display_name="Nonfiction",
-        fiction=False, 
-        audiences=Classifier.AUDIENCES_ADULT,
-        **common_args
-    )
-
-    ya_children = Lane(
-        _db, 
-        full_name="Children & Young Adult", 
-        fiction=Lane.BOTH_FICTION_AND_NONFICTION,
-        audiences=[YA, CHILDREN],
-        **common_args
-    )
+    for language_set in other_languages:
+        name = LanguageCodes.name_for_languageset(language_set)
+        language_lane = Lane(
+            _db, full_name=name,
+            genres=None,
+            fiction=Lane.BOTH_FICTION_AND_NONFICTION,
+            searchable=True,
+            languages=language_set,
+        )
+        language_lanes.append(language_lane)
 
     lane = Lane(
         _db, 
         full_name="Other Languages", 
-        sublanes=[adult_fiction, adult_nonfiction, ya_children],
+        sublanes=language_lanes,
+        exclude_languages=exclude_languages,
         searchable=True,
-        **common_args
+        genres=None,
     )
     lane.default_for_language = True
     return lane

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -63,7 +63,9 @@ def make_lanes_default(_db):
         seen_languages = seen_languages.union(set(languages))
         top_level_lanes.append(lane_for_small_collection(_db, language_set))
 
-    top_level_lanes.append(lane_for_other_languages(_db, seen_languages))
+    other_languages_lane = lane_for_other_languages(_db, seen_languages)
+    if other_languages_lane:
+        top_level_lanes.append(other_languages_lane)
 
     return LaneList.from_description(_db, None, top_level_lanes)
 
@@ -341,6 +343,9 @@ def lane_for_other_languages(_db, exclude_languages):
 
     language_lanes = []
     other_languages = Configuration.tiny_collection_languages()
+
+    if not other_languages:
+        return None
 
     for language_set in other_languages:
         name = LanguageCodes.name_for_languageset(language_set)

--- a/bin/informational/language_list
+++ b/bin/informational/language_list
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""List languages in the collection sorted by number of non-open access works."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import (
+     LanguageListScript
+)
+LanguageListScript().run()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -837,7 +837,6 @@ class TestFeedController(CirculationControllerTest):
                         counter[link['title']] += 1
                 eq_(2, counter['Nonfiction'])
                 eq_(2, counter['Fiction'])
-                eq_(1, counter['Other Languages'])
 
 
     def test_search(self):

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -108,6 +108,20 @@ class TestLaneCreation(DatabaseTest):
                 [x.languages for x in lane.sublanes.lanes]
             )
 
+        # If no tiny languages are configured, the other languages lane
+        # doesn't show up.
+        with temp_config() as config:
+            config[Configuration.POLICIES] = {
+                Configuration.LANGUAGE_POLICY: {
+                    Configuration.LARGE_COLLECTION_LANGUAGES : 'eng'
+                }
+            }
+
+            exclude = ['eng', 'spa']
+            lane = lane_for_other_languages(self._db, exclude)
+            eq_(None, lane)
+
+
     def test_make_lanes_default(self):
         with temp_config() as config:
             config[Configuration.POLICIES] = {
@@ -115,6 +129,7 @@ class TestLaneCreation(DatabaseTest):
                 Configuration.LANGUAGE_POLICY : {
                     Configuration.LARGE_COLLECTION_LANGUAGES : 'eng',
                     Configuration.SMALL_COLLECTION_LANGUAGES : 'spa,chi',
+                    Configuration.TINY_COLLECTION_LANGUAGES : 'ger,fre,ita'
                 }
             }
             lane_list = make_lanes_default(self._db)

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -88,15 +88,25 @@ class TestLaneCreation(DatabaseTest):
 
     def test_lane_for_other_languages(self):
 
-        exclude = ['eng', 'spa']
-        lane = lane_for_other_languages(self._db, exclude)
-        eq_(None, lane.languages)
-        eq_(exclude, lane.exclude_languages)
-        eq_("Other Languages", lane.name)
-        eq_(
-            ['Adult Fiction', 'Adult Nonfiction', 'Children & Young Adult'],
-            [x.name for x in lane.sublanes.lanes]
-        )
+        with temp_config() as config:
+            config[Configuration.POLICIES] = {
+                Configuration.LANGUAGE_POLICY: {
+                    Configuration.TINY_COLLECTION_LANGUAGES : 'ger,fre,ita'
+                }
+            }
+
+            exclude = ['eng', 'spa']
+            lane = lane_for_other_languages(self._db, exclude)
+            eq_(None, lane.languages)
+            eq_(exclude, lane.exclude_languages)
+            eq_("Other Languages", lane.name)
+            eq_(
+                ['German', 'French', 'Italian'],
+                [x.name for x in lane.sublanes.lanes]
+            )
+            eq_([['ger'], ['fre'], ['ita']],
+                [x.languages for x in lane.sublanes.lanes]
+            )
 
     def test_make_lanes_default(self):
         with temp_config() as config:


### PR DESCRIPTION
This branch changes the "Other Languages" lane to have sublanes for languages specified in the config file, instead of audiences and fiction status.

It also has a script that prints out all the languages with at least one non-open access work and the number of works they have.