### PR TITLE
More accurate language count

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -495,12 +495,18 @@ class LanguageListScript(Script):
             LicensePool.licenses_owned > 0
         ).filter(
             Edition.medium==Edition.BOOK_MEDIUM
+        ).filter(
+            Edition.language != None
         )
-
-        sorted_languages = sorted(query.all(), key=lambda x: -x[1])
+        name = LanguageCodes.name_for_languageset
+        sorted_languages = sorted(
+            query.all(), key=lambda x: (
+                -x[1], name(x[0])
+            )
+        )
         sorted_languages = [
-            (language, count, LanguageCodes.name_for_languageset([language]))
-            for (language, count) in sorted_languages if language
+            (language, count, name(language))
+            for (language, count) in sorted_languages
         ]
 
         print "\n".join(["%s %i (%s)" % l for l in sorted_languages])


### PR DESCRIPTION
This branch changes the LanguageScript to exclude things that aren't books (i.e. foreign-language movies) and LicensePools where no licenses are currently owned. I also improved the script output to a) give human-readable language names to the person running the script, who probably doesn't know all the language codes, and b) provide a sample value for `tiny_language_collections` which can be edited to taste.

I also changed the code so that if two languages have the same number of books, they're ordered by the English name of the language.