### PR TITLE
Got the content server bibliographic coverage provider to work.

### DIFF
--- a/api/coverage.py
+++ b/api/coverage.py
@@ -139,7 +139,10 @@ class OPDSImportCoverageProvider(CoverageProvider):
         # id_mapping maps our local identifiers to identifiers the
         # foreign data source will reocgnize.
         id_mapping = self.create_identifier_mapping(batch)
-        foreign_identifiers = id_mapping.keys()
+        if id_mapping:
+            foreign_identifiers = id_mapping.keys()
+        else:
+            foreign_identifiers = batch
 
         response = self.lookup.lookup(foreign_identifiers)
 
@@ -344,7 +347,20 @@ class ContentServerBibliographicCoverageProvider(OPDSImportCoverageProvider):
             _db, DataSource.OA_CONTENT_SERVER
         )
         super(ContentServerBibliographicCoverageProvider, self).__init__(
-            service_name, lookup=lookup, output_source=output_source,
-            expect_license_pool=True, presentation_ready_on_success=True
+            service_name, input_identifier_types=None,
+            output_source=output_source, lookup=lookup,
+            expect_license_pool=True, presentation_ready_on_success=True,
             **kwargs
         )
+
+    @property
+    def items_that_need_coverage(self):
+        """Only identifiers associated with an open-access license
+        need coverage.
+        """
+        qu = super(ContentServerBibliographicCoverageProvider, 
+                   self).items_that_need_coverage
+        qu = qu.join(Identifier.licensed_through).filter(
+            LicensePool.open_access==True
+        )
+        return qu

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -35,6 +35,7 @@ from core.coverage import (
 from core.util.http import BadResponseException
 
 from api.coverage import (
+    ContentServerBibliographicCoverageProvider,
     MetadataWranglerCoverageProvider,
     MetadataWranglerCollectionReaper,
     OPDSImportCoverageProvider,
@@ -321,3 +322,24 @@ class TestMetadataWranglerCollectionReaper(DatabaseTest):
         # The syncing record has been deleted from the database
         assert doubly_sync_record not in remaining_records
         eq_([sync_cr, reaped_cr, doubly_reap_record], remaining_records)
+
+
+class TestContentServerBibliographicCoverageProvider(DatabaseTest):
+
+    def test_only_open_access_books_considered(self):
+
+        lookup = MockSimplifiedOPDSLookup(self._url)        
+        provider = ContentServerBibliographicCoverageProvider(
+            self._db, lookup=lookup
+        )
+
+        # Here's an open-access work.
+        w1 = self._work(with_license_pool=True, with_open_access_download=True)
+
+        # Here's a work that's not open-access.
+        w2 = self._work(with_license_pool=True, with_open_access_download=False)
+        w2.license_pools[0].open_access = False
+
+        # Only the open-access work needs coverage.
+        eq_([w1.license_pools[0].identifier],
+            provider.items_that_need_coverage.all())


### PR DESCRIPTION
This branch makes ContentServerBibliographicCoverageProvider actually do what it's supposed to--update the metadata of open-access books by running them through the content server's lookup protocol. It looks like this stopped working once I refactored coverage.py on May 27. This time there are tests.