### PR TITLE
Add series lanes and a groups feed for all books related to a particular work.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -845,9 +845,7 @@ class WorkController(CirculationManagerController):
         )
         annotator = self.manager.annotator(lane)
         feed = AcquisitionFeed.groups(
-            self._db, lane.DISPLAY_NAME, url, lane,
-            annotator=annotator,
-            ignore_feed_size=True,
+            self._db, lane.DISPLAY_NAME, url, lane, annotator=annotator,
             use_materialized_works=use_materialized_works
         )
         return feed_response(unicode(feed.content))

--- a/api/controller.py
+++ b/api/controller.py
@@ -815,7 +815,7 @@ class WorkController(CirculationManagerController):
         )
         annotator = self.manager.annotator(lane)
         feed = AcquisitionFeed.page(
-            self._db, 'Related Works', url, lane,
+            self._db, lane.DISPLAY_NAME, url, lane,
             annotator=annotator, cache_type=CachedFeed.RECOMMENDATIONS_TYPE,
             use_materialized_works=use_materialized_works
         )
@@ -853,7 +853,7 @@ class WorkController(CirculationManagerController):
         if not series:
             return NO_SUCH_LANE.detailed("%s is not in a series" % edition.title)
 
-        feed_title = self._series_feed_title(series)
+        feed_title = SeriesLane.lane_name_from_series_title(series)
         lane = SeriesLane(self._db, pool, feed_title)
         use_materialized_works = not self.manager.testing
         url = self.cdn_url_for(
@@ -868,15 +868,6 @@ class WorkController(CirculationManagerController):
         )
 
         return feed_response(unicode(feed.content))
-
-    def _series_feed_title(self, series_title):
-        feed_title = "Other Books in "
-        if series_title[:3].lower() != 'the':
-            feed_title += "the "
-        feed_title += series_title
-        if series_title.lower().endswith(' series'):
-            return feed_title
-        return feed_title + ' series'
 
 
 class AnalyticsController(CirculationManagerController):

--- a/api/controller.py
+++ b/api/controller.py
@@ -809,7 +809,6 @@ class WorkController(CirculationManagerController):
             # NoveList isn't configured.
             return NO_SUCH_LANE.detailed("Recommendations not available: %r" % e)
 
-        use_materialized_works = not self.manager.testing
         url = self.cdn_url_for(
             'recommendations', data_source=data_source,
             identifier_type=identifier_type, identifier=identifier
@@ -817,8 +816,7 @@ class WorkController(CirculationManagerController):
         annotator = self.manager.annotator(lane)
         feed = AcquisitionFeed.page(
             self._db, lane.DISPLAY_NAME, url, lane,
-            annotator=annotator, cache_type=CachedFeed.RECOMMENDATIONS_TYPE,
-            use_materialized_works=use_materialized_works
+            annotator=annotator, cache_type=CachedFeed.RECOMMENDATIONS_TYPE
         )
 
         return feed_response(unicode(feed.content))
@@ -829,6 +827,7 @@ class WorkController(CirculationManagerController):
         pool = self.load_licensepool(data_source, identifier_type, identifier)
         if isinstance(pool, ProblemDetail):
             return pool
+
         try:
             lane_name = "Books Related to %s by %s" % (
                 pool.work.title, pool.work.author
@@ -838,15 +837,14 @@ class WorkController(CirculationManagerController):
             # No related books were found.
             return NO_SUCH_LANE.detailed(e.message)
 
-        use_materialized_works = not self.manager.testing
+
         url = self.cdn_url_for(
             'related_books', data_source=data_source,
             identifier_type=identifier_type, identifier=identifier
         )
         annotator = self.manager.annotator(lane)
         feed = AcquisitionFeed.groups(
-            self._db, lane.DISPLAY_NAME, url, lane, annotator=annotator,
-            use_materialized_works=use_materialized_works
+            self._db, lane.DISPLAY_NAME, url, lane, annotator=annotator
         )
         return feed_response(unicode(feed.content))
 
@@ -883,7 +881,6 @@ class WorkController(CirculationManagerController):
 
         feed_title = SeriesLane.lane_name_from_series_title(series)
         lane = SeriesLane(self._db, pool, feed_title)
-        use_materialized_works = not self.manager.testing
         url = self.cdn_url_for(
             'series', data_source=data_source,
             identifier_type=identifier_type, identifier=identifier
@@ -891,8 +888,7 @@ class WorkController(CirculationManagerController):
         annotator = self.manager.annotator(lane)
         feed = AcquisitionFeed.page(
             self._db, feed_title, url, lane,
-            annotator=annotator, cache_type=CachedFeed.SERIES_TYPE,
-            use_materialized_works=use_materialized_works
+            annotator=annotator, cache_type=CachedFeed.SERIES_TYPE
         )
 
         return feed_response(unicode(feed.content))

--- a/api/controller.py
+++ b/api/controller.py
@@ -891,15 +891,14 @@ class WorkController(CirculationManagerController):
         if not series:
             return NO_SUCH_LANE.detailed("%s is not in a series" % edition.title)
 
-        feed_title = SeriesLane.lane_name_from_series_title(series)
-        lane = SeriesLane(self._db, pool, feed_title)
+        lane = SeriesLane(self._db, pool)
         url = self.cdn_url_for(
             'series', data_source=data_source,
             identifier_type=identifier_type, identifier=identifier
         )
         annotator = self.manager.annotator(lane)
         feed = AcquisitionFeed.page(
-            self._db, feed_title, url, lane,
+            self._db, lane.display_name, url, lane,
             annotator=annotator, cache_type=CachedFeed.SERIES_TYPE
         )
 
@@ -915,6 +914,7 @@ class AnalyticsController(CirculationManagerController):
             return Response({}, 200)
         else:
             return INVALID_ANALYTICS_EVENT_TYPE
+
 
 class ServiceStatusController(CirculationManagerController):
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -848,7 +848,6 @@ class WorkController(CirculationManagerController):
             self._db, lane.DISPLAY_NAME, url, lane,
             annotator=annotator,
             ignore_feed_size=True,
-            cache_type=CachedFeed.RECOMMENDATIONS_TYPE,
             use_materialized_works=use_materialized_works
         )
         return feed_response(unicode(feed.content))

--- a/api/controller.py
+++ b/api/controller.py
@@ -801,7 +801,8 @@ class WorkController(CirculationManagerController):
             AcquisitionFeed.single_entry(self._db, work, annotator)
         )
 
-    def recommendations(self, data_source, identifier_type, identifier, mock_api=None):
+    def recommendations(self, data_source, identifier_type, identifier,
+                        novelist_api=None):
         """Serve a feed of recommendations related to a given book."""
 
         pool = self.load_licensepool(data_source, identifier_type, identifier)
@@ -810,7 +811,9 @@ class WorkController(CirculationManagerController):
 
         lane_name = "Recommendations for %s by %s" % (pool.work.title, pool.work.author)
         try:
-            lane = RecommendationLane(self._db, pool, lane_name, mock_api=mock_api)
+            lane = RecommendationLane(
+                self._db, pool, lane_name, novelist_api=novelist_api
+            )
         except ValueError, e:
             # NoveList isn't configured.
             return NO_SUCH_LANE.detailed("Recommendations not available: %r" % e)
@@ -827,7 +830,8 @@ class WorkController(CirculationManagerController):
 
         return feed_response(unicode(feed.content))
 
-    def related(self, data_source, identifier_type, identifier, mock_api=None):
+    def related(self, data_source, identifier_type, identifier,
+                novelist_api=None):
         """Serve a groups feed of books related to a given book."""
 
         pool = self.load_licensepool(data_source, identifier_type, identifier)
@@ -838,7 +842,9 @@ class WorkController(CirculationManagerController):
             lane_name = "Books Related to %s by %s" % (
                 pool.work.title, pool.work.author
             )
-            lane = RelatedBooksLane(self._db, pool, lane_name, mock_api=mock_api)
+            lane = RelatedBooksLane(
+                self._db, pool, lane_name, novelist_api=novelist_api
+            )
         except ValueError, e:
             # No related books were found.
             return NO_SUCH_LANE.detailed(e.message)

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -453,9 +453,11 @@ class RelatedBooksLane(LicensePoolBasedLane):
             lane_name = "Recommendations for %s by %s" % (
                 license_pool.work.title, license_pool.work.author
             )
-            sublanes.append(RecommendationLane(
+            recommendation_lane = RecommendationLane(
                 _db, license_pool, lane_name, novelist_api=novelist_api
-            ))
+            )
+            if recommendation_lane.recommendations:
+                sublanes.append(recommendation_lane)
         except ValueError, e:
             # NoveList isn't configured.
             pass

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -432,8 +432,8 @@ class RelatedBooksLane(LicensePoolBasedLane):
     DISPLAY_NAME = "Related Books"
 
     def __init__(self, _db, license_pool, full_name, display_name=None,
-                 mock_api=None):
-        sublanes = self._get_sublanes(_db, license_pool, mock_api=mock_api)
+                 novelist_api=None):
+        sublanes = self._get_sublanes(_db, license_pool, novelist_api=novelist_api)
         if not sublanes:
             edition = license_pool.presentation_edition
             raise ValueError(
@@ -445,7 +445,7 @@ class RelatedBooksLane(LicensePoolBasedLane):
             invisible=True
         )
 
-    def _get_sublanes(self, _db, license_pool, mock_api=None):
+    def _get_sublanes(self, _db, license_pool, novelist_api=None):
         sublanes = []
 
         # Create a recommendations sublane.
@@ -454,7 +454,7 @@ class RelatedBooksLane(LicensePoolBasedLane):
                 license_pool.work.title, license_pool.work.author
             )
             sublanes.append(RecommendationLane(
-                _db, license_pool, lane_name, mock_api=mock_api
+                _db, license_pool, lane_name, novelist_api=novelist_api
             ))
         except ValueError, e:
             # NoveList isn't configured.
@@ -513,8 +513,8 @@ class RecommendationLane(LicensePoolBasedLane):
     MAX_CACHE_AGE = 7*24*60*60      # one week
 
     def __init__(self, _db, license_pool, full_name, display_name=None,
-            mock_api=None):
-        self.api = mock_api or NoveListAPI.from_config(_db)
+            novelist_api=None):
+        self.api = novelist_api or NoveListAPI.from_config(_db)
         super(RecommendationLane, self).__init__(
             _db, license_pool, full_name, display_name=display_name
         )

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -465,8 +465,7 @@ class RelatedBooksLane(LicensePoolBasedLane):
         # Create a series sublane.
         series = license_pool.presentation_edition.series
         if series:
-            lane_name = SeriesLane.lane_name_from_series_title(series)
-            sublanes.append(SeriesLane(_db, license_pool, lane_name))
+            sublanes.append(SeriesLane(_db, license_pool))
 
         return sublanes
 
@@ -479,7 +478,12 @@ class RelatedBooksLane(LicensePoolBasedLane):
 class SeriesLane(LicensePoolBasedLane):
     """A lane of Works in a series based on a particular LicensePool"""
 
-    DISPLAY_NAME = "Other Books in this Series"
+    def __init__(self, _db, license_pool):
+        series_name = license_pool.presentation_edition.series
+        full_name = display_name = series_name
+        super(SeriesLane, self).__init__(
+            _db, license_pool, full_name, display_name=display_name
+        )
 
     def apply_filters(self, qu, work_model=Work, *args, **kwargs):
         edition = self.license_pool.presentation_edition
@@ -494,16 +498,6 @@ class SeriesLane(LicensePoolBasedLane):
         qu = qu.join(work_edition).filter(work_edition.series==series)
         qu = qu.order_by(work_edition.series_position, work_edition.title)
         return qu
-
-    @classmethod
-    def lane_name_from_series_title(cls, series_title):
-        feed_title = "Other Books in "
-        if series_title[:3].lower() != 'the':
-            feed_title += "the "
-        feed_title += series_title
-        if series_title.lower().endswith(' series'):
-            return feed_title
-        return feed_title + ' series'
 
 
 class RecommendationLane(LicensePoolBasedLane):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -491,10 +491,8 @@ class SeriesLane(LicensePoolBasedLane):
         # Aliasing Edition here allows this query to function
         # regardless of work_model and existing joins.
         work_edition = aliased(Edition)
-        qu = qu.join(work_edition).filter(
-            work_edition.series==series,
-            work_edition.id!=edition.id
-        )
+        qu = qu.join(work_edition).filter(work_edition.series==series)
+        qu = qu.order_by(work_edition.series_position, work_edition.title)
         return qu
 
     @classmethod

--- a/api/novelist.py
+++ b/api/novelist.py
@@ -402,10 +402,13 @@ class NoveListCoverageProvider(CoverageProvider):
 
         if edition.series or edition.series_position:
             metadata.primary_identifier = identifier
-            # Series data from NoveList is appealing, but we want to avoid
+            # Series data from NoveList is appealing, but we need to avoid
             # creating any potentially-inaccurate ISBN equivalencies on the
             # license source identifier.
+            #
+            # So just remove the identifiers from the metadata object entirely.
             metadata.identifiers = []
+            # Before creating an edition for the original identifier.
             novelist_edition, ignore = metadata.edition(self._db)
             metadata.apply(novelist_edition)
 

--- a/api/novelist.py
+++ b/api/novelist.py
@@ -29,6 +29,7 @@ from core.util import TitleProcessor
 
 class NoveListAPI(object):
 
+    IS_CONFIGURED = None
     log = logging.getLogger("NoveList API")
     version = "2.2"
 
@@ -58,8 +59,10 @@ class NoveListAPI(object):
 
     @classmethod
     def is_configured(cls):
-        profile, password = cls.values()
-        return bool(profile and password)
+        if cls.IS_CONFIGURED is None:
+            profile, password = cls.values()
+            cls.IS_CONFIGURED = bool(profile and password)
+        return cls.IS_CONFIGURED
 
     def __init__(self, _db, profile, password):
         self._db = _db

--- a/api/opds.py
+++ b/api/opds.py
@@ -246,18 +246,26 @@ class CirculationManagerAnnotator(Annotator):
             entry.append(tag)
 
         # Add a link for related recommendations if available.
-        if NoveListAPI.is_configured():
+        if self.related_books_available(active_license_pool):
             feed.add_link_to_entry(
                 entry,
                 rel='related',
                 type=OPDSFeed.ACQUISITION_FEED_TYPE,
                 title='Recommended Works',
                 href=self.url_for(
-                    'recommendations',
+                    'related_books',
                     data_source=data_source_name, identifier_type=identifier.type,
                     identifier=identifier.identifier, _external=True
                 )
             )
+
+    @classmethod
+    def related_books_available(cls, license_pool):
+        """:return: bool asserting whether related books are available for a
+        particular work
+        """
+        series = license_pool.presentation_edition.series
+        return NoveListAPI.is_configured() or series
 
     def annotate_feed(self, feed, lane):
         if self.patron:

--- a/api/routes.py
+++ b/api/routes.py
@@ -181,6 +181,11 @@ def permalink(data_source, identifier_type, identifier):
 def recommendations(data_source, identifier_type, identifier):
     return app.manager.work_controller.recommendations(data_source, identifier_type, identifier)
 
+@app.route('/works/<data_source>/<identifier_type>/<path:identifier>/related_books')
+@returns_problem_detail
+def related_books(data_source, identifier_type, identifier):
+    return app.manager.work_controller.related(data_source, identifier_type, identifier)
+
 @app.route('/works/<data_source>/<identifier_type>/<path:identifier>/report', methods=['GET', 'POST'])
 @returns_problem_detail
 def report(data_source, identifier_type, identifier):

--- a/api/routes.py
+++ b/api/routes.py
@@ -186,6 +186,11 @@ def recommendations(data_source, identifier_type, identifier):
 def report(data_source, identifier_type, identifier):
     return app.manager.work_controller.report(data_source, identifier_type, identifier)
 
+@app.route('/works/<data_source>/<identifier_type>/<path:identifier>/series')
+@returns_problem_detail
+def series(data_source, identifier_type, identifier):
+    return app.manager.work_controller.series(data_source, identifier_type, identifier)
+
 @app.route('/analytics/<data_source>/<identifier_type>/<path:identifier>/<event_type>')
 @returns_problem_detail
 def track_analytics_event(data_source, identifier_type, identifier, event_type):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -732,7 +732,7 @@ class TestWorkController(CirculationControllerTest):
             )
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
-        eq_('Related Works', feed['feed']['title'])
+        eq_('Recommended Books', feed['feed']['title'])
         eq_(0, len(feed['entries']))
 
         # Delete the cache and prep a recommendation result.
@@ -740,15 +740,15 @@ class TestWorkController(CirculationControllerTest):
         self._db.delete(cached_empty_feed)
         metadata.recommendations = [self.english_2.license_pools[0].identifier]
         mock_api.setup(metadata)
-
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.recommendations(
                 self.datasource, self.identifier.type, self.identifier.identifier,
                 mock_api=mock_api
             )
+        # A feed is returned with the proper recommendation.
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
-        eq_('Related Works', feed['feed']['title'])
+        eq_('Recommended Books', feed['feed']['title'])
         eq_(1, len(feed['entries']))
         [entry] = feed['entries']
         eq_(self.english_2.title, entry['title'])
@@ -822,6 +822,7 @@ class TestWorkController(CirculationControllerTest):
         eq_(1, len(feed['entries']))
         [entry] = feed['entries']
         eq_(self.english_2.title, entry['title'])
+
 
 class TestFeedController(CirculationControllerTest):
 
@@ -924,7 +925,6 @@ class TestFeedController(CirculationControllerTest):
                         counter[link['title']] += 1
                 eq_(2, counter['Nonfiction'])
                 eq_(2, counter['Fiction'])
-
 
     def test_search(self):
         # Put two works into the search index

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -810,13 +810,13 @@ class TestWorkController(CirculationControllerTest):
         # Two books are in the series feed. The original work and its companion
         [e2] = [e for e in feed['entries'] if e['title'] == self.french_1.title]
         [collection_link] = [link for link in e2['links'] if link['rel']=='collection']
-        eq_("Other Books in this Series", collection_link['title'])
+        eq_("Around the World", collection_link['title'])
         expected = urllib.quote(work_url + 'series')
         eq_(True, collection_link['href'].endswith(expected))
 
         [e3] = [e for e in feed['entries'] if e['title'] == self.english_1.title]
         [collection_link] = [link for link in e3['links'] if link['rel']=='collection']
-        eq_("Other Books in this Series", collection_link['title'])
+        eq_("Around the World", collection_link['title'])
         expected = urllib.quote(work_url + 'series')
         eq_(True, collection_link['href'].endswith(expected))
 
@@ -863,7 +863,7 @@ class TestWorkController(CirculationControllerTest):
             )
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
-        eq_('Other Books in the Like As If Whatever Mysteries series', feed['feed']['title'])
+        eq_("Like As If Whatever Mysteries", feed['feed']['title'])
         [entry] = feed['entries']
         eq_(self.english_1.title, entry['title'])
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -797,11 +797,16 @@ class TestWorkController(CirculationControllerTest):
         [e1] = [e for e in feed['entries'] if e['title'] == self.english_2.title]
         [collection_link] = [link for link in e1['links'] if link['rel']=='collection']
         eq_("Recommended Books", collection_link['title'])
+        work_url = "/works/%s/%s/%s/" % (self.datasource, self.identifier.type, self.identifier.identifier)
+        expected = urllib.quote(work_url + 'recommendations')
+        eq_(True, collection_link['href'].endswith(expected))
 
         # One book is in the series feed.
         [e2] = [e for e in feed['entries'] if e['title'] == self.french_1.title]
         [collection_link] = [link for link in e2['links'] if link['rel']=='collection']
         eq_("Other Books in this Series", collection_link['title'])
+        expected = urllib.quote(work_url + 'series')
+        eq_(True, collection_link['href'].endswith(expected))
 
     def test_report_problem_get(self):
         with self.app.test_request_context("/"):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -797,7 +797,7 @@ class TestWorkController(CirculationControllerTest):
             )
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
-        eq_(2, len(feed['entries']))
+        eq_(3, len(feed['entries']))
 
         # One book is in the recommendations feed.
         [e1] = [e for e in feed['entries'] if e['title'] == self.english_2.title]
@@ -807,12 +807,19 @@ class TestWorkController(CirculationControllerTest):
         expected = urllib.quote(work_url + 'recommendations')
         eq_(True, collection_link['href'].endswith(expected))
 
-        # One book is in the series feed.
+        # Two books are in the series feed. The original work and its companion
         [e2] = [e for e in feed['entries'] if e['title'] == self.french_1.title]
         [collection_link] = [link for link in e2['links'] if link['rel']=='collection']
         eq_("Other Books in this Series", collection_link['title'])
         expected = urllib.quote(work_url + 'series')
         eq_(True, collection_link['href'].endswith(expected))
+
+        [e3] = [e for e in feed['entries'] if e['title'] == self.english_1.title]
+        [collection_link] = [link for link in e3['links'] if link['rel']=='collection']
+        eq_("Other Books in this Series", collection_link['title'])
+        expected = urllib.quote(work_url + 'series')
+        eq_(True, collection_link['href'].endswith(expected))
+
 
     def test_report_problem_get(self):
         with self.app.test_request_context("/"):
@@ -837,7 +844,7 @@ class TestWorkController(CirculationControllerTest):
         eq_("bar", complaint.detail)
 
     def test_series(self):
-        # If the edition doesn't have a series, a ProblemDetail is returned.
+        # If the work doesn't have a series, a ProblemDetail is returned.
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.series(
                 self.datasource, self.identifier.type, self.identifier.identifier
@@ -845,9 +852,10 @@ class TestWorkController(CirculationControllerTest):
         eq_(404, response.status_code)
         eq_("http://librarysimplified.org/terms/problem/unknown-lane", response.uri)
 
-        # If the edition is in a series without other volumes, an empty feed
-        # is returned.
+        # If the work is in a series without other volumes, a feed is
+        # returned containing only that work.
         self.lp.presentation_edition.series = "Like As If Whatever Mysteries"
+        self.lp.presentation_edition.series_position = 8
         SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.series(
@@ -856,14 +864,16 @@ class TestWorkController(CirculationControllerTest):
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
         eq_('Other Books in the Like As If Whatever Mysteries series', feed['feed']['title'])
-        eq_([], feed['entries'])
+        [entry] = feed['entries']
+        eq_(self.english_1.title, entry['title'])
 
         # Remove cache.
         [cached_empty_feed] = self._db.query(CachedFeed).all()
         self._db.delete(cached_empty_feed)
-        # When other volumes present themselves, the feed has entries.
+        # When other volumes present themselves, the feed has more entries.
         other_volume = self.english_2.license_pools[0].presentation_edition
         other_volume.series = "Like As If Whatever Mysteries"
+        other_volume.series_position = 1
         SessionManager.refresh_materialized_views(self._db)
 
         with self.app.test_request_context('/'):
@@ -872,9 +882,29 @@ class TestWorkController(CirculationControllerTest):
             )
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
-        eq_(1, len(feed['entries']))
-        [entry] = feed['entries']
-        eq_(self.english_2.title, entry['title'])
+        eq_(2, len(feed['entries']))
+        [e1, e2] = feed['entries']
+        # The entries are sorted according to their series_position.
+        eq_(self.english_2.title, e1['title'])
+        eq_(self.english_1.title, e2['title'])
+
+        # Remove cache.
+        [cached_empty_feed] = self._db.query(CachedFeed).all()
+        self._db.delete(cached_empty_feed)
+        # Barring series_position, the entries are sorted according to their
+        # titles.
+        self.lp.presentation_edition.series_position = None
+        other_volume.series_position = None
+        with self.app.test_request_context('/'):
+            response = self.manager.work_controller.series(
+                self.datasource, self.identifier.type, self.identifier.identifier
+            )
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(2, len(feed['entries']))
+        [e1, e2] = feed['entries']
+        eq_(self.english_1.title, e1['title'])
+        eq_(self.english_2.title, e2['title'])
 
 
 class TestFeedController(CirculationControllerTest):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -730,7 +730,7 @@ class TestWorkController(CirculationControllerTest):
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.recommendations(
                 self.datasource, self.identifier.type, self.identifier.identifier,
-                mock_api=mock_api
+                novelist_api=mock_api
             )
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
@@ -747,7 +747,7 @@ class TestWorkController(CirculationControllerTest):
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.recommendations(
                 self.datasource, self.identifier.type, self.identifier.identifier,
-                mock_api=mock_api
+                novelist_api=mock_api
             )
         # A feed is returned with the proper recommendation.
         eq_(200, response.status_code)
@@ -793,7 +793,7 @@ class TestWorkController(CirculationControllerTest):
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.related(
                 self.datasource, self.identifier.type, self.identifier.identifier,
-                mock_api=mock_api
+                novelist_api=mock_api
             )
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -726,6 +726,7 @@ class TestWorkController(CirculationControllerTest):
         mock_api = MockNoveListAPI()
         mock_api.setup(metadata)
 
+        SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.recommendations(
                 self.datasource, self.identifier.type, self.identifier.identifier,
@@ -741,6 +742,8 @@ class TestWorkController(CirculationControllerTest):
         self._db.delete(cached_empty_feed)
         metadata.recommendations = [self.english_2.license_pools[0].identifier]
         mock_api.setup(metadata)
+
+        SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.recommendations(
                 self.datasource, self.identifier.type, self.identifier.identifier,
@@ -778,6 +781,8 @@ class TestWorkController(CirculationControllerTest):
         # Prep book with a book in its series and a recommendation.
         self.lp.presentation_edition.series = "Around the World"
         self.french_1.presentation_edition.series = "Around the World"
+        SessionManager.refresh_materialized_views(self._db)
+
         source = DataSource.lookup(self._db, self.datasource)
         metadata = Metadata(source)
         mock_api = MockNoveListAPI()
@@ -843,6 +848,7 @@ class TestWorkController(CirculationControllerTest):
         # If the edition is in a series without other volumes, an empty feed
         # is returned.
         self.lp.presentation_edition.series = "Like As If Whatever Mysteries"
+        SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.series(
                 self.datasource, self.identifier.type, self.identifier.identifier
@@ -858,6 +864,7 @@ class TestWorkController(CirculationControllerTest):
         # When other volumes present themselves, the feed has entries.
         other_volume = self.english_2.license_pools[0].presentation_edition
         other_volume.series = "Like As If Whatever Mysteries"
+        SessionManager.refresh_materialized_views(self._db)
 
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.series(
@@ -963,7 +970,7 @@ class TestFeedController(CirculationControllerTest):
 
                 feed = feedparser.parse(response.data)
                 entries = feed['entries']
-                
+
                 counter = Counter()
                 for entry in entries:
                     links = [x for x in entry.links if x['rel'] == 'collection']

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -171,7 +171,7 @@ class TestBaseController(CirculationControllerTest):
         assert isinstance(value, Patron)
 
     def test_load_lane(self):
-        eq_(self.manager, self.controller.load_lane(None, None))
+        eq_(self.manager.top_level_lane, self.controller.load_lane(None, None))
         chinese = self.controller.load_lane('chi', None)
         eq_("Chinese", chinese.name)
         eq_("Chinese", chinese.display_name)

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -121,7 +121,6 @@ class TestLaneCreation(DatabaseTest):
             lane = lane_for_other_languages(self._db, exclude)
             eq_(None, lane)
 
-
     def test_make_lanes_default(self):
         with temp_config() as config:
             config[Configuration.POLICIES] = {
@@ -151,4 +150,3 @@ class TestLaneCreation(DatabaseTest):
             eq_(['Best Sellers', 'Fiction', 'Nonfiction', 'Young Adult Fiction', 'Young Adult Nonfiction', 'Children and Middle Grade'],
                 [x.display_name for x in english_lane.sublanes.lanes]
             )
-

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -1,4 +1,4 @@
-from nose.tools import set_trace, eq_
+from nose.tools import set_trace, eq_, assert_raises
 
 from . import (
     DatabaseTest,
@@ -19,6 +19,7 @@ from api.lanes import (
     lanes_for_large_collection,
     lane_for_small_collection,
     lane_for_other_languages,
+    RelatedBooksLane,
 )
 
 from core.lane import Lane
@@ -149,4 +150,16 @@ class TestLaneCreation(DatabaseTest):
             )
             eq_(['Best Sellers', 'Fiction', 'Nonfiction', 'Young Adult Fiction', 'Young Adult Nonfiction', 'Children and Middle Grade'],
                 [x.display_name for x in english_lane.sublanes.lanes]
+            )
+
+
+class TestRelatedBooksLane(DatabaseTest):
+
+    def test_initialization(self):
+        work = self._work(with_license_pool=True)
+        [lp] = work.license_pools
+        with temp_config() as config:
+            config['integrations'][Configuration.NOVELIST_INTEGRATION] = {}
+            assert_raises(
+                ValueError, RelatedBooksLane, self._db, lp, ""
             )

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -47,6 +47,7 @@ from core.opds import (
 )
 
 from core.util.cdn import cdnify
+from api.novelist import NoveListAPI
 
 class TestCirculationManagerAnnotator(DatabaseTest):
 
@@ -256,6 +257,7 @@ class TestOPDS(DatabaseTest):
         # If there are no related works, there's no related books link.
         work = self._work(with_open_access_download=True)
         with temp_config() as config:
+            NoveListAPI.IS_CONFIGURED = None
             config['integrations'][Configuration.NOVELIST_INTEGRATION] = {}
             feed = AcquisitionFeed(
                 self._db, "test", "url", [work],
@@ -269,6 +271,7 @@ class TestOPDS(DatabaseTest):
         # If NoveList is configured (and thus recommendations are available),
         # there's is a related books link.
         with temp_config() as config:
+            NoveListAPI.IS_CONFIGURED = None
             config['integrations'][Configuration.NOVELIST_INTEGRATION] = {
                 Configuration.NOVELIST_PROFILE : "library",
                 Configuration.NOVELIST_PASSWORD : "yep"


### PR DESCRIPTION
This branch:
- Makes sure that NoveList series information is applied to a licensed edition if series data isn't currently captured.
- Creates a lane for series.
- Creates a groups-feed-intended parent lane RelatedBooksLane, and trains the CirculationManagerAnnotator on how to deal with it and its chil'rens.
- Allows LicensePool-based sublanes to have proper URLs.
- Puts a link to related books in a Work's OPDS entry if appropriate.

I mostly hate the `DISPLAY_NAME` for these lanes and wish they were simpler while staying clear. 😕 

Fixes #234.