### PR TITLE
Make metadata wrangler coverage provider respect cutoff_time

### DIFF
--- a/api/coverage.py
+++ b/api/coverage.py
@@ -216,7 +216,8 @@ class MetadataWranglerCoverageProvider(OPDSImportCoverageProvider):
             service_name=self.SERVICE_NAME,
             input_identifier_types=input_identifier_types,
             output_source=output_source,
-            operation=operation or self.OPERATION
+            operation=operation or self.OPERATION,
+            **kwargs
         )
 
         if not self.lookup.authenticated:

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -194,14 +194,17 @@ class TestOPDSImportCoverageProvider(DatabaseTest):
 
 class TestMetadataWranglerCoverageProvider(DatabaseTest):
 
-    def setup(self):
-        super(TestMetadataWranglerCoverageProvider, self).setup()
-        self.source = DataSource.lookup(self._db, DataSource.METADATA_WRANGLER)
+    def create_provider(self, **kwargs):
         with temp_config() as config:
             config[Configuration.INTEGRATIONS][Configuration.METADATA_WRANGLER_INTEGRATION] = {
                 Configuration.URL : "http://url.gov"
             }
-            self.provider = MetadataWranglerCoverageProvider(self._db)
+            return MetadataWranglerCoverageProvider(self._db, **kwargs)
+
+    def setup(self):
+        super(TestMetadataWranglerCoverageProvider, self).setup()
+        self.source = DataSource.lookup(self._db, DataSource.METADATA_WRANGLER)
+        self.provider = self.create_provider()
 
     def test_create_identifier_mapping(self):
         # Most identifiers map to themselves.
@@ -273,8 +276,8 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
         one_hour_from_now = (
             datetime.datetime.utcnow() + datetime.timedelta(seconds=3600)
         )
-        provider_with_cutoff = MetadataWranglerCoverageProvider(
-            self._db, cutoff_time=one_hour_from_now
+        provider_with_cutoff = self.create_provider(
+            cutoff_time=one_hour_from_now
         )
 
         # The book starts showing up in items_that_need_coverage.


### PR DESCRIPTION
This makes it possible to force a refresh of coverage. Other coverage providers support this but the essential **kwargs weren't being propagated to the superconstructor.