### PR TITLE
Search coverage provider

### DIFF
--- a/api/coverage.py
+++ b/api/coverage.py
@@ -375,6 +375,15 @@ class SearchIndexCoverageProvider(WorkCoverageProvider):
     """Make sure the search index is up-to-date for every Work."""
 
     def __init__(self, _db, index_name, index_client=None, **kwargs):
+        if index_client:
+            # This would only happen during a test.
+            self.search_index_client = index_client
+        else:
+            self.search_index_client = ExternalSearchIndex(
+                works_index=index_name
+            )
+            
+        index_name = self.search_index_client.works_index
         self.operation_name = WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION + '-' + index_name
         super(SearchIndexCoverageProvider, self).__init__(
             _db, 
@@ -383,13 +392,6 @@ class SearchIndexCoverageProvider(WorkCoverageProvider):
             **kwargs
         )
 
-        if index_client:
-            # This would only happen during a test.
-            self.search_index_client = index_client
-        else:
-            self.search_index_client = ExternalSearchIndex(
-                works_index=index_name
-            )
 
     def process_item(self, work):
         """Update the search index for one item.

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -38,7 +38,7 @@ class OPDSImportCoverageProvider(CoverageProvider):
     """
 
     def __init__(self, service_name, input_identifier_types, output_source,
-                 lookup=None, workset_size=25, expect_license_pool=False,
+                 lookup=None, batch_size=25, expect_license_pool=False,
                  presentation_ready_on_success=False, **kwargs):
         """Basic constructor.
 
@@ -54,7 +54,7 @@ class OPDSImportCoverageProvider(CoverageProvider):
         self.expect_license_pool=expect_license_pool
         self.presentation_ready_on_success=presentation_ready_on_success
         super(OPDSImportCoverageProvider, self).__init__(
-            service_name, input_identifier_types, output_source, workset_size=workset_size, 
+            service_name, input_identifier_types, output_source, batch_size=batch_size, 
             **kwargs
         )
 

--- a/api/monitor.py
+++ b/api/monitor.py
@@ -8,54 +8,12 @@ import logging
 from config import Configuration
 from core.monitor import (
     EditionSweepMonitor,
-    IdentifierSweepMonitor,
-    WorkSweepMonitor,
 )
 from core.model import (
     DataSource,
     Edition,
-    Hyperlink,
-    Identifier,
     LicensePool,
-    Work,
 )
-from core.opds import OPDSFeed
-from core.opds_import import (
-    SimplifiedOPDSLookup,
-    OPDSImporter,
-)
-from core.external_search import (
-    ExternalSearchIndex,
-)
-
-class SearchIndexUpdateMonitor(WorkSweepMonitor):
-    """Make sure the search index is up-to-date for every work.
-    """
-
-    def __init__(self, _db, batch_size=100, interval_seconds=3600*24, works_index=None):
-        super(SearchIndexUpdateMonitor, self).__init__(
-            _db, 
-            "Index Update Monitor %s" % works_index, 
-            interval_seconds)
-        self.batch_size = batch_size
-        self.search_index_client = ExternalSearchIndex(works_index=works_index)
-
-    def work_query(self):
-        return self._db.query(Work).filter(Work.presentation_ready==True)
-
-    def process_batch(self, batch):
-        # TODO: Perfect opportunity for a bulk upload.
-        highest_id = 0
-        for work in batch:
-            if work.id > highest_id:
-                highest_id = work.id
-            work.update_external_index(self.search_index_client)
-            if not work.title:
-                logging.warn(
-                    "Work %d is presentation-ready but has no title?" % work.id
-                )
-        return highest_id
-
 
 class UpdateOpenAccessURL(EditionSweepMonitor):
     """Set Edition.open_access_full_url for all Gutenberg works."""

--- a/api/novelist.py
+++ b/api/novelist.py
@@ -372,7 +372,7 @@ class NoveListCoverageProvider(CoverageProvider):
 
         super(NoveListCoverageProvider, self).__init__(
             "NoveList Coverage Provider", [Identifier.ISBN],
-            self.source, workset_size=25
+            self.source, batch_size=25
         )
 
     @property

--- a/bin/repair/search_index
+++ b/bin/repair/search_index
@@ -5,13 +5,5 @@ import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
-from api.monitor import (
-    SearchIndexUpdateMonitor,
-)
-from core.scripts import RunMonitorScript
-
-if len(sys.argv) > 1:
-    index = sys.argv[1]
-else:
-    index = None
-RunMonitorScript(SearchIndexUpdateMonitor, works_index=index).run()
+from scripts import UpdateSearchIndexScript
+UpdateSearchIndexScript().run()

--- a/scripts.py
+++ b/scripts.py
@@ -20,6 +20,7 @@ from psycopg2.extras import NumericRange
 
 from api.lanes import make_lanes
 from api.controller import CirculationManager
+from api.coverage import SearchIndexCoverageProvider
 from api.threem import ThreeMCirculationSweep
 from api.overdrive import OverdriveAPI
 from core import log
@@ -42,6 +43,7 @@ from core.model import (
 from core.scripts import (
     Script as CoreScript,
     RunCoverageProvidersScript,
+    RunCoverageProviderScript,
     IdentifierInputScript,
 )
 from core.lane import (
@@ -522,3 +524,23 @@ class LanguageListScript(Script):
 
         print "\n".join(["%s %i (%s)" % l for l in sorted_languages])
         print json.dumps([l[0] for l in sorted_languages])
+
+
+class UpdateSearchIndexScript(RunCoverageProviderScript):
+
+    @classmethod
+    def arg_parser(cls):
+        parser = RunCoverageProviderScript.arg_parser()
+        parser.add_argument(
+            '--works-index', 
+            help='The ElasticSearch index to update, if other than the default.'
+        )
+        return parser
+
+    def extract_additional_command_line_arguments(self, args):
+        return dict(index_name=args.works_index)
+
+    def __init__(self):
+        super(UpdateSearchIndexScript, self).__init__(
+            SearchIndexCoverageProvider
+        )

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -245,7 +245,7 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
         )
         relicensed_licensepool.update_availability(1, 0, 0, 0)
 
-        items = self.provider.items_that_need_coverage.all()
+        items = self.provider.items_that_need_coverage().all()
         # Provider ignores anything that has been reaped and doesn't have
         # licenses.
         assert reaper_cr.identifier not in items
@@ -271,7 +271,7 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
 
         # We have a coverage record already, so this book doesn't show
         # up in items_that_need_coverage
-        items = self.provider.items_that_need_coverage.all()
+        items = self.provider.items_that_need_coverage().all()
         eq_([], items)
 
         # But if we send a cutoff_time that's later than the time
@@ -285,7 +285,7 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
 
         # The book starts showing up in items_that_need_coverage.
         eq_([edition.primary_identifier], 
-            provider_with_cutoff.items_that_need_coverage.all())
+            provider_with_cutoff.items_that_need_coverage().all())
 
 
 class TestMetadataWranglerCollectionReaper(DatabaseTest):
@@ -317,7 +317,7 @@ class TestMetadataWranglerCollectionReaper(DatabaseTest):
         # An open access license pool
         open_access_lp = self._licensepool(None)
 
-        items = self.reaper.items_that_need_coverage.all()
+        items = self.reaper.items_that_need_coverage().all()
         eq_(1, len(items))
         # Items that are licensed are ignored.
         assert licensed_lp.identifier not in items
@@ -377,7 +377,7 @@ class TestContentServerBibliographicCoverageProvider(DatabaseTest):
 
         # Only the open-access work needs coverage.
         eq_([w1.license_pools[0].identifier],
-            provider.items_that_need_coverage.all())
+            provider.items_that_need_coverage().all())
 
 
 class TestSeachIndexCoverageProvider(DatabaseTest):
@@ -417,6 +417,7 @@ class TestSeachIndexCoverageProvider(DatabaseTest):
         # different index (e.g. because the index format has changed
         # and we're recreating the search index), we can get a second
         # WorkCoverageRecord for _that_ index.
+        index.works_index = 'works-index-2'
         provider2 = SearchIndexCoverageProvider(self._db, "works-index-2", index)
         provider2.run()
 


### PR DESCRIPTION
This branch removes the search index update monitor, replacing it with the much more flexible SearchIndexCoverageProvider.

Many of the changes have to do with other coverage providers, dealing with the change in the signature of `items_that_need_coverage`.