### PR TITLE
Remove licensepools from series lanes

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -882,23 +882,14 @@ class WorkController(CirculationManagerController):
         controller = ComplaintController()
         return controller.register(pool, data)
 
-    def series(self, data_source, identifier_type, identifier):
+    def series(self, series_name):
         """Serve a feed of books in the same series as a given book."""
 
-        pool = self.load_licensepool(data_source, identifier_type, identifier)
-        if isinstance(pool, ProblemDetail):
-            return pool
+        if not series_name:
+            return NO_SUCH_LANE.detailed("No series provided")
 
-        edition = pool.presentation_edition
-        series = edition.series
-        if not series:
-            return NO_SUCH_LANE.detailed("%s is not in a series" % edition.title)
-
-        lane = SeriesLane(self._db, pool)
-        url = self.cdn_url_for(
-            'series', data_source=data_source,
-            identifier_type=identifier_type, identifier=identifier
-        )
+        lane = SeriesLane(self._db, series_name)
+        url = self.cdn_url_for('series', series_name=series_name)
         annotator = self.manager.annotator(lane)
         feed = AcquisitionFeed.page(
             self._db, lane.display_name, url, lane,

--- a/api/routes.py
+++ b/api/routes.py
@@ -177,6 +177,11 @@ def work():
     annotator = CirculationManagerAnnotator(app.manager.circulation, None)
     return app.manager.urn_lookup.work_lookup(annotator, 'work')
 
+@app.route('/works/series/<series_name>')
+@returns_problem_detail
+def series(series_name):
+    return app.manager.work_controller.series(series_name)
+
 @app.route('/works/<data_source>/<identifier_type>/<path:identifier>')
 @returns_problem_detail
 def permalink(data_source, identifier_type, identifier):
@@ -196,11 +201,6 @@ def related_books(data_source, identifier_type, identifier):
 @returns_problem_detail
 def report(data_source, identifier_type, identifier):
     return app.manager.work_controller.report(data_source, identifier_type, identifier)
-
-@app.route('/works/<data_source>/<identifier_type>/<path:identifier>/series')
-@returns_problem_detail
-def series(data_source, identifier_type, identifier):
-    return app.manager.work_controller.series(data_source, identifier_type, identifier)
 
 @app.route('/analytics/<data_source>/<identifier_type>/<path:identifier>/<event_type>')
 @returns_problem_detail

--- a/migration/20160614-1-remove-licensepools-from-series-lanes.sql
+++ b/migration/20160614-1-remove-licensepools-from-series-lanes.sql
@@ -1,0 +1,1 @@
+UPDATE cachedfeeds set license_pool_id=NULL where type='series';

--- a/migration/20160614-1-remove-licensepools-from-series-lanes.sql
+++ b/migration/20160614-1-remove-licensepools-from-series-lanes.sql
@@ -1,1 +1,0 @@
-UPDATE cachedfeeds set license_pool_id=NULL where type='series';

--- a/migration/20160620-remove-license-pools-from-series-cachedfeeds.sql
+++ b/migration/20160620-remove-license-pools-from-series-cachedfeeds.sql
@@ -1,0 +1,1 @@
+update cachedfeeds set license_pool_id=NULL where type='series';

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -811,15 +811,13 @@ class TestWorkController(CirculationControllerTest):
         [e2] = [e for e in feed['entries'] if e['title'] == self.french_1.title]
         [collection_link] = [link for link in e2['links'] if link['rel']=='collection']
         eq_("Around the World", collection_link['title'])
-        expected = urllib.quote(work_url + 'series')
+        expected = urllib.quote('series/Around the World')
         eq_(True, collection_link['href'].endswith(expected))
 
         [e3] = [e for e in feed['entries'] if e['title'] == self.english_1.title]
         [collection_link] = [link for link in e3['links'] if link['rel']=='collection']
         eq_("Around the World", collection_link['title'])
-        expected = urllib.quote(work_url + 'series')
         eq_(True, collection_link['href'].endswith(expected))
-
 
     def test_report_problem_get(self):
         with self.app.test_request_context("/"):
@@ -846,9 +844,7 @@ class TestWorkController(CirculationControllerTest):
     def test_series(self):
         # If the work doesn't have a series, a ProblemDetail is returned.
         with self.app.test_request_context('/'):
-            response = self.manager.work_controller.series(
-                self.datasource, self.identifier.type, self.identifier.identifier
-            )
+            response = self.manager.work_controller.series("")
         eq_(404, response.status_code)
         eq_("http://librarysimplified.org/terms/problem/unknown-lane", response.uri)
 
@@ -859,7 +855,7 @@ class TestWorkController(CirculationControllerTest):
         SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.series(
-                self.datasource, self.identifier.type, self.identifier.identifier
+                "Like As If Whatever Mysteries"
             )
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
@@ -878,7 +874,7 @@ class TestWorkController(CirculationControllerTest):
 
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.series(
-                self.datasource, self.identifier.type, self.identifier.identifier
+                "Like As If Whatever Mysteries"
             )
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
@@ -897,7 +893,7 @@ class TestWorkController(CirculationControllerTest):
         other_volume.series_position = None
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.series(
-                self.datasource, self.identifier.type, self.identifier.identifier
+                "Like As If Whatever Mysteries"
             )
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -848,10 +848,8 @@ class TestWorkController(CirculationControllerTest):
         eq_(404, response.status_code)
         eq_("http://librarysimplified.org/terms/problem/unknown-lane", response.uri)
 
-        # If the work is in a series without other volumes, a feed is
-        # returned containing only that work.
+        # If the work is in a series, a feed is returned.
         self.lp.presentation_edition.series = "Like As If Whatever Mysteries"
-        self.lp.presentation_edition.series_position = 8
         SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.series(
@@ -862,45 +860,6 @@ class TestWorkController(CirculationControllerTest):
         eq_("Like As If Whatever Mysteries", feed['feed']['title'])
         [entry] = feed['entries']
         eq_(self.english_1.title, entry['title'])
-
-        # Remove cache.
-        [cached_empty_feed] = self._db.query(CachedFeed).all()
-        self._db.delete(cached_empty_feed)
-        # When other volumes present themselves, the feed has more entries.
-        other_volume = self.english_2.license_pools[0].presentation_edition
-        other_volume.series = "Like As If Whatever Mysteries"
-        other_volume.series_position = 1
-        SessionManager.refresh_materialized_views(self._db)
-
-        with self.app.test_request_context('/'):
-            response = self.manager.work_controller.series(
-                "Like As If Whatever Mysteries"
-            )
-        eq_(200, response.status_code)
-        feed = feedparser.parse(response.data)
-        eq_(2, len(feed['entries']))
-        [e1, e2] = feed['entries']
-        # The entries are sorted according to their series_position.
-        eq_(self.english_2.title, e1['title'])
-        eq_(self.english_1.title, e2['title'])
-
-        # Remove cache.
-        [cached_empty_feed] = self._db.query(CachedFeed).all()
-        self._db.delete(cached_empty_feed)
-        # Barring series_position, the entries are sorted according to their
-        # titles.
-        self.lp.presentation_edition.series_position = None
-        other_volume.series_position = None
-        with self.app.test_request_context('/'):
-            response = self.manager.work_controller.series(
-                "Like As If Whatever Mysteries"
-            )
-        eq_(200, response.status_code)
-        feed = feedparser.parse(response.data)
-        eq_(2, len(feed['entries']))
-        [e1, e2] = feed['entries']
-        eq_(self.english_1.title, e1['title'])
-        eq_(self.english_2.title, e2['title'])
 
 
 class TestFeedController(CirculationControllerTest):


### PR DESCRIPTION
Fixes #253, removing licensepools from SeriesLanes. It also:
- changes the way that URLs are created for some of these QueryGeneratedLanes (which is not a great name, since all Lanes are QueryGenerated - very open to ideas on this).
- moves some tests out of controller and instead tests the `works()` and `materialized_works()` methods directly for QueryGeneratedLanes.