### PR TITLE
Propagate counts_as_covered when calling items_that_need_coverage

### DIFF
--- a/api/coverage.py
+++ b/api/coverage.py
@@ -208,9 +208,9 @@ class MetadataWranglerCoverageProvider(OPDSImportCoverageProvider):
                 "it will not know which collection you're asking about."
             )
 
-    def items_that_need_coverage(self, identifiers=None):
+    def items_that_need_coverage(self, identifiers=None, **kwargs):
         """Returns items that are licensed and have not been covered"""
-        uncovered = super(MetadataWranglerCoverageProvider, self).items_that_need_coverage(identifiers)
+        uncovered = super(MetadataWranglerCoverageProvider, self).items_that_need_coverage(identifiers, **kwargs)
         reaper_covered = self._db.query(Identifier).\
                 join(Identifier.coverage_records).\
                 filter(CoverageRecord.data_source==self.output_source).\
@@ -251,9 +251,11 @@ class MetadataWranglerCollectionReaper(MetadataWranglerCoverageProvider):
     SERVICE_NAME = "Metadata Wrangler Reaper"
     OPERATION = CoverageRecord.REAP_OPERATION
 
-    def items_that_need_coverage(self, identifiers=None):
+    def items_that_need_coverage(self, identifiers=None, **kwargs):
         """Retreives Identifiers that have been synced and are no longer licensed"""
 
+        # TODO: currently we ignore count_as_covered and any other keyword
+        # arguments passed in here.
         qu = self._db.query(Identifier).select_from(LicensePool).\
             join(LicensePool.identifier).join(CoverageRecord).\
             filter(LicensePool.licenses_owned==0, LicensePool.open_access!=True).\
@@ -338,12 +340,12 @@ class ContentServerBibliographicCoverageProvider(OPDSImportCoverageProvider):
             **kwargs
         )
 
-    def items_that_need_coverage(self, identifiers=None):
+    def items_that_need_coverage(self, identifiers=None, **kwargs):
         """Only identifiers associated with an open-access license
         need coverage.
         """
         qu = super(ContentServerBibliographicCoverageProvider, 
-                   self).items_that_need_coverage(identifiers)
+                   self).items_that_need_coverage(identifiers, **kwargs)
         qu = qu.join(Identifier.licensed_through).filter(
             LicensePool.open_access==True
         )

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -252,15 +252,25 @@ class MetadataWranglerCollectionReaper(MetadataWranglerCoverageProvider):
     OPERATION = CoverageRecord.REAP_OPERATION
 
     def items_that_need_coverage(self, identifiers=None, **kwargs):
-        """Retreives Identifiers that have been synced and are no longer licensed"""
+        """Retrieves Identifiers that have been synced and are no longer licensed
 
-        # TODO: currently we ignore count_as_covered and any other keyword
-        # arguments passed in here.
+        :param count_as_covered: Ignored because we are always looking
+            for identifiers that got coverage from a _different_
+            CoverageProvider, not identifiers that are missing
+            coverage per se.
+
+        :param count_as_missing_before: Ignored because we are always
+            looking for identifiers have coverage from a _different_
+            CoverageProvider.
+
+        """
         qu = self._db.query(Identifier).select_from(LicensePool).\
             join(LicensePool.identifier).join(CoverageRecord).\
             filter(LicensePool.licenses_owned==0, LicensePool.open_access!=True).\
             filter(CoverageRecord.data_source==self.output_source).\
-            filter(CoverageRecord.operation==CoverageRecord.SYNC_OPERATION)
+            filter(CoverageRecord.operation==CoverageRecord.SYNC_OPERATION).\
+            filter(CoverageRecord.status==CoverageRecord.SUCCESS)
+
         if identifiers:
             qu = qu.filter(Identifier.id.in_([x.id for x in identifiers]))
         return qu

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -299,7 +299,7 @@ class TestMetadataWranglerCollectionReaper(DatabaseTest):
         # A Wrangler-synced item that doesn't have any owned licenses
         covered_unlicensed_lp = self._licensepool(None, open_access=False, set_edition_as_presentation=True)
         covered_unlicensed_lp.update_availability(0, 0, 0, 0)
-        self._coverage_record(
+        cr = self._coverage_record(
             covered_unlicensed_lp.presentation_edition, self.source,
             operation=CoverageRecord.SYNC_OPERATION
         )
@@ -321,6 +321,10 @@ class TestMetadataWranglerCollectionReaper(DatabaseTest):
         assert uncovered_unlicensed_lp.identifier not in items
         # Only synced items without owned licenses are returned.
         eq_([covered_unlicensed_lp.identifier], items)
+
+        # Items that had unsuccessful syncs are not returned.
+        cr.status = CoverageRecord.TRANSIENT_FAILURE
+        eq_([], self.reaper.items_that_need_coverage().all())
 
     def test_finalize_batch(self):
         """Metadata Wrangler sync coverage records are deleted from the db

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -259,6 +259,27 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
         eq_([edition.primary_identifier], 
             provider_with_cutoff.items_that_need_coverage().all())
 
+    def test_items_that_need_coverage_respects_count_as_covered(self):
+        # Here's a coverage record with a transient failure.
+        identifier = self._identifier()
+        cr = self._coverage_record(
+            identifier, self.provider.output_source, 
+            operation=self.provider.operation,
+            status=CoverageRecord.TRANSIENT_FAILURE
+        )
+        
+        # Ordinarily, a transient failure does not count as coverage.
+        [needs_coverage] = self.provider.items_that_need_coverage().all()
+        eq_(needs_coverage, identifier)
+
+        # But if we say that transient failure counts as coverage, it
+        # does count.
+        eq_([],
+            self.provider.items_that_need_coverage(
+                count_as_covered=CoverageRecord.TRANSIENT_FAILURE
+            ).all()
+        )
+
 
 class TestMetadataWranglerCollectionReaper(DatabaseTest):
 


### PR DESCRIPTION
This branch changes the circulation manager coverage providers so that they pass along `counts_as_covered` when calling `items_that_need_coverage`. The `CoverageProviderScript` passes in that argument, and a CoverageProvider that doesn't accept it will crash.

I added tests for two cases: first, the MetadataWranglerCoverageProvider, which behaves like normal coverage providers, and second, the MetadataWranglerCollectionReaper, which ignores `counts_as_covered` because it is always looking for identifiers that were successfully covered by a _different_ CoverageProvider (MetadataWranglerCoverageProvider).