### PR TITLE
Fixed overdrive sync when no format is locked in.

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -411,10 +411,23 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         # format into fulfillment_info and let the circulation API
         # make the decision.
         usable_formats = []
+
+        # If a format is already locked in, it will be in formats.
         for format in checkout.get('formats', []):
             format_type = format.get('formatType')
             if format_type in cls.DEFAULT_READABLE_FORMATS:
                 usable_formats.append(format_type)
+
+        # If a format hasn't been selected yet, available formats are in actions.
+        actions = checkout.get('actions', {})
+        format_action = actions.get('format', {})
+        format_fields = format_action.get('fields', [])
+        for field in format_fields:
+            if field.get('name', "") == "formatType":
+                format_options = field.get("options", [])
+                for format_type in format_options:
+                    if format_type in cls.DEFAULT_READABLE_FORMATS:
+                        usable_formats.append(format_type)
 
         if not usable_formats:
             # Either this book is not available in any format readable

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -265,6 +265,18 @@ class TestExtractData(OverdriveAPITest):
         loan_info = DummyOverdriveAPI.process_checkout_data(not_on_kindle)
         eq_("2fadd2ac-a8ec-4938-a369-4c3260e8922b", loan_info.identifier)
 
+        data, format_locked_in = self.sample_json("checkout_response_locked_in_format.json")
+
+        # A book that's on loan with a format locked in shows up.
+        loan_info = DummyOverdriveAPI.process_checkout_data(format_locked_in)
+        assert loan_info != None
+
+        data, no_format_locked_in = self.sample_json("checkout_response_no_format_locked_in.json")
+
+        # A book that's on loan with no format locked in also shows up.
+        loan_info = DummyOverdriveAPI.process_checkout_data(no_format_locked_in)
+        assert loan_info != None
+
         # TODO: In the future both of these tests should return a
         # LoanInfo with appropriate FulfillmentInfo. The calling code
         # would then decide whether or not to show the loan.


### PR DESCRIPTION
This restores books that were checked out in Overdrive but not locked in to a format to the loans feed.