### PR TITLE
Any format that can be fulfilled through simplified should show up in the loans feed.

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -406,16 +406,12 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         start = cls._pd(checkout.get('checkoutDate'))
         end = cls._pd(checkout.get('expires'))
         
-        # TODO: Instead of making the decision here not to show a book
-        # fulfilled in an incompatible format, put the fulfillment
-        # format into fulfillment_info and let the circulation API
-        # make the decision.
         usable_formats = []
 
         # If a format is already locked in, it will be in formats.
         for format in checkout.get('formats', []):
             format_type = format.get('formatType')
-            if format_type in cls.DEFAULT_READABLE_FORMATS:
+            if format_type in cls.FORMATS:
                 usable_formats.append(format_type)
 
         # If a format hasn't been selected yet, available formats are in actions.
@@ -426,7 +422,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
             if field.get('name', "") == "formatType":
                 format_options = field.get("options", [])
                 for format_type in format_options:
-                    if format_type in cls.DEFAULT_READABLE_FORMATS:
+                    if format_type in cls.FORMATS:
                         usable_formats.append(format_type)
 
         if not usable_formats:


### PR DESCRIPTION
This change will fix the StaleDataErrors we're occasionally seeing on fulfill.

The problem is that you can fulfill a loan as a format that's not supported by the default client (eg PDF), and if you also get your loans feed at the same time, the loan can get removed from the database after the fulfill request has fetched it. 

Any format that can be fulfilled by the circulation manager shouldn't be removed when you sync.

DEFAULT_READABLE_FORMATS was put in for Kindle format, and that's not in FORMATS either, so this should still work. It means PDFs borrowed via Overdrive will show up in the loans feed again, and you'll get an error when you try to download them.