### PR TITLE
Removed code that only updated Axis 360 with circulation data once.

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -262,26 +262,18 @@ class Axis360CirculationMonitor(Monitor):
         license_pool, new_license_pool = availability.license_pool(self._db)
         edition, new_edition = bibliographic.edition(self._db)
         license_pool.edition = edition
-        if new_license_pool:
-            policy = ReplacementPolicy(
-                subjects=True,
-                contributions=True,
-                formats=True,
-                identifiers=False,
-            )
-            availability.apply(
-                pool=license_pool, 
-                replace=policy,
-            )
-
+        policy = ReplacementPolicy(
+            identifiers=False,
+            subjects=True,
+            contributions=True,
+            formats=True,
+        )
+        availability.apply(
+            pool=license_pool, 
+            replace=policy,
+        )
         if new_edition:
-            bibliographic.apply(
-                edition, 
-                replace_identifiers=False,
-                replace_subjects=True, 
-                replace_contributions=True,
-                replace_formats=True,
-            )
+            bibliographic.apply(edition, replace=policy)
 
         if new_license_pool or new_edition:
             # At this point we have done work equivalent to that done by 

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -211,6 +211,33 @@ class TestCirculationMonitor(DatabaseTest):
                        and x.operation is None]
             eq_(1, len(records))
 
+    def test_process_book_updates_old_licensepool(self):
+        """If the LicensePool already exists, the circulation monitor
+        updates it.
+        """
+        edition, licensepool = self._edition(
+            with_license_pool=True, identifier_type=Identifier.AXIS_360_ID,
+            identifier_id=u'0003642860'
+        )
+        # We start off with availability information based on the
+        # default for test data.
+        eq_(1, licensepool.licenses_owned)
+
+        identifier = IdentifierData(
+            type=licensepool.identifier.type,
+            identifier=licensepool.identifier.identifier
+        )
+        metadata = Metadata(DataSource.AXIS_360, primary_identifier=identifier)
+        monitor = Axis360CirculationMonitor(self._db)
+        monitor.api = None
+        edition, licensepool = monitor.process_book(
+            metadata, self.AVAILABILITY_DATA
+        )
+
+        # Now we have information based on the CirculationData.
+        eq_(9, licensepool.licenses_owned)
+
+
 class TestResponseParser(object):
 
     @classmethod


### PR DESCRIPTION
Previously, the Axis 360 monitor only called CirculationData.apply() when a LicensePool was new. This bug meant updates never showed up. 

I have left in place the code that only calls Metadata.apply() when an Edition is new, because that update takes a long time and bibliographic metadata generally doesn't change. 