### PR TITLE
Get service_status working again

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -178,3 +178,18 @@ class Authenticator(object):
             doc[type] = provider_info
 
         return json.dumps(doc)
+
+
+class BasicAuthAuthenticator(Authenticator):
+
+    TYPE = Authenticator.BASIC_AUTH
+
+    def testing_patron(self, _db):
+        """Return a real Patron object reserved for testing purposes.
+
+        :return: A 2-tuple (Patron, password)
+        """
+        if self.test_username is None or self.test_password is None:
+            return None, None
+        header = dict(username=self.test_username, password=self.test_password)
+        return self.authenticated_patron(_db, header), self.test_password

--- a/api/config.py
+++ b/api/config.py
@@ -117,19 +117,6 @@ class Configuration(CoreConfiguration):
         return cls.required(cls.DEFAULT_NOTIFICATION_EMAIL_ADDRESS)
 
     @classmethod
-    def authentication_policy(cls):
-        # Find the name and configuration of the integration to be used
-        # when doing authentication
-        name = cls.policy(cls.AUTHENTICATION)
-        if not name:
-            # Authentication does not happen locally in this system.
-            return {}
-        integration = cls.integration(name, required=True)
-        integration = dict(integration)
-        integration[cls.NAME] = name
-        return integration
-
-    @classmethod
     def load(cls):
         CoreConfiguration.load()
         config = CoreConfiguration.instance

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -1,7 +1,7 @@
 from nose.tools import set_trace
 import requests
 import logging
-from authenticator import Authenticator
+from authenticator import BasicAuthAuthenticator
 from config import Configuration
 from circulation_exceptions import RemoteInitiatedServerError
 import urlparse
@@ -11,9 +11,8 @@ from core.model import (
     Patron,
 )
 
-class FirstBookAuthenticationAPI(Authenticator):
+class FirstBookAuthenticationAPI(BasicAuthAuthenticator):
 
-    TYPE = Authenticator.BASIC_AUTH
     NAME = 'First Book'
 
     SUCCESS_MESSAGE = 'Valid Code Pin Pair'
@@ -22,12 +21,14 @@ class FirstBookAuthenticationAPI(Authenticator):
 
     log = logging.getLogger("First Book authentication API")
 
-    def __init__(self, host, key):
+    def __init__(self, host, key, test_username=None, test_password=None):
         if '?' in host:
             host += '&'
         else:
             host += '?'
         self.root = host + 'key=' + key
+        self.test_username = test_username
+        self.test_password = test_password
 
     @classmethod
     def from_config(cls):
@@ -37,7 +38,10 @@ class FirstBookAuthenticationAPI(Authenticator):
         if not host:
             cls.log.warning("No First Book client configured.")
             return None
-        return cls(host, key)
+        test_username = config.get(Configuration.AUTHENTICATION_TEST_USERNAME)
+        test_password = config.get(Configuration.AUTHENTICATION_TEST_PASSWORD)
+        return cls(host, key, test_username=test_username, 
+                   test_password=test_password)
 
     def request(self, url):
         return requests.get(url)


### PR DESCRIPTION
This branch fixes the service_status controller, which broke when we switched the way authentication mechanisms are configured.

This code has no test coverage because it involves the interaction of a lot of pieces that are difficult to test. This is why we didn't notice service_status was broken in the first place. I'm not happy about this but I'm not unhappy enough to put in the work necessary to cover this code in a way that's useful.

I've manually verified that this works for Millenium Patron and FirstBook authenticators. We also get an appropriate error message if the configuration is invalid or not accepted by the authenticator.

Currently we only verify a site's basic auth provider. In theory we should verify that we can authenticate test patrons with all auth providers, but I don't know how this would even work with an OAuth provider, so I didn't try to write the code.