### PR TITLE
Changed to the new cdnify API.

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -395,8 +395,8 @@ class CirculationAPI(object):
             raise NoOpenAccessDownload()
 
         rep = fulfillment.resource.representation
-        cdn_host = Configuration.cdn_host(Configuration.CDN_OPEN_ACCESS_CONTENT)
-        content_link = cdnify(rep.url, cdn_host)
+        cdns = Configuration.cdns()
+        content_link = cdnify(rep.url, cdns)
         media_type = rep.media_type
         return FulfillmentInfo(
             identifier_type=licensepool.identifier.type,

--- a/api/opds.py
+++ b/api/opds.py
@@ -534,8 +534,7 @@ class CirculationManagerAnnotator(Annotator):
         return link_tag
 
     def open_access_link(self, lpdm):
-        cdn_host = Configuration.cdn_host(Configuration.CDN_OPEN_ACCESS_CONTENT)
-        url = cdnify(lpdm.resource.url, cdn_host)
+        url = cdnify(lpdm.resource.url, Configuration.cdns())
         kw = dict(rel=OPDSFeed.OPEN_ACCESS_REL, href=url)
         rep = lpdm.resource.representation
         if rep and rep.media_type:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -82,7 +82,7 @@ class TestCirculationManager(CirculationManager):
 
     def cdn_url_for(self, view, *args, **kwargs):
         base_url = url_for(view, *args, **kwargs)
-        return cdnify(base_url, "http://cdn/")
+        return cdnify(base_url, {"": "http://cdn/"})
 
 class ControllerTest(DatabaseTest):
     """A test that requires a functional app server."""

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -67,6 +67,7 @@ class TestCirculationManagerAnnotator(DatabaseTest):
         # The resource URL associated with a LicensePoolDeliveryMechanism
         # becomes the `href` of an open-access `link` tag.
         [lpdm] = self.work.license_pools[0].delivery_mechanisms
+        lpdm.resource.url = "http://foo.com/thefile.epub"
         link_tag = self.annotator.open_access_link(lpdm)
         eq_(lpdm.resource.url, link_tag.get('href'))
 
@@ -74,15 +75,15 @@ class TestCirculationManagerAnnotator(DatabaseTest):
         # replaces the original hostname.
         with temp_config() as config:
             cdn_host = "https://cdn.com/"
+            cdns = {
+                "foo.com" : cdn_host
+            }
             config[Configuration.INTEGRATIONS] = {
-                Configuration.CDN_INTEGRATION : {
-                    Configuration.CDN_OPEN_ACCESS_CONTENT : cdn_host
-                }
+                Configuration.CDN_INTEGRATION : cdns
             }
             link_tag = self.annotator.open_access_link(lpdm)
             link_url = link_tag.get('href')
-            assert link_url.startswith(cdn_host)
-            assert link_url == cdnify(lpdm.resource.url, cdn_host)
+            eq_("https://cdn.com/thefile.epub", link_url)
 
     def test_top_level_title(self):
         eq_("Test Top Level Title", self.annotator.top_level_title())


### PR DESCRIPTION
This branch changes the circ manager to use the new `cdnify` API created by https://github.com/NYPL-Simplified/server_core/pull/322.