### PR TITLE
Removed assumptions from tests

### DIFF
--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -154,7 +154,11 @@ class TestCirculationMonitor(DatabaseTest):
         with temp_config() as config:
             provider = LocalAnalyticsProvider()
             analytics = Analytics([provider])
-            config[Configuration.POLICIES][Configuration.ANALYTICS_POLICY] = analytics
+            config = {
+                Configuration.POLICIES : {
+                    Configuration.ANALYTICS_POLICY : analytics 
+                }
+            }
             
             monitor = Axis360CirculationMonitor(self._db)
             monitor.api = None

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1035,7 +1035,12 @@ class TestAnalyticsController(CirculationControllerTest):
 
     def test_track_event(self):
         with temp_config() as config:
-            config[Configuration.POLICIES][Configuration.ANALYTICS_POLICY] = ["core.local_analytics_provider"]
+
+            config = {
+                Configuration.POLICIES : {
+                    Configuration.ANALYTICS_POLICY : ["core.local_analytics_provider"]
+                }
+            }
 
             with self.app.test_request_context("/"):
                 response = self.manager.analytics_controller.track_event(self.datasource, self.identifier.type, self.identifier.identifier, "invalid_type")


### PR DESCRIPTION
This branch makes the circulation tests pass with my rock-bottom minimal configuration which specifies nothing except the database connection information. Previously there were two tests that assumed that the configuration had a (potentially empty) ''policies' section.