### PR TITLE
Handle two more server-side 3M errors.

### DIFF
--- a/api/threem.py
+++ b/api/threem.py
@@ -412,7 +412,7 @@ class ErrorParser(ThreeMParser):
             # authentication internal to 3M has failed? Anyway, it
             # happens relatively frequently.
             return RemoteInitiatedServerError(
-                response.content.ThreeMAPI.SERVICE_NAME
+                message, ThreeMAPI.SERVICE_NAME
             )
 
         m = self.loan_limit_reached.search(message)

--- a/tests/files/threem/error_authentication_failed.xml
+++ b/tests/files/threem/error_authentication_failed.xml
@@ -1,0 +1,1 @@
+<Error xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Code>Gen-001</Code><Message>Authentication failed</Message></Error>

--- a/tests/files/threem/error_unknown.xml
+++ b/tests/files/threem/error_unknown.xml
@@ -1,0 +1,1 @@
+<Error xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Code>Gen-001</Code><Message>Unknown error</Message></Error>

--- a/tests/test_threem.py
+++ b/tests/test_threem.py
@@ -283,6 +283,7 @@ class TestErrorParser(ThreeMAPITest):
         error = ErrorParser().process_all(msg)
         assert isinstance(error, RemoteInitiatedServerError)
         eq_(ThreeMAPI.SERVICE_NAME, error.service_name)
+        eq_("Unknown error", error.message)
 
     def test_remote_authentication_failed_becomes_remote_initiated_server_error(self):
         """Simulate the message we get when the error message is
@@ -293,6 +294,7 @@ class TestErrorParser(ThreeMAPITest):
         error = ErrorParser().process_all(msg)
         assert isinstance(error, RemoteInitiatedServerError)
         eq_(ThreeMAPI.SERVICE_NAME, error.service_name)
+        eq_("Authentication failed", error.message)
 
     def test_malformed_error_message_becomes_remote_initiated_server_error(self):
         msg = """<weird>This error does not follow the standard set out by 3M.</weird>"""

--- a/tests/test_threem.py
+++ b/tests/test_threem.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import datetime
 import os
 from nose.tools import (
@@ -275,6 +276,23 @@ class TestErrorParser(ThreeMAPITest):
         doc = error.as_problem_detail_document()
         eq_(502, doc.status_code)
         eq_("Integration error communicating with 3M", doc.detail)
+
+    def test_unknown_error_becomes_remote_initiated_server_error(self):
+        """Simulate the message we get when ¯\_(ツ)_/¯."""
+        msg=self.sample_data("error_unknown.xml")
+        error = ErrorParser().process_all(msg)
+        assert isinstance(error, RemoteInitiatedServerError)
+        eq_(ThreeMAPI.SERVICE_NAME, error.service_name)
+
+    def test_remote_authentication_failed_becomes_remote_initiated_server_error(self):
+        """Simulate the message we get when the error message is
+        'Authentication failed' but our authentication information is
+        set up correctly.
+        """
+        msg=self.sample_data("error_authentication_failed.xml")
+        error = ErrorParser().process_all(msg)
+        assert isinstance(error, RemoteInitiatedServerError)
+        eq_(ThreeMAPI.SERVICE_NAME, error.service_name)
 
     def test_malformed_error_message_becomes_remote_initiated_server_error(self):
         msg = """<weird>This error does not follow the standard set out by 3M.</weird>"""


### PR DESCRIPTION
This branch turns two more 3M errors into RemoteInitiatedServerErrors, meaning that they get shown as 502 errors instead of 500 errors, helping us distinguish between problems we need to fix and problems 3M needs to fix.

This time it's "Unknown error" and "Authentication failed". "Authentication failed" sure _sounds_ like it's our problem, but 3M doesn't check patron credentials, and if you give 3M the wrong client credentials you don't get this "Authentication failed" message at all; you get a 401 error with no entity-body. So we can reliably say that when 3M sends us "Authentication failed" it's always because something went wrong on the 3M side.