### PR TITLE
Use os.path.abspath to get static js file path.

### DIFF
--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -260,6 +260,6 @@ def admin_base(**kwargs):
 @returns_problem_detail
 @requires_admin
 def admin_js():
-    directory = os.path.join(os.path.dirname(__file__), "node_modules", "simplified-circulation-web", "dist")
+    directory = os.path.join(os.path.abspath(os.path.dirname(__file__)), "node_modules", "simplified-circulation-web", "dist")
     return flask.send_from_directory(directory, "circulation-web.js")
 


### PR DESCRIPTION
This was necessary to make the admin interface work on qa.