### PR TITLE
Identical delivery mechanisms are interchangeable.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -355,7 +355,7 @@ class CirculationManagerController(object):
         """Turn user input into a LicensePoolDeliveryMechanism object.""" 
         mechanism = get_one(
             self._db, LicensePoolDeliveryMechanism, license_pool=pool,
-            delivery_mechanism_id=mechanism_id
+            delivery_mechanism_id=mechanism_id, on_multiple='interchangeable'
         )
         return mechanism or BAD_DELIVERY_MECHANISM
 


### PR DESCRIPTION
This branch stops a crash when a book has multiple delivery mechanisms with the same media type and DRM scheme. (This happens currently for EPUBs published by Standard Ebooks - they have an "EPUB" version, presumably EPUB 2, and an EPUB 3 version.)

The 'solution' is to just pick one at random. This is good enough to stop the crash but it would be better to always prefer the EPUB 3 version, based on the extension associated with the Resource associated with the LicensePoolDeliveryMechanism object.