### PR TITLE
Handle patron exceeded hold limit

### DIFF
--- a/api/circulation_exceptions.py
+++ b/api/circulation_exceptions.py
@@ -5,6 +5,7 @@ from core.problem_details import (
     INTERNAL_SERVER_ERROR,
 )
 from problem_details import (
+    HOLD_LIMIT_REACHED,
     NO_LICENSES,
 )
 
@@ -86,7 +87,10 @@ class CannotHold(CirculationException):
     status_code = 500
 
 class PatronHoldLimitReached(CannotHold):
-    status_code = 403
+
+    def as_problem_detail_document(self, debug=False):
+        """Return a suitable problem detail document."""
+        return HOLD_LIMIT_REACHED
 
 class CannotReleaseHold(CirculationException):
     status_code = 500

--- a/api/controller.py
+++ b/api/controller.py
@@ -597,6 +597,8 @@ class LoanController(CirculationManagerController):
             problem_doc = INVALID_CREDENTIALS
         except PatronLoanLimitReached, e:
             problem_doc = LOAN_LIMIT_REACHED.with_debug(str(e))
+        except PatronHoldLimitReached, e:
+            problem_doc = e.as_problem_detail_document()
         except DeliveryMechanismError, e:
             return BAD_DELIVERY_MECHANISM.with_debug(
                 str(e), status_code=e.status_code

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -154,7 +154,6 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         response = self.patron_request(
             patron, pin, self.CHECKOUTS_ENDPOINT, extra_headers=headers,
             data=payload)
-
         if response.status_code == 400:
             error = response.json()
             code = error['errorCode']
@@ -499,6 +498,8 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
                 # The patron has this book checked out and cannot yet
                 # renew their loan.
                 raise CannotRenew()
+            elif code == 'PatronExceededHoldLimit':
+                raise PatronHoldLimitReached()
             else:
                 raise CannotHold(code)
         else:

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -65,6 +65,13 @@ LOAN_LIMIT_REACHED = pd(
       _("You have reached your loan limit. You cannot borrow anything further until you return something."),
 )
 
+HOLD_LIMIT_REACHED = pd(
+      "http://librarysimplified.org/terms/problem/hold-limit-reached",
+      403,
+      _("Hold limit reached."),
+      _("You have reached your hold limit and cannot put more books on hold."),
+)
+
 OUTSTANDING_FINES = pd(
       "http://librarysimplified.org/terms/problem/outstanding-fines",
       403,

--- a/tests/files/threem/error_exceeded_hold_limit.xml
+++ b/tests/files/threem/error_exceeded_hold_limit.xml
@@ -1,0 +1,1 @@
+<Error xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Code>Gen-001</Code><Message>Patron cannot have more than 15 holds</Message></Error>

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -618,14 +618,14 @@ class TestLoanController(CirculationControllerTest):
                 pool, NoAvailableCopies()
             )
             self.manager.circulation.queue_hold(
-                pool, PatronLoanLimitReached()
+                pool, PatronHoldLimitReached()
             )
             response = self.manager.loans.borrow(
                 pool.data_source.name, pool.identifier.type, 
                 pool.identifier.identifier
             )
             assert isinstance(response, ProblemDetail)
-            eq_(LOAN_LIMIT_REACHED.uri, response.uri)
+            eq_(HOLD_LIMIT_REACHED.uri, response.uri)
 
     def test_borrow_fails_with_outstanding_fines(self):
         threem_edition, pool = self._edition(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -608,6 +608,25 @@ class TestLoanController(CirculationControllerTest):
              assert isinstance(response, ProblemDetail)
              eq_(INVALID_INPUT.uri, response.uri)
 
+    def test_hold_fails_when_patron_is_at_hold_limit(self):
+        edition, pool = self._edition(with_license_pool=True)
+        pool.open_access = False
+        with self.app.test_request_context(
+                "/", headers=dict(Authorization=self.valid_auth)):
+            patron = self.manager.loans.authenticated_patron_from_request()
+            self.manager.circulation.queue_checkout(
+                pool, NoAvailableCopies()
+            )
+            self.manager.circulation.queue_hold(
+                pool, PatronLoanLimitReached()
+            )
+            response = self.manager.loans.borrow(
+                pool.data_source.name, pool.identifier.type, 
+                pool.identifier.identifier
+            )
+            assert isinstance(response, ProblemDetail)
+            eq_(LOAN_LIMIT_REACHED.uri, response.uri)
+
     def test_borrow_fails_with_outstanding_fines(self):
         threem_edition, pool = self._edition(
             with_open_access_download=False,

--- a/tests/test_threem.py
+++ b/tests/test_threem.py
@@ -175,6 +175,13 @@ class TestThreeMAPI(ThreeMAPITest):
         eq_(pool.identifier.type, response.identifier_type)
         eq_(pool.identifier.identifier, response.identifier)
 
+    def test_place_hold_fails_if_exceeded_hold_limit(self):
+        patron = self._patron()        
+        edition, pool = self._edition(with_license_pool=True)
+        self.api.queue_response(400, content=self.sample_data("error_exceeded_hold_limit.xml"))
+        assert_raises(PatronHoldLimitReached, self.api.place_hold,
+                      patron, 'pin', pool)
+
 # Tests of the various parser classes.
 #
 
@@ -257,6 +264,12 @@ class TestErrorParser(ThreeMAPITest):
         error = ErrorParser().process_all(msg)
         assert isinstance(error, PatronLoanLimitReached)
         eq_(u'Patron cannot loan more than 12 documents', error.message)
+
+    def test_exceeded_hold_limit(self):
+        msg=self.sample_data("error_exceeded_hold_limit.xml")
+        error = ErrorParser().process_all(msg)
+        assert isinstance(error, PatronHoldLimitReached)
+        eq_(u'Patron cannot have more than 15 holds', error.message)
 
     def test_wrong_status(self):
         msg=self.sample_data("error_no_licenses.xml")


### PR DESCRIPTION
This branch improves error handling for the errors that occur when you try to put an Overdrive or 3M book on hold, but you already have reached your hold limit.

AFAICT Axis 360 doesn't impose loan or hold limits. The same is true for Feedbooks. I filed
https://github.com/NYPL-Simplified/circulation/issues/305 to add support for loan and hold limits on the circ manager side.