### PR TITLE
Look up 3M books on the metadata wrangler by ISBN

### DIFF
--- a/api/coverage.py
+++ b/api/coverage.py
@@ -250,7 +250,7 @@ class MetadataWranglerCoverageProvider(OPDSImportCoverageProvider):
         """
         mapping = dict()
         for identifier in batch:
-            if identifier.type == Identifier.AXIS_360_ID:
+            if identifier.type in [Identifier.AXIS_360_ID, Identifier.THREEM_ID]:
                 for e in identifier.equivalencies:
                     if e.output.type == Identifier.ISBN:
                         mapping[e.output] = identifier

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -232,17 +232,21 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
         # Most identifiers map to themselves.
         overdrive = self._identifier(Identifier.OVERDRIVE_ID)
 
-        # But Axis 360 identifiers map to equivalent ISBNs.
+        # But Axis 360 and 3M identifiers map to equivalent ISBNs.
         axis = self._identifier(Identifier.AXIS_360_ID)
-        isbn = self._identifier(Identifier.ISBN)
+        threem = self._identifier(Identifier.THREEM_ID)
+        isbn_axis = self._identifier(Identifier.ISBN)
+        isbn_threem = self._identifier(Identifier.ISBN)
 
         who_says = DataSource.lookup(self._db, DataSource.AXIS_360)
 
-        axis.equivalent_to(who_says, isbn, 1)
+        axis.equivalent_to(who_says, isbn_axis, 1)
+        threem.equivalent_to(who_says, isbn_threem, 1)
 
-        mapping = self.provider.create_identifier_mapping([overdrive, axis])
+        mapping = self.provider.create_identifier_mapping([overdrive, axis, threem])
         eq_(overdrive, mapping[overdrive])
-        eq_(axis, mapping[isbn])
+        eq_(axis, mapping[isbn_axis])
+        eq_(threem, mapping[isbn_threem])
 
     def test_items_that_need_coverage(self):
         source = DataSource.lookup(self._db, DataSource.METADATA_WRANGLER)


### PR DESCRIPTION
This will allow other libraries to look up 3M books that aren't in NYPL's 3M collection.

This fixes #247 