### PR TITLE
Scripts to display raw data from Overdrive

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -548,7 +548,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         else:
             book_id = book['id']
             circulation_link = book['availability_link']
-        return book_id, self.get(circulation_link, {})
+        return book, self.get(circulation_link, {})
 
     def update_licensepool(self, book):
         """Update availability information for a single book.
@@ -564,7 +564,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         # Retrieve current circulation information about this book
         book_id = None
         try:
-            book_id, (status_code, headers, content) = self.circulation_lookup(
+            book, (status_code, headers, content) = self.circulation_lookup(
                 book
             )
         except Exception, e:
@@ -581,8 +581,8 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
             )
             return None, None, False
 
-        #set_trace()
         book.update(json.loads(content))
+        book_id = book['id']
         license_pool, is_new = LicensePool.for_foreign_id(
             self._db, DataSource.OVERDRIVE, Identifier.OVERDRIVE_ID, book_id)
         if is_new:

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -562,7 +562,6 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         created for the LicensePool and set as presentation-ready.
         """
         # Retrieve current circulation information about this book
-        book_id = None
         try:
             book, (status_code, headers, content) = self.circulation_lookup(
                 book
@@ -577,7 +576,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         if status_code != 200:
             self.log.error(
                 "Could not get availability for %s: status code %s",
-                book_id, status_code
+                book['id'], status_code
             )
             return None, None, False
 

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -536,7 +536,20 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
             # There was never a hold to begin with, so we're fine.
             return True
         raise CannotReleaseHold(response.content)
-       
+
+    def circulation_lookup(self, book):
+        if isinstance(book, basestring):
+            book_id = book
+            circulation_link = self.AVAILABILITY_ENDPOINT % dict(
+                collection_token=self.collection_token,
+                product_id=book_id
+            )
+            book = dict(id=book_id)
+        else:
+            book_id = book['id']
+            circulation_link = book['availability_link']
+        return book_id, self.get(circulation_link, {})
+
     def update_licensepool(self, book):
         """Update availability information for a single book.
 
@@ -549,30 +562,22 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         created for the LicensePool and set as presentation-ready.
         """
         # Retrieve current circulation information about this book
-        orig_book = book
         book_id = None
-        if isinstance(book, basestring):
-            book_id = book
-            circulation_link = self.AVAILABILITY_ENDPOINT % dict(
-                collection_token=self.collection_token,
-                product_id=book_id
-            )
-            book = dict(id=book_id)
-        else:
-            book_id = book['id']
-            circulation_link = book['availability_link']
         try:
-            status_code, headers, content = self.get(circulation_link, {})
+            book_id, (status_code, headers, content) = self.circulation_lookup(
+                book
+            )
         except Exception, e:
             status_code = None
             self.log.error(
                 "HTTP exception communicating with Overdrive",
                 exc_info=e
             )
+
         if status_code != 200:
             self.log.error(
                 "Could not get availability for %s: status code %s",
-                book['id'], status_code
+                book_id, status_code
             )
             return None, None, False
 

--- a/api/threem.py
+++ b/api/threem.py
@@ -245,7 +245,7 @@ class ThreeMAPI(BaseThreeMAPI, BaseCirculationAPI):
             self.log.info("Updating %s (%s)", e.title, e.author)
         else:
             self.log.info(
-                "Updating unknown work %s", identifier.identifier
+                "Updating unknown work %s", pool.identifier
             )
         # Update availability and send out notifications.
         pool.update_availability(

--- a/bin/informational/overdrive-raw-bibliographic
+++ b/bin/informational/overdrive-raw-bibliographic
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+from nose.tools import set_trace
+import json
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from core.scripts import IdentifierInputScript
+from api.overdrive import OverdriveAPI
+
+class OverdriveRawBibliographicScript(IdentifierInputScript):
+    def run(self):
+        overdrive = OverdriveAPI(self._db)
+        args = self.parse_command_line(self._db)
+        for identifier in args.identifiers:
+            data = overdrive.metadata_lookup(identifier)
+            print json.dumps(data, sort_keys=True, indent=4,
+                             separators=(',', ': '))
+            print
+
+OverdriveRawBibliographicScript().run()

--- a/bin/informational/overdrive-raw-circulation
+++ b/bin/informational/overdrive-raw-circulation
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+from nose.tools import set_trace
+import json
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from core.scripts import IdentifierInputScript
+from api.overdrive import OverdriveAPI
+
+class OverdriveRawCirculationScript(IdentifierInputScript):
+    def run(self):
+        overdrive = OverdriveAPI(self._db)
+        args = self.parse_command_line(self._db)
+        for identifier in args.identifiers:
+            book_id, (status_code, headers, content) = overdrive.circulation_lookup(
+                  identifier.identifier
+            )
+            data = json.loads(content)
+            print json.dumps(data, sort_keys=True, indent=4,
+                             separators=(',', ': '))
+            print
+
+OverdriveRawCirculationScript().run()

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -209,6 +209,21 @@ class TestOverdriveAPI(OverdriveAPITest):
         eq_(dict(id="an identifier"), book)
         eq_(200, status_code)
         eq_("foo", content)
+        
+    def test_update_licensepool_error(self):
+        # Create an identifier.
+        identifier = self._identifier(
+            identifier_type=Identifier.OVERDRIVE_ID
+        )
+        ignore, availability = self.sample_json(
+            "overdrive_availability_information.json"
+        )
+        api = DummyOverdriveAPI(self._db)
+        api.queue_response(response_code=500, content=availability)
+        book = dict(id=identifier.identifier, availability_link=self._url)
+        pool, was_new, changed = api.update_licensepool(book)
+        eq_(None, pool)
+
 
     def test_update_licensepool_provides_bibliographic_coverage(self):
         # Create an identifier.

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -203,10 +203,10 @@ class TestOverdriveAPI(OverdriveAPITest):
         api = DummyOverdriveAPI(self._db)
         api.queue_response(content="foo")
 
-        book_id, (status_code, headers, content) = api.circulation_lookup(
+        book, (status_code, headers, content) = api.circulation_lookup(
             "an identifier"
         )
-        eq_("an identifier", book_id)
+        eq_(dict(id="an identifier"), book)
         eq_(200, status_code)
         eq_("foo", content)
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -196,6 +196,20 @@ class TestOverdriveAPI(OverdriveAPITest):
         eq_(0, pool.patrons_in_hold_queue)
         assert pool.last_checked is not None
 
+    def test_circulation_lookup(self):
+        """Test the method that actually looks up Overdrive circulation
+        information.
+        """
+        api = DummyOverdriveAPI(self._db)
+        api.queue_response(content="foo")
+
+        book_id, (status_code, headers, content) = api.circulation_lookup(
+            "an identifier"
+        )
+        eq_("an identifier", book_id)
+        eq_(200, status_code)
+        eq_("foo", content)
+
     def test_update_licensepool_provides_bibliographic_coverage(self):
         # Create an identifier.
         identifier = self._identifier(


### PR DESCRIPTION
Sometimes it's useful to see exactly what Overdrive says when asked for bibliographic or circulation data. This branch creates two new informational scripts for dumping this information to standard output. Previously I was writing one-off scripts for this and I'm tired of it.