### PR TITLE
Instead of parsing the Millenium patron dump as HTML, parse it as a text file delimited by <BR>\n

### DIFF
--- a/tests/files/millenium_patron/dump.embedded_html.html
+++ b/tests/files/millenium_patron/dump.embedded_html.html
@@ -1,0 +1,7 @@
+<HTML><BODY>REC INFO[p!]=p<BR>
+This line is malformed and does not end with a BR tag.
+THIS FIELD[would]=work but it doesn't end with a BR tag either.
+This line is malformed and contains no equal sign.<BR>
+MESSAGE[pm]=This message<BR>includes <a href="http://example.com/">HTML</a>.<BR>
+P BARCODE[pb]=abcd<BR>
+</BODY></HTML>

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -49,6 +49,19 @@ class TestMilleniumPatronAPI(DatabaseTest):
         # The 'note' field has a list of values, not just one.
         eq_(2, len(response['NOTE[px]']))
 
+    def test_parse_poorly_behaved_dump(self):
+        self.api.enqueue("dump.embedded_html.html")
+        response = self.api.dump("good barcode")
+
+        # All the unparseable lines in this file were ignored.
+        eq_(set(['REC INFO[p!]', 'MESSAGE[pm]', 'P BARCODE[pb]']),
+            set(response.keys()))
+
+        eq_('p', response['REC INFO[p!]'])
+        eq_(['abcd'], response['P BARCODE[pb]'])
+        eq_('This message<BR>includes <a href="http://example.com/">HTML</a>.',
+            response['MESSAGE[pm]'])
+
     def test_pintest_no_such_barcode(self):
         self.api.enqueue("pintest.no such barcode.html")
         eq_(False, self.api.pintest("wrong barcode", "pin"))


### PR DESCRIPTION
This seems like a clunkier solution than what we had before, but it's more robust on the data we actually have. The problem with parsing the dump as HTML is that the values may themselves contain HTML, including (presumably, though I haven't seen it) BR tags. Whereas I've never seen a value in the patron dump that contained embedded newlines--it looks like they get changed to dollar signs.