### PR TITLE
Properly handle an error if it occurs when getting the list of 3M events

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -358,10 +358,15 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
             loans = self.get_patron_checkouts(patron, pin)
             holds = self.get_patron_holds(patron, pin)
         except PatronAuthorizationFailedException, e:
-            # TODO: This allows us to do account syncing
-            # even when running against the test ILS, which
-            # does not use barcodes recognized by Overdrive.
-            self.log.error(
+            # This frequently happens because Overdrive performs
+            # checks for blocked or expired accounts upon initial
+            # authorization, where the circulation manager would let
+            # the 'authorization' part succeed and block the patron's
+            # access afterwards.
+            #
+            # It's common enough that it's hardly worth mentioning, but it
+            # could theoretically be the sign of a larger problem.
+            self.log.info(
                 "Overdrive authentication failed, assuming no loans.",
                 exc_info=e
             )

--- a/api/threem.py
+++ b/api/threem.py
@@ -754,6 +754,7 @@ class ThreeMEventMonitor(Monitor):
             most_recent_timestamp = start
             self.log.info("Asking for events between %r and %r", start, cutoff)
             try:
+                event = None
                 events = self.api.get_events_between(start, cutoff, full_slice)
                 for event in events:
                     event_timestamp = self.handle_event(*event)
@@ -765,8 +766,16 @@ class ThreeMEventMonitor(Monitor):
                         self._db.commit()
                 self._db.commit()
             except Exception, e:
-                self.log.error("Fatal error processing 3M event %r.", event,
-                               exc_info=e)
+                if event:
+                    self.log.error(
+                        "Fatal error processing 3M event %r.", event,
+                        exc_info=e
+                    )
+                else:
+                    self.log.error(
+                        "Fatal error getting list of 3M events.",
+                        exc_info=e
+                    )
                 raise e
             self.timestamp.timestamp = most_recent_timestamp
         self.log.info("Handled %d events total", i)


### PR DESCRIPTION
This branch stops a couple minor problems from cluttering up our error log.

First: When the 3M monitor gets an error handling a 3M event it's logged and reraised, killing the script. When the monitor get an error _getting the list of events_ it's not logged because of an undefined variable. The script is still killed but the reason why is lost. (Although the reason why is almost certainly a timeout.) This simple branch makes sure the error is properly logged before being reraised.

Second: When a patron's card is blocked or expired, we don't allow them to carry out transactions but we do let them sync their list of loans. But Overdrive won't even let such a patron get their list of loans. We were logging this at the 'error' level because it seemed impossible that the ILS would authorize the patron but Overdrive would refuse to do so; but actually it happens all the time and is almost never a serious problem.