### PR TITLE
Make the 'Children/Middle Grades' lane searchable.

### DIFF
--- a/api/lanes.py
+++ b/api/lanes.py
@@ -228,6 +228,7 @@ def lanes_for_large_collection(_db, languages):
         fiction=Lane.BOTH_FICTION_AND_NONFICTION,
         include_best_sellers=True,
         include_staff_picks=True,
+        searchable=True,
         sublanes=[
             Lane(_db, full_name="Picture Books", age_range=[0,1,2,3,4],
                  genres=None, fiction=Lane.BOTH_FICTION_AND_NONFICTION,

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -77,6 +77,14 @@ class TestLaneCreation(DatabaseTest):
         assert 'History' in history.genre_names
         assert 'European History' in history.genre_names
 
+        # The Children lane is searchable; the others are not.
+        ya_fiction, ya_nonfiction, children = lane.sublanes.lanes[3:6]
+        eq_(False, nonfiction.searchable)
+        eq_(False, ya_fiction.searchable)
+
+        eq_("Children and Middle Grade", children.name)
+        eq_(True, children.searchable)
+
     def test_lane_for_small_collection(self):
         lane = lane_for_small_collection(self._db, ['eng', 'spa', 'chi'])
         eq_(u"English/español/Chinese", lane.display_name)


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/circulation/issues/317, making it safe to leave the iPad with your five-year-old.