### PR TITLE
WWW-Authenticate header omitted for XMLHttpRequests

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -299,8 +299,11 @@ class CirculationManagerController(object):
     def authenticate(self):
         """Sends a 401 response that demands authentication."""
         data = self.manager.opds_authentication_document
-        headers= { 'WWW-Authenticate' : 'Basic realm="%s"' % _("Library card"),
-                   'Content-Type' : OPDSAuthenticationDocument.MEDIA_TYPE }
+        headers = { 'Content-Type' : OPDSAuthenticationDocument.MEDIA_TYPE }
+        # if requested from a web client, don't include WWW-Authenticate header,
+        # which forces the default browser authentication prompt
+        if not flask.request.headers.get("X-Requested-With") == "XMLHttpRequest":
+            headers['WWW-Authenticate'] = 'Basic realm="%s"' % _("Library card")
         return Response(data, 401, headers)
 
     def load_lane(self, language_key, name):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -176,15 +176,19 @@ class TestBaseController(CirculationControllerTest):
         value = self.controller.authenticated_patron(dict(username="5", password="5555"))
         assert isinstance(value, Patron)
 
-
     def test_authentication_sends_proper_headers(self):
         '''
         Make sure the reals header has quotes around the realm name.  
         Without quotes, some iOS versions don't recognize the header value.
         '''
-        response = self.controller.authenticate()
         
+        with self.app.test_request_context("/"):
+            response = self.controller.authenticate()
         eq_(response.headers['WWW-Authenticate'], u'Basic realm="Library card"')
+
+        with self.app.test_request_context("/", headers={"X-Requested-With": "XMLHttpRequest"}):
+            response = self.controller.authenticate()            
+        eq_(None, response.headers.get("WWW-Authenticate"))
 
     def test_load_lane(self):
         eq_(self.manager.top_level_lane, self.controller.load_lane(None, None))


### PR DESCRIPTION
In order for NYPL-Simplified/opds-web-client to display a custom login form based on OPDS authentication data from the server (title, login and password labels, etc), the `WWW-Authenticate` response header must be omitted because it triggers the browser's default basic authentication popup. This branch changes basic authentication so that this response header is omitted when the `X-Requested-With` request header is present and set to the commonly used `XMLHttpRequest`.