### PR TITLE
Allow a client to do authdata token-based authentication through the interface normally used for username/password authentication.

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -76,9 +76,9 @@ class Authenticator(object):
 
         valid = True
         if self.identifier_re:
-            valid = valid and (self.identifier_re.match(identifier) is not None)
+            valid = valid and identifier and (self.identifier_re.match(identifier) is not None)
         if self.password_re:
-            valid = valid and (self.password_re.match(password) is not None)
+            valid = valid and password and (self.password_re.match(password) is not None)
         return valid
 
     def decode_token(self, token):


### PR DESCRIPTION
This branch changes our implementation of the Adobe Vendor ID service to support token-based authentication even for clients that don't normally support it. This is all clients, because Adobe's client-side implementation can only use username/password authentication in some key places.

Here's how it works: you can get a single-use token by triggering the `create_authdata` endpoint. 
At this point you're supposed to sign in with an authData request, including the token as your authData. Instead, we have you sign in with a standard request (_not_ an authData request) and pass the single-use token in as the username, leaving the password blank.

If the password is blank, we try doing a token lookup based on the "username". Only if that fails do we try doing a username/password lookup.