### PR TITLE
convert strings to utf8 before posting data to google analytics

### DIFF
--- a/api/google_analytics_provider.py
+++ b/api/google_analytics_provider.py
@@ -45,6 +45,8 @@ class GoogleAnalyticsProvider(object):
                 'cd10': edition.language,
                 'cd11': work.top_genre()
             })
+        # urlencode doesn't like unicode strings so we convert them to utf8
+        fields = {k: unicode(v).encode('utf8') for k, v in fields.iteritems()}
         params = re.sub(r"=None(&?)", r"=\1", urllib.urlencode(fields))
         self.post("http://www.google-analytics.com/collect", params)
 

--- a/api/google_analytics_provider.py
+++ b/api/google_analytics_provider.py
@@ -52,10 +52,6 @@ class GoogleAnalyticsProvider(object):
 
     def post(self, url, params):
         response = HTTP.post_with_timeout(url, params)
-        logging.info(
-            "Posted %s to %s and received (%d)",
-            params, url, response.status_code
-        )
 
         
 Provider = GoogleAnalyticsProvider

--- a/api/google_analytics_provider.py
+++ b/api/google_analytics_provider.py
@@ -3,7 +3,6 @@ import uuid
 import urllib
 import re
 from core.util.http import HTTP
-import logging
 
 class GoogleAnalyticsProvider(object):
     INTEGRATION_NAME = "Google Analytics"

--- a/api/google_analytics_provider.py
+++ b/api/google_analytics_provider.py
@@ -13,7 +13,6 @@ class GoogleAnalyticsProvider(object):
         return cls(tracking_id)
 
     def __init__(self, tracking_id):
-        logging.info("Google Analytics Provider init with tracking id: %s", tracking_id)
         self.tracking_id = tracking_id
 
     def collect_event(self, _db, license_pool, event_type, time, **kwargs):

--- a/tests/test_google_analytics_provider.py
+++ b/tests/test_google_analytics_provider.py
@@ -41,7 +41,7 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
     def test_collect_event_with_work(self):
         ga = MockGoogleAnalyticsProvider("faketrackingid")
         work = self._work(
-            title="title", authors="author", fiction=True,
+            title=u"pi\u00F1ata", authors=u"chlo\u00E9", fiction=True,
             audience="audience", language="lang", 
             with_license_pool=True, genre="Folklore"
         )
@@ -61,8 +61,8 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
         eq_(str(now), params['cd1'][0])
         eq_(lp.identifier.identifier, params['cd2'][0])
         eq_(lp.identifier.type, params['cd3'][0])
-        eq_("title", params['cd4'][0])
-        eq_("author", params['cd5'][0])
+        eq_(u"pi\u00F1ata".encode('utf8'), params['cd4'][0])
+        eq_(u"chlo\u00E9".encode('utf8'), params['cd5'][0])
         eq_("fiction", params['cd6'][0])
         eq_("audience", params['cd7'][0])
         eq_(work.target_age_string, params['cd8'][0])


### PR DESCRIPTION
`GoogleAnalyticsProvider` uses `urllib.urlencode` to post data to an analytics API endpoint, but when data includes `Unicode` strings it produces an error like this:

```
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf3' in position 9: ordinal not in range(128)
```

This branch solves this problem by converting all strings to `UTF-8` before passing them to `urllib.urlencode`.