### PR TITLE
Added ndg-httpsclient requirement.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,9 @@ cairosvg
 py-bcrypt
 Flask-Babel
 
+# Ensure that we support SNI-based SSL
+ndg-httpsclient
+
 # In circ, feedparser is only used in tests.
 feedparser
 


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/server_core/issues/361 by adding ndg-httpsclient to the requirements list.