### PR TITLE
Handle firstbook error

### DIFF
--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -119,7 +119,9 @@ class DummyFirstBookAuthentationAPI(FirstBookAuthenticationAPI):
             raise requests.exceptions.ConnectionError("Could not connect!")
         elif self.failure_status_code:
             # Simulate a server returning an unexpected error code.
-            return DummyFirstBookResponse(self.failure_status_code)
+            return DummyFirstBookResponse(
+                self.failure_status_code, "Error %s" % self.failure_status_code
+            )
         qa = urlparse.parse_qs(url)
         if 'accesscode' in qa and 'pin' in qa:
             [code] = qa['accesscode']

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -59,12 +59,12 @@ class FirstBookAuthenticationAPI(BasicAuthAuthenticator):
         try:
             response = self.request(url)
         except requests.exceptions.ConnectionError, e:
-            raise RemoteInitiatedServerError(str(e.message))
+            raise RemoteInitiatedServerError(str(e.message), self.NAME)
         if response.status_code != 200:
             msg = "Got unexpected response code %d. Content: %s" % (
                 response.status_code, response.content
             )
-            raise RemoteInitiatedServerError(msg)
+            raise RemoteInitiatedServerError(msg, self.NAME)
         if self.SUCCESS_MESSAGE in response.content:
             return True
         return False
@@ -106,11 +106,20 @@ class DummyFirstBookAuthentationAPI(FirstBookAuthenticationAPI):
     SUCCESS = '"Valid Code Pin Pair"'
     FAILURE = '{"code":404,"message":"Access Code Pin Pair not found"}'
 
-    def __init__(self, valid={}):
+    def __init__(self, valid={}, bad_connection=False, 
+                 failure_status_code=None):
         self.root = "http://example.com/"
         self.valid = valid
+        self.bad_connection = bad_connection
+        self.failure_status_code = failure_status_code
 
     def request(self, url):
+        if self.bad_connection:
+            # Simulate a bad connection.
+            raise requests.exceptions.ConnectionError("Could not connect!")
+        elif self.failure_status_code:
+            # Simulate a server returning an unexpected error code.
+            return DummyFirstBookResponse(self.failure_status_code)
         qa = urlparse.parse_qs(url)
         if 'accesscode' in qa and 'pin' in qa:
             [code] = qa['accesscode']
@@ -119,6 +128,5 @@ class DummyFirstBookAuthentationAPI(FirstBookAuthenticationAPI):
                 return DummyFirstBookResponse(200, self.SUCCESS)
             else:
                 return DummyFirstBookResponse(200, self.FAILURE)
-
 
 AuthenticationAPI = FirstBookAuthenticationAPI

--- a/tests/test_firstbook.py
+++ b/tests/test_firstbook.py
@@ -1,9 +1,17 @@
 from nose.tools import (
+    assert_raises_regexp,
     eq_,
     set_trace,
 )
 
-from api.firstbook import DummyFirstBookAuthentationAPI
+from api.firstbook import (
+    BrokenFirstBookAuthentationAPI
+    DummyFirstBookAuthentationAPI,
+)
+
+#from api.circulation_exceptions import (
+#    RemoteInitiatedServerError
+#)
 
 class TestFirstBook(object):
     
@@ -28,4 +36,11 @@ class TestFirstBook(object):
 
     def test_patron_info(self):
         eq_("1234", self.api.patron_info("1234").get('barcode'))
+
+    def test_broken_service_pintest(self):
+        api = DummyFirstBookAuthentationAPI(failure_status_code=502)
+        assert_raises_regexp(
+            RemoteInitiatedServerError, "blah",
+            api.pintest, "key", "pin"
+        )
     

--- a/tests/test_firstbook.py
+++ b/tests/test_firstbook.py
@@ -5,13 +5,12 @@ from nose.tools import (
 )
 
 from api.firstbook import (
-    BrokenFirstBookAuthentationAPI
     DummyFirstBookAuthentationAPI,
 )
 
-#from api.circulation_exceptions import (
-#    RemoteInitiatedServerError
-#)
+from api.circulation_exceptions import (
+    RemoteInitiatedServerError
+)
 
 class TestFirstBook(object):
     
@@ -40,7 +39,16 @@ class TestFirstBook(object):
     def test_broken_service_pintest(self):
         api = DummyFirstBookAuthentationAPI(failure_status_code=502)
         assert_raises_regexp(
-            RemoteInitiatedServerError, "blah",
+            RemoteInitiatedServerError, 
+            "Got unexpected response code 502. Content: Error 502",
+            api.pintest, "key", "pin"
+        )
+    
+    def test_bad_connection_pintest(self):
+        api = DummyFirstBookAuthentationAPI(bad_connection=True)
+        assert_raises_regexp(
+            RemoteInitiatedServerError, 
+            "Could not connect!",
             api.pintest, "key", "pin"
         )
     


### PR DESCRIPTION
This branch ensures that errors from the First Book API are properly turned into `RemoteInitiatedServerError` exceptions. Previously the constructor was initiated without the required service name.