### PR TITLE
Finalize batch

### DIFF
--- a/api/coverage.py
+++ b/api/coverage.py
@@ -338,7 +338,7 @@ class MetadataWranglerCollectionReaper(MetadataWranglerCoverageProvider):
                 )
         for record in coverage_records.all():
             self._db.delete(record)
-
+        super(MetadataWranglerCollectionReaper, self).finalize_batch()
 
 class ContentServerBibliographicCoverageProvider(OPDSImportCoverageProvider):
     """Make sure our records for open-access books match what the content


### PR DESCRIPTION
This branch updates the circ manager to reflect the fact that `CoverageProvider.finalize_batch()` now commits the database session. We have a coverage provider that implements `finalize_batch` and we want to make sure it calls the superclass.