### PR TITLE
Fetch and return fulfillment content instead of redirecting to it.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -731,6 +731,7 @@ class LoanController(CirculationManagerController):
                 # We need to fetch the content and return it instead of redirecting to it.
                 try:
                     status_code, headers, content = do_get(fulfillment.content_link, headers={})
+                    headers = dict(headers)
                 except RemoteIntegrationException, e:
                     return e.as_problem_detail_document(debug=False)
             else:

--- a/api/controller.py
+++ b/api/controller.py
@@ -657,8 +657,9 @@ class LoanController(CirculationManagerController):
 
         If successful, this will serve the patron a downloadable copy of
         the book, or a DRM license file which can be used to get the
-        book). Alternatively, it may serve an HTTP redirect that sends the
-        patron to a copy of the book or a license file.
+        book). Alternatively, for a streaming delivery mechanism it may
+        serve an OPDS entry with a link to a third-party web page that
+        streams the content.
         """
         do_get = do_get or Representation.simple_http_get
 


### PR DESCRIPTION
This fixes https://github.com/NYPL-Simplified/circulation-patron-web/issues/14