### PR TITLE
Fix and test the client for the metadata wrangler collection reaper

### DIFF
--- a/tests/files/opds/metadata_reaper_response.opds
+++ b/tests/files/opds/metadata_reaper_response.opds
@@ -1,0 +1,22 @@
+<feed xmlns:bibframe="http://bibframe.org/vocab/" xmlns:simplified="http://librarysimplified.org/terms/" xmlns:app="http://www.w3.org/2007/app" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom">
+  <id>http://oacontent.alpha.librarysimplified.org/lookup?urn=http%3A%2F%2Fwww.gutenberg.org%2Febooks%2F2020110</id>
+  <title>Lookup results</title>
+  <updated>2016-06-14T20:02:55Z</updated>
+  <link href="http://oacontent.alpha.librarysimplified.org/lookup?urn=http%3A%2F%2Fwww.gutenberg.org%2Febooks%2F2020110" rel="self"/>
+  <simplified:message>
+    <id>urn:isbn:1234</id>
+    <simplified:status_code>200</simplified:status_code>
+    <schema:description>Successfully removed</schema:description>
+  </simplified:message>
+  <simplified:message>
+    <id>http://www.gutenberg.org/ebooks/2020110</id>
+    <simplified:status_code>404</simplified:status_code>
+    <schema:description>Not in collection catalog</schema:description>
+  </simplified:message>
+ <simplified:message>
+    <id>http://www.gutenberg.org/ebooks/2020110</id>
+    <simplified:status_code>404</simplified:status_code>
+    <schema:description>I've never heard of this work.</schema:description>
+  </simplified:message>
+</feed>
+


### PR DESCRIPTION
This branch changes the metadata wrangler collection reaper to accommodate the changes made by
https://github.com/NYPL-Simplified/metadata_wrangler/pull/85, and adds a test for previously untested code. Instead of attempting a full OPDS feed import, we just extract OPDSMessage objects from the feed. Those messages will tel us which items were successfully reaped and which ones failed for some reason.
