### PR TITLE
Changed search index update script to use a Monitor instead of a CoverageProvider.

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -8,6 +8,7 @@ import sys
 import time
 import urlparse
 import logging
+import argparse
 
 from sqlalchemy import (
     or_,
@@ -21,7 +22,7 @@ from psycopg2.extras import NumericRange
 
 from api.lanes import make_lanes
 from api.controller import CirculationManager
-from api.coverage import SearchIndexCoverageProvider
+from api.monitor import SearchIndexMonitor
 from api.threem import ThreeMCirculationSweep
 from api.overdrive import OverdriveAPI
 from core import log
@@ -46,6 +47,7 @@ from core.scripts import (
     RunCoverageProvidersScript,
     RunCoverageProviderScript,
     IdentifierInputScript,
+    RunMonitorScript,
 )
 from core.lane import (
     Pagination,
@@ -548,21 +550,17 @@ class CompileTranslationsScript(Script):
         
         os.system("pybabel compile -f -d translations")
 
-class UpdateSearchIndexScript(RunCoverageProviderScript):
+class UpdateSearchIndexScript(RunMonitorScript):
 
-    @classmethod
-    def arg_parser(cls):
-        parser = RunCoverageProviderScript.arg_parser()
+    def __init__(self):
+        parser = argparse.ArgumentParser()
         parser.add_argument(
             '--works-index', 
             help='The ElasticSearch index to update, if other than the default.'
         )
-        return parser
+        parsed = parser.parse_args()
 
-    def extract_additional_command_line_arguments(self, args):
-        return dict(index_name=args.works_index)
-
-    def __init__(self):
         super(UpdateSearchIndexScript, self).__init__(
-            SearchIndexCoverageProvider
+            SearchIndexMonitor,
+            index_name=parsed.works_index,
         )

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,30 @@
+from nose.tools import (
+    set_trace,
+    eq_,
+)
+
+from . import (
+    DatabaseTest,
+)
+
+from api.monitor import SearchIndexMonitor
+
+from core.external_search import DummyExternalSearchIndex
+
+class TestSearchIndexMonitor(DatabaseTest):
+
+    def test_run(self):
+        index = DummyExternalSearchIndex()
+
+        # Here's a work.
+        work = self._work()
+        work.presentation_ready = True
+
+        # Here's a Monitor that can index it.
+        monitor = SearchIndexMonitor(self._db, "works-index", index)
+
+        # Let's run the monitor.
+        monitor.run()
+
+        # The work was added to the search index.
+        eq_([('works', 'work-type', work.id)], index.docs.keys())


### PR DESCRIPTION
With https://github.com/NYPL-Simplified/server_core/pull/377, creating search documents is very fast, so it's no longer expensive to reindex all the works. Without the CoverageRecords, I can make a complete search index in 10 minutes!