### PR TITLE
update_licensepool should handle unhelpful errors, and errors in building a series feed should be propagated

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -926,6 +926,7 @@ class WorkController(CirculationManagerController):
             return NO_SUCH_LANE.detailed(e.message)
 
         annotator = self.manager.annotator(lane)
+        facets = load_facets_from_request()
         if isinstance(facets, ProblemDetail):
             return facets
         pagination = load_pagination_from_request()

--- a/api/controller.py
+++ b/api/controller.py
@@ -952,10 +952,16 @@ class WorkController(CirculationManagerController):
 
         lane = SeriesLane(self._db, series_name)
         annotator = self.manager.annotator(lane)
+        facets = load_facets_from_request()
+        if isinstance(facets, ProblemDetail):
+            return facets
+        pagination = load_pagination_from_request()
+        if isinstance(pagination, ProblemDetail):
+            return pagination
         url = annotator.feed_url(
             lane,
-            facets=load_facets_from_request(),
-            pagination=load_pagination_from_request()
+            facets=facets,
+            pagination=pagination,
         )
 
         feed = AcquisitionFeed.page(

--- a/api/controller.py
+++ b/api/controller.py
@@ -832,10 +832,16 @@ class WorkController(CirculationManagerController):
         lane = ContributorLane(self._db, contributor_name)
 
         annotator = self.manager.annotator(lane)
+        facets = load_facets_from_request()
+        if isinstance(facets, ProblemDetail):
+            return facets
+        pagination = load_pagination_from_request()
+        if isinstance(pagination, ProblemDetail):
+            return pagination
         url = annotator.feed_url(
             lane,
-            facets=load_facets_from_request(),
-            pagination=load_pagination_from_request()
+            facets=facets,
+            pagination=pagination,
         )
 
         feed = AcquisitionFeed.page(
@@ -882,10 +888,16 @@ class WorkController(CirculationManagerController):
             return NO_SUCH_LANE.detailed(_("Recommendations not available"))
 
         annotator = self.manager.annotator(lane)
+        facets = load_facets_from_request()
+        if isinstance(facets, ProblemDetail):
+            return facets
+        pagination = load_pagination_from_request()
+        if isinstance(pagination, ProblemDetail):
+            return pagination
         url = annotator.feed_url(
             lane,
-            facets=load_facets_from_request(),
-            pagination=load_pagination_from_request()
+            facets=facets,
+            pagination=pagination,
         )
 
         feed = AcquisitionFeed.page(
@@ -914,10 +926,15 @@ class WorkController(CirculationManagerController):
             return NO_SUCH_LANE.detailed(e.message)
 
         annotator = self.manager.annotator(lane)
+        if isinstance(facets, ProblemDetail):
+            return facets
+        pagination = load_pagination_from_request()
+        if isinstance(pagination, ProblemDetail):
+            return pagination
         url = annotator.feed_url(
             lane,
-            facets=load_facets_from_request(),
-            pagination=load_pagination_from_request()
+            facets=facets,
+            pagination=pagination,
         )
 
         feed = AcquisitionFeed.groups(

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -608,7 +608,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         )
         circulation_data.apply(licensepool, replace)
 
-    def update_licensepool(self, book):
+    def update_licensepool(self, book_id):
         """Update availability information for a single book.
 
         If the book has never been seen before, a new LicensePool
@@ -622,7 +622,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         # Retrieve current circulation information about this book
         try:
             book, (status_code, headers, content) = self.circulation_lookup(
-                book
+                book_id
             )
         except Exception, e:
             status_code = None
@@ -634,11 +634,13 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         if status_code != 200:
             self.log.error(
                 "Could not get availability for %s: status code %s",
-                book['id'], status_code
+                book_id, status_code
             )
             return None, None, False
 
         book.update(json.loads(content))
+
+        # Update book_id now that we know we have new data.
         book_id = book['id']
         license_pool, is_new = LicensePool.for_foreign_id(
             self._db, DataSource.OVERDRIVE, Identifier.OVERDRIVE_ID, book_id)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -970,14 +970,26 @@ class TestWorkController(CirculationControllerTest):
         eq_(404, response.status_code)
         eq_("http://librarysimplified.org/terms/problem/unknown-lane", response.uri)
 
+        name = 'John Bull'
+        
+        # Similarly if the pagination data is bad.
+        with self.app.test_request_context('/?size=abc'):
+            response = self.manager.work_controller.contributor(name)
+            eq_(400, response.status_code)
+
+        # Or if the facet data is bad.
+        with self.app.test_request_context('/?order=nosuchorder'):
+            response = self.manager.work_controller.contributor(name)
+            eq_(400, response.status_code)
+        
         # If the work has a contributor, a feed is returned.
         SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context('/'):
-            response = self.manager.work_controller.contributor("John Bull")
+            response = self.manager.work_controller.contributor(name)
 
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
-        eq_('John Bull', feed['feed']['title'])
+        eq_(name, feed['feed']['title'])
         [entry] = feed['entries']
         eq_(self.english_1.title, entry['title'])
 
@@ -1002,16 +1014,37 @@ class TestWorkController(CirculationControllerTest):
         mock_api.setup(metadata)
 
         SessionManager.refresh_materialized_views(self._db)
+        args = [self.datasource, self.identifier.type,
+                self.identifier.identifier]
+        kwargs = dict(novelist_api=mock_api)
+        
+        # We get a 400 response if the pagination data is bad.
+        with self.app.test_request_context('/?size=abc'):
+            response = self.manager.work_controller.recommendations(
+                *args, **kwargs
+            )
+            eq_(400, response.status_code)
+
+        # Or if the facet data is bad.
+        mock_api.setup(metadata)
+        with self.app.test_request_context('/?order=nosuchorder'):
+            response = self.manager.work_controller.recommendations(
+                *args, **kwargs
+            )
+            eq_(400, response.status_code)
+
+        # Show it working.
+        mock_api.setup(metadata)
         with self.app.test_request_context('/'):
             response = self.manager.work_controller.recommendations(
-                self.datasource, self.identifier.type, self.identifier.identifier,
-                novelist_api=mock_api
+                *args, **kwargs
             )
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
         eq_('Recommended Books', feed['feed']['title'])
         eq_(0, len(feed['entries']))
 
+       
         # Delete the cache and prep a recommendation result.
         [cached_empty_feed] = self._db.query(CachedFeed).all()
         self._db.delete(cached_empty_feed)

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -323,11 +323,10 @@ class TestOverdriveAPI(OverdriveAPITest):
             "overdrive_availability_information.json"
         )
         api = DummyOverdriveAPI(self._db)
-        api.queue_response(response_code=500, content=availability)
+        api.queue_response(response_code=500, content="An error occured.")
         book = dict(id=identifier.identifier, availability_link=self._url)
         pool, was_new, changed = api.update_licensepool(book)
         eq_(None, pool)
-
 
     def test_update_licensepool_provides_bibliographic_coverage(self):
         # Create an identifier.


### PR DESCRIPTION
This branch fixes two unrelated issues: 

The overdrive collection reaper crash in https://github.com/NYPL-Simplified/circulation/issues/350

and https://github.com/NYPL-Simplified/circulation/issues/351
