### PR TITLE
Send an analytics event when the circulation manager initiates a loan.

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -299,7 +299,7 @@ class CirculationAPI(object):
             __transaction.commit()
 
             if loan and new_loan:
-                # Send out a circulation event to record the fact that
+                # Send out an analytics event to record the fact that
                 # a loan was initiated through the circulation
                 # manager.
                 Analytics.collect_event(

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -8,6 +8,7 @@ import re
 import time
 from flask.ext.babel import lazy_gettext as _
 
+from core.analytics import Analytics
 from core.model import (
     get_one,
     Identifier,
@@ -98,6 +99,8 @@ class CirculationAPI(object):
     between different circulation APIs.
     """
 
+    CIRCULATION_MANAGER_INITIATED_LOAN_EVENT_TYPE = "circulation_manager_check_out"
+    
     def __init__(self, _db, overdrive=None, threem=None, axis=None):
         self._db = _db
         self.overdrive = overdrive
@@ -222,10 +225,21 @@ class CirculationAPI(object):
                 on_multiple='interchangeable'
             )
 
+        new_loan = False
         try:
             loan_info = api.checkout(
                 patron, pin, licensepool, internal_format
             )
+
+            # We asked the API to create a loan and it gave us a
+            # LoanInfo object, rather than raising an exception like
+            # AlreadyCheckedOut.
+            #
+            # For record-keeping purposes we're going to treat this as
+            # a newly transacted loan, although it's possible that the
+            # API does something unusual like return LoanInfo instead
+            # of raising AlreadyCheckedOut.
+            new_loan = True
         except AlreadyCheckedOut:
             # This is good, but we didn't get the real loan info.
             # Just fake it.
@@ -268,7 +282,7 @@ class CirculationAPI(object):
             # We successfuly secured a loan.  Now create it in our
             # database.
             __transaction = self._db.begin_nested()
-            loan, is_new = licensepool.loan_to(
+            loan, new_loan_record = licensepool.loan_to(
                 patron, start=loan_info.start_date or now,
                 end=loan_info.end_date)
 
@@ -283,7 +297,16 @@ class CirculationAPI(object):
                 # Delete the record of the hold.
                 self._db.delete(existing_hold)
             __transaction.commit()
-            return loan, None, is_new
+
+            if loan and new_loan:
+                # Send out a circulation event to record the fact that
+                # a loan was initiated through the circulation
+                # manager.
+                Analytics.collect_event(
+                    self._db, licensepool,
+                    self.CIRCULATION_MANAGER_INITIATED_LOAN_EVENT_TYPE
+                )
+            return loan, None, new_loan_record
 
         # At this point we know that we neither successfully
         # transacted a loan, nor discovered a preexisting loan.

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -55,7 +55,6 @@ from api.config import (
 )
 
 from core.analytics import Analytics
-from core.local_analytics_provider import LocalAnalyticsProvider
 
 
 class TestAxis360API(DatabaseTest):
@@ -170,14 +169,6 @@ class TestCirculationMonitor(DatabaseTest):
 
     def test_process_book(self):
         with temp_config() as config:
-            provider = LocalAnalyticsProvider()
-            analytics = Analytics([provider])
-            config = {
-                Configuration.POLICIES : {
-                    Configuration.ANALYTICS_POLICY : analytics 
-                }
-            }
-            
             monitor = Axis360CirculationMonitor(self._db)
             monitor.api = None
             edition, license_pool = monitor.process_book(

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -6,6 +6,11 @@ from nose.tools import (
     eq_,
 )
 
+from api.config import (
+    Configuration,
+    temp_config,
+)
+
 from datetime import (
     datetime, 
     timedelta,
@@ -17,6 +22,7 @@ from api.circulation import (
     HoldInfo,
 )
 
+from core.analytics import Analytics
 from core.model import (
     DataSource,
     Identifier,
@@ -53,6 +59,55 @@ class TestCirculationAPI(DatabaseTest):
             self.patron, '1234'
         )
 
+    def test_borrow_sends_analytics_event(self):
+        now = datetime.utcnow()
+        loaninfo = LoanInfo(
+            self.pool.identifier.type,
+            self.pool.identifier.identifier,
+            now, now + timedelta(seconds=3600),
+        )
+        self.remote.queue_checkout(loaninfo)
+        now = datetime.utcnow()
+
+        config = {
+            Configuration.POLICIES: {
+                Configuration.ANALYTICS_POLICY: ["core.mock_analytics_provider"]
+            }
+        }
+        with temp_config(config) as config:
+            loan, hold, is_new = self.borrow()
+
+            # The Loan looks good.
+            eq_(loaninfo.identifier, loan.license_pool.identifier.identifier)
+            eq_(self.patron, loan.patron)
+            eq_(None, hold)
+            eq_(True, is_new)
+
+            # An analytics event was created.
+            mock = Analytics.instance().providers[0]
+            eq_(1, mock.count)
+            eq_(MockCirculationAPI.CIRCULATION_MANAGER_INITIATED_LOAN_EVENT_TYPE,
+                mock.event_type)
+            
+            # Try to 'borrow' the same book again.
+            self.remote.queue_checkout(AlreadyCheckedOut())
+            loan, hold, is_new = self.borrow()
+            eq_(False, is_new)
+
+            # Since the loan already existed, no new analytics event was
+            # sent.
+            eq_(1, mock.count)
+            
+            # Now try to renew the book.
+            self.remote.queue_checkout(loaninfo)
+            loan, hold, is_new = self.borrow()
+            eq_(False, is_new)
+
+            # Renewals are counted as loans, since from an accounting
+            # perspective they _are_ loans.
+            eq_(2, mock.count)
+
+            
     def test_attempt_borrow_with_existing_remote_loan(self):
         """The patron has a remote loan that the circ manager doesn't know
         about, and they just tried to borrow a book they already have

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -29,6 +29,7 @@ from core.model import (
     Loan,
     Hold,
 )
+from core.mock_analytics_provider import MockAnalyticsProvider
 
 from . import DatabaseTest
 from api.testing import MockCirculationAPI
@@ -75,6 +76,10 @@ class TestCirculationAPI(DatabaseTest):
             }
         }
         with temp_config(config) as config:
+            provider = MockAnalyticsProvider()
+            analytics = Analytics.initialize(
+                ['core.mock_analytics_provider'], config
+            )
             loan, hold, is_new = self.borrow()
 
             # The Loan looks good.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -80,7 +80,6 @@ import random
 import json
 import urllib
 from core.analytics import Analytics
-from core.local_analytics_provider import LocalAnalyticsProvider
 
 class TestCirculationManager(CirculationManager):
 
@@ -1369,12 +1368,15 @@ class TestAnalyticsController(CirculationControllerTest):
 
     def test_track_event(self):
         with temp_config() as config:
-
             config = {
                 Configuration.POLICIES : {
                     Configuration.ANALYTICS_POLICY : ["core.local_analytics_provider"]
                 }
             }
+
+            analytics = Analytics.initialize(
+                ['core.local_analytics_provider'], config
+            )            
 
             with self.app.test_request_context("/"):
                 response = self.manager.analytics_controller.track_event(self.datasource, self.identifier.type, self.identifier.identifier, "invalid_type")


### PR DESCRIPTION
This branch creates a new type of analytics event which is only sent out when a loan is initiated through the circulation manager. (As distinct from the 'checkout' event, which is sent out when the circulation manager discovers from the licensing authority that a book got checked out by _someone_.)

Tracking loans initiated by the circulation manager is important for NYPL in particular, so we can get statistics on usage of the SimplyE app vis-a-vis other ways of borrowing books.

The event is sent out when the CirculationAPI tells the licensing authority to borrow a book, and the licensing authority sends back a `LoanInfo` object (rather than raising an exception like `AlreadyCheckedOut`). Assuming the licensing authority interfaces are written correctly, this should track the stuff we want to track: new loans and loan renewals.