### PR TITLE
Don't crash sync if local data is inconsistent.

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -575,11 +575,29 @@ class CirculationAPI(object):
         local_loans_by_identifier = {}
         local_holds_by_identifier = {}
         for l in local_loans:
+            if not l.license_pool:
+                self.log.error("Active loan with no license pool!")
+                continue
             i = l.license_pool.identifier
+            if not i:
+                self.log.error(
+                    "Active loan on license pool %s, which has no identifier!",
+                    l.license_pool
+                )
+                continue
             key = (i.type, i.identifier)
             local_loans_by_identifier[key] = l
         for h in local_holds:
+            if not h.license_pool:
+                self.log.error("Active hold with no license pool!")
+                continue
             i = h.license_pool.identifier
+            if not i:
+                self.log.error(
+                    "Active hold on license pool %r, which has no identifier!",
+                    h.license_pool
+                )
+                continue
             key = (i.type, i.identifier)
             local_holds_by_identifier[key] = h
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -421,6 +421,27 @@ class TestOPDS(DatabaseTest):
         [annotations_link] = [x for x in links if x['rel'].lower() == "http://www.w3.org/ns/oa#annotationService".lower()]
         assert '/annotations' in annotations_link['href']
 
+    def test_active_loan_feed_ignores_inconsistent_local_data(self):
+        patron = self.default_patron
+
+        work1 = self._work(language="eng", with_license_pool=True)
+        loan, ignore = work1.license_pools[0].loan_to(patron)
+        work2 = self._work(language="eng", with_license_pool=True)
+        hold, ignore = work2.license_pools[0].on_hold_to(patron)
+
+        # Uh-oh, our local loan data is bad.
+        loan.license_pool.identifier = None
+
+        # Our local hold data is also bad.
+        hold.license_pool = None
+
+        # We can still get a feed...
+        feed_obj = CirculationManagerLoanAndHoldAnnotator.active_loans_for(
+            None, patron, test_mode=True)
+
+        # ...but it's empty.
+        assert '<entry>' not in unicode(feed_obj)
+        
     def test_acquisition_feed_includes_license_information(self):
         work = self._work(with_open_access_download=True)
         pool = work.license_pools[0]


### PR DESCRIPTION
This branch makes sure `sync_data` doesn't crash when considering a local loan whose license pool (or the license pool's identifier) is missing. The bad loan is just ignored and will hopefully be replaced by good loan data direct from the loan source.