### PR TITLE
Make Axis 360 API `place_hold` compatible with what CirculationAPI expects

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -116,8 +116,7 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI):
     def checkin(self, patron, pin, licensepool):
         pass
 
-    def place_hold(self, patron, pin, licensepool, format_type,
-                   hold_notification_email):
+    def place_hold(self, patron, pin, licensepool, hold_notification_email):
         if not hold_notification_email:
             hold_notification_email = self.default_notification_email_address(
                 patron, pin
@@ -127,7 +126,7 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI):
         identifier = licensepool.identifier
         title_id = identifier.identifier
         patron_id = patron.authorization_identifier
-        params = dict(titleId=title_id, patronId=patron_id, format=format_type,
+        params = dict(titleId=title_id, patronId=patron_id,
                       email=hold_notification_email)
         response = self.request(url, params=params)
         hold_info = HoldResponseParser().process_all(response.content)

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -117,7 +117,7 @@ class TestAxis360API(DatabaseTest):
         patron = self.default_patron
         with temp_config() as config:
             config['default_notification_email_address'] = "notifications@example.com"
-            response = self.api.place_hold(patron, 'pin', pool, 'format', None)
+            response = self.api.place_hold(patron, 'pin', pool, None)
             eq_(1, response.hold_position)
             eq_(response.identifier_type, pool.identifier.type)
             eq_(response.identifier, pool.identifier.identifier)


### PR DESCRIPTION
The doc says the 'format' field is obsolete, and we don't have the information anyway, so I took it out.