### PR TITLE
Made target in annotation detail json instead of string, and fixed tests.

### DIFF
--- a/api/annotations.py
+++ b/api/annotations.py
@@ -64,7 +64,8 @@ class AnnotationWriter(object):
         item["type"] = "Annotation"
         item["motivation"] = annotation.motivation
         item["body"] = annotation.content
-        item["target"] = annotation.target
+        if annotation.target:
+            item["target"] = json.loads(annotation.target)
 
         return item
 


### PR DESCRIPTION
This fixes a bug in annotations that Aferdita found - the target was a string of the json instead of json. 

I also noticed that some of my tests weren't running, so that's fixed too.