### PR TITLE
Cache facets script args

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -324,6 +324,12 @@ class CacheRepresentationPerLane(LaneSweeperScript):
             type=int,
             default=None
         )
+        parser.add_argument(
+            '--min-depth', 
+            help='Start processing lanes once you reach this depth.',
+            type=int,
+            default=1
+        )
         return parser
 
     def __init__(self, _db=None, cmd_args=None):
@@ -341,7 +347,8 @@ class CacheRepresentationPerLane(LaneSweeperScript):
                     self.languages.append(alpha)
                 else:
                     self.log.warn("Ignored unrecognized language code %s", alpha)
-        self.max_depth = parsed.max_depth        
+        self.max_depth = parsed.max_depth
+        self.min_depth = parsed.min_depth
 
         # Return the parsed arguments in case a subclass needs to
         # process more args.
@@ -372,7 +379,9 @@ class CacheRepresentationPerLane(LaneSweeperScript):
         
         if self.max_depth is not None and lane.depth > self.max_depth:
             return False
-
+        if self.min_depth is not None and lane.depth < self.min_depth:
+            return False
+        
         return True
 
     def cache_url(self, annotator, lane, languages):

--- a/scripts.py
+++ b/scripts.py
@@ -401,7 +401,8 @@ class CacheRepresentationPerLane(LaneSweeperScript):
             "Generated %d feed(s) for %s. Took %.2fsec to make %d bytes.",
             len(cached_feeds), lane_key, (b-a), total_size
         )
-
+        return cached_feeds
+        
 class CacheFacetListsPerLane(CacheRepresentationPerLane):
     """Cache the first two pages of every facet list for this lane."""
 
@@ -458,6 +459,7 @@ class CacheFacetListsPerLane(CacheRepresentationPerLane):
         parser.add_argument(
             '--pages',
             help="Number of pages to cache for each collection. Default: %d" % default_pages,
+            type=int,
             default=default_pages
         )
         return parser
@@ -487,6 +489,7 @@ class CacheFacetListsPerLane(CacheRepresentationPerLane):
         self.collections = self.filter_facets(
             parsed.collection, Facets.COLLECTION_FACET_GROUP_NAME
         )
+        self.pages = parsed.pages
         return parsed
         
     def do_generate(self, lane):
@@ -522,7 +525,7 @@ class CacheFacetListsPerLane(CacheRepresentationPerLane):
                         order=sort_order, order_ascending=True
                     )
                     title = lane.display_name
-                    for pagenum in (0, 2):
+                    for pagenum in range(0, self.pages):
                         yield AcquisitionFeed.page(
                             self._db, title, url, lane, annotator, 
                             facets=facets, pagination=pagination,


### PR DESCRIPTION
This branch adds a number of command-line arguments to the `cache_opds_lane_facets` scripts. We disabled the script when we drastically increased the number of facets that needed to be cached. But most patrons don't go around changing the facets; they stick with a couple different sets of facets. This branch makes it possible to tell the cache script to only cache the most commonly used sets of facets, whatever that might be. This gives us almost all the benefit of the old script while drastically cutting down on the time it takes to run.

Just so you can keep the overall design in your head, here's the output of running the script with `--help`.

```
usage: cache_opds_lane_facets [-h] [--language LANGUAGE]
                              [--max-depth MAX_DEPTH] [--min-depth MIN_DEPTH]
                              [--order ORDER] [--availability AVAILABILITY]
                              [--collection COLLECTION] [--pages PAGES]

optional arguments:
  -h, --help            show this help message and exit
  --language LANGUAGE   Process only lanes that include books in this
                        language.
  --max-depth MAX_DEPTH
                        Stop processing lanes once you reach this depth.
  --min-depth MIN_DEPTH
                        Start processing lanes once you reach this depth.
  --order ORDER         Generate feeds for this ordering. Possible values:
                        author, title, added. Default: author
  --availability AVAILABILITY
                        Generate feeds for this availability setting. Possible
                        values: all, now, always. Default: all
  --collection COLLECTION
                        Generate feeds for this collection within each lane.
                        Possible values: full, main, featured. Default: main
  --pages PAGES         Number of pages to cache for each collection. Default:
                        2
```