### PR TITLE
Use audience to create various "Related Books" lanes

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -905,13 +905,25 @@ class AnnotationController(CirculationManagerController):
 
 class WorkController(CirculationManagerController):
 
-    def contributor(self, contributor_name):
+    def _lane_details(self, languages, audiences):
+        if languages:
+            languages = languages.split(',')
+        if audiences:
+            audiences = [urllib.unquote_plus(a) for a in audiences.split(',')]
+
+        return languages, audiences
+
+    def contributor(self, contributor_name, languages, audiences):
         """Serve a feed of books written by a particular author"""
 
         if not contributor_name:
             return NO_SUCH_LANE.detailed(_("No contributor provided"))
 
-        lane = ContributorLane(self._db, contributor_name)
+        languages, audiences = self._lane_details(languages, audiences)
+
+        lane = ContributorLane(
+            self._db, contributor_name, languages=languages, audiences=audiences
+        )
 
         annotator = self.manager.annotator(lane)
         facets = load_facets_from_request()
@@ -1044,13 +1056,15 @@ class WorkController(CirculationManagerController):
         controller = ComplaintController()
         return controller.register(pool, data)
 
-    def series(self, series_name):
+    def series(self, series_name, languages, audiences):
         """Serve a feed of books in the same series as a given book."""
 
         if not series_name:
             return NO_SUCH_LANE.detailed(_("No series provided"))
 
-        lane = SeriesLane(self._db, series_name)
+        languages, audiences = self._lane_details(languages, audiences)
+
+        lane = SeriesLane(self._db, series_name, languages, audiences)
         annotator = self.manager.annotator(lane)
         facets = load_facets_from_request()
         if isinstance(facets, ProblemDetail):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -398,6 +398,8 @@ class QueryGeneratedLane(Lane):
         key = ''
         if (self.audiences and
             Classifier.AUDIENCES.difference(self.audiences)):
+            # There are audiences and they're not the default
+            # "any audience", so add them to the URL.
             audiences = [urllib.quote_plus(a) for a in sorted(self.audiences)]
             key += ','.join(audiences)
         return key
@@ -579,7 +581,7 @@ class RecommendationLane(LicensePoolBasedLane):
     MAX_CACHE_AGE = 7*24*60*60      # one week
 
     def __init__(self, _db, license_pool, full_name, display_name=None,
-                 novelist_api=None, source_audience=None, parent=None):
+                 novelist_api=None, parent=None):
         self.api = novelist_api or NoveListAPI.from_config(_db)
         super(RecommendationLane, self).__init__(
             _db, license_pool, full_name, display_name=display_name,

--- a/api/routes.py
+++ b/api/routes.py
@@ -240,13 +240,17 @@ def work():
     annotator = CirculationManagerAnnotator(app.manager.circulation, None)
     return app.manager.urn_lookup.work_lookup(annotator, 'work')
 
-@app.route('/works/contributor/<contributor_name>')
+@app.route('/works/contributor/<contributor_name>', defaults=dict(languages=None, audiences=None))
+@app.route('/works/contributor/<contributor_name>/<languages>', defaults=dict(audiences=None))
+@app.route('/works/contributor/<contributor_name>/<languages>/<audiences>')
 @allows_patron_web()
 @returns_problem_detail
 def contributor(contributor_name):
     return app.manager.work_controller.contributor(contributor_name)
 
-@app.route('/works/series/<series_name>')
+@app.route('/works/series/<series_name>', defaults=dict(languages=None, audiences=None))
+@app.route('/works/series/<series_name>/<languages>', defaults=dict(audiences=None))
+@app.route('/works/series/<series_name>/<languages>/<audiences>')
 @allows_patron_web()
 @returns_problem_detail
 def series(series_name):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1162,7 +1162,7 @@ class TestWorkController(CirculationControllerTest):
     def test_contributor(self):
         # For works without a contributor name, a ProblemDetail is returned.
         with self.app.test_request_context('/'):
-            response = self.manager.work_controller.contributor('')
+            response = self.manager.work_controller.contributor('', None, None)
         eq_(404, response.status_code)
         eq_("http://librarysimplified.org/terms/problem/unknown-lane", response.uri)
 
@@ -1170,18 +1170,18 @@ class TestWorkController(CirculationControllerTest):
         
         # Similarly if the pagination data is bad.
         with self.app.test_request_context('/?size=abc'):
-            response = self.manager.work_controller.contributor(name)
+            response = self.manager.work_controller.contributor(name, None, None)
             eq_(400, response.status_code)
 
         # Or if the facet data is bad.
         with self.app.test_request_context('/?order=nosuchorder'):
-            response = self.manager.work_controller.contributor(name)
+            response = self.manager.work_controller.contributor(name, None, None)
             eq_(400, response.status_code)
         
         # If the work has a contributor, a feed is returned.
         SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context('/'):
-            response = self.manager.work_controller.contributor(name)
+            response = self.manager.work_controller.contributor(name, None, None)
 
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
@@ -1336,15 +1336,15 @@ class TestWorkController(CirculationControllerTest):
         [e2] = [e for e in feed['entries'] if e['title'] == same_series.title]
         title, href = collection_link(e2)
         eq_("Around the World", title)
-        expected_series_link = urllib.quote('series/Around the World')
+        expected_series_link = urllib.quote('series/Around the World/eng/Adult')
         eq_(True, href.endswith(expected_series_link))
 
         # The other book by this contributor is in the contributor feed.
         [e3] = [e for e in feed['entries'] if e['title'] == same_author.title]
         title, href = collection_link(e3)
         eq_("John Bull", title)
-        expected_contributor_link = urllib.quote('contributor/John Bull')
-        eq_(True, href.endswith(expected_contributor_link))
+        expected_contributor_link = urllib.quote('contributor/John Bull/eng/')
+        eq_(True, href.endswith(unicode(expected_contributor_link)))
 
         # The original book is listed in both the series and contributor feeds.
         title_to_link_ending = {
@@ -1383,7 +1383,7 @@ class TestWorkController(CirculationControllerTest):
     def test_series(self):
         # If the work doesn't have a series, a ProblemDetail is returned.
         with self.app.test_request_context('/'):
-            response = self.manager.work_controller.series("")
+            response = self.manager.work_controller.series("", None, None)
         eq_(404, response.status_code)
         eq_("http://librarysimplified.org/terms/problem/unknown-lane", response.uri)
 
@@ -1391,18 +1391,18 @@ class TestWorkController(CirculationControllerTest):
         self.lp.presentation_edition.series = series_name
         # Similarly if the pagination data is bad.
         with self.app.test_request_context('/?size=abc'):
-            response = self.manager.work_controller.series(series_name)
+            response = self.manager.work_controller.series(series_name, None, None)
             eq_(400, response.status_code)
 
         # Or if the facet data is bad
         with self.app.test_request_context('/?order=nosuchorder'):
-            response = self.manager.work_controller.series(series_name)
+            response = self.manager.work_controller.series(series_name, None, None)
             eq_(400, response.status_code)
             
         # If the work is in a series, a feed is returned.
         SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context('/'):
-            response = self.manager.work_controller.series(series_name)
+            response = self.manager.work_controller.series(series_name, None, None)
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
         eq_(series_name, feed['feed']['title'])

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1299,7 +1299,8 @@ class TestWorkController(CirculationControllerTest):
         )
 
         self.lp.presentation_edition.series = "Around the World"
-        self.french_1.presentation_edition.series = "Around the World"
+        same_series = self._work(with_license_pool=True)
+        same_series.presentation_edition.series = "Around the World"
         SessionManager.refresh_materialized_views(self._db)
 
         source = DataSource.lookup(self._db, self.datasource)
@@ -1332,7 +1333,7 @@ class TestWorkController(CirculationControllerTest):
         eq_(True, href.endswith(expected))
 
         # The other book in the series is in the series feed.
-        [e2] = [e for e in feed['entries'] if e['title'] == self.french_1.title]
+        [e2] = [e for e in feed['entries'] if e['title'] == same_series.title]
         title, href = collection_link(e2)
         eq_("Around the World", title)
         expected_series_link = urllib.quote('series/Around the World')

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1387,7 +1387,7 @@ class TestWorkController(CirculationControllerTest):
         title, href = collection_link(e3)
         eq_("John Bull", title)
         expected_contributor_link = urllib.quote('contributor/John Bull/eng/')
-        eq_(True, href.endswith(unicode(expected_contributor_link)))
+        eq_(True, href.endswith(expected_contributor_link))
 
         # The original book is listed in both the series and contributor feeds.
         title_to_link_ending = {

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -208,7 +208,9 @@ class TestRelatedBooksLane(DatabaseTest):
 
     def setup(self):
         super(TestRelatedBooksLane, self).setup()
-        self.work = self._work(with_license_pool=True)
+        self.work = self._work(
+            with_license_pool=True, audience=Classifier.AUDIENCE_YOUNG_ADULT
+        )
         [self.lp] = self.work.license_pools
         self.edition = self.lp.presentation_edition
 
@@ -259,6 +261,11 @@ class TestRelatedBooksLane(DatabaseTest):
             mock_api.setup(response)
             result = RelatedBooksLane(self._db, self.lp, "", novelist_api=mock_api)
             eq_(3, len(result.sublanes))
+
+            # The book's audience list is passed down to all sublanes.
+            for sublane in result.sublanes:
+                eq_(sorted(list(result.audiences)), sorted(list(sublane.audiences)))
+
             contributor, recommendations, series = result.sublanes
             eq_(True, isinstance(recommendations, RecommendationLane))
             eq_(True, isinstance(series, SeriesLane))

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -5,6 +5,7 @@ from . import (
     DatabaseTest,
 )
 
+from core.classifier import Classifier
 from core.lane import (
     Lane,
     LaneList,
@@ -28,6 +29,7 @@ from api.lanes import (
     lane_for_small_collection,
     lane_for_other_languages,
     ContributorLane,
+    QueryGeneratedLane,
     RecommendationLane,
     RelatedBooksLane,
     SeriesLane,
@@ -170,6 +172,36 @@ class TestLaneCreation(DatabaseTest):
             eq_(['Best Sellers', 'Fiction', 'Nonfiction', 'Young Adult Fiction', 'Young Adult Nonfiction', 'Children and Middle Grade'],
                 [x.display_name for x in english_lane.sublanes.lanes]
             )
+
+
+class TestQueryGeneratedLane(DatabaseTest):
+
+    def test_initialization_sets_appropriate_audiences(self):
+        children_lane = QueryGeneratedLane(
+            self._db, '', source_audience=Classifier.AUDIENCE_CHILDREN
+        )
+        eq_(set([Classifier.AUDIENCE_CHILDREN]), children_lane.audiences)
+
+        ya_lane = QueryGeneratedLane(
+            self._db, '', source_audience=Classifier.AUDIENCE_YOUNG_ADULT
+        )
+        eq_(sorted(Classifier.AUDIENCES_JUVENILE), sorted(ya_lane.audiences))
+
+        adult_lane = QueryGeneratedLane(
+            self._db, '', source_audience=Classifier.AUDIENCE_ADULT
+        )
+        eq_(sorted(Classifier.AUDIENCES), sorted(adult_lane.audiences))
+
+        adults_only_lane = QueryGeneratedLane(
+            self._db, '', source_audience=Classifier.AUDIENCE_ADULTS_ONLY
+        )
+        eq_(sorted(Classifier.AUDIENCES), sorted(adults_only_lane.audiences))
+
+        strict_adult_lane = QueryGeneratedLane(
+            self._db, '', source_audience=Classifier.AUDIENCE_ADULTS_ONLY,
+            strict=True
+        )
+        eq_(set([Classifier.AUDIENCE_ADULTS_ONLY]), strict_adult_lane.audiences)
 
 
 class TestRelatedBooksLane(DatabaseTest):


### PR DESCRIPTION
Now the RelatedBooksLane and all of its sublanes return books based on a sensible language and audience. Since these lanes are intended to recommend further reading to patrons, it's helpful to make sure those books are in a preferred language and intended for an appropriate audience. Ta-da.

Here are some things I feel awkward about:
- Adding languages & audiences to the contributor and series URLs. These could be passed as parameters on the URL instead. That tends to be how how handle facets, though, so I pushed them into the URL.
- QueryGeneratedLane#apply_filters is beginning to look suspiciously similar to Lane#apply_filters, minus the lane_query_hook. Trying to make a quick change to `super` resulted in a lot of failing tests, though, so I'm going to leave it as-is for the time being.

Resolves NYPL-Simplified/operations#40.