### PR TITLE
Move authentication configuration

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -768,16 +768,26 @@ class BasicAuthenticationProvider(AuthenticationProvider):
         """Load a BasicAuthenticationProvider from site configuration."""
         return cls(**config)
 
+    # Used in the constructor to signify that the default argument
+    # value for the class should be used (as distinct from None, which
+    # indicates that no value should be used.)
+    class_default = object()
+    
     def __init__(self,
-                 identifier_regular_expression=DEFAULT_IDENTIFIER_REGULAR_EXPRESSION,
-                 password_regular_expression=DEFAULT_PASSWORD_REGULAR_EXPRESSION,
+                 identifier_regular_expression=class_default,
+                 password_regular_expression=class_default,
                  test_username=None, test_password=None):
         """Create a BasicAuthenticationProvider.
         """
+        if identifier_regular_expression is self.class_default:
+            identifier_regular_expression = self.DEFAULT_IDENTIFIER_REGULAR_EXPRESSION
         if identifier_regular_expression:
             identifier_regular_expression = re.compile(
                 identifier_regular_expression
             )
+        if password_regular_expression is self.class_default:
+            password_regular_expression = self.DEFAULT_PASSWORD_REGULAR_EXPRESSION
+
         if password_regular_expression:
             password_regular_expression = re.compile(
                 password_regular_expression

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -798,17 +798,22 @@ class BasicAuthenticationProvider(AuthenticationProvider):
         """Load a BasicAuthenticationProvider from site configuration."""
         return cls(**config)
 
-    def __init__(self, identifier_re=None, password_re=None,
+    def __init__(self, identifier_regular_expression=None,
+                 password_regular_expression=None,
                  test_username=None, test_password=None):
         """Create a BasicAuthenticationProvider.
         """
-        if identifier_re:
-            identifier_re = re.compile(identifier_re)
-        if password_re:
-            password_re = re.compile(password_re)
+        if identifier_regular_expression:
+            identifier_regular_expression = re.compile(
+                identifier_regular_expression
+            )
+        if password_regular_expression:
+            password_regular_expression = re.compile(
+                password_regular_expression
+            )
 
-        self.identifier_re = identifier_re
-        self.password_re = password_re
+        self.identifier_re = identifier_regular_expression
+        self.password_re = password_regular_expression
         self.test_username = test_username
         self.test_password = test_password
         self.log = logging.getLogger(self.NAME)

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -397,6 +397,7 @@ class Authenticator(object):
                 config
             )
         module_name = config['module']
+        config = dict(config)
         del config['module']
         provider_module = importlib.import_module(module_name)
         provider_class = getattr(provider_module, "AuthenticationProvider")

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -761,49 +761,26 @@ class BasicAuthenticationProvider(AuthenticationProvider):
     # passwords.
     alphanumerics_plus = re.compile("^[A-Za-z0-9@.-]+$")
     DEFAULT_IDENTIFIER_REGULAR_EXPRESSION = alphanumerics_plus
-    DEFAULT_PASSWORD_REGULAR_EXPRESSION = None
-   
-    @classmethod
-    def config_values(cls, configuration_section):
-        """Retrieve constructor values from site configuration.
+    DEFAULT_PASSWORD_REGULAR_EXPRESSION = None        
 
-        Can be overridden from a subclass to pull additional values.
-
-        :param required: Whether or not the absence of any configuration
-        should be considered an error.
-        """
-        config = configuration_section
-        args = dict()
-        if config:
-            args['identifier_re'] = config.get(
-                Configuration.IDENTIFIER_REGULAR_EXPRESSION,
-                cls.DEFAULT_IDENTIFIER_REGULAR_EXPRESSION
-            )
-            args['password_re'] = config.get(
-                Configuration.PASSWORD_REGULAR_EXPRESSION,
-                cls.DEFAULT_PASSWORD_REGULAR_EXPRESSION
-            )
-            args['test_username'] = config.get(
-                Configuration.AUTHENTICATION_TEST_USERNAME,
-                None
-            )
-            args['test_password'] = config.get(
-                Configuration.AUTHENTICATION_TEST_PASSWORD,
-                None
-            )
-        return config, args
-        
-    
     @classmethod
     def from_config(cls, config):
         """Load a BasicAuthenticationProvider from site configuration."""
         return cls(**config)
-
+    
     def __init__(self, identifier_regular_expression=None,
                  password_regular_expression=None,
                  test_username=None, test_password=None):
         """Create a BasicAuthenticationProvider.
         """
+        identifier_regular_expression = (
+            identifier_regular_expression or
+            self.DEFAULT_IDENTIFIER_REGULAR_EXPRESSION
+        )
+        password_regular_expression = (
+            password_regular_expression or
+            self.DEFAULT_PASSWORD_REGULAR_EXPRESSION
+        )
         if identifier_regular_expression:
             identifier_regular_expression = re.compile(
                 identifier_regular_expression

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -767,20 +767,13 @@ class BasicAuthenticationProvider(AuthenticationProvider):
     def from_config(cls, config):
         """Load a BasicAuthenticationProvider from site configuration."""
         return cls(**config)
-    
-    def __init__(self, identifier_regular_expression=None,
-                 password_regular_expression=None,
+
+    def __init__(self,
+                 identifier_regular_expression=DEFAULT_IDENTIFIER_REGULAR_EXPRESSION,
+                 password_regular_expression=DEFAULT_PASSWORD_REGULAR_EXPRESSION,
                  test_username=None, test_password=None):
         """Create a BasicAuthenticationProvider.
         """
-        identifier_regular_expression = (
-            identifier_regular_expression or
-            self.DEFAULT_IDENTIFIER_REGULAR_EXPRESSION
-        )
-        password_regular_expression = (
-            password_regular_expression or
-            self.DEFAULT_PASSWORD_REGULAR_EXPRESSION
-        )
         if identifier_regular_expression:
             identifier_regular_expression = re.compile(
                 identifier_regular_expression

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -317,7 +317,7 @@ class Authenticator(object):
         if (not isinstance(authentication_policy, dict)
             or not 'providers' in authentication_policy):
             raise CannotLoadConfiguration(
-                "Authentication policy must be a dictionary with key 'providers'"
+                "Authentication policy must be a dictionary with key 'providers'."
             )
         bearer_token_signing_secret = authentication_policy.get(
             'bearer_token_signing_secret'

--- a/api/config.py
+++ b/api/config.py
@@ -52,8 +52,8 @@ class Configuration(CoreConfiguration):
    
     DEFAULT_NOTIFICATION_EMAIL_ADDRESS = "default_notification_email_address"
 
-    IDENTIFIER_REGULAR_EXPRESSION = "barcode_regular_expression"
-    PASSWORD_REGULAR_EXPRESSION = "pin_regular_expression"
+    IDENTIFIER_REGULAR_EXPRESSION = "identifier_regular_expression"
+    PASSWORD_REGULAR_EXPRESSION = "password_regular_expression"
 
     @classmethod
     def lending_policy(cls):

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -38,26 +38,17 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
     
     log = logging.getLogger("First Book authentication API")
 
-    @classmethod
-    def config_values(cls):
-        config, values = super(FirstBookAuthenticationAPI, cls).config_values()
-        host = config.get(Configuration.URL)
-        key = config.get(cls.SECRET_KEY)
-        if not (host and key):
+    def __init__(self, url=None, key=None, **kwargs):
+        if not (url and key):
             raise CannotLoadConfiguration(
                 "First Book server not configured."
             )
-        values['host'] = host
-        values['key'] = key
-        return config, values
-
-    def __init__(self, host, key, **kwargs):
         super(FirstBookAuthenticationAPI, self).__init__(**kwargs)
-        if '?' in host:
-            host += '&'
+        if '?' in url:
+            url += '&'
         else:
-            host += '?'
-        self.root = host + 'key=' + key
+            url += '?'
+        self.root = url + 'key=' + key
 
     # Begin implementation of BasicAuthenticationProvider abstract
     # methods.

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -47,29 +47,21 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
     REPORTED_LOST = re.compile("^CARD([0-9]{14})REPORTEDLOST")
 
     DEFAULT_CURRENCY = "USD"
-    
-    @classmethod
-    def config_values(cls):
-        config, values = super(MilleniumPatronAPI, cls).config_values()
-        host = config.get(Configuration.URL)
-        if not host:
+       
+    def __init__(self, url=None, authorization_identifier_blacklist=[],
+                 **kwargs):
+        if not url:
             raise CannotLoadConfiguration(
                 "Millenium Patron API server not configured."
             )
-        values['host'] = host
-        blacklist_strings = config.get(
-            Configuration.AUTHORIZATION_IDENTIFIER_BLACKLIST, []
-        )
-        values['authorization_blacklist'] = blacklist_strings
-        return config, values
-    
-    def __init__(self, host, authorization_blacklist=[], **kwargs):
+
         super(MilleniumPatronAPI, self).__init__(**kwargs)
-        if not host.endswith('/'):
-            host = host + "/"
-        self.root = host
+        if not url.endswith('/'):
+            url = url + "/"
+        self.root = url
         self.parser = etree.HTMLParser()
-        self.blacklist = [re.compile(x, re.I) for x in authorization_blacklist]
+        self.blacklist = [re.compile(x, re.I)
+                          for x in authorization_identifier_blacklist]
 
     # Begin implementation of BasicAuthenticationProvider abstract
     # methods.

--- a/api/mock_authentication.py
+++ b/api/mock_authentication.py
@@ -22,29 +22,18 @@ class MockAuthenticationProvider(BasicAuthenticationProvider):
     """
 
     NAME = "Mock Authentication Provider"
-    PATRONS = 'patrons'
-    EXPIRED_PATRONS = 'expired_patrons'
-    PATRONS_WITH_FINES = 'patrons_with_fines'
-    
-    @classmethod
-    def config_values(cls):
-        config, values = super(MockAuthenticationProvider, cls).config_values()
-        if cls.PATRONS not in config:
-            logging.getLogger(cls.NAME).warn(
-                "No patrons configured for mock authentication provider."
-            )
-
-        values['patrons'] = config.get(cls.PATRONS)
-        values['expired_patrons'] = config.get(cls.EXPIRED_PATRONS)
-        values['patrons_with_fines'] = config.get(cls.PATRONS_WITH_FINES)
-        return config, values
-        
+           
     def __init__(self, patrons=None, expired_patrons=None,
                  patrons_with_fines=None, *args, **kwargs):
+        super(MockAuthenticationProvider, self).__init__(*args, **kwargs)
+        if not patrons:
+            self.log.warn(
+                "No patrons configured for mock authentication provider."
+            )
+            patrons = {}
         self.patrons = patrons
         self.expired_patrons = expired_patrons
         self.patrons_with_fines = patrons_with_fines
-        super(MockAuthenticationProvider, self).__init__(*args, **kwargs)
 
     # Begin implementation of BasicAuthenticationProvider abstract
     # methods.

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -358,12 +358,49 @@ class TestAuthenticator(DatabaseTest):
     def test_config_fails_when_no_providers_specified(self):
         with temp_config() as config:
             config[Configuration.POLICIES] = {
-                Configuration.AUTHENTICATION_POLICY: []
+                Configuration.AUTHENTICATION_POLICY: {}
             }
             assert_raises_regexp(
-                CannotLoadConfiguration, "No authentication policy given."
+                CannotLoadConfiguration, "No authentication policy given.",
+                Authenticator.from_config, self._db
             )
-        
+
+    def test_config_fails_when_providers_is_not_a_dictionary(self):
+        with temp_config() as config:
+            config[Configuration.POLICIES] = {
+                Configuration.AUTHENTICATION_POLICY: "api.millenium_patron"
+            }
+            assert_raises_regexp(
+                CannotLoadConfiguration, "Authentication policy must be a dictionary with key 'providers'.",
+                Authenticator.from_config, self._db                
+            )        
+
+    def test_config_fails_when_provider_is_not_a_dictionary(self):
+        with temp_config() as config:
+            config[Configuration.POLICIES] = {
+                Configuration.AUTHENTICATION_POLICY: {
+                    "providers": ["api.millenium_patron"]
+                }
+            }
+            assert_raises_regexp(
+                CannotLoadConfiguration, "Provider 'api.millenium_patron' is invalid; must be a dictionary.",
+                Authenticator.from_config, self._db                
+            )        
+
+    def test_config_fails_when_provider_dictionary_does_not_define_module(self):
+        with temp_config() as config:
+            config[Configuration.POLICIES] = {
+                Configuration.AUTHENTICATION_POLICY: {
+                    "providers": [
+                        {"config": "value"}
+                    ]
+                }
+            }
+            assert_raises_regexp(
+                CannotLoadConfiguration, "Provider configuration does not define 'module':",
+                Authenticator.from_config, self._db                
+            )        
+            
     def test_register_provider_basic_auth(self):
         config = {
             "module": "api.firstbook",

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -134,7 +134,18 @@ class ControllerTest(DatabaseTest):
         
         with temp_config() as config:
             config[Configuration.POLICIES] = {
-                Configuration.AUTHENTICATION_POLICY : "api.mock_authentication",
+                Configuration.AUTHENTICATION_POLICY : {
+                    "providers": [
+                        {
+                            "module": "api.mock_authentication",
+                            "patrons": { "unittestuser": "unittestpassword",
+                                         "unittestuser2" : "unittestpassword2",
+                            },
+                            "expired_patrons": { "expired" : "password" },
+                            "patrons_with_fines": { "ihavefines" : "password" },
+                        }
+                    ],
+                },
                 Configuration.LANGUAGE_POLICY : {
                     Configuration.LARGE_COLLECTION_LANGUAGES : 'eng',
                     Configuration.SMALL_COLLECTION_LANGUAGES : 'spa,chi',
@@ -144,13 +155,6 @@ class ControllerTest(DatabaseTest):
                 Configuration.CIRCULATION_MANAGER_INTEGRATION : {
                     "url": 'http://test-circulation-manager/'
                 },
-                MockAuthenticationProvider.NAME : {
-                    "patrons": { "unittestuser": "unittestpassword",
-                                 "unittestuser2" : "unittestpassword2",
-                    },
-                    "expired_patrons": { "expired" : "password" },
-                    "patrons_with_fines": { "ihavefines" : "password" },
-                }
             }
             lanes = make_lanes_default(_db)
             self.manager = TestCirculationManager(

--- a/tests/test_firstbook.py
+++ b/tests/test_firstbook.py
@@ -29,15 +29,11 @@ class TestFirstBook(object):
 
     def test_from_config(self):
         api = None
-        with temp_config() as config:
-            data = {
-                Configuration.URL : "http://example.com/",
-                FirstBookAuthenticationAPI.SECRET_KEY : "the_key",
-            }
-            config[Configuration.INTEGRATIONS] = {
-                FirstBookAuthenticationAPI.NAME : data
-            }
-            api = FirstBookAuthenticationAPI.from_config()
+        config = {
+            Configuration.URL : "http://example.com/",
+            FirstBookAuthenticationAPI.SECRET_KEY : "the_key",
+        }
+        api = FirstBookAuthenticationAPI.from_config(config)
 
         # Verify that the configuration details were stored properly.
         eq_('http://example.com/?key=the_key', api.root)
@@ -49,15 +45,11 @@ class TestFirstBook(object):
         eq_(True, api.server_side_validation("foo@bar", "1234"))
 
         # Try another case where the root URL has multiple arguments.
-        with temp_config() as config:
-            data = {
-                Configuration.URL : "http://example.com/?foo=bar",
-                FirstBookAuthenticationAPI.SECRET_KEY : "the_key",
-            }
-            config[Configuration.INTEGRATIONS] = {
-                FirstBookAuthenticationAPI.NAME : data
-            }
-            api = FirstBookAuthenticationAPI.from_config()        
+        config = {
+            Configuration.URL : "http://example.com/?foo=bar",
+            FirstBookAuthenticationAPI.SECRET_KEY : "the_key",
+        }
+        api = FirstBookAuthenticationAPI.from_config(config)
         eq_('http://example.com/?foo=bar&key=the_key', api.root)
         
     def test_authentication_success(self):

--- a/tests/test_firstbook.py
+++ b/tests/test_firstbook.py
@@ -37,7 +37,7 @@ class TestFirstBook(object):
 
         # Verify that the configuration details were stored properly.
         eq_('http://example.com/?key=the_key', api.root)
-            
+
         # Test the default server-side authentication regular expressions.
         eq_(False, api.server_side_validation("foo' or 1=1 --;", "1234"))
         eq_(False, api.server_side_validation("foo", "12 34"))

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -22,8 +22,8 @@ class MockResponse(object):
 
 class MockAPI(MilleniumPatronAPI):
 
-    def __init__(self, root="", *args, **kwargs):
-        super(MockAPI, self).__init__(root, *args, **kwargs)
+    def __init__(self, url="http://test-url/", *args, **kwargs):
+        super(MockAPI, self).__init__(url, *args, **kwargs)
         self.queue = []
 
     def sample_data(self, filename):
@@ -47,15 +47,11 @@ class TestMilleniumPatronAPI(DatabaseTest):
 
     def test_from_config(self):
         api = None
-        with temp_config() as config:
-            data = {
-                Configuration.URL : "http://example.com",
-                Configuration.AUTHORIZATION_IDENTIFIER_BLACKLIST : ["a", "b"]
-            }
-            config[Configuration.INTEGRATIONS] = {
-                MilleniumPatronAPI.NAME : data
-            }
-            api = MilleniumPatronAPI.from_config()
+        config = {
+            Configuration.URL : "http://example.com",
+            Configuration.AUTHORIZATION_IDENTIFIER_BLACKLIST : ["a", "b"]
+        }
+        api = MilleniumPatronAPI.from_config(config)
         eq_("http://example.com/", api.root)
         eq_(["a", "b"], [x.pattern for x in api.blacklist])
             
@@ -329,7 +325,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         patrondata = self.api.patron_dump_to_patrondata('alice', content)
         eq_("SECOND_barcode", patrondata.authorization_identifier)
 
-        api = MockAPI(authorization_blacklist=["second"])
+        api = MockAPI(authorization_identifier_blacklist=["second"])
         patrondata = api.patron_dump_to_patrondata('alice', content)
         eq_("FIRST_barcode", patrondata.authorization_identifier)
         
@@ -337,7 +333,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         """A patron may end up with no authorization identifier whatsoever
         because they're all blacklisted.
         """
-        api = MockAPI(authorization_blacklist=["barcode"])
+        api = MockAPI(authorization_identifier_blacklist=["barcode"])
         content = api.sample_data("dump.two_barcodes.html")
         patrondata = api.patron_dump_to_patrondata('alice', content)
         eq_(patrondata.NO_VALUE, patrondata.authorization_identifier)

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -43,13 +43,13 @@ class TestMilleniumPatronAPI(DatabaseTest):
 
     def setup(self):
         super(TestMilleniumPatronAPI, self).setup()
-        self.api = MockAPI()
+        self.api = MockAPI(identifier_regular_expression=None)
 
     def test_from_config(self):
         api = None
         config = {
             Configuration.URL : "http://example.com",
-            Configuration.AUTHORIZATION_IDENTIFIER_BLACKLIST : ["a", "b"]
+            Configuration.AUTHORIZATION_IDENTIFIER_BLACKLIST : ["a", "b"],
         }
         api = MilleniumPatronAPI.from_config(config)
         eq_("http://example.com/", api.root)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -33,7 +33,11 @@ class TestLaneScript(DatabaseTest):
         """
         with temp_config() as config:
             config[Configuration.POLICIES] = {
-                Configuration.AUTHENTICATION_POLICY : "api.mock_authentication",
+                Configuration.AUTHENTICATION_POLICY : {
+                    "providers": [
+                        { "module" : "api.mock_authentication" }
+                    ]
+                },
                 Configuration.LANGUAGE_POLICY : {
                     Configuration.LARGE_COLLECTION_LANGUAGES : 'eng',
                     Configuration.SMALL_COLLECTION_LANGUAGES : 'fre',
@@ -115,7 +119,6 @@ class TestCacheFacetListsPerLane(TestLaneScript):
                 testing=True
             )
             eq_(['title', 'added'], script.orders)
-
             script = CacheFacetListsPerLane(
                 self._db, ["--availability=all", "--availability=always"],
                 testing=True


### PR DESCRIPTION
Currently you use the `authentication` section of the configuration to explain which modules to load. 

```
"authentication" : ["api.provider1", "api.provider2"]
```

Then you configure each module separately in the `integrations` section.

```
integrations : { 
"API Provider 1": { ... },
"API Provider 2": { ... },
}
```

This has a couple pitfalls. In particular, it's impossible to define two different authentication providers that happen to use the same module. You can put "api.module1" twice in `authentications`, but both providers will be initialized using the same settings.

This branch changes it so that an authentication provider is configured inside `authentication`:

```
"authentication" : {
 "providers": [
  { "module": "api.provider1", 
    "config_value": "1"
  },
  { "module": "api.provider2",
    "config_value": "2"
  }
 ]
}
```

This will probably not be necessary for a while, but since my big authentication refactor branch requires a change to the authentication configuration, I figured I would get this smaller branch in (which also changes the authentication configuration) before we actually have to deploy any changes. Also, I have to rewrite the documentation on how to configure your authentication settings, and I don't want to have to rewrite it twice.

The big code change here is that the contents of the authentication configuration (minus the `module` bit) are passed as keyword arguments into the `AuthenticationProvider` constructor. The `config_values` method is gone. The code that (for example) turned the config setting `authorization_identifier_blacklist` to the constructor argument `authorization_blacklist` is gone. I just renamed the constructor argument to match the name of the config setting.