### PR TITLE
Add test to servicestatus

### DIFF
--- a/api/services.py
+++ b/api/services.py
@@ -47,7 +47,6 @@ class ServiceStatus(object):
                 self._db
             )
             # Stick it in a list so we can use it once we leave the function.
-            print patron, password
             patron_info.append((patron, password))
 
         # Look up the test patron and verify their credentials. If

--- a/api/services.py
+++ b/api/services.py
@@ -22,12 +22,12 @@ class ServiceStatus(object):
 
     SUCCESS_MSG = re.compile('^SUCCESS: ([0-9]+.[0-9]+)sec')
 
-    def __init__(self, _db):
+    def __init__(self, _db, auth=None, overdrive=None, threem=None, axis=None):
         self._db = _db
-        self.auth = Authenticator.from_config(self._db)
-        self.overdrive = OverdriveAPI.from_environment(self._db)
-        self.threem = ThreeMAPI.from_environment(self._db)
-        self.axis = Axis360API.from_environment(self._db)
+        self.auth = auth or Authenticator.from_config(self._db)
+        self.overdrive = overdrive or OverdriveAPI.from_environment(self._db)
+        self.threem = threem or ThreeMAPI.from_environment(self._db)
+        self.axis = axis or Axis360API.from_environment(self._db)
 
     def loans_status(self, response=False):
         """Checks the length of request times for patron activity.
@@ -47,17 +47,25 @@ class ServiceStatus(object):
                 self._db
             )
             # Stick it in a list so we can use it once we leave the function.
+            print patron, password
             patron_info.append((patron, password))
 
+        # Look up the test patron and verify their credentials. If
+        # this doesn't work, nothing else will work, either.
         service = 'Patron authentication'
         self._add_timing(status, service, do_patron)
-        if not patron_info or patron_info == [(None, None)]:
+        success = False
+        patron = password = None
+        if patron_info:
+            [(patron, password)] = patron_info
+            if patron:
+                success = True                
+        if not success:
+            print "ERROR"
             error = "Could not create patron with configured credentials."
             self.log.error(error)
             status[service] = error
             return status
-        [(patron, password)] = patron_info
-
         for api in [self.overdrive, self.threem, self.axis]:
             if not api:
                 continue

--- a/api/services.py
+++ b/api/services.py
@@ -60,7 +60,6 @@ class ServiceStatus(object):
             if patron:
                 success = True                
         if not success:
-            print "ERROR"
             error = "Could not create patron with configured credentials."
             self.log.error(error)
             status[service] = error

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,9 +1,34 @@
-from . import DatabaseTest
+import json
+
+from . import (
+    DatabaseTest,
+    sample_data
+)
 from nose.tools import set_trace, eq_
 from api.services import ServiceStatus
 from api.config import (
     Configuration,
     temp_config,
+)
+
+from api.axis import (
+    MockAxis360API,
+)
+from api.overdrive import (
+    DummyOverdriveAPI,
+)
+from api.threem import (
+    MockThreeMAPI,
+)
+from api.authenticator import (
+    Authenticator
+)
+from api.mock_authentication import (
+    MockAuthenticationProvider
+)
+
+from core.model import (
+    DataSource,
 )
 
 class TestServiceStatusMonitor(DatabaseTest):
@@ -44,3 +69,59 @@ class TestServiceStatusMonitor(DatabaseTest):
             service_status = ServiceStatus(self._db)
             assert service_status.auth != None
             assert service_status.auth.basic_auth_provider != None
+
+    def test_loans_status(self):
+        
+        provider = MockAuthenticationProvider(
+            patrons={"user": "pass"},
+            test_username="user",
+            test_password="pass",
+        )
+        auth = Authenticator(provider)
+
+        class MockPatronActivity(object):
+            def __init__(self, _db, data_source_name):
+                self.source = DataSource.lookup(_db, data_source_name)
+                self.succeed = True
+                
+            def patron_activity(self, patron, pin):
+                if self.succeed:
+                    # Simulate a patron with nothing going on.
+                    return
+                else:
+                    raise ValueError("Doomed to fail!")
+        
+        overdrive = MockPatronActivity(self._db, DataSource.OVERDRIVE)
+        threem = MockPatronActivity(self._db, DataSource.BIBLIOTHECA)
+        axis = MockPatronActivity(self._db, DataSource.AXIS_360)
+
+        # Test a scenario where all providers succeed.
+        status = ServiceStatus(self._db, auth, overdrive, threem, axis)
+        response = status.loans_status(response=True)
+        for value in response.values():
+            assert value.startswith('SUCCESS')
+
+        # Simulate a failure in one of the providers.
+        overdrive.succeed = False
+        response = status.loans_status(response=True)
+        eq_("FAILURE: Doomed to fail!", response['Overdrive patron account'])
+
+        # Simulate failures on the ILS level.
+        def test_with_broken_basic_auth_provider(value):
+            class BrokenBasicAuthProvider(object):
+                def testing_patron(self, _db):
+                    return value
+        
+            auth.basic_auth_provider = BrokenBasicAuthProvider()
+            response = status.loans_status(response=True)
+            eq_({'Patron authentication':
+                 'Could not create patron with configured credentials.'},
+                response)
+
+        # Test patron can't authenticate
+        test_with_broken_basic_auth_provider(
+            (None, "password that didn't work")
+        )
+
+        # Auth provider is just totally broken.
+        test_with_broken_basic_auth_provider(None)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -11,15 +11,6 @@ from api.config import (
     temp_config,
 )
 
-from api.axis import (
-    MockAxis360API,
-)
-from api.overdrive import (
-    DummyOverdriveAPI,
-)
-from api.threem import (
-    MockThreeMAPI,
-)
 from api.authenticator import (
     Authenticator
 )


### PR DESCRIPTION
This branch fixes a problem with the expected return value of `testing_patron` which was tripping up the ServiceStatus class (the only code that actually calls it outside of tests).

Problems with ServiceStatus plague us, and we don't see them because of a lack of test coverage, so I've improved the test coverage somewhat by adding a test for `ServiceStatus.loans_status`.