### PR TITLE
Include DRM autodiscovery tags in OPDS feeds

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -644,11 +644,10 @@ class CirculationManagerAnnotator(Annotator):
                 vendor_id, jwt = authdata.encode(patron_identifier)
 
                 drm_link = OPDSFeed.makeelement("{%s}licensor" % OPDSFeed.DRM_NS)
-                server_id = OPDSFeed.makeelement("{%s}vendor" % OPDSFeed.DRM_NS)
-                server_id.text = vendor_id
+                vendor_attr = "{%s}vendor" % OPDSFeed.DRM_NS
+                drm_link.attrib[vendor_attr] = vendor_id
                 patron_key = OPDSFeed.makeelement("{%s}clientToken" % OPDSFeed.DRM_NS)
                 patron_key.text = jwt
-                drm_link.append(server_id)
                 drm_link.append(patron_key)
                 cached = [drm_link]
             self._adobe_id_tags[patron_identifier] = cached

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -160,20 +160,72 @@ class TestCirculationManagerAnnotator(DatabaseTest):
         # Both entries are identical.
         eq_(etree.tostring(feed1), etree.tostring(feed2))
 
-    def test_adobe_id_tags(self):
+    def test_fulfill_link_includes_device_registration_tags(self):
+        """Verify that when Adobe Vendor ID delegation is included, the
+        fulfill link for an Adobe delivery mechanism includes instructions
+        on how to get a Vendor ID.
+        """
+        [pool] = self.work.license_pools
+        identifier = pool.identifier
+        patron = self._patron()
+        loan, ignore = pool.loan_to(patron, start=datetime.datetime.utcnow())
+        adobe_delivery_mechanism, ignore = DeliveryMechanism.lookup(
+            self._db, "text/html", DeliveryMechanism.ADOBE_DRM
+        )
+        other_delivery_mechanism, ignore = DeliveryMechanism.lookup(
+            self._db, "text/html", DeliveryMechanism.OVERDRIVE_DRM
+        )
 
         with temp_config() as config:
-            # When vendor ID delegation is not configured,
-            # adobe_id_tags() returns
-            # an empty list.
+            library_uri = "http://a-library/"
+            secret = "a-secret"
+            vendor_id = "Some Vendor"
+            config[Configuration.INTEGRATIONS][Configuration.ADOBE_VENDOR_ID_INTEGRATION] = {
+                Configuration.ADOBE_VENDOR_ID : vendor_id,
+                AuthdataUtility.LIBRARY_URI_KEY : library_uri,
+                AuthdataUtility.AUTHDATA_SECRET_KEY : secret,
+            }
+        
+            # The fulfill link for Adobe DRM includes information
+            # on how to get an Adobe ID in the drm:licensor tag.
+            link = self.annotator.fulfill_link(
+                pool.data_source.name, pool.identifier, pool, loan,
+                adobe_delivery_mechanism
+            )
+            licensor = link.getchildren()[-1]
+            eq_("{http://librarysimplified.org/terms/drm}licensor",
+                licensor.tag)
+
+            # The tag is the same one we get by calling adobe_id_tags().
+            [expect] = self.annotator.adobe_id_tags(patron.external_identifier)
+            eq_(licensor, expect)
+            
+            # The fulfill link for some other kind of DRM does not
+            # include the drm:licensor tag.
+            link = self.annotator.fulfill_link(
+                pool.data_source.name, pool.identifier, pool, loan,
+                other_delivery_mechanism
+            )
+            for child in link.getchildren():
+                assert child.tag != "{http://librarysimplified.org/terms/drm}licensor"
+        
+    def test_no_adobe_id_tags_when_vendor_id_not_configured(self):
+
+        with temp_config() as config:
+            """When vendor ID delegation is not configured, adobe_id_tags()
+            returns an empty list.
+            """
             config[Configuration.INTEGRATIONS][Configuration.ADOBE_VENDOR_ID_INTEGRATION] = {}
-            eq_([], CirculationManagerAnnotator.adobe_id_tags(
+            eq_([], self.annotator.adobe_id_tags(
                 "patron identifier")
             )
 
-            # When it is configured, adobe_id_tags() returns a list
-            # containing a single tag. The tag contains the
-            # information necessary to get an Adobe ID.
+    def test_adobe_id_tags_when_vendor_id_configured(self):
+        """When vendor ID delegation is configured, adobe_id_tags()
+        returns a list containing a single tag. The tag contains
+        the information necessary to get an Adobe ID.
+        """
+        with temp_config() as config:
             library_uri = "http://a-library/"
             secret = "a-secret"
             vendor_id = "Some Vendor"
@@ -184,23 +236,34 @@ class TestCirculationManagerAnnotator(DatabaseTest):
             }
 
             patron_identifier = "patron identifier"
-            [element] = CirculationManagerAnnotator.adobe_id_tags(
+            [element] = self.annotator.adobe_id_tags(
                 patron_identifier
             )
             eq_('{http://librarysimplified.org/terms/drm}licensor', element.tag)
 
             vendor, token = element.getchildren()
             eq_('{http://librarysimplified.org/terms/drm}vendor', vendor.tag)
-            eq_("Some Vendor", vendor.text)
+            eq_(vendor_id, vendor.text)
             
             eq_('{http://librarysimplified.org/terms/drm}clientToken', token.tag)
-            # token.text is a JWT.
+            # token.text is a JWT which we can decode, since we know the
+            # secret.
             token = token.text
             decoded = jwt.decode(token, secret, AuthdataUtility.ALGORITHM)
             eq_(library_uri, decoded['iss'])
             eq_(patron_identifier, decoded['sub'])
-            
 
+            # If we call adobe_id_tags again we'll get the exact same
+            # tag object -- it's cached.
+            eq_([element], self.annotator.adobe_id_tags(patron_identifier))
+
+            # If we call adobe_id_tags again but pass in a different
+            # identifier, we'll get a different value. (But this
+            # shouldn't happen because any given request is for one
+            # specific patron.)
+            assert self.annotator.adobe_id_tags("another one") != [element]
+
+            
 class TestOPDS(DatabaseTest):
 
     def setup(self):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -15,6 +15,7 @@ from core.lane import (
     Lane,
 )
 from core.model import (
+    DataSource,
     Work,
     Representation,
     DeliveryMechanism,
@@ -196,8 +197,19 @@ class TestCirculationManagerAnnotator(DatabaseTest):
             eq_("{http://librarysimplified.org/terms/drm}licensor",
                 licensor.tag)
 
-            # The tag is the same one we get by calling adobe_id_tags().
-            [expect] = self.annotator.adobe_id_tags(patron.external_identifier)
+            # An Adobe ID-specific identifier has been created for the patron.
+            [adobe_id_identifier] = patron.credentials
+            eq_(self.annotator.ADOBE_ID_PATRON_IDENTIFIER,
+                adobe_id_identifier.type)
+            eq_(DataSource.INTERNAL_PROCESSING,
+                adobe_id_identifier.data_source.name)
+            eq_(None, adobe_id_identifier.expires)
+            
+            # The drm:licensor tag is the one we get by calling
+            # adobe_id_tags() on that identifier.
+            [expect] = self.annotator.adobe_id_tags(
+                adobe_id_identifier.credential
+            )
             eq_(licensor, expect)
             
             # The fulfill link for some other kind of DRM does not

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -253,9 +253,10 @@ class TestCirculationManagerAnnotator(DatabaseTest):
             )
             eq_('{http://librarysimplified.org/terms/drm}licensor', element.tag)
 
-            vendor, token = element.getchildren()
-            eq_('{http://librarysimplified.org/terms/drm}vendor', vendor.tag)
-            eq_(vendor_id, vendor.text)
+            key = '{http://librarysimplified.org/terms/drm}vendor'
+            eq_(vendor_id, element.attrib[key])
+            
+            [token] = element.getchildren()
             
             eq_('{http://librarysimplified.org/terms/drm}clientToken', token.tag)
             # token.text is a JWT which we can decode, since we know the


### PR DESCRIPTION
This branch includes a <drm:licensor> tag beneath any appropriate <link> tag with rel="fulfill". This completes the circulation manager part of DRM autodiscovery (as opposed to the Vendor ID implementation, which also happens to be kept in the circulation manager code).

The DRM autodiscovery spec is here: https://github.com/NYPL-Simplified/Simplified/wiki/DRMAutodiscoverySpecs#drm-extensions-to-opds

This code will only work for Adobe; we'll need to handle LCP and (especially) URMS differently.

The <drm:licensor> tag includes a drm:vendor attribute, which explains who is providing the Adobe vendor ID. It also includes a <drm:clientToken> tag, which gives an authdata value that identifies and authenticates the currently logged in patron. The authdata value is a JWT created from site configuration and a new permanent Credential associated with the patron and used solely for this purpose. This lets us invalidate the Credential if the patron runs into a problem, and it stops the Adobe vendor ID server from having any information that can be tied to the patron.

The JWT is cached on the CirculationManagerAnnotator object so that we don't generate different JWTs for the same patron over the course of a single request. I've checked that CirculationManagerAnnotator is created per-request but I would appreciate it if you could confirm this.