### PR TITLE
Authdata lookup always ends up pulling the final value from a DelegatedPatronIdentifier

### DIFF
--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -373,7 +373,7 @@ class AdobeVendorIDModel(object):
             DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID, value_generator
         )
         return (identifier.delegated_identifier,
-                "Delegated account ID %s" % identifier.delegated_identifier)
+                self.urn_to_label(identifier.delegated_identifier))
 
     def patron_from_authdata_lookup(self, authdata):
         """Look up a patron by their persistent authdata token."""
@@ -386,15 +386,8 @@ class AdobeVendorIDModel(object):
         return credential.patron
 
     def urn_to_label(self, urn):
-        credential = Credential.lookup_by_token(
-            self._db, self.data_source, self.VENDOR_ID_UUID_TOKEN_TYPE, 
-            urn, allow_persistent_token=True
-        )
-        if not credential:
-            return None
-        patron = credential.patron
-        uuid, label = self.uuid_and_label(credential.patron)
-        return label
+        """We have no information about patrons, so labels are sparse."""
+        return "Delegated account ID %s" % urn
 
     def uuid(self):
         """Create a new UUID URN compatible with the Vendor ID system."""
@@ -596,5 +589,5 @@ class AuthdataUtility(object):
             _db, self.library_uri, patron_identifier_credential.credential,
             DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID, create_function
         )
-        return patron_identifier_credential.credential, delegated_identifier
+        return patron_identifier_credential, delegated_identifier
 

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -89,8 +89,9 @@ class TestVendorIDModel(VendorIDTest):
         assert u.endswith('685b35c00f05')
 
     def test_uuid_and_label_respects_existing_id(self):
-        uuid, label = self.model.uuid_and_label(self.bob_patron)
-        uuid2, label2 = self.model.uuid_and_label(self.bob_patron)
+        with self.temp_config():
+            uuid, label = self.model.uuid_and_label(self.bob_patron)
+            uuid2, label2 = self.model.uuid_and_label(self.bob_patron)
         eq_(uuid, uuid2)
         eq_(label, label2)
 
@@ -109,7 +110,8 @@ class TestVendorIDModel(VendorIDTest):
         )
 
         # Now uuid_and_label works.
-        uuid, label = self.model.uuid_and_label(self.bob_patron)
+        with self.temp_config():
+            uuid, label = self.model.uuid_and_label(self.bob_patron)
         eq_("A dummy value", uuid)
         eq_("Delegated account ID A dummy value", label)
 
@@ -136,7 +138,8 @@ class TestVendorIDModel(VendorIDTest):
         # If the DelegatedPatronIdentifier and the Credential
         # have different values, the DelegatedPatronIdentifier wins.
         old_style_credential.credential = "A different value."
-        uuid, label = self.model.uuid_and_label(self.bob_patron)
+        with self.temp_config():
+            uuid, label = self.model.uuid_and_label(self.bob_patron)
         eq_("A dummy value", uuid)
         
         # We can even delete the old-style Credential, and
@@ -144,7 +147,8 @@ class TestVendorIDModel(VendorIDTest):
         # it.
         self._db.delete(old_style_credential)
         self._db.commit()
-        uuid, label = self.model.uuid_and_label(self.bob_patron)
+        with self.temp_config():
+            uuid, label = self.model.uuid_and_label(self.bob_patron)
         eq_("A dummy value", uuid)
 
         
@@ -235,7 +239,8 @@ class TestVendorIDModel(VendorIDTest):
         eq_("Delegated account ID %s" % uuid, label)
         
     def test_username_password_lookup_success(self):
-        urn, label = self.model.standard_lookup(self.credentials)
+        with self.temp_config():
+            urn, label = self.model.standard_lookup(self.credentials)
 
         # There is now an anonymized identifier associated with Bob's
         # patron account.
@@ -310,9 +315,10 @@ class TestVendorIDModel(VendorIDTest):
         # Adobe to authenticate him via that token, so it passes in
         # the token credential as the 'username' and leaves the
         # password blank.
-        urn, label = self.model.standard_lookup(
-            dict(username=token.credential)
-        )
+        with self.temp_config():
+            urn, label = self.model.standard_lookup(
+                dict(username=token.credential)
+            )
 
         # There is now an anonymized identifier associated with Bob's
         # patron account.
@@ -361,7 +367,8 @@ class TestVendorIDModel(VendorIDTest):
         eq_(None, label)
 
     def test_urn_to_label_success(self):
-        urn, label = self.model.standard_lookup(self.credentials)
+        with self.temp_config():
+            urn, label = self.model.standard_lookup(self.credentials)
         label2 = self.model.urn_to_label(urn)
         eq_(label, label2)
         eq_("Delegated account ID %s" % urn, label)

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -342,9 +342,10 @@ class TestVendorIDModel(VendorIDTest):
         eq_(urn, bob_delegated_patron_identifier.delegated_identifier)
 
         # A future attempt to authenticate with the token will succeed.
-        urn, label = self.model.standard_lookup(
-            dict(username=token.credential)
-        )
+        with self.temp_config():
+            urn, label = self.model.standard_lookup(
+                dict(username=token.credential)
+            )
         eq_(urn, bob_delegated_patron_identifier.delegated_identifier)
 
     def test_authdata_lookup_failure_no_token(self):


### PR DESCRIPTION
This branch changes the semi-deprecated `uuid_and_label(patron)` method so that it migrates a patron's Adobe account ID from a Credential to a DelegatedPatronIdentifier (though this shouldn't be necessary because of the migration script). Then it always uses the value found in the DelegatedPatronIdentifier, not the value found in the Credential.

If in the future a patron needs to have their Adobe ID changed, you just need to delete both their "Vendor ID UUID" Credential (the old style) and their "Identifier for Adobe account ID purposes" Credential (the new style). There's no need to make sure the two types of credentials are kept in sync. In fact, once the migration script runs we could in theory delete everyone's "Vendor ID UUID" Credentials--the same information will be kept in the DelegatedPatronIdentifiers.