### PR TITLE
Reset patron adobe id script

### DIFF
--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -400,14 +400,13 @@ class AdobeVendorIDModel(object):
 
     @classmethod
     def get_or_create_patron_identifier_credential(cls, patron):
-        from opds import CirculationManagerAnnotator
         _db = Session.object_session(patron)
         def refresh(credential):
             credential.credential = str(uuid.uuid1())
         data_source = DataSource.lookup(_db, DataSource.INTERNAL_PROCESSING)
         patron_identifier_credential = Credential.lookup(
             _db, data_source,
-            CirculationManagerAnnotator.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
+            AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
             patron, refresher_method=refresh, allow_persistent_token=True
         )
         return patron_identifier_credential
@@ -422,6 +421,15 @@ class AuthdataUtility(object):
     (from this library and potentially others).
     """
 
+    # The type of the Credential created to identify a patron to the
+    # Vendor ID Service. Using this as an alias keeps the Vendor ID
+    # Service from knowing anything about the patron's true
+    # identity. This Credential is permanent (unlike a patron's
+    # username or authorization identifier), but can be revoked (if
+    # the patron needs to reset their Adobe account ID) with no
+    # consequences other than losing their currently checked-in books.
+    ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER = "Identifier for Adobe account ID purposes"
+    
     ALGORITHM = 'HS256'
     
     def __init__(self, vendor_id, library_uri, secret, other_libraries={}):

--- a/api/opds.py
+++ b/api/opds.py
@@ -38,16 +38,7 @@ from annotations import AnnotationWriter
 from adobe_vendor_id import AuthdataUtility
 
 class CirculationManagerAnnotator(Annotator):
-
-    # The name of the Credential created to identify a patron to the
-    # Vendor ID Service. Using this as an alias keeps the Vendor ID
-    # Service from knowing anything about the patron's true
-    # identity. This Credential is permanent (unlike a patron's
-    # username or authorization identifier), but can be revoked (if
-    # the patron needs to reset their Adobe ID) with no consequences
-    # other than losing their currently checked-in books.
-    ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER = "Identifier for Adobe account ID purposes"
-    
+   
     def __init__(self, circulation, lane, patron=None,
                  active_loans_by_work={}, active_holds_by_work={},
                  active_fulfillments_by_work={},
@@ -613,7 +604,7 @@ class CirculationManagerAnnotator(Annotator):
             def refresh(credential):
                 credential.credential = str(uuid.uuid1())
             patron_identifier = Credential.lookup(
-                _db, internal, self.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER, patron,
+                _db, internal, AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER, patron,
                 refresher_method=refresh, allow_persistent_token=True
             )
             patron_identifier = patron_identifier.credential

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -120,7 +120,7 @@ class TestVendorIDModel(VendorIDTest):
         internal = DataSource.lookup(self._db, DataSource.INTERNAL_PROCESSING)
         bob_anonymized_identifier = Credential.lookup(
             self._db, internal,
-            CirculationManagerAnnotator.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
+            AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
             self.bob_patron, None
         )
 
@@ -247,7 +247,7 @@ class TestVendorIDModel(VendorIDTest):
         internal = DataSource.lookup(self._db, DataSource.INTERNAL_PROCESSING)
         bob_anonymized_identifier = Credential.lookup(
             self._db, internal,
-            CirculationManagerAnnotator.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
+            AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
             self.bob_patron, None
         )
 
@@ -287,7 +287,7 @@ class TestVendorIDModel(VendorIDTest):
         internal = DataSource.lookup(self._db, DataSource.INTERNAL_PROCESSING)
         bob_anonymized_identifier = Credential.lookup(
             self._db, internal,
-            CirculationManagerAnnotator.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
+            AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
             self.bob_patron, None
         )
 
@@ -325,7 +325,7 @@ class TestVendorIDModel(VendorIDTest):
         internal = DataSource.lookup(self._db, DataSource.INTERNAL_PROCESSING)
         bob_anonymized_identifier = Credential.lookup(
             self._db, internal,
-            CirculationManagerAnnotator.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
+            AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
             self.bob_patron, None
         )
 
@@ -713,7 +713,7 @@ class TestAuthdataUtility(VendorIDTest):
 
         # The new credential contains an anonymized patron identifier
         # used solely to connect the patron to their Adobe ID.
-        eq_(CirculationManagerAnnotator.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
+        eq_(AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
             new_credential.type)
 
         # We can use that identifier to look up a DelegatedPatronIdentifier

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -214,7 +214,7 @@ class TestCirculationManagerAnnotator(DatabaseTest):
             # An Adobe ID-specific identifier has been created for the patron.
             [adobe_id_identifier] = [x for x in patron.credentials
                                      if x not in old_credentials]
-            eq_(self.annotator.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
+            eq_(AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
                 adobe_id_identifier.type)
             eq_(DataSource.INTERNAL_PROCESSING,
                 adobe_id_identifier.data_source.name)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -5,6 +5,11 @@ from nose.tools import (
 
 import contextlib
 
+from api.adobe_vendor_id import (
+    AdobeVendorIDModel,
+    AuthdataUtility,
+)
+
 from api.config import (
     temp_config,
     Configuration,
@@ -15,14 +20,68 @@ from core.lane import (
     Facets,
 )
 
+from core.model import (
+    DataSource,
+    Credential,
+)
+
 from . import (
     DatabaseTest,
 )
 
 from scripts import (
+    AdobeAccountIDResetScript,
     CacheRepresentationPerLane,
     CacheFacetListsPerLane,
 )
+
+class TestAdobeAccountIDResetScript(DatabaseTest):
+
+    def test_process_patron(self):
+        patron = self._patron()
+    
+        # This patron has old-style and new-style Credentials that link
+        # them to Adobe account IDs (hopefully the same ID, though that
+        # doesn't matter here.
+        def set_value(credential):
+            credential.value = "a credential"
+
+        # Data source doesn't matter -- even if it's incorrect, a Credential
+        # of the appropriate type will be deleted.
+        data_source = DataSource.lookup(self._db, DataSource.OVERDRIVE)
+
+        # Create two Credentials that will be deleted and one that will be
+        # left alone.
+        for type in (AdobeVendorIDModel.VENDOR_ID_UUID_TOKEN_TYPE,
+                     AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
+                     "Some other type"
+        ):
+
+            credential = Credential.lookup(
+                self._db, data_source, type, patron,
+                set_value, True
+            )
+
+        eq_(3, len(patron.credentials))
+
+        # Run the patron through the script.
+        script = AdobeAccountIDResetScript(self._db)
+
+        # A dry run does nothing.
+        script.dry_run = True
+        script.process_patron(patron)
+        self._db.commit()
+        eq_(3, len(patron.credentials))
+
+        # Now try it for real.
+        script.dry_run = False
+        script.process_patron(patron)
+        self._db.commit()
+                
+        # The two Adobe-related credentials are gone. The other one remains.
+        [credential] = patron.credentials
+        eq_("Some other type", credential.type)
+    
 
 class TestLaneScript(DatabaseTest):
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -68,13 +68,13 @@ class TestAdobeAccountIDResetScript(DatabaseTest):
         script = AdobeAccountIDResetScript(self._db)
 
         # A dry run does nothing.
-        script.dry_run = True
+        script.delete = False
         script.process_patron(patron)
         self._db.commit()
         eq_(3, len(patron.credentials))
 
         # Now try it for real.
-        script.dry_run = False
+        script.delete = True
         script.process_patron(patron)
         self._db.commit()
                 


### PR DESCRIPTION
This branch creates a `PatronInputScript` whose job is to delete all of a Patron's credentials that connect them to an Adobe account ID. Since this is very bad if it happens by accident, the script gives you lots of opportunities to back out of making a change.

I also moved the constant `CirculationManagerAnnotator.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER` to `AuthdataUtility`, since it's used from a lot of different pieces of code, not just the OPDS feed generation.