### PR TITLE
License link

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -588,6 +588,7 @@ class Authenticator(object):
                 ("privacy-policy", Configuration.privacy_policy_url()),
                 ("copyright", Configuration.acknowledgements_url()),
                 ("about", Configuration.about_url()),
+                ("license", Configuration.license_url()),
         ):
             if value:
                 links[rel] = dict(href=value, type="text/html")

--- a/api/opds.py
+++ b/api/opds.py
@@ -342,6 +342,7 @@ class CirculationManagerAnnotator(Annotator):
                 ("privacy-policy", Configuration.privacy_policy_url()),
                 ("copyright", Configuration.acknowledgements_url()),
                 ("about", Configuration.about_url()),
+                ("license", Configuration.license_url()),
         ):
             if value:
                 d = dict(href=value, type="text/html", rel=rel)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -709,6 +709,7 @@ class TestAuthenticator(DatabaseTest):
                 Configuration.PRIVACY_POLICY: "http://privacy",
                 Configuration.COPYRIGHT: "http://copyright",
                 Configuration.ABOUT: "http://about",
+                Configuration.LICENSE: "http://license/",
             }
 
             with self.app.test_request_context("/"):        
@@ -732,6 +733,7 @@ class TestAuthenticator(DatabaseTest):
                 eq_("http://privacy", links['privacy-policy']['href'])
                 eq_("http://copyright", links['copyright']['href'])
                 eq_("http://about", links['about']['href'])
+                eq_("http://license/", links['license']['href'])
                 
                 # While we're in this context, let's also test
                 # create_authentication_headers.

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -72,6 +72,37 @@ class TestCirculationManagerAnnotator(DatabaseTest):
             None, Fantasy, test_mode=True, top_level_title="Test Top Level Title"
         )
 
+    def test_add_configuration_links(self):
+        mock_feed = []
+        link_config = {
+            Configuration.TERMS_OF_SERVICE: "http://terms/",
+            Configuration.PRIVACY_POLICY: "http://privacy/",
+            Configuration.COPYRIGHT: "http://copyright/",
+            Configuration.ABOUT: "http://about/",
+            Configuration.LICENSE: "http://license/",
+        }
+        with temp_config() as config:
+            config['links'] = link_config
+            CirculationManagerAnnotator.add_configuration_links(mock_feed)
+
+        # Five links were added to the "feed"
+        eq_(5, len(mock_feed))
+
+        # They are the links we'd expect.
+        links = {}
+        for link in mock_feed:
+            rel = link.attrib['rel']
+            href = link.attrib['href']
+            type = link.attrib['type']
+
+            eq_("text/html", type)
+
+            # Convert the link relation into a key to the configuration.
+            config_value = rel.replace('-', '_')
+
+            # Check that the configuration value made it into the link.
+            eq_(href, link_config[config_value])
+            
     def test_open_access_link(self):
 
         # The resource URL associated with a LicensePoolDeliveryMechanism


### PR DESCRIPTION
This branch adds the ability to specify a link with rel="license" which will show up in OPDS feeds and the Authentication for OPDS document.

I added a previously missing test of the functionality for adding these links to an OPDS feed.