### PR TITLE
Fixed a confusion between DeliveryMechanism and LicensePoolDeliveryMechanism in call to fulfill_open_access.

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -419,7 +419,7 @@ class CirculationAPI(object):
         DeliveryMechanism.
 
         :param licensepool: The title to be fulfilled.
-        :param requested_lpdm: A DeliveryMechanism.
+        :param delivery_mechanism: A DeliveryMechanism.
         """
         if isinstance(delivery_mechanism, LicensePoolDeliveryMechanism):
             self.log.warn("LicensePoolDeliveryMechanism passed into fulfill_open_access, should be DeliveryMechanism.")

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -385,7 +385,7 @@ class CirculationAPI(object):
 
         if licensepool.open_access:
             fulfillment = self.fulfill_open_access(
-                licensepool, delivery_mechanism
+                licensepool, delivery_mechanism.delivery_mechanism
             )
         else:
             api = self.api_for_license_pool(licensepool)


### PR DESCRIPTION
This stupid bug (caused by naming a variable `delivery_mechanism` when it actually holds a `LicensePoolDeliveryMechanism`) had the effect of making `fulfill_open_access` fulfill whatever DeliveryMechanism happened to be the first one created for that LicensePool, regardless of what the patron actually asked for.

I had to add a lot of testing for `fulfill_open_access` because it previously had no test coverage.