### PR TITLE
Related books facets/pagination improvements

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1,6 +1,7 @@
 import re
 from nose.tools import set_trace
 import contextlib
+from copy import deepcopy
 from core.config import (
     Configuration as CoreConfiguration,
     CannotLoadConfiguration,
@@ -138,3 +139,40 @@ def temp_config(new_config=None, replacement_classes=None):
         all_replacement_classes.extend(replacement_classes)
     with core_temp_config(new_config, all_replacement_classes) as i:
         yield i
+
+class FacetConfig(object):
+    """A class that implements the facet-related methods of
+    Configuration, and allows modifications to the enabled
+    and default facets. For use when a controller needs to
+    use a facet configuration different from the site-wide
+    facets. 
+    """
+    @classmethod
+    def from_config(cls):
+        facet_policy = Configuration.policy(Configuration.FACET_POLICY, default=dict())
+        enabled_facets = deepcopy(facet_policy.get(Configuration.ENABLED_FACETS_KEY,
+                                               Configuration.DEFAULT_ENABLED_FACETS))
+        default_facets = deepcopy(facet_policy.get(Configuration.DEFAULT_FACET_KEY,
+                                               Configuration.DEFAULT_FACET))
+        return FacetConfig(enabled_facets, default_facets)
+
+    def __init__(self, enabled_facets, default_facets):
+        self._enabled_facets = enabled_facets
+        self._default_facets = default_facets
+
+    def enabled_facets(self, group_name):
+        return self._enabled_facets.get(group_name)
+
+    def default_facet(self, group_name):
+        return self._default_facets.get(group_name)
+
+    def enable_facet(self, group_name, facet):
+        self._enabled_facets.setdefault(group_name, [])
+        if facet not in self._enabled_facets[group_name]:
+            self._enabled_facets[group_name] += [facet]
+
+    def set_default_facet(self, group_name, facet):
+        self.enable_facet(group_name, facet)
+        self._default_facets[group_name] = facet
+
+

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -572,7 +572,6 @@ class SeriesLane(QueryGeneratedLane):
             languages=self.language_key,
             audiences=self.audience_key
         )
-        kwargs[Facets.ORDER_FACET_GROUP_NAME] = Facets.ORDER_SERIES_POSITION
         return self.ROUTE, kwargs
 
     def lane_query_hook(self, qu, **kwargs):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -574,6 +574,20 @@ class SeriesLane(QueryGeneratedLane):
         )
         return self.ROUTE, kwargs
 
+    def featured_works(self, use_materialized_works=True):
+        if not use_materialized_works:
+            qu = self.works()
+        else:
+            qu = self.materialized_works()
+
+        # Aliasing Edition here allows this query to function
+        # regardless of work_model and existing joins.
+        work_edition = aliased(Edition)
+        qu = qu.join(work_edition).order_by(work_edition.series_position, work_edition.title)
+        target_size = Configuration.featured_lane_size()
+        qu = qu.limit(target_size)
+        return qu.all()
+
     def lane_query_hook(self, qu, **kwargs):
         if not self.series:
             return None

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -15,6 +15,7 @@ from core.lane import (
     Lane,
     LaneList,
     QueryGeneratedLane,
+    Facets,
 )
 from core.model import (
     get_one,
@@ -571,6 +572,7 @@ class SeriesLane(QueryGeneratedLane):
             languages=self.language_key,
             audiences=self.audience_key
         )
+        kwargs[Facets.ORDER_FACET_GROUP_NAME] = Facets.ORDER_SERIES_POSITION
         return self.ROUTE, kwargs
 
     def lane_query_hook(self, qu, **kwargs):
@@ -581,7 +583,6 @@ class SeriesLane(QueryGeneratedLane):
         # regardless of work_model and existing joins.
         work_edition = aliased(Edition)
         qu = qu.join(work_edition).filter(work_edition.series==self.series)
-        qu = qu.order_by(work_edition.series_position, work_edition.title)
         return qu
 
 
@@ -641,6 +642,6 @@ class ContributorLane(QueryGeneratedLane):
             if self.contributor.viaf:
                 clauses.append(Contributor.viaf==self.contributor.viaf)
         or_clause = or_(*clauses)
-        qu = qu.filter(or_clause).order_by(work_edition.title.asc())
+        qu = qu.filter(or_clause)
 
         return qu

--- a/api/opds.py
+++ b/api/opds.py
@@ -105,10 +105,7 @@ class CirculationManagerAnnotator(Annotator):
         return (lane_name, languages)
 
     def facet_url(self, facets):
-        lane_name, languages = self._lane_name_and_languages(self.lane)
-        kwargs = dict(facets.items())
-        return self.cdn_url_for(
-            self.facet_view, lane_name=lane_name, languages=languages, _external=True, **kwargs)
+        return self.feed_url(self.lane, facets=facets, default_route=self.facet_view)
 
     def permalink_for(self, work, license_pool, identifier):
         return self.url_for(
@@ -124,12 +121,12 @@ class CirculationManagerAnnotator(Annotator):
     def default_lane_url(self):
         return self.groups_url(None)
 
-    def feed_url(self, lane, facets=None, pagination=None):
+    def feed_url(self, lane, facets=None, pagination=None, default_route='feed'):
         if (isinstance(lane, QueryGeneratedLane) and
             hasattr(lane, 'url_arguments')):
             route, kwargs = lane.url_arguments
         else:
-            route = 'feed'
+            route = default_route
             lane_name, languages = self._lane_name_and_languages(lane)
             kwargs = dict(lane_name=lane_name, languages=languages)
         if facets != None:

--- a/api/routes.py
+++ b/api/routes.py
@@ -68,11 +68,6 @@ def get_locale():
     languages = Configuration.localization_languages()
     return request.accept_languages.best_match(languages)
 
-h = ErrorHandler(app, app.config['DEBUG'])
-@app.errorhandler(Exception)
-def exception_handler(exception):
-    return h.handle(exception)
-
 @app.teardown_request
 def shutdown_session(exception):
     if (hasattr(app, 'manager') 
@@ -116,6 +111,12 @@ else:
         def decorated(f):
             return f
         return decorated
+
+h = ErrorHandler(app, app.config['DEBUG'])
+@app.errorhandler(Exception)
+@allows_patron_web()
+def exception_handler(exception):
+    return h.handle(exception)
 
 def dir_route(path, *args, **kwargs):
     """Decorator to create routes that work with or without a trailing slash."""

--- a/api/routes.py
+++ b/api/routes.py
@@ -241,21 +241,21 @@ def work():
     annotator = CirculationManagerAnnotator(app.manager.circulation, None)
     return app.manager.urn_lookup.work_lookup(annotator, 'work')
 
-@app.route('/works/contributor/<contributor_name>', defaults=dict(languages=None, audiences=None))
-@app.route('/works/contributor/<contributor_name>/<languages>', defaults=dict(audiences=None))
+@dir_route('/works/contributor/<contributor_name>', defaults=dict(languages=None, audiences=None))
+@dir_route('/works/contributor/<contributor_name>/<languages>', defaults=dict(audiences=None))
 @app.route('/works/contributor/<contributor_name>/<languages>/<audiences>')
 @allows_patron_web()
 @returns_problem_detail
-def contributor(contributor_name):
-    return app.manager.work_controller.contributor(contributor_name)
+def contributor(contributor_name, languages, audiences):
+    return app.manager.work_controller.contributor(contributor_name, languages, audiences)
 
-@app.route('/works/series/<series_name>', defaults=dict(languages=None, audiences=None))
-@app.route('/works/series/<series_name>/<languages>', defaults=dict(audiences=None))
+@dir_route('/works/series/<series_name>', defaults=dict(languages=None, audiences=None))
+@dir_route('/works/series/<series_name>/<languages>', defaults=dict(audiences=None))
 @app.route('/works/series/<series_name>/<languages>/<audiences>')
 @allows_patron_web()
 @returns_problem_detail
-def series(series_name):
-    return app.manager.work_controller.series(series_name)
+def series(series_name, languages, audiences):
+    return app.manager.work_controller.series(series_name, languages, audiences)
 
 @app.route('/works/<data_source>/<identifier_type>/<path:identifier>')
 @allows_patron_web()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,79 @@
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+
+from api.config import (
+    Configuration,
+    temp_config,
+    FacetConfig
+)
+from core.facets import FacetConstants as Facets
+
+class TestFacetConfig(object):
+
+    def setup(self):
+        self.enabled = {
+            Facets.ORDER_FACET_GROUP_NAME: [
+                Facets.ORDER_TITLE, Facets.ORDER_AUTHOR
+            ]
+        }
+
+        self.default = {
+            Facets.ORDER_FACET_GROUP_NAME: Facets.ORDER_TITLE
+        }
+
+    def test_from_config(self):
+        with temp_config() as config:
+            config[Configuration.POLICIES] = {}
+
+            facet_config = FacetConfig.from_config()
+            eq_(Configuration.DEFAULT_ENABLED_FACETS, facet_config._enabled_facets)
+            eq_(Configuration.DEFAULT_FACET, facet_config._default_facets)
+
+        with temp_config() as config:
+            config[Configuration.POLICIES][Configuration.FACET_POLICY] = {
+                Configuration.ENABLED_FACETS_KEY: self.enabled,
+                Configuration.DEFAULT_FACET_KEY: self.default,
+            }
+
+            facet_config = FacetConfig.from_config()
+            eq_(self.enabled, facet_config._enabled_facets)
+            eq_(self.default, facet_config._default_facets)
+
+    def test_enabled_facets(self):
+        facet_config = FacetConfig(self.enabled, self.default)
+
+        eq_([Facets.ORDER_TITLE, Facets.ORDER_AUTHOR], facet_config.enabled_facets(Facets.ORDER_FACET_GROUP_NAME))
+        eq_(None, facet_config.enabled_facets(Facets.COLLECTION_FACET_GROUP_NAME))
+
+    def test_default_facet(self):
+        facet_config = FacetConfig(self.enabled, self.default)
+
+        eq_(Facets.ORDER_TITLE, facet_config.default_facet(Facets.ORDER_FACET_GROUP_NAME))
+        eq_(None, facet_config.default_facet(Facets.COLLECTION_FACET_GROUP_NAME))
+
+    def test_enable_facet(self):
+        facet_config = FacetConfig(self.enabled, self.default)
+
+        facet_config.enable_facet(Facets.ORDER_FACET_GROUP_NAME, Facets.ORDER_SERIES_POSITION)
+        eq_([Facets.ORDER_TITLE, Facets.ORDER_AUTHOR, Facets.ORDER_SERIES_POSITION],
+            facet_config.enabled_facets(Facets.ORDER_FACET_GROUP_NAME))
+
+        facet_config.enable_facet(Facets.COLLECTION_FACET_GROUP_NAME, Facets.COLLECTION_MAIN)
+        eq_([Facets.COLLECTION_MAIN], facet_config.enabled_facets(Facets.COLLECTION_FACET_GROUP_NAME))
+
+    def test_set_default_facet(self):
+        facet_config = FacetConfig(self.enabled, self.default)
+
+        facet_config.set_default_facet(Facets.ORDER_FACET_GROUP_NAME, Facets.ORDER_AUTHOR)
+        eq_(Facets.ORDER_AUTHOR, facet_config.default_facet(Facets.ORDER_FACET_GROUP_NAME))
+        
+        facet_config.set_default_facet(Facets.ORDER_FACET_GROUP_NAME, Facets.ORDER_SERIES_POSITION)
+        eq_(Facets.ORDER_SERIES_POSITION, facet_config.default_facet(Facets.ORDER_FACET_GROUP_NAME))
+        eq_([Facets.ORDER_TITLE, Facets.ORDER_AUTHOR, Facets.ORDER_SERIES_POSITION],
+            facet_config.enabled_facets(Facets.ORDER_FACET_GROUP_NAME))
+
+        facet_config.set_default_facet(Facets.COLLECTION_FACET_GROUP_NAME, Facets.COLLECTION_MAIN)
+        eq_(Facets.COLLECTION_MAIN, facet_config.default_facet(Facets.COLLECTION_FACET_GROUP_NAME))
+        eq_([Facets.COLLECTION_MAIN], facet_config.enabled_facets(Facets.COLLECTION_FACET_GROUP_NAME))

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1245,6 +1245,52 @@ class TestWorkController(CirculationControllerTest):
         [entry] = feed['entries']
         eq_(self.english_1.title, entry['title'])
 
+        # The feed has facet links.
+        links = feed['feed']['links']
+        facet_links = [link for link in links if link['rel'] == 'http://opds-spec.org/facet']
+        eq_(9, len(facet_links))
+
+        another_work = self._work(
+            "Not open access", name, with_license_pool=True)
+        another_work.license_pools[0].open_access = False
+
+        # Facets work.
+        SessionManager.refresh_materialized_views(self._db)
+        with self.app.test_request_context("/?order=title"):
+            response = self.manager.work_controller.contributor(name, None, None)
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(2, len(feed['entries']))
+
+        with self.app.test_request_context("/?available=always"):
+            response = self.manager.work_controller.contributor(name, None, None)
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(1, len(feed['entries']))
+        [entry] = feed['entries']
+        eq_(self.english_1.title, entry['title'])
+
+        # Pagination works.
+        with self.app.test_request_context("/?size=1"):
+            response = self.manager.work_controller.contributor(name, None, None)
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(1, len(feed['entries']))
+        [entry] = feed['entries']
+        eq_(another_work.title, entry['title'])
+
+        with self.app.test_request_context("/?after=1"):
+            response = self.manager.work_controller.contributor(name, None, None)
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(1, len(feed['entries']))
+        [entry] = feed['entries']
+        eq_(self.english_1.title, entry['title'])
+
     def test_permalink(self):
         with self.app.test_request_context("/"):
             response = self.manager.work_controller.permalink(self.datasource, self.identifier.type, self.identifier.identifier)
@@ -1318,6 +1364,12 @@ class TestWorkController(CirculationControllerTest):
         eq_(self.english_2.title, entry['title'])
         eq_(self.english_2.author, entry['author'])
 
+        # The feed has facet links.
+        links = feed['feed']['links']
+        facet_links = [link for link in links if link['rel'] == 'http://opds-spec.org/facet']
+        eq_(9, len(facet_links))
+
+
         with temp_config() as config:
             with self.app.test_request_context('/'):
                 config['integrations'][Configuration.NOVELIST_INTEGRATION] = {}
@@ -1326,6 +1378,85 @@ class TestWorkController(CirculationControllerTest):
                 )
             eq_(404, response.status_code)
             eq_("http://librarysimplified.org/terms/problem/unknown-lane", response.uri)
+
+        another_work = self._work("Before Quite British", "Not Before John Bull", with_open_access_download=True)
+
+        metadata.recommendations = [
+            self.english_1.license_pools[0].identifier,
+            another_work.license_pools[0].identifier,
+        ]
+        mock_api.setup(metadata)
+
+        # Facets work.
+        SessionManager.refresh_materialized_views(self._db)
+        with self.app.test_request_context("/?order=title"):
+            response = self.manager.work_controller.recommendations(
+                self.datasource, self.identifier.type, self.identifier.identifier,
+                novelist_api=mock_api
+            )
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(2, len(feed['entries']))
+        [entry1, entry2] = feed['entries']
+        eq_(another_work.title, entry1['title'])
+        eq_(self.english_1.title, entry2['title'])
+
+        metadata.recommendations = [
+            self.english_1.license_pools[0].identifier,
+            another_work.license_pools[0].identifier,
+        ]
+        mock_api.setup(metadata)
+
+        with self.app.test_request_context("/?order=author"):
+            response = self.manager.work_controller.recommendations(
+                self.datasource, self.identifier.type, self.identifier.identifier,
+                novelist_api=mock_api
+            )
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(2, len(feed['entries']))
+        [entry1, entry2] = feed['entries']
+        eq_(self.english_1.title, entry1['title'])
+        eq_(another_work.title, entry2['title'])
+
+        metadata.recommendations = [
+            self.english_1.license_pools[0].identifier,
+            another_work.license_pools[0].identifier,
+        ]
+        mock_api.setup(metadata)
+
+        # Pagination works.
+        with self.app.test_request_context("/?size=1&order=title"):
+            response = self.manager.work_controller.recommendations(
+                self.datasource, self.identifier.type, self.identifier.identifier,
+                novelist_api=mock_api
+            )
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(1, len(feed['entries']))
+        [entry] = feed['entries']
+        eq_(another_work.title, entry['title'])
+
+        metadata.recommendations = [
+            self.english_1.license_pools[0].identifier,
+            another_work.license_pools[0].identifier,
+        ]
+        mock_api.setup(metadata)
+
+        with self.app.test_request_context("/?after=1&order=title"):
+            response = self.manager.work_controller.recommendations(
+                self.datasource, self.identifier.type, self.identifier.identifier,
+                novelist_api=mock_api
+            )
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(1, len(feed['entries']))
+        [entry] = feed['entries']
+        eq_(self.english_1.title, entry['title'])
 
     def test_related_books(self):
         # A book with no related books returns a ProblemDetail.
@@ -1392,7 +1523,7 @@ class TestWorkController(CirculationControllerTest):
         [e2] = [e for e in feed['entries'] if e['title'] == same_series.title]
         title, href = collection_link(e2)
         eq_("Around the World", title)
-        expected_series_link = urllib.quote('series/Around the World/eng/Adult')
+        expected_series_link = 'series/%s/eng/Adult?order=series' % urllib.quote("Around the World")
         eq_(True, href.endswith(expected_series_link))
 
         # The other book by this contributor is in the contributor feed.
@@ -1462,6 +1593,69 @@ class TestWorkController(CirculationControllerTest):
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
         eq_(series_name, feed['feed']['title'])
+        [entry] = feed['entries']
+        eq_(self.english_1.title, entry['title'])
+
+        # The feed has facet links.
+        links = feed['feed']['links']
+        facet_links = [link for link in links if link['rel'] == 'http://opds-spec.org/facet']
+        eq_(12, len(facet_links))
+
+        another_work = self._work("Before Quite British", "Not Before John Bull", with_open_access_download=True)
+        another_work.license_pools[0].presentation_edition.series = series_name
+
+        # Facets work.
+        SessionManager.refresh_materialized_views(self._db)
+        with self.app.test_request_context("/?order=title"):
+            response = self.manager.work_controller.series(series_name, None, None)
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(2, len(feed['entries']))
+        [entry1, entry2] = feed['entries']
+        eq_(another_work.title, entry1['title'])
+        eq_(self.english_1.title, entry2['title'])
+
+        with self.app.test_request_context("/?order=author"):
+            response = self.manager.work_controller.series(series_name, None, None)
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(2, len(feed['entries']))
+        [entry1, entry2] = feed['entries']
+        eq_(self.english_1.title, entry1['title'])
+        eq_(another_work.title, entry2['title'])
+
+        self.english_1.license_pools[0].presentation_edition.series_position = 0
+        another_work.license_pools[0].series_position = 1
+
+        SessionManager.refresh_materialized_views(self._db)
+        with self.app.test_request_context("/?order=series"):
+            response = self.manager.work_controller.series(series_name, None, None)
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(2, len(feed['entries']))
+        [entry1, entry2] = feed['entries']
+        eq_(self.english_1.title, entry1['title'])
+        eq_(another_work.title, entry2['title'])
+
+        # Pagination works.
+        with self.app.test_request_context("/?size=1&order=title"):
+            response = self.manager.work_controller.series(series_name, None, None)
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(1, len(feed['entries']))
+        [entry] = feed['entries']
+        eq_(another_work.title, entry['title'])
+
+        with self.app.test_request_context("/?after=1&order=title"):
+            response = self.manager.work_controller.series(series_name, None, None)
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(1, len(feed['entries']))
         [entry] = feed['entries']
         eq_(self.english_1.title, entry['title'])
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1381,6 +1381,10 @@ class TestWorkController(CirculationControllerTest):
 
         another_work = self._work("Before Quite British", "Not Before John Bull", with_open_access_download=True)
 
+        # Delete the cache again and prep a recommendation result.
+        [cached_feed] = self._db.query(CachedFeed).all()
+        self._db.delete(cached_feed)
+
         metadata.recommendations = [
             self.english_1.license_pools[0].identifier,
             another_work.license_pools[0].identifier,
@@ -1604,6 +1608,10 @@ class TestWorkController(CirculationControllerTest):
         another_work = self._work("Before Quite British", "Not Before John Bull", with_open_access_download=True)
         another_work.license_pools[0].presentation_edition.series = series_name
 
+        # Delete the cache
+        [cached_feed] = self._db.query(CachedFeed).all()
+        self._db.delete(cached_feed)
+        
         # Facets work.
         SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context("/?order=title"):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1490,8 +1490,12 @@ class TestWorkController(CirculationControllerTest):
         )
 
         self.lp.presentation_edition.series = "Around the World"
-        same_series = self._work(with_license_pool=True)
+        self.lp.presentation_edition.series_position = 1
+
+        same_series = self._work(title="ZZZ", authors="ZZZ ZZZ", with_license_pool=True)
         same_series.presentation_edition.series = "Around the World"
+        same_series.presentation_edition.series_position = 0
+
         SessionManager.refresh_materialized_views(self._db)
 
         source = DataSource.lookup(self._db, self.datasource)
@@ -1548,6 +1552,11 @@ class TestWorkController(CirculationControllerTest):
             title, href = collection_link(entry)
             eq_(True, href.endswith(title_to_link_ending[title]))
             del title_to_link_ending[title]
+
+        # The series feed is sorted by series position.
+        [series_e1, series_e2] = [e for e in feed['entries'] if collection_link(e)[0]=="Around the World"]
+        eq_(same_series.title, series_e1['title'])
+        eq_(self.english_1.title, series_e2['title'])
 
     def test_report_problem_get(self):
         with self.app.test_request_context("/"):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1531,7 +1531,7 @@ class TestWorkController(CirculationControllerTest):
         [e2] = [e for e in feed['entries'] if e['title'] == same_series.title]
         title, href = collection_link(e2)
         eq_("Around the World", title)
-        expected_series_link = 'series/%s/eng/Adult?order=series' % urllib.quote("Around the World")
+        expected_series_link = 'series/%s/eng/Adult' % urllib.quote("Around the World")
         eq_(True, href.endswith(expected_series_link))
 
         # The other book by this contributor is in the contributor feed.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1612,7 +1612,7 @@ class TestWorkController(CirculationControllerTest):
         # The feed has facet links.
         links = feed['feed']['links']
         facet_links = [link for link in links if link['rel'] == 'http://opds-spec.org/facet']
-        eq_(12, len(facet_links))
+        eq_(10, len(facet_links))
 
         another_work = self._work("Before Quite British", "Not Before John Bull", with_open_access_download=True)
         another_work.license_pools[0].presentation_edition.series = series_name
@@ -1648,6 +1648,17 @@ class TestWorkController(CirculationControllerTest):
 
         SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context("/?order=series"):
+            response = self.manager.work_controller.series(series_name, None, None)
+
+        eq_(200, response.status_code)
+        feed = feedparser.parse(response.data)
+        eq_(2, len(feed['entries']))
+        [entry1, entry2] = feed['entries']
+        eq_(self.english_1.title, entry1['title'])
+        eq_(another_work.title, entry2['title'])
+
+        # Series is the default facet.
+        with self.app.test_request_context("/"):
             response = self.manager.work_controller.series(series_name, None, None)
 
         eq_(200, response.status_code)


### PR DESCRIPTION
This branch implements facets and pagination for all the related books lanes and fixes various errors:

Fixes #344 
Fixes #375 
Fixes #343 

Getting the facets for the series lane right ended up being really complicated. I considered removing them and having it always sorted by series position, but there are series that aren't really ordered and have many authors. I made the related books feed link to a feed that's sorted by series position. I just realize now that I don't know how the lane is sorted in that feed... I'll have to check.