### PR TITLE
Return a different <drm:licensor> tag every time, since a tag object can only be in one place in the tree.

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -1,4 +1,5 @@
 import urllib
+import copy
 from nose.tools import set_trace
 from flask import url_for
 from lxml import etree
@@ -646,6 +647,8 @@ class CirculationManagerAnnotator(Annotator):
                 drm_link.append(patron_key)
                 cached = [drm_link]
             self._adobe_id_tags[patron_identifier] = cached
+        else:
+            cached = copy.deepcopy(cached)
         return cached
         
     def open_access_link(self, lpdm):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -256,7 +256,7 @@ class TestCirculationManagerAnnotator(DatabaseTest):
             [expect] = self.annotator.adobe_id_tags(
                 adobe_id_identifier.credential
             )
-            eq_(licensor, expect)
+            eq_(etree.tostring(expect), etree.tostring(licensor))
             
     def test_no_adobe_id_tags_when_vendor_id_not_configured(self):
 
@@ -303,15 +303,11 @@ class TestCirculationManagerAnnotator(DatabaseTest):
             eq_(library_uri, decoded['iss'])
             eq_(patron_identifier, decoded['sub'])
 
-            # If we call adobe_id_tags again we'll get the exact same
-            # tag object -- it's cached.
-            eq_([element], self.annotator.adobe_id_tags(patron_identifier))
-
-            # If we call adobe_id_tags again but pass in a different
-            # identifier, we'll get a different value. (But this
-            # shouldn't happen because any given request is for one
-            # specific patron.)
-            assert self.annotator.adobe_id_tags("another one") != [element]
+            # If we call adobe_id_tags again we'll get a distinct tag
+            # object that renders to the same XML.
+            [same_tag] = self.annotator.adobe_id_tags(patron_identifier)
+            assert same_tag is not element
+            eq_(etree.tostring(element), etree.tostring(same_tag))
 
             
 class TestOPDS(DatabaseTest):


### PR DESCRIPTION
Previously `adobe_id_tags` was returning the same ElementTree object every time. This saved time, but because a tag object can only have one parent, code that was supposed to be sticking different tags in different parts of the document was actually moving a single tag further and further down the document.

This branch makes sure that on subsequent calls `adobe_id_tags` returns a copy of the cached tag object, not the cached tag object itself.