### PR TITLE
Base64-encode JWTs so that Adobe doesn't choke on them.

### DIFF
--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -519,7 +519,9 @@ class AuthdataUtility(object):
             payload['iat'] = self.numericdate(iat) # Issued At
         if exp:
             payload['exp'] = self.numericdate(exp) # Expiration Time
-        return jwt.encode(payload, self.secret, algorithm=self.ALGORITHM)
+        return base64.encodestring(
+            jwt.encode(payload, self.secret, algorithm=self.ALGORITHM)
+        )
 
     def decode(self, authdata):
         """Decode and verify an authdata JWT from one of the libraries managed
@@ -530,6 +532,12 @@ class AuthdataUtility(object):
         :raise jwt.exceptions.DecodeError: When the JWT is not valid
         for any reason.
         """
+        try:
+            authdata = base64.decodestring(authdata)
+        except Exception, e:
+            # Do nothing -- the authdata was not encoded to begin with.
+            pass
+        
         # First, decode the authdata without checking the signature.
         decoded = jwt.decode(
             authdata, algorithm=self.ALGORITHM,

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -601,7 +601,10 @@ class TestAuthdataUtility(VendorIDTest):
         authdata = self.authdata._encode(
             self.authdata.library_uri, patron_identifier, now, expires
         )
-        eq_('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwOi8vbXktbGlicmFyeS5vcmcvIiwiaWF0IjoxNDUxNjQ5NjAwLjAsInN1YiI6IlBhdHJvbiBpZGVudGlmaWVyIiwiZXhwIjoxNTE0ODA4MDAwLjB9.n7VRVv3gIyLmNxTzNRTEfCdjoky0T0a1Jhehcag1oQw', authdata)
+        eq_(
+            base64.encodestring('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwOi8vbXktbGlicmFyeS5vcmcvIiwiaWF0IjoxNDUxNjQ5NjAwLjAsInN1YiI6IlBhdHJvbiBpZGVudGlmaWVyIiwiZXhwIjoxNTE0ODA4MDAwLjB9.n7VRVv3gIyLmNxTzNRTEfCdjoky0T0a1Jhehcag1oQw'),
+            authdata
+        )
 
     def test_decode_from_another_library(self):        
 
@@ -639,7 +642,6 @@ class TestAuthdataUtility(VendorIDTest):
             secret = "Some other library secret",
         )
         vendor_id, authdata = foreign_authdata.encode("A patron")
-
         # They can encode, but we cna't decode.
         assert_raises_regexp(
             DecodeError, "Unknown library: http://some-other-library.org/",

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1,3 +1,4 @@
+import base64
 import datetime
 import os
 import re
@@ -297,9 +298,10 @@ class TestCirculationManagerAnnotator(DatabaseTest):
             [token] = element.getchildren()
             
             eq_('{http://librarysimplified.org/terms/drm}clientToken', token.tag)
-            # token.text is a JWT which we can decode, since we know the
-            # secret.
+            # token.text is a base64-encoded JWT which we can decode,
+            # since we know the secret.
             token = token.text
+            token = base64.decodestring(token)
             decoded = jwt.decode(token, secret, AuthdataUtility.ALGORITHM)
             eq_(library_uri, decoded['iss'])
             eq_(patron_identifier, decoded['sub'])


### PR DESCRIPTION
This branch transparently base64-encodes JWTs on the way out and decodes them on the way in, in hopes that Adobe will let them pass unhindered.