### PR TITLE
Service status can handle the case where attemp to get patron results in ProblemDetail

### DIFF
--- a/api/services.py
+++ b/api/services.py
@@ -7,6 +7,7 @@ from core.scripts import (
     Script,
     IdentifierInputScript,
 )
+from core.util.problem_detail import ProblemDetail
 
 from config import Configuration
 from authenticator import Authenticator
@@ -58,9 +59,14 @@ class ServiceStatus(object):
         if patron_info:
             [(patron, password)] = patron_info
             if patron:
-                success = True                
+                if isinstance(patron, ProblemDetail):
+                    response = patron.response
+                    error = response[0] # The JSON representation of the ProblemDetail
+                else:
+                    success = True
+            else:
+                error = "Could not create patron with configured credentials."
         if not success:
-            error = "Could not create patron with configured credentials."
             self.log.error(error)
             status[service] = error
             return status

--- a/api/services.py
+++ b/api/services.py
@@ -56,6 +56,7 @@ class ServiceStatus(object):
         self._add_timing(status, service, do_patron)
         success = False
         patron = password = None
+        error = "Could not create patron with configured credentials."
         if patron_info:
             [(patron, password)] = patron_info
             if patron:
@@ -64,8 +65,7 @@ class ServiceStatus(object):
                     error = response[0] # The JSON representation of the ProblemDetail
                 else:
                     success = True
-            else:
-                error = "Could not create patron with configured credentials."
+                    error = None
         if not success:
             self.log.error(error)
             status[service] = error


### PR DESCRIPTION
We're seeing a problem on NYPL circulation where the attempt to get the test patron results in a ProblemDetail, and we can't even see what the ProblemDetail is because the service status code is treating the ProblemDetail as though it were a Patron object. This branch should at least let us see what the real problem is.