### PR TITLE
Adobe vendor id resilience

### DIFF
--- a/api/threem.py
+++ b/api/threem.py
@@ -115,6 +115,7 @@ class ThreeMAPI(BaseThreeMAPI, BaseCirculationAPI):
         patron_id = patron.authorization_identifier
         path = "circulation/patron/%s" % patron_id
         response = self.request(path)
+        print response.content
         return PatronCirculationParser().process_all(response.content)
 
     TEMPLATE = "<%(request_type)s><ItemId>%(item_id)s</ItemId><PatronId>%(patron_id)s</PatronId></%(request_type)s>"

--- a/api/threem.py
+++ b/api/threem.py
@@ -115,7 +115,6 @@ class ThreeMAPI(BaseThreeMAPI, BaseCirculationAPI):
         patron_id = patron.authorization_identifier
         path = "circulation/patron/%s" % patron_id
         response = self.request(path)
-        print response.content
         return PatronCirculationParser().process_all(response.content)
 
     TEMPLATE = "<%(request_type)s><ItemId>%(item_id)s</ItemId><PatronId>%(patron_id)s</PatronId></%(request_type)s>"

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -593,6 +593,19 @@ class TestAuthdataUtility(VendorIDTest):
         decoded = self.authdata.decode(authdata)
         eq_(("http://my-library.org/", "Patron identifier"), decoded)
 
+    def test_decode_round_trip_with_intermediate_mischief(self):        
+        patron_identifier = "Patron identifier"
+        vendor_id, authdata = self.authdata.encode(patron_identifier)
+        eq_("The Vendor ID", vendor_id)
+
+        # A mischievious party in the middle decodes our authdata
+        # without telling us.
+        authdata = base64.decodestring(authdata)
+        
+        # But it still works.
+        decoded = self.authdata.decode(authdata)
+        eq_(("http://my-library.org/", "Patron identifier"), decoded)
+        
     def test_encode(self):
         """Test that _encode gives a known value with known input."""
         patron_identifier = "Patron identifier"


### PR DESCRIPTION
This branch makes the JWT decoding code more resilient in the face of something weird is doing to the token before sending it to the circ manager. I also add debugging logs so that we can get a better picture of what exactly Adobe is doing.

As always, this needs to go into production because Adobe is hard-coded to talk to production.