### PR TITLE
Shorten client token

### DIFF
--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -682,7 +682,7 @@ class AuthdataUtility(object):
         if not patron_identifier:
             raise ValueError("No patron identifier specified")
         now = datetime.datetime.utcnow()
-        expires = self.numericdate(now + datetime.timedelta(minutes=60))
+        expires = int(self.numericdate(now + datetime.timedelta(minutes=60)))
         authdata = self._encode_short_client_token(
             self.short_name, patron_identifier, expires
         )
@@ -703,7 +703,7 @@ class AuthdataUtility(object):
             self.log.error(
                 "Password portion of short client token exceeds 76 characters; Adobe will probably truncate it."
             )
-        return base + " " + signature
+        return base + "|" + signature
             
     def decode_short_client_token(self, token):
         """Attempt to interpret a 'username' and 'password' as a short
@@ -717,7 +717,7 @@ class AuthdataUtility(object):
             raise ValueError(
                 'Supposed client token "%s" does not contain a space.' % token
             )
-        username, password = token.rsplit(' ', 1)
+        username, password = token.rsplit('|', 1)
         return self.decode_two_part_short_client_token(username, password)
         
     def decode_two_part_short_client_token(self, username, password):
@@ -783,9 +783,9 @@ class AuthdataUtility(object):
     EPOCH = datetime.datetime(1970, 1, 1)
 
     @classmethod
-    def numericdate(cls, d):
+    def numericdate(cls, d, integer_seconds=False):
         """Turn a datetime object into a NumericDate as per RFC 7519."""
-        return int((d-cls.EPOCH).total_seconds())
+        return (d-cls.EPOCH).total_seconds()
 
     def migrate_adobe_id(self, patron):
         """If the given patron has an Adobe ID stored as a Credential, also

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -724,8 +724,11 @@ class AuthdataUtility(object):
         """Decode a short client token that has already been split into
         two parts.
         """
-        # NOTE: This is a temporary log statement used to check whether
-        # Adobe mangles username or password in transit.
+        # NOTE: This is a temporary log statement used to check
+        # whether Adobe mangles username or password in transit. Since
+        # we never use username and password for its intended purpose,
+        # there's no risk of exposing confidential patron information
+        # while this log is in place.
         self.log.info("Decoding %s/%s as a short client token.",
                       username, password)
         signature = base64.decodestring(password)

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -724,6 +724,10 @@ class AuthdataUtility(object):
         """Decode a short client token that has already been split into
         two parts.
         """
+        # NOTE: This is a temporary log statement used to check whether
+        # Adobe mangles username or password in transit.
+        self.log.info("Decoding %s/%s as a short client token.",
+                      username, password)
         signature = base64.decodestring(password)
         return self._decode_short_client_token(username, signature)
 

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -783,7 +783,7 @@ class AuthdataUtility(object):
     EPOCH = datetime.datetime(1970, 1, 1)
 
     @classmethod
-    def numericdate(cls, d, integer_seconds=False):
+    def numericdate(cls, d):
         """Turn a datetime object into a NumericDate as per RFC 7519."""
         return (d-cls.EPOCH).total_seconds()
 

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -694,7 +694,6 @@ class AuthdataUtility(object):
         signature = self.short_token_signer.sign(
             base, self.short_token_signing_key
         )
-        base = base64.encodestring(base)
         signature = base64.encodestring(signature)
         if len(base) > 80:
             self.log.error(
@@ -718,14 +717,13 @@ class AuthdataUtility(object):
             raise ValueError(
                 'Supposed client token "%s" does not contain a space.' % token
             )
-        username, password = token.split(' ', 1)
+        username, password = token.rsplit(' ', 1)
         return self.decode_two_part_short_client_token(username, password)
         
     def decode_two_part_short_client_token(self, username, password):
         """Decode a short client token that has already been split into
         two parts.
         """
-        username = base64.decodestring(username)
         signature = base64.decodestring(password)
         return self._decode_short_client_token(username, signature)
 
@@ -787,7 +785,7 @@ class AuthdataUtility(object):
     @classmethod
     def numericdate(cls, d):
         """Turn a datetime object into a NumericDate as per RFC 7519."""
-        return (d-cls.EPOCH).total_seconds()
+        return int((d-cls.EPOCH).total_seconds())
 
     def migrate_adobe_id(self, patron):
         """If the given patron has an Adobe ID stored as a Credential, also

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -270,7 +270,7 @@ class TestVendorIDModel(VendorIDTest):
             # Because this library shares the other library's secret,
             # it can decode a short client token issued by the other library,
             # and issue an Adobe ID (UUID).
-            token, signature = short_client_token.split(" ")
+            token, signature = short_client_token.rsplit(" ", 1)
             uuid, label = self.model.short_client_token_lookup(
                 token, signature
             )
@@ -814,15 +814,14 @@ class TestAuthdataUtility(VendorIDTest):
         value = self.authdata._encode_short_client_token(
             "a library", "a patron identifier", 1234.5
         )
-        eq_('YSBsaWJyYXJ5fDEyMzQuNXxhIHBhdHJvbiBpZGVudGlmaWVy\n YoNGn7f38mF531KSWJ/o1H0Z3chbC+uTE+t7pAwqYxM=\n',
+        eq_('a library|1234.5|a patron identifier YoNGn7f38mF531KSWJ/o1H0Z3chbC+uTE+t7pAwqYxM=\n',
             value
         )
 
         # Dissect the known value to show how it works.
-        token, signature = value.split(" ")
+        token, signature = value.rsplit(" ", 1)
 
-        # Both token and signature are base64-encoded.
-        token = base64.decodestring(token)
+        # Signature are base64-encoded; token is not.
         signature = base64.decodestring(signature)
 
         # The token comes from the library name, the patron identifier,

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -821,7 +821,7 @@ class TestAuthdataUtility(VendorIDTest):
         # Dissect the known value to show how it works.
         token, signature = value.rsplit("|", 1)
 
-        # Signature are base64-encoded; token is not.
+        # Signature is base64-encoded; token is not.
         signature = base64.decodestring(signature)
 
         # The token comes from the library name, the patron identifier,

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -270,7 +270,7 @@ class TestVendorIDModel(VendorIDTest):
             # Because this library shares the other library's secret,
             # it can decode a short client token issued by the other library,
             # and issue an Adobe ID (UUID).
-            token, signature = short_client_token.rsplit(" ", 1)
+            token, signature = short_client_token.rsplit("|", 1)
             uuid, label = self.model.short_client_token_lookup(
                 token, signature
             )
@@ -814,12 +814,12 @@ class TestAuthdataUtility(VendorIDTest):
         value = self.authdata._encode_short_client_token(
             "a library", "a patron identifier", 1234.5
         )
-        eq_('a library|1234.5|a patron identifier YoNGn7f38mF531KSWJ/o1H0Z3chbC+uTE+t7pAwqYxM=\n',
+        eq_('a library|1234.5|a patron identifier|YoNGn7f38mF531KSWJ/o1H0Z3chbC+uTE+t7pAwqYxM=\n',
             value
         )
 
         # Dissect the known value to show how it works.
-        token, signature = value.rsplit(" ", 1)
+        token, signature = value.rsplit("|", 1)
 
         # Signature are base64-encoded; token is not.
         signature = base64.decodestring(signature)


### PR DESCRIPTION
In consultation with Aferdita, I created this branch which makes a number of changes which shortens the length of the client token. The current length for a normal NYPL token was 76, dangerously close to the maximum of 80.

* I save three characters by giving the time of token generation as an integer number of seconds rather than a float.
* I save about 33% by not base64-encoding the client token.

To improve reliability, I changed the character that separates token from signature to a pipe character. (Formerly the separator was a space.) The client needs to know to split on the rightmost pipe. Since it's  guaranteed that the token contains multiple pipe characters, there's no risk of writing a system that works in the easy case and breaks when pipes are introduced in unusual cases--the pipes are already there. This wasn't true when the separator character was a space.

It's possible that Adobe will mangle the username and password in transit; I added a temporary log statement to check whether this happens.