### PR TITLE
Fix import exception

### DIFF
--- a/api/circulation_exceptions.py
+++ b/api/circulation_exceptions.py
@@ -4,10 +4,8 @@ from core.problem_details import (
     INTEGRATION_ERROR,
     INTERNAL_SERVER_ERROR,
 )
-from problem_details import (
-    HOLD_LIMIT_REACHED,
-    NO_LICENSES,
-)
+from problem_details import *
+
 
 class CirculationException(Exception):
     """An exception occured when carrying out a circulation operation.

--- a/tests/test_circulation_exceptions.py
+++ b/tests/test_circulation_exceptions.py
@@ -1,0 +1,28 @@
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+from api.circulation_exceptions import *
+from api.problem_details import *
+
+class TestCirculationExceptions(object):
+    def test_as_problem_detail_document(self):
+        """Verify that circulation exceptions can be turned into ProblemDetail
+        documents.
+        """
+
+        e = RemoteInitiatedServerError("message", "some service")
+        doc = e.as_problem_detail_document()
+        eq_("Integration error communicating with some service", doc.detail)
+
+        e = AuthorizationExpired()
+        eq_(EXPIRED_CREDENTIALS, e.as_problem_detail_document())
+
+        e = AuthorizationBlocked()
+        eq_(BLOCKED_CREDENTIALS, e.as_problem_detail_document())
+
+        e = PatronHoldLimitReached()
+        eq_(HOLD_LIMIT_REACHED, e.as_problem_detail_document())
+
+        e = NoLicenses()
+        eq_(NO_LICENSES, e.as_problem_detail_document())


### PR DESCRIPTION
This branch fixes some import exceptions caused by my assumption that circulation_exceptions imported all the problem detail documents from problem_details. Rather than import the missing exceptions (which will cause this problem again later on) I changed the import statement to import all the problem detail documents.

To verify the fix I added tests of all CirculationExceptions that implement to_problem_detail_document.