### PR TITLE
Make it possible to turn off certificate verification when talking to the Millenium Patron API.

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -684,9 +684,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         # and if this edition is newly made, then associate pool and edition
         # as presentation_edition
         if ((not license_pool.presentation_edition) and is_new_edition): 
-            edition_changed = license_pool.set_presentation_edition(
-                policy=None
-            )
+            edition_changed = license_pool.set_presentation_edition()
 
         if is_new_pool:
             license_pool.open_access = False


### PR DESCRIPTION
Both instances of the Millenium Patron API we've actually tried to run a circulation manager against have a problem with their SSL certificates. The servers don't have the full SSL chain connecting them to a trusted certificate authority, so they fail the certificate verification when `requests` tries to validate the cert.

This branch adds a configuration option for the Millenium Patron authenticator that turns off SSL validation. The value of the configuration option is passed as a keyword argument to HTTP.request_with_timeout(), which (check core/util/http.py) passes it along as a keyword argument to `requests.request`. (doc: http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification)

For reasons given in the test I can't test this whole chain, but I've made it as testable as possible.

The end state should always be to fix the SSL certificate on the Millenium Patron server, but this lets us get a circulation manager up and running while waiting for the fix to be put in place.