### PR TITLE
Add Adobe ID information to feed level, not just entry level

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -332,7 +332,7 @@ class CirculationManagerAnnotator(Annotator):
         feed.add_link_to_feed(feed.feed, **annotations_link)
 
         self.add_configuration_links(feed)
-
+        
     @classmethod
     def add_configuration_links(cls, feed):
         for rel, value in (
@@ -582,7 +582,20 @@ class CirculationManagerAnnotator(Annotator):
         )
         link_tag.extend(children)
         return link_tag
-   
+
+    @classmethod
+    def _adobe_patron_identifier(self, patron):
+        _db = Session.object_session(patron)
+        internal = DataSource.lookup(_db, DataSource.INTERNAL_PROCESSING)
+
+        def refresh(credential):
+            credential.credential = str(uuid.uuid1())
+        patron_identifier = Credential.lookup(
+            _db, internal, AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER, patron,
+            refresher_method=refresh, allow_persistent_token=True
+        )
+        return patron_identifier.credential
+    
     def drm_device_registration_tags(self, license_pool, active_loan,
                                      delivery_mechanism):
         """Construct OPDS Extensions for DRM tags that explain how to 
@@ -598,21 +611,13 @@ class CirculationManagerAnnotator(Annotator):
             # with the DRM server.
             _db = Session.object_session(active_loan)
             patron = active_loan.patron
-            internal = DataSource.lookup(_db, DataSource.INTERNAL_PROCESSING)
-
-            def refresh(credential):
-                credential.credential = str(uuid.uuid1())
-            patron_identifier = Credential.lookup(
-                _db, internal, AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER, patron,
-                refresher_method=refresh, allow_persistent_token=True
-            )
-            patron_identifier = patron_identifier.credential
-
+            patron_identifier = self._adobe_patron_identifier(patron)
+            
             # Generate a <drm:licensor> tag that can feed into the
             # Vendor ID service.
             return self.adobe_id_tags(patron_identifier)
         return []
-
+   
     def adobe_id_tags(self, patron_identifier):
         """Construct tags using the DRM Extensions for OPDS standard that
         explain how to get an Adobe ID for this patron.
@@ -704,7 +709,7 @@ class CirculationManagerLoanAndHoldAnnotator(CirculationManagerAnnotator):
         feed_obj = AcquisitionFeed(db, "Active loans and holds", url, works, annotator)
         annotator.annotate_feed(feed_obj, None)
         return feed_obj
-
+    
     @classmethod
     def single_loan_feed(cls, circulation, loan, test_mode=False):
         db = Session.object_session(loan)
@@ -749,6 +754,30 @@ class CirculationManagerLoanAndHoldAnnotator(CirculationManagerAnnotator):
                 db, "Active loan for unknown work", url, [], annotator)
         return AcquisitionFeed.single_entry(db, work, annotator)
 
+    def drm_device_registration_feed_tags(self, patron):
+        """Return tags that provide information on DRM device deregistration
+        independent of any particular loan. These tags will go under
+        the <feed> tag.
+
+        This allows us to deregister an Adobe ID, in preparation for
+        logout, even if there is no active loan that requires one.
+        """
+        patron_identifier = self._adobe_patron_identifier(patron)
+        tags = copy.deepcopy(self.adobe_id_tags(patron_identifier))
+        attr = '{%s}scheme' % OPDSFeed.DRM_NS
+        for tag in tags:
+            tag.attrib[attr] = "http://librarysimplified.org/terms/drm/scheme/ACS"
+        return tags
+
+    def annotate_feed(self, feed, lane):
+        """Add feed-level DRM device registration tags to the feed."""
+        super(CirculationManagerLoanAndHoldAnnotator, self).annotate_feed(
+            feed, lane
+        )
+        if self.patron:
+            tags = self.drm_device_registration_feed_tags(self.patron)
+            for tag in tags:
+                feed.feed.append(tag)
 
 class PreloadFeed(AcquisitionFeed):
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -784,10 +784,9 @@ class TestOPDS(WithVendorIDTest):
         """ 
         annotator = CirculationManagerLoanAndHoldAnnotator(None, None, test_mode=True)
         patron = self._patron()
-
-        [feed_tag] = annotator.drm_device_registration_feed_tags(patron)
-        
-        [generic_tag] = annotator.adobe_id_tags(patron)
+        with self.temp_config() as config:
+            [feed_tag] = annotator.drm_device_registration_feed_tags(patron)
+            [generic_tag] = annotator.adobe_id_tags(patron)
 
         # The feed-level tag has the drm:scheme attribute set.
         key = '{http://librarysimplified.org/terms/drm}scheme'

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -787,8 +787,7 @@ class TestOPDS(WithVendorIDTest):
 
         [feed_tag] = annotator.drm_device_registration_feed_tags(patron)
         
-        adobe_identifier = annotator._adobe_patron_identifier(patron)
-        [generic_tag] = annotator.adobe_id_tags(adobe_identifier)
+        [generic_tag] = annotator.adobe_id_tags(patron)
 
         # The feed-level tag has the drm:scheme attribute set.
         key = '{http://librarysimplified.org/terms/drm}scheme'

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -515,14 +515,41 @@ class TestOPDS(WithVendorIDTest):
         assert identifier.identifier in annotations_link['href']
 
     def test_active_loan_feed(self):
-        patron = self._patron()
-        raw = CirculationManagerLoanAndHoldAnnotator.active_loans_for(
-            None, patron, test_mode=True)
-        # Nothing in the feed.
-        raw = unicode(raw)
-        feed = feedparser.parse(raw)
-        eq_(0, len(feed['entries']))
+        with self.temp_config() as config:
+            patron = self._patron()
+            cls = CirculationManagerLoanAndHoldAnnotator
+            raw = cls.active_loans_for(None, patron, test_mode=True)
+            # No entries in the feed...
+            raw = unicode(raw)
+            feed = feedparser.parse(raw)
+            eq_(0, len(feed['entries']))
 
+            # ... but we do have DRM licensing information.
+            tree = etree.fromstring(raw)
+            parser = OPDSXMLParser()
+            licensor = parser._xpath1(tree, "//atom:feed/drm:licensor")
+
+            adobe_patron_identifier = cls._adobe_patron_identifier(
+                patron
+            )
+
+            # The DRM licensing information includes the Adobe vendor ID
+            # and the patron's patron identifier for Adobe purposes.
+            eq_('Some Vendor',
+                licensor.attrib['{http://librarysimplified.org/terms/drm}vendor'])
+            [client_token] = licensor.getchildren()
+            assert client_token.text.startswith('A LIBRARY')
+            assert adobe_patron_identifier in client_token.text
+
+            # Unlike other places this tag shows up, we use the
+            # 'scheme' attribute to explicitly state that this
+            # <drm:licensor> tag is talking about an ACS licensing
+            # scheme. Since we're in a <feed> and not a <link> to a
+            # specific book, that context would otherwise be lost.
+            eq_('http://librarysimplified.org/terms/drm/scheme/ACS',
+                licensor.attrib['{http://librarysimplified.org/terms/drm}scheme'])
+
+            
         now = datetime.datetime.utcnow()
         tomorrow = now + datetime.timedelta(days=1)
 
@@ -750,6 +777,29 @@ class TestOPDS(WithVendorIDTest):
         eq_("http://streaming_link", fulfill_links[0]['href'])
 
 
+    def test_drm_device_registration_feed_tags(self):
+        """Check that drm_device_registration_feed_tags returns 
+        a generic drm:licensor tag, except with the drm:scheme attribute 
+        set.
+        """ 
+        annotator = CirculationManagerLoanAndHoldAnnotator(None, None, test_mode=True)
+        patron = self._patron()
+
+        [feed_tag] = annotator.drm_device_registration_feed_tags(patron)
+        
+        adobe_identifier = annotator._adobe_patron_identifier(patron)
+        [generic_tag] = annotator.adobe_id_tags(adobe_identifier)
+
+        # The feed-level tag has the drm:scheme attribute set.
+        key = '{http://librarysimplified.org/terms/drm}scheme'
+        eq_("http://librarysimplified.org/terms/drm/scheme/ACS",
+            feed_tag.attrib[key])
+
+        # If we remove that attribute, the feed-level tag is the same as the
+        # generic tag.
+        del feed_tag.attrib[key]
+        eq_(etree.tostring(feed_tag), etree.tostring(generic_tag))
+        
     def test_borrow_link_raises_unfulfillable_work(self):
         edition, pool = self._edition(with_license_pool=True)
         kindle_mechanism = pool.set_delivery_mechanism(


### PR DESCRIPTION
This branch makes sure that an Adobe ID token is always available from a patron's bookshelf feed, even if the bookshelf has no books in it. I do this by including a <drm:licensor> tag beneath the <feed> tag itself (other <drm:licensor> tags show up beneath <link> tags) and including a drm:scheme attribute to explain what kind of DRM scheme it's talking about (context that's not necessary within a <link> tag).

The SimplyE app needs a recent Adobe ID token to deregister the device whenever a patron logs out or switches libraries. The token needs to be available even if the patron currently has no books checked out that require an Adobe ID to fulfill.