### PR TITLE
Periodically commit during the Adobe patron identifier migration. 

### DIFF
--- a/migration/20161102-adobe-id-is-delegated-patron-identifier.py
+++ b/migration/20161102-adobe-id-is-delegated-patron-identifier.py
@@ -31,6 +31,7 @@ for patron in qu:
     count += 1
     if not (count % 100):
         print count
+        _db.commit()
     if credential is None or delegated_identifier is None:
         # This patron did not have an Adobe ID in the first place.
         # Do nothing.
@@ -41,5 +42,4 @@ for patron in qu:
         delegated_identifier.delegated_identifier
     )
     print output
-    _db.commit()
 _db.commit()

--- a/migration/20161102-adobe-id-is-delegated-patron-identifier.py
+++ b/migration/20161102-adobe-id-is-delegated-patron-identifier.py
@@ -24,8 +24,9 @@ if not authdata:
     print "Adobe IDs not configured, doing nothing."
 
 count = 0
-print "Processing %d patrons." % _db.query(Patron).count()
-for patron in _db.query(Patron):
+qu = _db.query(Patron)
+print "Processing %d patrons." % qu.count()
+for patron in qu:
     credential, delegated_identifier = authdata.migrate_adobe_id(patron)
     count += 1
     if not (count % 100):
@@ -40,4 +41,5 @@ for patron in _db.query(Patron):
         delegated_identifier.delegated_identifier
     )
     print output
+    _db.commit()
 _db.commit()


### PR DESCRIPTION
Otherwise, if there are a lot of patrons to migrate, this can eat up all database resources.