### PR TITLE
Implement DRM Device Management Protocol

### DIFF
--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -236,8 +236,8 @@ class DeviceManagementRequestHandler(object):
             )
         except Exception, e:
             return bad_bearer_token.detailed(
-                _('Invalid OAuth bearer token: "%s"') % (
-                    short_client_token
+                _('Invalid OAuth bearer token "%s": %s') % (
+                    short_client_token, e.message
                 )
             )
             
@@ -871,6 +871,11 @@ class AuthdataUtility(object):
             raise ValueError(
                 'Supposed client token "%s" does not contain a space.' % token
             )
+        if not '|' in token:
+            raise ValueError(
+                'Supposed client token "%s" does not contain a pipe.' % token
+            )
+
         username, password = token.rsplit('|', 1)
         return self.decode_two_part_short_client_token(username, password)
         

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -121,7 +121,8 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
             incoming_media_type = flask.request.headers.get('Content-Type')
             if incoming_media_type != device_ids:
                 return UNSUPPORTED_MEDIA_TYPE.detailed(
-                    _("Expected %s document.") % device_ids
+                    _("Expected %(media_type)s document.",
+                      media_type=device_ids)
                 )
             output = handler.register_device(flask.request.data)
             if isinstance(output, ProblemDetail):

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -124,12 +124,6 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
         
     def device_id_handler(self, device_id):
         """Manage one of the device IDs associated with an Adobe ID."""       
-        patron = self.authenticated_patron_from_request()
-        if isinstance(patron, ProblemDetail):
-            return patron
-        if isinstance(patron, Response):
-            return patron
-
         handler = DeviceManagementRequestHandler.from_request(flask.request)
         if isinstance(handler, ProblemDetail):
             return handler

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -504,29 +504,22 @@ class AdobeVendorIDModel(object):
             uuid_and_label = (None, None)
         return uuid_and_label
 
-    def to_delegated_patron_identifier(
+    def to_delegated_patron_identifier_uuid(
             self, library_uri, foreign_patron_identifier, value_generator=None
     ):
         """Create or lookup a DelegatedPatronIdentifier containing an Adobe
         account ID for the given library and foreign patron ID.
 
-        :return: A 2-tuple (DelegatedPatronIdentifier, is_new)
+        :return: A 2-tuple (UUID, label)
         """
         if not library_uri or not foreign_patron_identifier:
-            return None, False
+            return None, None
         value_generator = value_generator or self.uuid
-        return DelegatedPatronIdentifier.get_one_or_create(
+        identifier, is_new = DelegatedPatronIdentifier.get_one_or_create(
             self._db, library_uri, foreign_patron_identifier,
             DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID, value_generator
         )
-   
-    def to_delegated_patron_identifier_uuid(self, *args, **kwargs):
-        """Create or lookup a DelegatedPatronIdentifier containing an Adobe
-        account ID for the given library and foreign patron ID.
 
-        :return: A 2-tuple (UUID, label)
-        """
-        identifier, is_new = self.to_delegated_patron_identifier(*args, **kwargs)
         if identifier is None:
             return None, None
         return (identifier.delegated_identifier,

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -218,7 +218,7 @@ class DeviceManagementRequestHandler(object):
             _("You must authenticate with a valid OAuth bearer token.")
         )
         authorization = request.headers.get('Authorization')
-        if not authorization.startswith('Bearer '):
+        if not authorization or not authorization.startswith('Bearer '):
             return bad_bearer_token
         short_client_token = authorization[len('Bearer '):]
 

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -109,6 +109,7 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
         
         device_ids = self.DEVICE_ID_LIST_MEDIA_TYPE
         if flask.request.method=='GET':
+            # Serve a list of device IDs.
             output = handler.device_list()
             if isinstance(output, ProblemDetail):
                 return output
@@ -116,6 +117,7 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
             headers['Content-Type'] = device_ids
             return Response(output, 200, headers)
         elif flask.request.method=='POST':
+            # Add a device ID to the list.
             incoming_media_type = flask.request.headers.get('Content-Type')
             if incoming_media_type != device_ids:
                 return UNSUPPORTED_MEDIA_TYPE.detailed(
@@ -135,7 +137,8 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
 
         if flask.request.method != 'DELETE':
             return METHOD_NOT_ALLOWED.detailed("Only DELETE is supported.")
-        
+
+        # Delete the specified device ID.
         output = handler.deregister_device(device_id)
         if isinstance(output, ProblemDetail):
             return output
@@ -247,7 +250,8 @@ class DeviceManagementRequestHandler(object):
                 _("You may only register one device ID at a time.")
             )
         for device_id in device_ids:
-            self.credential.register_drm_device_identifier(device_id)
+            if device_id:
+                self.credential.register_drm_device_identifier(device_id)
         return 'Success'
             
     def deregister_device(self, device_id):

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -121,13 +121,15 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
             incoming_media_type = flask.request.headers.get('Content-Type')
             if incoming_media_type != device_ids:
                 return UNSUPPORTED_MEDIA_TYPE.detailed(
-                    "Expected %s document." % device_ids
+                    _("Expected %s document.") % device_ids
                 )
             output = handler.register_device(flask.request.data)
             if isinstance(output, ProblemDetail):
                 return output
             return Response(output, 200, self.PLAIN_TEXT_HEADERS)
-        return METHOD_NOT_ALLOWED.detailed("Only GET and POST are supported.")
+        return METHOD_NOT_ALLOWED.detailed(
+            _("Only GET and POST are supported.")
+        )
         
     def device_id_handler(self, device_id):
         """Manage one of the device IDs associated with an Adobe ID."""       
@@ -136,7 +138,7 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
             return handler
 
         if flask.request.method != 'DELETE':
-            return METHOD_NOT_ALLOWED.detailed("Only DELETE is supported.")
+            return METHOD_NOT_ALLOWED.detailed(_("Only DELETE is supported."))
 
         # Delete the specified device ID.
         output = handler.deregister_device(device_id)

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -123,13 +123,13 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
         return METHOD_NOT_ALLOWED.detailed("Only GET and POST are supported.")
         
     def device_id_handler(self, device_id):
-        """Manage one of the device IDs associated with an Adobe ID."""
+        """Manage one of the device IDs associated with an Adobe ID."""       
         patron = self.authenticated_patron_from_request()
         if isinstance(patron, ProblemDetail):
             return patron
         if isinstance(patron, Response):
             return patron
-        
+
         handler = DeviceManagementRequestHandler.from_request(flask.request)
         if isinstance(handler, ProblemDetail):
             return handler

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -94,7 +94,7 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
         :return: A DeviceManagementRequestHandler
         """
         if not patron:
-            return INVALID_CREDENTIALS.detailed("No authenticated patron")
+            return INVALID_CREDENTIALS.detailed(_("No authenticated patron"))
 
         credential = AdobeVendorIDModel.get_or_create_patron_identifier_credential(
             patron

--- a/api/base_controller.py
+++ b/api/base_controller.py
@@ -1,0 +1,81 @@
+import flask
+from flask import Response
+from core.util.problem_detail import ProblemDetail
+from circulation_exceptions import *
+from problem_details import *
+from flask.ext.babel import lazy_gettext as _
+
+class BaseCirculationManagerController(object):
+    """Define minimal standards for a circulation manager controller,
+    mainly around authentication.
+    """
+    
+    def __init__(self, manager):
+        """:param manager: A CirculationManager object."""
+        self.manager = manager
+        self._db = self.manager._db
+        self.circulation = self.manager.circulation
+        self.url_for = self.manager.url_for
+        self.cdn_url_for = self.manager.cdn_url_for
+
+    def authorization_header(self):
+        """Get the authentication header."""
+
+        # This is the basic auth header.
+        header = flask.request.authorization
+
+        # If we're using a token instead, flask doesn't extract it for us.
+        if not header:
+            if 'Authorization' in flask.request.headers:
+                header = flask.request.headers['Authorization']
+
+        return header
+
+    def authenticated_patron_from_request(self):
+        header = self.authorization_header()
+
+        if not header:
+            # No credentials were provided.
+            return self.authenticate()
+        try:
+            patron = self.authenticated_patron(header)
+        except RemoteInitiatedServerError,e:
+            return REMOTE_INTEGRATION_FAILED.detailed(
+                _("Error in authentication service")
+            )
+        if isinstance(patron, ProblemDetail):
+            flask.request.patron = None
+            return patron
+        else:
+            flask.request.patron = patron
+            return patron
+
+    def authenticated_patron(self, authorization_header):
+        """Look up the patron authenticated by the given authorization header.
+
+        The header could contain a barcode and pin or a token for an
+        external service.
+
+        If there's a problem, return a Problem Detail Document.
+
+        If there's no problem, return a Patron object.
+        """
+        patron = self.manager.auth.authenticated_patron(
+            self._db, authorization_header
+        )
+        if not patron:
+            return INVALID_CREDENTIALS
+
+        if isinstance(patron, ProblemDetail):
+            return patron
+
+        return patron
+
+    def authenticate(self):
+        """Sends a 401 response that demands authentication."""
+        if not self.manager.opds_authentication_document:
+            self.manager.opds_authentication_document = self.manager.auth.create_authentication_document()
+
+        data = self.manager.opds_authentication_document
+        headers = self.manager.auth.create_authentication_headers()
+        return Response(data, 401, headers)

--- a/api/controller.py
+++ b/api/controller.py
@@ -102,7 +102,11 @@ from lanes import (
     SeriesLane,
 )
 
-from adobe_vendor_id import AdobeVendorIDController
+from adobe_vendor_id import (
+    AdobeVendorIDController,
+    DeviceManagementProtocolController,
+    AuthdataUtility,
+)
 from axis import Axis360API
 from overdrive import OverdriveAPI
 from threem import ThreeMAPI
@@ -111,6 +115,7 @@ from novelist import (
     NoveListAPI,
     MockNoveListAPI,
 )
+from base_controller import BaseCirculationManagerController
 from testing import MockCirculationAPI
 from services import ServiceStatus
 from core.analytics import Analytics
@@ -254,7 +259,7 @@ class CirculationManager(object):
         if adobe.get(AuthdataUtility.AUTHDATA_SECRET_KEY):
             try:
                 authdata = AuthdataUtility.from_config()
-                self.adobe_device_management = DeviceManagementProtocolController()
+                self.adobe_device_management = DeviceManagementProtocolController(self)
             except CannotLoadConfiguration, e:
                 self.log.warn("DRM Device Management Protocol controller is disabled due to missing or incomplete Adobe configuration. This may be cause for concern.")
 
@@ -267,77 +272,7 @@ class CirculationManager(object):
         )
 
 
-class CirculationManagerController(object):
-
-    def __init__(self, manager):
-        self.manager = manager
-        self._db = self.manager._db
-        self.circulation = self.manager.circulation
-        self.url_for = self.manager.url_for
-        self.cdn_url_for = self.manager.cdn_url_for
-
-    def authorization_header(self):
-        """Get the authentication header."""
-
-        # This is the basic auth header.
-        header = flask.request.authorization
-
-        # If we're using a token instead, flask doesn't extract it for us.
-        if not header:
-            if 'Authorization' in flask.request.headers:
-                header = flask.request.headers['Authorization']
-
-        return header
-
-
-    def authenticated_patron_from_request(self):
-        header = self.authorization_header()
-
-        if not header:
-            # No credentials were provided.
-            return self.authenticate()
-        try:
-            patron = self.authenticated_patron(header)
-        except RemoteInitiatedServerError,e:
-            return REMOTE_INTEGRATION_FAILED.detailed(
-                _("Error in authentication service")
-            )
-        if isinstance(patron, ProblemDetail):
-            flask.request.patron = None
-            return patron
-        else:
-            flask.request.patron = patron
-            return patron
-
-    def authenticated_patron(self, authorization_header):
-        """Look up the patron authenticated by the given authorization header.
-
-        The header could contain a barcode and pin or a token for an
-        external service.
-
-        If there's a problem, return a Problem Detail Document.
-
-        If there's no problem, return a Patron object.
-        """
-        patron = self.manager.auth.authenticated_patron(
-            self._db, authorization_header
-        )
-        if not patron:
-            return INVALID_CREDENTIALS
-
-        if isinstance(patron, ProblemDetail):
-            return patron
-
-        return patron
-
-    def authenticate(self):
-        """Sends a 401 response that demands authentication."""
-        if not self.manager.opds_authentication_document:
-            self.manager.opds_authentication_document = self.manager.auth.create_authentication_document()
-
-        data = self.manager.opds_authentication_document
-        headers = self.manager.auth.create_authentication_headers()
-        return Response(data, 401, headers)
+class CirculationManagerController(BaseCirculationManagerController):
 
     def load_lane(self, language_key, name):
         """Turn user input into a Lane object."""
@@ -1110,7 +1045,7 @@ class WorkController(CirculationManagerController):
         )
         return feed_response(unicode(feed.content))
 
-
+    
 class AnalyticsController(CirculationManagerController):
 
     def track_event(self, data_source, identifier_type, identifier, event_type):

--- a/api/opds.py
+++ b/api/opds.py
@@ -37,7 +37,7 @@ from core.util.cdn import cdnify
 from novelist import NoveListAPI
 from lanes import QueryGeneratedLane
 from annotations import AnnotationWriter
-from adobe_vendor_id import AuthdataUtility
+
 
 class CirculationManagerAnnotator(Annotator):
    
@@ -591,6 +591,8 @@ class CirculationManagerAnnotator(Annotator):
 
         def refresh(credential):
             credential.credential = str(uuid.uuid1())
+        # Avoid circular import    
+        from adobe_vendor_id import AuthdataUtility
         patron_identifier = Credential.lookup(
             _db, internal, AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER, patron,
             refresher_method=refresh, allow_persistent_token=True
@@ -639,6 +641,8 @@ class CirculationManagerAnnotator(Annotator):
         cached = self._adobe_id_tags.get(patron_identifier)
         if cached is None:
             cached = []
+            # Avoid circular import    
+            from adobe_vendor_id import AuthdataUtility
             authdata = AuthdataUtility.from_config()
             if authdata:
                 # TODO: We would like to call encode() here, and have

--- a/api/opds.py
+++ b/api/opds.py
@@ -31,14 +31,13 @@ from core.model import (
     Edition,
 )
 from core.lane import Lane
-from adobe_vendor_id import AuthdataUtility
 from circulation import BaseCirculationAPI
 from core.app_server import cdn_url_for
 from core.util.cdn import cdnify
 from novelist import NoveListAPI
 from lanes import QueryGeneratedLane
 from annotations import AnnotationWriter
-
+from adobe_vendor_id import AuthdataUtility
 
 class CirculationManagerAnnotator(Annotator):
    

--- a/api/opds.py
+++ b/api/opds.py
@@ -31,6 +31,7 @@ from core.model import (
     Edition,
 )
 from core.lane import Lane
+from adobe_vendor_id import AuthdataUtility
 from circulation import BaseCirculationAPI
 from core.app_server import cdn_url_for
 from core.util.cdn import cdnify
@@ -591,8 +592,6 @@ class CirculationManagerAnnotator(Annotator):
 
         def refresh(credential):
             credential.credential = str(uuid.uuid1())
-        # Avoid circular import    
-        from adobe_vendor_id import AuthdataUtility
         patron_identifier = Credential.lookup(
             _db, internal, AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER, patron,
             refresher_method=refresh, allow_persistent_token=True
@@ -641,8 +640,6 @@ class CirculationManagerAnnotator(Annotator):
         cached = self._adobe_id_tags.get(patron_identifier)
         if cached is None:
             cached = []
-            # Avoid circular import    
-            from adobe_vendor_id import AuthdataUtility
             authdata = AuthdataUtility.from_config()
             if authdata:
                 # TODO: We would like to call encode() here, and have

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -246,10 +246,3 @@ NO_ANNOTATION = pd(
     title=_("No annotation."),
     detail=_("The annotation you requested does not exist."),
 )
-
-REQUEST_ENTITY_TOO_LARGE = pd(
-    "http://librarysimplified.org/terms/problem/request-entity-too-large",
-    status_code=413,
-    title=_("Request entity too large."),
-    detail=_("You submitted a document that was too large for the server to handle."),
-)

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -246,3 +246,10 @@ NO_ANNOTATION = pd(
     title=_("No annotation."),
     detail=_("The annotation you requested does not exist."),
 )
+
+REQUEST_ENTITY_TOO_LARGE = pd(
+    "http://librarysimplified.org/terms/problem/request-entity-too-large",
+    status_code=413,
+    title=_("Request entity too large."),
+    detail=_("You submitted a document that was too large for the server to handle."),
+)

--- a/api/routes.py
+++ b/api/routes.py
@@ -309,6 +309,17 @@ def adobe_vendor_id_accountinfo():
 def adobe_vendor_id_status():
     return app.manager.adobe_vendor_id.status_handler()
 
+# DRM Device Management Protocol implementation for ACS.
+@app.route('/AdobeAuth/devices')
+@returns_problem_detail
+def adobe_drm_devices(self, methods=['GET', 'POST']):
+    return app.manager.adobe_vendor_id.device_id_list_handler()
+
+@app.route('/AdobeAuth/devices/<device_id>')
+@returns_problem_detail
+def adobe_drm_device(self, device_id, methods=['DELETE']):
+    return app.manager.adobe_vendor_id.device_id_handler(device_id)
+    
 # Route that redirects to the authentication URL for an OAuth provider
 @app.route('/oauth_authenticate')
 @returns_problem_detail

--- a/api/routes.py
+++ b/api/routes.py
@@ -313,13 +313,13 @@ def adobe_vendor_id_status():
 @app.route('/AdobeAuth/devices')
 @requires_auth
 @returns_problem_detail
-def adobe_drm_devices(self, methods=['GET', 'POST']):
+def adobe_drm_devices(methods=['GET', 'POST']):
     return app.manager.adobe_device_management.device_id_list_handler()
 
 @app.route('/AdobeAuth/devices/<device_id>')
 @requires_auth
 @returns_problem_detail
-def adobe_drm_device(self, device_id, methods=['DELETE']):
+def adobe_drm_device(device_id, methods=['DELETE']):
     return app.manager.adobe_device_management.device_id_handler(device_id)
     
 # Route that redirects to the authentication URL for an OAuth provider

--- a/api/routes.py
+++ b/api/routes.py
@@ -311,14 +311,16 @@ def adobe_vendor_id_status():
 
 # DRM Device Management Protocol implementation for ACS.
 @app.route('/AdobeAuth/devices')
+@requires_auth
 @returns_problem_detail
 def adobe_drm_devices(self, methods=['GET', 'POST']):
-    return app.manager.adobe_vendor_id.device_id_list_handler()
+    return app.manager.adobe_device_management.device_id_list_handler()
 
 @app.route('/AdobeAuth/devices/<device_id>')
+@requires_auth
 @returns_problem_detail
 def adobe_drm_device(self, device_id, methods=['DELETE']):
-    return app.manager.adobe_vendor_id.device_id_handler(device_id)
+    return app.manager.adobe_device_management.device_id_handler(device_id)
     
 # Route that redirects to the authentication URL for an OAuth provider
 @app.route('/oauth_authenticate')

--- a/api/testing.py
+++ b/api/testing.py
@@ -12,6 +12,32 @@ from api.circulation import (
     LoanInfo,
     HoldInfo,
 )
+from api.config import Configuration
+from api.adobe_vendor_id import AuthdataUtility
+
+class MockAdobeConfiguration(object):
+    """Contains the constants necessary to set up an Adobe
+    AuthdataUtility.  This is used in test_adobe_vendor_id.py (to test
+    the basic functionality) and test_controller.py (to create an
+    AdobeVendorIDController for use in testing.)
+    """
+    
+    TEST_NODE_VALUE = 114740953091845
+    TEST_VENDOR_ID = "vendor id"
+    TEST_LIBRARY_URI = "http://me/"
+    TEST_LIBRARY_SHORT_NAME = "Lbry"
+    TEST_SECRET = "some secret"
+    TEST_OTHER_LIBRARY_URI = "http://you/"
+    TEST_OTHER_LIBRARIES  = {TEST_OTHER_LIBRARY_URI: ("you", "secret2")}
+
+    MOCK_ADOBE_CONFIGURATION = {
+        Configuration.ADOBE_VENDOR_ID: TEST_VENDOR_ID,
+        Configuration.ADOBE_VENDOR_ID_NODE_VALUE: TEST_NODE_VALUE,
+        AuthdataUtility.LIBRARY_URI_KEY: TEST_LIBRARY_URI,
+        AuthdataUtility.LIBRARY_SHORT_NAME_KEY: TEST_LIBRARY_SHORT_NAME,
+        AuthdataUtility.AUTHDATA_SECRET_KEY: TEST_SECRET,
+        AuthdataUtility.OTHER_LIBRARIES_KEY: TEST_OTHER_LIBRARIES,
+    }
 
 
 class MockRemoteAPI(BaseCirculationAPI):

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -1051,15 +1051,7 @@ class TestAuthdataUtility(VendorIDTest):
         )
         eq_("My Adobe ID", uuid)
         eq_('Delegated account ID My Adobe ID', label)
-
-
-class MockRequest(object):
-    """Mock just enough of a Flask request to test
-    DeviceManagementRequestHandler.
-    """
-    def __init__(self, patron):
-        self.patron = patron
-        
+       
 
 class TestDeviceManagementRequestHandler(TestAuthdataUtility):
     
@@ -1102,21 +1094,3 @@ class TestDeviceManagementRequestHandler(TestAuthdataUtility):
         handler = DeviceManagementRequestHandler(credential)
         # Device IDs are sorted alphabetically.
         eq_("bar\nfoo", handler.device_list())
-
-    def test_from_request_success(self):
-        patron = self._patron()
-        request = MockRequest(patron=patron)
-        result = DeviceManagementRequestHandler.from_request(request)
-        assert isinstance(result, DeviceManagementRequestHandler)
-
-        # We are about to register devices against the Credential
-        # representing this patron's identifier for Adobe account ID
-        # purposes.
-        #
-        # This Credential didn't exist before we called from_request(),
-        # but that's fine--it does now.
-        credential = result.credential
-        eq_(patron, result.credential.patron)
-        eq_(AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
-            credential.type)
-        

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -1064,6 +1064,12 @@ class TestDeviceManagementRequestHandler(TestAuthdataUtility):
             [x.device_identifier for x in credential.drm_device_identifiers]
         )
 
+    def test_register_drm_device_identifier_does_nothing_on_no_input(self):
+        credential = self._credential()
+        handler = DeviceManagementRequestHandler(credential)
+        handler.register_device("")
+        eq_([], credential.drm_device_identifiers)
+        
     def test_register_drm_device_identifier_failure(self):
         """You can only register one device in a single call."""
         credential = self._credential()

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -1136,3 +1136,18 @@ class TestDeviceManagementRequestHandler(TestAuthdataUtility):
             result.delegated_patron_identifier.patron_identifier)
         eq_(self.authdata.library_uri,
             result.delegated_patron_identifier.library_uri)
+
+    def test_from_request_failure(self):
+        authenticator = MockAuthenticationProvider(
+            patrons={"validpatron" : "password" }
+        )
+        model = AdobeVendorIDModel(self._db, authenticator,
+                                   TestVendorIDModel.TEST_NODE_VALUE)
+
+        headers = {"Authorization" : "Not a bearer token"}
+        request = MockRequest(headers=headers)
+        result = DeviceManagementRequestHandler.from_request(
+            request, model, self.authdata
+        )
+        assert isinstance(result, ProblemDetail)
+        eq_(INVALID_CREDENTIALS.uri, result.uri)

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -1173,7 +1173,9 @@ class TestDeviceManagementRequestHandler(TestAuthdataUtility):
         )
         assert isinstance(result, ProblemDetail)
         eq_(INVALID_CREDENTIALS.uri, result.uri)
-        eq_('Invalid OAuth bearer token: "invalid token"', result.detail)
+        eq_('Invalid OAuth bearer token "invalid token": Supposed client token "invalid token" does not contain a pipe.',
+            result.detail
+        )
 
         # A correctly encoded, valid, token from a library not
         # recognized by self.authdata.
@@ -1195,3 +1197,4 @@ class TestDeviceManagementRequestHandler(TestAuthdataUtility):
         )
         assert isinstance(result, ProblemDetail)
         eq_(INVALID_CREDENTIALS.uri, result.uri)
+        eq_(u'Invalid OAuth bearer token "%s": I don\'t know how to handle tokens from library "ANOTHER"' % token, result.detail)

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -1094,3 +1094,4 @@ class TestDeviceManagementRequestHandler(TestAuthdataUtility):
         handler = DeviceManagementRequestHandler(credential)
         # Device IDs are sorted alphabetically.
         eq_("bar\nfoo", handler.device_list())
+        

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -1130,5 +1130,5 @@ class TestDeviceManagementRequestHandler(TestAuthdataUtility):
 
         assert isinstance(result, ProblemDetail)
         eq_(INVALID_CREDENTIALS.uri, result.uri)
-        eq_("No authenticated patron.", result.detail)
+        eq_("No authenticated patron", result.detail)
         

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -1119,16 +1119,4 @@ class TestDeviceManagementRequestHandler(TestAuthdataUtility):
         eq_(patron, result.credential.patron)
         eq_(AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER,
             credential.type)
-
-    def test_from_request_failure(self):
-        """You cannot create a DeviceManagementRequestHandler
-        from a request that does not have an authenticated patron.
-        """
-        # No valid patron
-        request = MockRequest(patron=None)
-        result = DeviceManagementRequestHandler.from_request(request)
-
-        assert isinstance(result, ProblemDetail)
-        eq_(INVALID_CREDENTIALS.uri, result.uri)
-        eq_("No authenticated patron", result.detail)
         

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -1138,12 +1138,25 @@ class TestDeviceManagementRequestHandler(TestAuthdataUtility):
             result.delegated_patron_identifier.library_uri)
 
     def test_from_request_failure(self):
+        """There are a lot of ways to fail to create a
+        DeviceManagementRequestHandler for a given request.
+        """
         authenticator = MockAuthenticationProvider(
             patrons={"validpatron" : "password" }
         )
         model = AdobeVendorIDModel(self._db, authenticator,
                                    TestVendorIDModel.TEST_NODE_VALUE)
 
+        # No Authorization header
+        request = MockRequest(headers={})
+        result = DeviceManagementRequestHandler.from_request(
+            request, model, self.authdata
+        )
+        assert isinstance(result, ProblemDetail)
+        eq_(INVALID_CREDENTIALS.uri, result.uri)
+        eq_("You must authenticate with a valid OAuth bearer token.",
+            result.detail)
+        
         headers = {"Authorization" : "Not a bearer token"}
         request = MockRequest(headers=headers)
         result = DeviceManagementRequestHandler.from_request(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1151,7 +1151,7 @@ class TestAnnotationController(CirculationControllerTest):
             eq_(AnnotationWriter.CONTENT_TYPE, response.headers['Content-Type'])
 
     def test_detail_for_other_patrons_annotation_returns_404(self):
-        patron = self.default_patron
+        patron = self._patron()
         self.pool.loan_to(patron)
 
         annotation, ignore = create(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2117,5 +2117,3 @@ class TestScopedSession(ControllerTest):
         # which is the same as self._db, the unscoped database session
         # used by most other unit tests.
         assert session1 != session2
-
-    

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2014,8 +2014,12 @@ class TestDeviceManagementProtocolController(ControllerTest):
 
     def test_device_id_handler_bad_auth(self):
         with self.app.test_request_context("/", method='DELETE'):
-            patron = self.controller.authenticated_patron_from_request()
-            response = self.controller.device_id_handler("device")
+            with temp_config() as config:
+                config[Configuration.INTEGRATIONS] = {
+                    "Circulation Manager" : { "url" : "http://foo/" }
+                }
+                patron = self.controller.authenticated_patron_from_request()
+                response = self.controller.device_id_handler("device")
             assert isinstance(response, ProblemDetail)
             eq_(401, response.status_code)
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -546,9 +546,13 @@ class TestOPDS(WithVendorIDTest):
             # and the patron's patron identifier for Adobe purposes.
             eq_('Some Vendor',
                 licensor.attrib['{http://librarysimplified.org/terms/drm}vendor'])
-            [client_token] = licensor.getchildren()
+            [client_token, device_management_link] = licensor.getchildren()
             assert client_token.text.startswith('A LIBRARY')
             assert adobe_patron_identifier in client_token.text
+            eq_("{http://www.w3.org/2005/Atom}link",
+                device_management_link.tag)
+            eq_("http://librarysimplified.org/terms/drm/rel/devices",
+                device_management_link.attrib['rel'])
 
             # Unlike other places this tag shows up, we use the
             # 'scheme' attribute to explicitly state that this


### PR DESCRIPTION
This branch implements the [DRM Device Management Protocol](https://github.com/NYPL-Simplified/Simplified/wiki/DRM-Device-Management) for Adobe ACS.

This is the first implementation of the protocol, so differences between the spec and the implementation might be a problem either in the spec or the implementation.

I have manually tested the code in `routes.py` and written unit tests for everything else.