### PR TITLE
Correct a call to the SeriesLane constructor

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1015,8 +1015,9 @@ class WorkController(CirculationManagerController):
             return NO_SUCH_LANE.detailed(_("No series provided"))
 
         languages, audiences = self._lane_details(languages, audiences)
-
-        lane = SeriesLane(self._db, series_name, languages, audiences)
+        lane = SeriesLane(self._db, series_name=series_name,
+                          languages=languages, audiences=audiences
+        )
         annotator = self.manager.annotator(lane)
 
         # This has special handling of facets because a series can

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1695,6 +1695,14 @@ class TestWorkController(CirculationControllerTest):
         [entry] = feed['entries']
         eq_(self.english_1.title, entry['title'])
 
+        # Language restrictions can remove books that would otherwise be
+        # in the feed.
+        with self.app.test_request_context("/"):
+            response = self.manager.work_controller.series(
+                series_name, 'fre', None
+            )
+            feed = feedparser.parse(response.data)
+            eq_(0, len(feed['entries']))
 
 class TestFeedController(CirculationControllerTest):
 


### PR DESCRIPTION
This branch fixes a problem with SeriesLane that causes me to get a lot of error notifications. I believe a similar problem with ContributorLane was fixed earlier.

Basically, positional methods are passed into the SeriesLane constructor, and there was a mismatch such that what was `languages` outside the constructor was `parent` inside the constructor.

I changed the constructor call to use positional arguments, and added a test.