### PR TITLE
Generate short client tokens with blank expiration time and enforce blank expiration time on input.

### DIFF
--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -881,9 +881,6 @@ class AuthdataUtility(object):
         library_short_name, expiration, patron_identifier = token.split("|", 2)
 
         library_short_name = library_short_name.upper()
-        # NOTE: See the note in _encode_short_client_token(). We no longer
-        # put expiration times in short client tokens. That field is blank and
-        # any value it might have is ignored.
         if expiration:
             raise ValueError('Expiration time must be blank.')
 

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -826,7 +826,17 @@ class AuthdataUtility(object):
     
     def _encode_short_client_token(self, library_short_name,
                                    patron_identifier, expires):
-        base = library_short_name + "|" + str(expires) + "|" + patron_identifier
+        # NOTE: We no longer put expiration time in the short
+        # token. It has to stay the same forever, because Adobe will
+        # not allow the deregistration of a device ID if the username
+        # or password(!) differs from the username and password used
+        # to register it. Even if the authentication API would
+        # confirm that the new username/password authorizes the same user.
+        # The authentication API isn't even consulted.
+        #
+        # expires = str(expires)
+        expires = ''
+        base = library_short_name + "|" + expires + "|" + patron_identifier
         signature = self.short_token_signer.sign(
             base, self.short_token_signing_key
         )
@@ -873,10 +883,15 @@ class AuthdataUtility(object):
         library_short_name, expiration, patron_identifier = token.split("|", 2)
 
         library_short_name = library_short_name.upper()
-        try:
-            expiration = float(expiration)
-        except ValueError:
-            raise ValueError('Expiration time "%s" is not numeric.' % expiration)
+        # NOTE: See the note in _encode_short_client_token(). We no longer
+        # put expiration times in short client tokens. That field is blank and
+        # any value it might have is ignored.
+        if expiration:
+            raise ValueError('Expiration time must be blank.')
+        #try:
+        #    expiration = float(expiration)
+        #except ValueError:
+        #    raise ValueError('Expiration time "%s" is not numeric.' % expiration)
 
         # We don't police the content of the patron identifier but there
         # has to be _something_ there.
@@ -896,15 +911,15 @@ class AuthdataUtility(object):
             )
         secret = self.secrets_by_library_uri[library_uri]
 
-        # Don't bother checking an expired token.
-        now = datetime.datetime.utcnow()
-        expiration = self.EPOCH + datetime.timedelta(seconds=expiration)
-        if expiration < now:
-            raise ValueError(
-                "Token %s expired at %s (now is %s)." % (
-                    token, expiration, now
-                )
-            )
+        # # Don't bother checking an expired token.
+        # now = datetime.datetime.utcnow()
+        # expiration = self.EPOCH + datetime.timedelta(seconds=expiration)
+        # if expiration < now:
+        #     raise ValueError(
+        #         "Token %s expired at %s (now is %s)." % (
+        #             token, expiration, now
+        #         )
+        #     )
 
         # Sign the token and check against the provided signature.
         key = self.short_token_signer.prepare_key(secret)

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -833,8 +833,6 @@ class AuthdataUtility(object):
         # to register it. Even if the authentication API would
         # confirm that the new username/password authorizes the same user.
         # The authentication API isn't even consulted.
-        #
-        # expires = str(expires)
         expires = ''
         base = library_short_name + "|" + expires + "|" + patron_identifier
         signature = self.short_token_signer.sign(
@@ -888,10 +886,6 @@ class AuthdataUtility(object):
         # any value it might have is ignored.
         if expiration:
             raise ValueError('Expiration time must be blank.')
-        #try:
-        #    expiration = float(expiration)
-        #except ValueError:
-        #    raise ValueError('Expiration time "%s" is not numeric.' % expiration)
 
         # We don't police the content of the patron identifier but there
         # has to be _something_ there.
@@ -910,16 +904,6 @@ class AuthdataUtility(object):
                 "I don't know the secret for library %s" % library_uri
             )
         secret = self.secrets_by_library_uri[library_uri]
-
-        # # Don't bother checking an expired token.
-        # now = datetime.datetime.utcnow()
-        # expiration = self.EPOCH + datetime.timedelta(seconds=expiration)
-        # if expiration < now:
-        #     raise ValueError(
-        #         "Token %s expired at %s (now is %s)." % (
-        #             token, expiration, now
-        #         )
-        #     )
 
         # Sign the token and check against the provided signature.
         key = self.short_token_signer.prepare_key(secret)

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -902,13 +902,6 @@ class TestAuthdataUtility(VendorIDTest):
             m, "library||patron", "signature"
         )
 
-        # The token must not have expired.
-        #assert_raises_regexp(
-        #    ValueError,
-        #    'Token mylibrary|0|patron expired at 1970-01-01 00:20:34',
-        #    m, "mylibrary|0|patron", "signature"
-        #)
-
         # Finally, the signature must be valid.
         assert_raises_regexp(
             ValueError, 'Invalid signature for',

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -810,7 +810,9 @@ class TestAuthdataUtility(VendorIDTest):
         # what would otherwise be normal base64 text. Similarly for
         # the semicolon which replaced the slash, and the at sign which
         # replaced the equals sign.
-        eq_('a library|1234.5|a patron identifier|YoNGn7f38mF531KSWJ;o1H0Z3chbC:uTE:t7pAwqYxM@',
+        #
+        # The expiration time is ignored.
+        eq_('a library||a patron identifier|IdA9biY5jO1IDoqvSUG3eKbw23p4kBi3DqBD2jQx;vs@',
             value
         )
 
@@ -821,9 +823,9 @@ class TestAuthdataUtility(VendorIDTest):
         # triggering an Adobe bug ; token is not.
         signature = AuthdataUtility.adobe_base64_decode(signature)
 
-        # The token comes from the library name, the patron identifier,
-        # and the time of creation.
-        eq_("a library|1234.5|a patron identifier", token)
+        # The token comes from the library name and the patron identifier.
+        # The time of creation is ignored.
+        eq_("a library||a patron identifier", token)
 
         # The signature comes from signing the token with the
         # secret associated with this library.
@@ -872,45 +874,45 @@ class TestAuthdataUtility(VendorIDTest):
             ValueError, "Invalid client token",
             m, "foo|", "signature"
         )
-        
-        # The expiration time must be numeric.
-        assert_raises_regexp(
-            ValueError, 'Expiration time "a time" is not numeric',
-            m, "library|a time|patron", "signature"
-        )
 
+        # The expiration time must be blank.
+        assert_raises_regexp(
+             ValueError, 'Expiration time must be blank.',
+             m, "library|some time|patron", "signature"
+        )      
+        
         # The patron identifier must not be blank.
         assert_raises_regexp(
-            ValueError, 'Token library|1234| has empty patron identifier',
-            m, "library|1234|", "signature"
+            ValueError, 'Token library|| has empty patron identifier',
+            m, "library||", "signature"
         )
         
         # The library must be a known one.
         assert_raises_regexp(
             ValueError,
             'I don\'t know how to handle tokens from library "LIBRARY"',
-            m, "library|1234|patron", "signature"
+            m, "library||patron", "signature"
         )
-
+        
         # We must have the shared secret for the given library.
         self.authdata.library_uris_by_short_name['LIBRARY'] = 'http://a-library.com/'
         assert_raises_regexp(
             ValueError,
             'I don\'t know the secret for library http://a-library.com/',
-            m, "library|1234|patron", "signature"
+            m, "library||patron", "signature"
         )
 
         # The token must not have expired.
-        assert_raises_regexp(
-            ValueError,
-            'Token mylibrary|1234|patron expired at 1970-01-01 00:20:34',
-            m, "mylibrary|1234|patron", "signature"
-        )
+        #assert_raises_regexp(
+        #    ValueError,
+        #    'Token mylibrary|0|patron expired at 1970-01-01 00:20:34',
+        #    m, "mylibrary|0|patron", "signature"
+        #)
 
         # Finally, the signature must be valid.
         assert_raises_regexp(
             ValueError, 'Invalid signature for',
-            m, "mylibrary|99999999999|patron", "signature"
+            m, "mylibrary||patron", "signature"
         )
 
     def test_adobe_base64_encode_decode(self):
@@ -946,7 +948,7 @@ class TestAuthdataUtility(VendorIDTest):
 
         # The signature part of the token has been encoded with our
         # custom encoding, not vanilla base64.
-        eq_('lib|0|1234|IQlGTjZ:J0VzNTI;WCEjKVoqX1M@', token)
+        eq_('lib||1234|IQlGTjZ:J0VzNTI;WCEjKVoqX1M@', token)
         
     def test_decode_two_part_short_client_token_uses_adobe_base64_encoding(self):
 


### PR DESCRIPTION
Let's say you register your device with Adobe as a SimplyE device, using the short client token `NYNYPL|some-timestamp|some-uuid|some-signature`. The `some-timestamp` value there is the time the token expires, about one hour in the future.

Adobe asks the SimplyE authentication API whether username "NYNYPL|some-timestamp|some-uuid" password "some-signature" is valid, and the authentication API says yes. You're good to go.

Six months later, you decide to log out of SimplyE. Your device sends username "NYNYPL|some-timestamp|some-uuid" password "some-signature" to Adobe as part of a deactivation request. Adobe asks the authentication API if this username/password combination is valid, but it's no longer valid. `some-timestamp` was six months ago (minus one hour) and the token has expired.

Okay, no problem. The circ manager gives out new tokens all the time. Just use one of the new ones. They all authenticate the same Adobe ID.

This won't work either. Adobe will only deregister a device using the _exact same username and password_ that was used to register it. And that username doesn't work anymore.

This means that the username and password can never change. We can't use a patron's actual username and password (though we're long past that point), because both of those change routinely. We can't use a meaningless token that expires after an hour (that's what this branch fixes). We have to use a meaningless token that never, ever changes.