### PR TITLE
Update CirculationData.apply() call

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -218,7 +218,7 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI):
                 licenses_reserved=0,
                 patrons_in_hold_queue=0,
             )
-            availability.apply(pool, False)
+            availability.apply(pool, ReplacementPolicy.from_license_source())
 
 
 class Axis360CirculationMonitor(Monitor):


### PR DESCRIPTION
This branch updates the CirculationData.apply() call used by the Axis 360 reaper to update our database with new circulation information from Axis. It used to take a boolean; now it takes a ReplacementPolicy.

This problem avoided our notice because for a long time we weren't running the Axis reaper at all.