### PR TITLE
Bookmark style annotations

### DIFF
--- a/api/annotations.py
+++ b/api/annotations.py
@@ -169,13 +169,21 @@ class AnnotationParser(object):
         else:
             content = None
 
-        annotation, is_new = Annotation.get_one_or_create(
-            _db, patron=patron,
-            identifier=identifier,
-            motivation=motivation,
-        )
+        target = json.dumps(target)
+        extra_kwargs = {}
+        if motivation == Annotation.IDLING:
+            # A given book can only have one 'idling' annotation.
+            pass
+        elif motivation == Annotation.BOOKMARKING:
+            # A given book can only have one 'bookmarking' annotation
+            # per target.
+            extra_kwargs['target'] = target
 
-        annotation.target = json.dumps(target)
+        annotation = Annotation.get_one_or_create(
+            _db, patron=patron, identifier=identifier,
+            **extra_kwargs
+        )
+        annotation.target = target
         if content:
             annotation.content = json.dumps(content)
         annotation.active = True

--- a/api/annotations.py
+++ b/api/annotations.py
@@ -179,9 +179,9 @@ class AnnotationParser(object):
             # per target.
             extra_kwargs['target'] = target
 
-        annotation = Annotation.get_one_or_create(
+        annotation, ignore = Annotation.get_one_or_create(
             _db, patron=patron, identifier=identifier,
-            **extra_kwargs
+            motivation=motivation, **extra_kwargs
         )
         annotation.target = target
         if content:

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -492,7 +492,7 @@ class TestAnnotationParser(AnnotationTest):
         self.pool.loan_to(self.patron)
 
         data = self._sample_jsonld()
-        data["motivation"] = "bookmarking"
+        data["motivation"] = "not-a-valid-motivation"
         data_json = json.dumps(data)
 
         annotation = AnnotationParser.parse(self._db, data_json, self.patron)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -348,12 +348,12 @@ class TestAnnotationParser(AnnotationTest):
         self.identifier = self.pool.identifier
         self.patron = self._patron()
         
-    def _sample_jsonld(self):
+    def _sample_jsonld(self, motivation=Annotation.IDLING):
         data = dict()
         data["@context"] = [AnnotationWriter.JSONLD_CONTEXT, 
                             {'ls': Annotation.LS_NAMESPACE}]
         data["type"] = "Annotation"
-        data["motivation"] = Annotation.IDLING.replace(Annotation.LS_NAMESPACE, 'ls:')
+        data["motivation"] = motivation.replace(Annotation.LS_NAMESPACE, 'ls:')
         data["body"] = {
             "type": "TextualBody",
             "bodyValue": "A good description of the topic that bears further investigation",


### PR DESCRIPTION
This branch implements https://github.com/NYPL-Simplified/circulation/issues/461. You can create an annotation with the 'bookmarking' motivation, and you can create multiple bookmarks per book, as long as you have a distinct target each time.