### PR TITLE
Make SIP2 client handle IOErrors and socket errors 

### DIFF
--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -238,15 +238,8 @@ class SIPClient(Constants):
     def connect(self):
         """Create a socket connection to a SIP server."""
         with self.socket_lock:
-            try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            except socket.error, msg:
-                self.log.warn("Error initializing socket: %s", msg[1])
-
-            try:
-                sock.connect((self.target_server, self.target_port))
-            except socket.error, msg:
-                self.log.warn("Error connecting to SIP server: %s", msg)
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect((self.target_server, self.target_port))
 
             # Since this is a new socket connection, reset the message count
             # and, potentially, logged_in.


### PR DESCRIPTION
Currently the SIP2 client opens a socket in its constructor and keeps that socket open forever. If the SIP2 server ever closes its socket, we never create a new one. 

In retrospect, this has obvious problems. SIP2 servers will close a socket after a certain amount of inactivity, rather than keep it open forever. Even if that wasn't the case, we need to be ready for socket connections that die due to network error.

This branch makes the smallest change I could make that has a shot at solving the problem. If an attempt to read or write to the socket fails, we create a new socket and try again. If it still fails, we reraise the exception.

I use an RLock to guarantee that only one thread is creating a socket at any given time, but I don't think this actually reduces the number of sockets that get created, so it might not be necessary. I could also use a normal Lock but RLock seems safer.

I've attached a test script I used to test the thread-safety and performance impact of this code. It creates a number of threads and has them all make SIP2 requests against a real server. Once in a while, a simulated error happens.

From my experiments with this script I think I've found that even though the client side code is thread-safe, it's not good to have two threads writing to the same socket simultaneously. This leads (I think) to garbled request messages and (definitely) timeouts on the server side.

One solution is to allow each thread of the app server to have its own `SIPClient`. A simpler solution might be to use the RLock to synchronize the entire request/response cycle, so that only one thread can be sending a request at a time. An even simpler solution would be to create a brand new socket connection for every single request. I've tested this and it doesn't seem to cause any problems on the server side.

[test_hammer_sip2_server.txt](https://github.com/NYPL-Simplified/circulation/files/873049/test_hammer_sip2_server.txt)
