### PR TITLE
Setting up admin authentication from the admin interface

### DIFF
--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.14"
+    "simplified-circulation-web": "0.0.15"
   }
 }

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -2,6 +2,13 @@ from core.util.problem_detail import ProblemDetail as pd
 from api.problem_details import *
 from flask.ext.babel import lazy_gettext as _
 
+ADMIN_AUTH_NOT_CONFIGURED = pd(
+    "http://librarysimplified.org/terms/problem/admin-auth-not-configured",
+    500,
+    _("Admin auth not configured"),
+    _("This circulation manager has not been configured to authenticate admins."),
+)
+
 INVALID_ADMIN_CREDENTIALS = pd(
       "http://librarysimplified.org/terms/problem/admin-credentials-invalid",
       401,
@@ -147,4 +154,53 @@ INCOMPLETE_COLLECTION_CONFIGURATION = pd(
     status_code=400,
     title=_("Incomplete collection configuration"),
     detail=_("The collection's configuration is missing a required field."),
+)
+
+MISSING_ADMIN_AUTH_SERVICE_NAME = pd(
+    "http://librarysimplified.org/terms/problem/missing-admin-auth-service-name",
+    status_code=400,
+    title=_("Missing admin authentication service name."),
+    detail=_("You must identify the admin authentication service by its name."),
+)
+
+UNKNOWN_ADMIN_AUTH_SERVICE_PROVIDER = pd(
+    "http://librarysimplified.org/terms/problem/unknown-admin-auth-service-provider",
+    status_code=400,
+    title=_("Unknown admin authentication service provider"),
+    detail=_("The provider is not one of the known admin authentication service providers."),
+)
+
+ADMIN_AUTH_SERVICE_NOT_FOUND = pd(
+    "http://librarysimplified.org/terms/problem/admin-auth-service-not-found",
+    status_code=400,
+    title=_("Admin authentication service not found."),
+    detail=_("Currently there can only be one admin authentication service, and the request does not match the existing one."),
+)
+
+NO_PROVIDER_FOR_NEW_ADMIN_AUTH_SERVICE = pd(
+    "http://librarysimplified.org/terms/problem/no-provider-for-new-admin-auth-service",
+    status_code=400,
+    title=_("No provider for new admin authentication service"),
+    detail=_("The specified admin authentication service doesn't exist. You can create it, but you must specify a provider."),
+)
+
+CANNOT_CHANGE_ADMIN_AUTH_SERVICE_PROVIDER = pd(
+    "http://librarysimplified.org/terms/problem/cannot-change-admin-auth-service-provider",
+    status_code=400,
+    title=_("Cannot change admin authentication service provider"),
+    detail=_("An admin authentication service's provider can't be changed once it has been set."),
+)
+
+INCOMPLETE_ADMIN_AUTH_SERVICE_CONFIGURATION = pd(
+    "http://librarysimplified.org/terms/problem/incomplete-admin-auth-service-configuration",
+    status_code=400,
+    title=_("Incomplete admin authentication service configuration"),
+    detail=_("The admin authentication service's configuration is missing a required field."),
+)
+
+INVALID_ADMIN_AUTH_DOMAIN_LIST = pd(
+    "http://librarysimplified.org/terms/problem/invalid-admin-auth-domain-list",
+    status_code=400,
+    title=_("Invalid admin authentication domain list"),
+    detail=_("The admin authentication domain list isn't in a valid format."),
 )

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -32,21 +32,39 @@ def setup_admin():
     if getattr(app, 'manager', None) is not None:
         setup_admin_controllers(app.manager)
 
+def allows_admin_auth_setup(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        setting_up = (app.manager.admin_sign_in_controller.auth == None)
+        return f(*args, setting_up=setting_up, **kwargs)
+    return decorated
+
 def requires_admin(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        admin = app.manager.admin_sign_in_controller.authenticated_admin_from_request()
-        if isinstance(admin, ProblemDetail):
-            return app.manager.admin_sign_in_controller.error_response(admin)
-        elif isinstance(admin, Response):
-            return admin
+        if 'setting_up' in kwargs:
+            setting_up = kwargs.pop('setting_up')
+        else:
+            setting_up = False
+
+        if not setting_up:
+            admin = app.manager.admin_sign_in_controller.authenticated_admin_from_request()
+            if isinstance(admin, ProblemDetail):
+                return app.manager.admin_sign_in_controller.error_response(admin)
+            elif isinstance(admin, Response):
+                return admin
+
         return f(*args, **kwargs)
     return decorated
 
 def requires_csrf_token(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        if flask.request.method in ["POST", "PUT", "DELETE"]:
+        if 'setting_up' in kwargs:
+            setting_up = kwargs.get('setting_up')
+        else:
+            setting_up = False
+        if not setting_up and flask.request.method in ["POST", "PUT", "DELETE"]:
             token = app.manager.admin_sign_in_controller.check_csrf_token()
             if isinstance(token, ProblemDetail):
                 return token
@@ -242,6 +260,19 @@ def collections():
         return data
     return flask.jsonify(**data)
 
+@app.route("/admin/admin_auth_services", methods=['GET', 'POST'])
+@returns_problem_detail
+@allows_admin_auth_setup
+@requires_csrf_token
+@requires_admin
+def admin_auth_services():
+    data = app.manager.admin_settings_controller.admin_auth_services()
+    if isinstance(data, ProblemDetail):
+        return data
+    if isinstance(data, Response):
+        return data
+    return flask.jsonify(**data)
+
 @app.route('/admin/sign_in_again')
 def admin_sign_in_again():
     """Allows an  admin with expired credentials to sign back in
@@ -261,28 +292,34 @@ def admin_sign_in_again():
 @app.route('/admin/web/book/<path:book>')
 @app.route('/admin/web/<path:etc>') # catchall for single-page URLs
 def admin_view(collection=None, book=None, **kwargs):
-    admin = app.manager.admin_sign_in_controller.authenticated_admin_from_request()
-    csrf_token = app.manager.admin_sign_in_controller.get_csrf_token()
-    if isinstance(admin, ProblemDetail) or csrf_token is None or isinstance(csrf_token, ProblemDetail):
-        redirect_url = flask.request.url
-        if (collection):
-            quoted_collection = urllib.quote(collection)
-            redirect_url = redirect_url.replace(
-                quoted_collection,
-                quoted_collection.replace("/", "%2F"))
-        if (book):
-            quoted_book = urllib.quote(book)
-            redirect_url = redirect_url.replace(
-                quoted_book,
-                quoted_book.replace("/", "%2F"))
-        return redirect(app.manager.url_for('admin_sign_in', redirect=redirect_url))
+    setting_up = (app.manager.admin_sign_in_controller.auth == None)
+    if not setting_up:
+        admin = app.manager.admin_sign_in_controller.authenticated_admin_from_request()
+        csrf_token = app.manager.admin_sign_in_controller.get_csrf_token()
+        if isinstance(admin, ProblemDetail) or csrf_token is None or isinstance(csrf_token, ProblemDetail):
+            redirect_url = flask.request.url
+            if (collection):
+                quoted_collection = urllib.quote(collection)
+                redirect_url = redirect_url.replace(
+                    quoted_collection,
+                    quoted_collection.replace("/", "%2F"))
+            if (book):
+                quoted_book = urllib.quote(book)
+                redirect_url = redirect_url.replace(
+                    quoted_book,
+                    quoted_book.replace("/", "%2F"))
+            return redirect(app.manager.url_for('admin_sign_in', redirect=redirect_url))
+    else:
+        csrf_token = None
     show_circ_events_download = (
-        "core.local_analytics_provider" in Configuration.policy("analytics")
+        "core.local_analytics_provider" in Configuration.policy("analytics") or []
     )
-    return flask.render_template_string(admin_template,
+    return flask.render_template_string(
+        admin_template,
         csrf_token=csrf_token,
         home_url=app.manager.url_for('acquisition_groups'),
-        show_circ_events_download=show_circ_events_download
+        show_circ_events_download=show_circ_events_download,
+        setting_up=setting_up,
     )
 
 @app.route('/admin')
@@ -292,14 +329,12 @@ def admin_base(**kwargs):
 
 @app.route('/admin/static/circulation-web.js')
 @returns_problem_detail
-@requires_admin
 def admin_js():
     directory = os.path.join(os.path.abspath(os.path.dirname(__file__)), "node_modules", "simplified-circulation-web", "dist")
     return flask.send_from_directory(directory, "circulation-web.js")
 
 @app.route('/admin/static/circulation-web.css')
 @returns_problem_detail
-@requires_admin
 def admin_css():
     directory = os.path.join(os.path.abspath(os.path.dirname(__file__)), "node_modules", "simplified-circulation-web", "dist")
     return flask.send_from_directory(directory, "circulation-web.css")

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -312,7 +312,7 @@ def admin_view(collection=None, book=None, **kwargs):
     else:
         csrf_token = None
     show_circ_events_download = (
-        "core.local_analytics_provider" in Configuration.policy("analytics") or []
+        "core.local_analytics_provider" in (Configuration.policy("analytics") or [])
     )
     return flask.render_template_string(
         admin_template,

--- a/api/admin/templates.py
+++ b/api/admin/templates.py
@@ -12,7 +12,8 @@ admin = """
     var circulationWeb = new CirculationWeb({
         csrfToken: \"{{ csrf_token }}\",
         homeUrl: \"{{ home_url }}\",
-        showCircEventsDownload: {{ "true" if show_circ_events_download else "false" }}
+        showCircEventsDownload: {{ "true" if show_circ_events_download else "false" }},
+        settingUp: {{ "true" if setting_up else "false" }}
     });
   </script>
 </body>


### PR DESCRIPTION
Fixes #475 
Fixes #444 

This branch changes the admin interface routes so that you can load the admin interface before you have configured admin authentication. It passes a settingUp flag to the javascript so the UI can restrict you to the appropriate form. The only API endpoint that will work is /admin_auth_services. Once you have successfully created an admin authentication service, you must log in with that service before you can do anything else. The new API endpoint can also be used for editing the admin authentication service later.

It's important to make sure that everyone who enables the admin interface sets up an admin authentication service right away, or else someone else could set one up and lock them out.

