### PR TITLE
Add basic health check route

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -362,3 +362,6 @@ def loadstorm_verify(code):
     else:
         return Response("", 404)
 
+@app.route('/healthcheck.html')
+def health_check():
+    return Response("", 200)


### PR DESCRIPTION
This small change helps the app stay up when combined with the AWS Application Load Balancer. Fixes NYPL-Simplified/circulation-docker#30.

For some reason, it doesn't work with the `/heartbeat` endpoint -- @phreekbird and I hypothesize that it's because it doesn't return an HTML file.