### PR TITLE
Patron has library

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -223,6 +223,7 @@ class WorkController(CirculationManagerController):
     def complaints(self, identifier_type, identifier):
         """Return detailed complaint information for admins."""
         
+        
         work = self.load_work(self.library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -452,11 +452,12 @@ class Authenticator(object):
         del config['module']
         provider_module = importlib.import_module(module_name)
         provider_class = getattr(provider_module, "AuthenticationProvider")
+        library = self.library(self._db)
         if issubclass(provider_class, BasicAuthenticationProvider):
-            provider = provider_class.from_config(self.library, config)
+            provider = provider_class.from_config(library, config)
             self.register_basic_auth_provider(provider)
         elif issubclass(provider_class, OAuthAuthenticationProvider):
-            provider = provider_class.from_config(self.library, config)
+            provider = provider_class.from_config(library, config)
             self.register_oauth_provider(provider)
         else:
             raise CannotLoadConfiguration(

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -678,11 +678,17 @@ class AuthenticationProvider(object):
     # different types of authentication.
     URI = None
 
-    # Each subclass MUST accept a library id in its constructor and
-    # MUST store it as .library_id. This allows the
-    # AuthenticationProvider to remember which library it manages
-    # without having to hold on to a Library object, which would be
-    # associated with a specific database session.
+    def __init__(self, library_id):
+        """Basic constructor.
+        
+        :param library_id: The database ID of the Library to be managed 
+        by this AuthenticationProvider.
+        """
+        if not isinstance(library_id, int):
+            raise Exception(
+                "Expected library_id to be an integer, got %r" % library_id
+            )
+        self.library_id = library_id
     
     def library(self, _db):
         return get_one(_db, Library, self.library_id)
@@ -844,11 +850,7 @@ class BasicAuthenticationProvider(AuthenticationProvider):
             pass the Library object to avoid contaminating with
             an object from a non-scoped session.
         """
-        if not isinstance(library_id, int):
-            raise Exception(
-                "Expected library_id to be an integer, got %r" % library_id
-            )
-        self.library_id = library_id
+        super(BasicAuthenticationProvider, self).__init__(library_id)
         if identifier_regular_expression is self.class_default:
             identifier_regular_expression = self.DEFAULT_IDENTIFIER_REGULAR_EXPRESSION
         if identifier_regular_expression:
@@ -1165,7 +1167,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
             we ask the patron to go through the OAuth validation
             process again.
         """
-        self.library_id = library_id
+        super(OAuthAuthenticationProvider, self).__init__(library_id)
         self.client_id = client_id
         self.client_secret = client_secret
         self.token_expiration_days = token_expiration_days

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -432,10 +432,6 @@ class Authenticator(object):
             for provider in oauth_providers:
                 self.oauth_providers_by_name[provider.NAME] = provider
         self.assert_ready_for_oauth()
-
-    @property
-    def library(self):
-        return get_one(self._db, Library, id=self.library_id)
         
     def assert_ready_for_oauth(self):
         """If this Authenticator has OAuth providers, ensure that it

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -342,6 +342,9 @@ class Authenticator(object):
     def from_config(cls, library):
         """Initialize an Authenticator from site configuration.
         """
+        if not isinstance(library, Library):
+            raise Exception("%s passed in where Library expected",
+                            library.__class__)
         _db = Session.object_session(library)
         # Commit just in case this is the first time the Library has
         # ever been loaded.
@@ -422,10 +425,6 @@ class Authenticator(object):
             for provider in oauth_providers:
                 self.oauth_providers_by_name[provider.NAME] = provider
         self.assert_ready_for_oauth()
-
-    @property
-    def library(self):
-        return get_one(self._db, Library, id=self.library_id)
         
     def assert_ready_for_oauth(self):
         """If this Authenticator has OAuth providers, ensure that it
@@ -1149,6 +1148,9 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
         self.client_secret = client_secret
         self.token_expiration_days = token_expiration_days
         self.log = logging.getLogger(self.NAME)
+
+    def library(self, _db):
+        return get_one(_db, Library, id=self.library_id)
         
     def authenticated_patron(self, _db, token):
         """Go from an OAuth provider token to an authenticated Patron.

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -373,7 +373,7 @@ class Authenticator(object):
             
         # Start with an empty list of authenticators.        
         authenticator = cls(
-            _db=_db, library_id=library,
+            _db=_db, library=library,
             bearer_token_signing_secret=bearer_token_signing_secret
         )
 

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -425,6 +425,9 @@ class Authenticator(object):
             for provider in oauth_providers:
                 self.oauth_providers_by_name[provider.NAME] = provider
         self.assert_ready_for_oauth()
+
+    def library(self, _db):
+        return get_one(_db, Library, id=self.library_id)
         
     def assert_ready_for_oauth(self):
         """If this Authenticator has OAuth providers, ensure that it
@@ -847,6 +850,9 @@ class BasicAuthenticationProvider(AuthenticationProvider):
         self.test_username = test_username
         self.test_password = test_password
         self.log = logging.getLogger(self.NAME)
+
+    def library(self, _db):
+        return get_one(_db, Library, id=self.library_id)
         
     def testing_patron(self, _db):
         """Look up a Patron object reserved for testing purposes.

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -171,9 +171,10 @@ class CirculationAPI(object):
     def __init__(self, library, api_map=None):
         """Constructor.
 
-        # TODO: This needs to take a database connection as well so that
-        # we can keep the scoped session. It should only store library_id
-        # or patron_id.
+        # TODO: This needs to take a database connection as well so
+        # that we can keep the scoped session. It should only store
+        # library_id or patron_id. OR, we need to make sure we create
+        # a new CirculationAPI on each request.
 
         :param library: A Library object representing the library
           whose circulation we're concerned with at the moment. TODO:
@@ -184,6 +185,7 @@ class CirculationAPI(object):
            API classes that should be instantiated to deal with these
            protocols. The default map will work fine unless you're a
            unit test.
+
         """
         self._db = Session.object_session(library)
         self.library = library

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -171,6 +171,10 @@ class CirculationAPI(object):
     def __init__(self, library, api_map=None):
         """Constructor.
 
+        # TODO: This needs to take a database connection as well so that
+        # we can keep the scoped session. It should only store library_id
+        # or patron_id.
+
         :param library: A Library object representing the library
           whose circulation we're concerned with at the moment. TODO:
           it would be better if this took a Patron, but currently

--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -104,7 +104,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
             return patrondata
         
         # Convert the PatronData into a Patron object.
-        patron, is_new = patrondata.get_or_create_patron(_db)
+        patron, is_new = patrondata.get_or_create_patron(_db, self.library_id)
 
         # Create a credential for the Patron.
         credential, is_new = self.create_token(_db, patron, token)

--- a/api/controller.py
+++ b/api/controller.py
@@ -133,8 +133,6 @@ class CirculationManager(object):
     def __init__(self, _db, lanes=None, testing=False):
 
         self.log = logging.getLogger("Circulation manager web app")
-        if isinstance(_db, Library):
-            raise Exception("library passed in where database expected")
 
         if not testing:
             try:

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -38,12 +38,12 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
     
     log = logging.getLogger("First Book authentication API")
 
-    def __init__(self, url=None, key=None, **kwargs):
+    def __init__(self, library, url=None, key=None, **kwargs):
         if not (url and key):
             raise CannotLoadConfiguration(
                 "First Book server not configured."
             )
-        super(FirstBookAuthenticationAPI, self).__init__(**kwargs)
+        super(FirstBookAuthenticationAPI, self).__init__(library, **kwargs)
         if '?' in url:
             url += '&'
         else:

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -38,12 +38,12 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
     
     log = logging.getLogger("First Book authentication API")
 
-    def __init__(self, library, url=None, key=None, **kwargs):
+    def __init__(self, library_id, url=None, key=None, **kwargs):
         if not (url and key):
             raise CannotLoadConfiguration(
                 "First Book server not configured."
             )
-        super(FirstBookAuthenticationAPI, self).__init__(library, **kwargs)
+        super(FirstBookAuthenticationAPI, self).__init__(library_id, **kwargs)
         if '?' in url:
             url += '&'
         else:

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -52,16 +52,17 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
     # of the Millenium Patron API server.
     VERIFY_CERTIFICATE = "verify_certificate"
     
-    def __init__(self, url=None, authorization_identifier_blacklist=[],
+    def __init__(self, library, url=None, authorization_identifier_blacklist=[],
                  verify_certificate=True, **kwargs):
         if not url:
             raise CannotLoadConfiguration(
                 "Millenium Patron API server not configured."
             )
 
-        super(MilleniumPatronAPI, self).__init__(**kwargs)
+        super(MilleniumPatronAPI, self).__init__(library, **kwargs)
         if not url.endswith('/'):
             url = url + "/"
+        self.library_id = library.id
         self.root = url
         self.verify_certificate=verify_certificate
         self.parser = etree.HTMLParser()

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -52,17 +52,16 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
     # of the Millenium Patron API server.
     VERIFY_CERTIFICATE = "verify_certificate"
     
-    def __init__(self, library, url=None, authorization_identifier_blacklist=[],
+    def __init__(self, library_id, url=None, authorization_identifier_blacklist=[],
                  verify_certificate=True, **kwargs):
         if not url:
             raise CannotLoadConfiguration(
                 "Millenium Patron API server not configured."
             )
 
-        super(MilleniumPatronAPI, self).__init__(library, **kwargs)
+        super(MilleniumPatronAPI, self).__init__(library_id, **kwargs)
         if not url.endswith('/'):
             url = url + "/"
-        self.library_id = library.id
         self.root = url
         self.verify_certificate=verify_certificate
         self.parser = etree.HTMLParser()

--- a/api/mock_authentication.py
+++ b/api/mock_authentication.py
@@ -23,9 +23,11 @@ class MockAuthenticationProvider(BasicAuthenticationProvider):
 
     NAME = "Mock Authentication Provider"
            
-    def __init__(self, patrons=None, expired_patrons=None,
+    def __init__(self, library, patrons=None, expired_patrons=None,
                  patrons_with_fines=None, *args, **kwargs):
-        super(MockAuthenticationProvider, self).__init__(*args, **kwargs)
+        super(MockAuthenticationProvider, self).__init__(
+            library, *args, **kwargs
+        )
         if not patrons:
             self.log.warn(
                 "No patrons configured for mock authentication provider."

--- a/api/mock_authentication.py
+++ b/api/mock_authentication.py
@@ -23,10 +23,10 @@ class MockAuthenticationProvider(BasicAuthenticationProvider):
 
     NAME = "Mock Authentication Provider"
            
-    def __init__(self, library, patrons=None, expired_patrons=None,
+    def __init__(self, library_id, patrons=None, expired_patrons=None,
                  patrons_with_fines=None, *args, **kwargs):
         super(MockAuthenticationProvider, self).__init__(
-            library, *args, **kwargs
+            library_id, *args, **kwargs
         )
         if not patrons:
             self.log.warn(

--- a/api/services.py
+++ b/api/services.py
@@ -27,7 +27,7 @@ class ServiceStatus(object):
     def __init__(self, library, auth=None, api_map=None):
         self._db = Session.object_session(library)
         self.circulation = CirculationAPI(library, api_map)
-        self.auth = auth or Authenticator.from_config(library)
+        self.auth = auth or Authenticator.from_config(self._db)
 
     @property
     def test_patron(self):

--- a/api/services.py
+++ b/api/services.py
@@ -27,7 +27,7 @@ class ServiceStatus(object):
     def __init__(self, library, auth=None, api_map=None):
         self._db = Session.object_session(library)
         self.circulation = CirculationAPI(library, api_map)
-        self.auth = auth or Authenticator.from_config(self._db)
+        self.auth = auth or Authenticator.from_config(library)
 
     @property
     def test_patron(self):

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -14,7 +14,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
 
     DATE_FORMATS = ["%Y%m%d", "%Y%m%d%Z%H%M%S", "%Y%m%d    %H%M%S"]
 
-    def __init__(self, server, port, login_user_id,
+    def __init__(self, library_id, server, port, login_user_id,
                  login_password, location_code, field_separator='|',
                  client=None,
                  **kwargs):
@@ -48,7 +48,9 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         object. Only intended for use during testing.
 
         """
-        super(SIP2AuthenticationProvider, self).__init__(**kwargs)
+        super(SIP2AuthenticationProvider, self).__init__(
+            library_id=library_id, **kwargs
+        )
         try:
             if client:
                 if callable(client):

--- a/scripts.py
+++ b/scripts.py
@@ -287,7 +287,7 @@ class LaneSweeperScript(Script):
         os.environ['AUTOINITIALIZE'] = "False"
         from api.app import app
         del os.environ['AUTOINITIALIZE']
-        app.manager = CirculationManager(Library.instance(_db), testing=testing)
+        app.manager = CirculationManager(_db, testing=testing)
         self.app = app
         self.base_url = Configuration.integration_url(
             Configuration.CIRCULATION_MANAGER_INTEGRATION, required=True

--- a/scripts.py
+++ b/scripts.py
@@ -37,6 +37,7 @@ from core.model import (
     Hold,
     Hyperlink,
     Identifier,
+    Library,
     LicensePool,
     LicensePoolDeliveryMechanism,
     Loan,
@@ -286,7 +287,7 @@ class LaneSweeperScript(Script):
         os.environ['AUTOINITIALIZE'] = "False"
         from api.app import app
         del os.environ['AUTOINITIALIZE']
-        app.manager = CirculationManager(self._db, testing=testing)
+        app.manager = CirculationManager(Library.instance(_db), testing=testing)
         self.app = app
         self.base_url = Configuration.integration_url(
             Configuration.CIRCULATION_MANAGER_INTEGRATION, required=True

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -926,11 +926,11 @@ class TestDashboardController(AdminControllerTest):
     def test_stats_inventory(self):
         with self.app.test_request_context("/"):
 
-            # At first, there are 3 open access titles in the database,
+            # At first, there is 1 open access title in the database,
             # created in CirculationControllerTest.setup.
             response = self.manager.admin_dashboard_controller.stats()
             inventory_data = response.get('inventory')
-            eq_(3, inventory_data.get('titles'))
+            eq_(1, inventory_data.get('titles'))
             eq_(0, inventory_data.get('licenses'))
             eq_(0, inventory_data.get('available_licenses'))
 
@@ -951,18 +951,18 @@ class TestDashboardController(AdminControllerTest):
 
             response = self.manager.admin_dashboard_controller.stats()
             inventory_data = response.get('inventory')
-            eq_(6, inventory_data.get('titles'))
+            eq_(4, inventory_data.get('titles'))
             eq_(15, inventory_data.get('licenses'))
             eq_(4, inventory_data.get('available_licenses'))
 
     def test_stats_vendors(self):
         with self.app.test_request_context("/"):
 
-            # At first, there are 3 open access titles in the database,
+            # At first, there is 1 open access title in the database,
             # created in CirculationControllerTest.setup.
             response = self.manager.admin_dashboard_controller.stats()
             vendor_data = response.get('vendors')
-            eq_(3, vendor_data.get('open_access'))
+            eq_(1, vendor_data.get('open_access'))
             eq_(None, vendor_data.get('overdrive'))
             eq_(None, vendor_data.get('bibliotheca'))
             eq_(None, vendor_data.get('axis360'))
@@ -993,7 +993,7 @@ class TestDashboardController(AdminControllerTest):
 
             response = self.manager.admin_dashboard_controller.stats()
             vendor_data = response.get('vendors')
-            eq_(3, vendor_data.get('open_access'))
+            eq_(1, vendor_data.get('open_access'))
             eq_(1, vendor_data.get('overdrive'))
             eq_(1, vendor_data.get('bibliotheca'))
             eq_(1, vendor_data.get('axis360'))

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1085,7 +1085,7 @@ class TestSettingsController(AdminControllerTest):
         library = get_one(self._db, Library)
         if library:
             self._db.delete(library)
-
+            
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
                 ("name", "The New York Public Library"),

--- a/tests/clever/test_clever.py
+++ b/tests/clever/test_clever.py
@@ -45,7 +45,7 @@ class TestCleverAuthenticationAPI(DatabaseTest):
     def setup(self):
         super(TestCleverAuthenticationAPI, self).setup()
         self.api = MockAPI(
-            self._default_library, 'fake_client_id', 'fake_client_secret', 2
+            self._default_library.id, 'fake_client_id', 'fake_client_secret', 2
         )
         os.environ['AUTOINITIALIZE'] = "False"
         from api.app import app
@@ -184,7 +184,7 @@ class TestCleverAuthenticationAPI(DatabaseTest):
         # We're about to call url_for, so we must create an
         # application context.
         my_api = CleverAuthenticationAPI(
-            self._default_library, "key", "secret", 2
+            self._default_library.id, "key", "secret", 2
         )
         with self.app.test_request_context("/"):
             params = my_api.external_authenticate_url("state")

--- a/tests/clever/test_clever.py
+++ b/tests/clever/test_clever.py
@@ -44,7 +44,9 @@ class TestCleverAuthenticationAPI(DatabaseTest):
 
     def setup(self):
         super(TestCleverAuthenticationAPI, self).setup()
-        self.api = MockAPI('fake_client_id', 'fake_client_secret', 2)
+        self.api = MockAPI(
+            self._default_library, 'fake_client_id', 'fake_client_secret', 2
+        )
         os.environ['AUTOINITIALIZE'] = "False"
         from api.app import app
         del os.environ['AUTOINITIALIZE']
@@ -181,7 +183,9 @@ class TestCleverAuthenticationAPI(DatabaseTest):
         """
         # We're about to call url_for, so we must create an
         # application context.
-        my_api = CleverAuthenticationAPI("key", "secret", 2)
+        my_api = CleverAuthenticationAPI(
+            self._default_library, "key", "secret", 2
+        )
         with self.app.test_request_context("/"):
             params = my_api.external_authenticate_url("state")
             eq_('https://clever.com/oauth/authorize?response_type=code&client_id=key&redirect_uri=http://localhost/oauth_callback&state=state', params)

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -8,7 +8,9 @@ from api.sip.client import MockSIPClient
 from api.sip import SIP2AuthenticationProvider
 from core.util.http import RemoteIntegrationException
 
-class TestSIP2AuthenticationProvider(object):
+from .. import DatabaseTest
+
+class TestSIP2AuthenticationProvider(DatabaseTest):
 
     # We feed sample data into the MockSIPClient, even though it adds
     # an extra step of indirection, because it lets us use as a
@@ -36,7 +38,8 @@ class TestSIP2AuthenticationProvider(object):
     def test_remote_authenticate(self):
         client = MockSIPClient()
         auth = SIP2AuthenticationProvider(
-            None, None, None, None, None, None, client=client
+            self._default_library.id, None, None, None, None, None, None,
+            client=client
         )
 
         # Some examples taken from a Sierra SIP API.
@@ -121,7 +124,8 @@ class TestSIP2AuthenticationProvider(object):
             RemoteIntegrationException,
             "Error accessing server.local: Doom!",
             SIP2AuthenticationProvider,
-            "server.local", None, None, None, None, client=CannotConnect
+            self._default_library.id, "server.local", None, None, None, None,
+            client=CannotConnect
         )
 
     def test_ioerror_during_send_becomes_remoteintegrationexception(self):
@@ -135,7 +139,8 @@ class TestSIP2AuthenticationProvider(object):
         client.target_server = 'server.local'
             
         provider = SIP2AuthenticationProvider(
-            None, None, None, None, None, client=client
+            self._default_library.id, None, None, None, None, None,
+            client=client
         )
         assert_raises_regexp(
             RemoteIntegrationException,

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -58,7 +58,7 @@ class TestVendorIDModel(VendorIDTest):
     def setup(self):
         super(TestVendorIDModel, self).setup()
         self.authenticator = MockAuthenticationProvider(
-            self._default_library,
+            self._default_library.id,
             patrons={"validpatron" : "password" }
         )
         self.model = AdobeVendorIDModel(self._db, self.authenticator,

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -58,6 +58,7 @@ class TestVendorIDModel(VendorIDTest):
     def setup(self):
         super(TestVendorIDModel, self).setup()
         self.authenticator = MockAuthenticationProvider(
+            self._default_library,
             patrons={"validpatron" : "password" }
         )
         self.model = AdobeVendorIDModel(self._db, self.authenticator,

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1189,12 +1189,15 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
             authorization_identifier=self._str,
             fines=Money(1, "USD"),
         )
-        provider = self.mock_basic(patrondata, patrondata)
+
+        library = self._library()
+        
+        provider = MockBasic(library, patrondata, patrondata)
         patron = provider.authenticate(self._db, self.credentials)
 
         # A server side Patron was created from the PatronData.
         assert isinstance(patron, Patron)
-        eq_(self._default_library, patron.library)
+        eq_(library, patron.library)
         eq_(patrondata.permanent_id, patron.external_identifier)
         eq_(patrondata.authorization_identifier,
             patron.authorization_identifier)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1189,6 +1189,7 @@ class TestBasicAuthenticationProviderAuthenticate(DatabaseTest):
 
         # A server side Patron was created from the PatronData.
         assert isinstance(patron, Patron)
+        eq_(self._default_library, patron.library)
         eq_(patrondata.permanent_id, patron.external_identifier)
         eq_(patrondata.authorization_identifier,
             patron.authorization_identifier)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1131,14 +1131,16 @@ class TestBasicAuthenticationProviderAuthenticate(DatabaseTest):
     def test_failure_when_remote_authentication_returns_problemdetail(self):
         patron = self._patron()
         patrondata = PatronData(permanent_id=patron.external_identifier)
-        provider = MockBasic(UNSUPPORTED_AUTHENTICATION_MECHANISM)
+        provider = MockBasic(
+            self._default_library, UNSUPPORTED_AUTHENTICATION_MECHANISM
+        )
         eq_(UNSUPPORTED_AUTHENTICATION_MECHANISM,
             provider.authenticate(self._db, self.credentials))
 
     def test_failure_when_remote_authentication_returns_none(self):
         patron = self._patron()
         patrondata = PatronData(permanent_id=patron.external_identifier)
-        provider = MockBasic(None)
+        provider = MockBasic(self._default_library, None)
         eq_(None,
             provider.authenticate(self._db, self.credentials))
         
@@ -1165,7 +1167,7 @@ class TestBasicAuthenticationProviderAuthenticate(DatabaseTest):
         authentication provider. But we handle it.
         """
         patrondata = PatronData(permanent_id=self._str)
-        provider = MockBasic(patrondata)
+        provider = MockBasic(self._default_library, patrondata)
 
         # When we call remote_authenticate(), we get patrondata, but
         # there is no corresponding local patron, so we call
@@ -1183,6 +1185,7 @@ class TestBasicAuthenticationProviderAuthenticate(DatabaseTest):
             fines=Money(1, "USD"),
         )
         provider = MockBasic(self._default_library, patrondata)
+        set_trace()
         patron = provider.authenticate(self._db, self.credentials)
 
         # A server side Patron was created from the PatronData.
@@ -1217,7 +1220,7 @@ class TestBasicAuthenticationProviderAuthenticate(DatabaseTest):
             username=new_username,
         )
 
-        provider = MockBasic(patrondata)
+        provider = MockBasic(self._default_library, patrondata)
         patron2 = provider.authenticate(self._db, self.credentials)
 
         # We were able to match our local patron to the patron held by the

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1184,8 +1184,7 @@ class TestBasicAuthenticationProviderAuthenticate(DatabaseTest):
             authorization_identifier=self._str,
             fines=Money(1, "USD"),
         )
-        provider = MockBasic(self._default_library, patrondata)
-        set_trace()
+        provider = MockBasic(self._default_library, patrondata, patrondata)
         patron = provider.authenticate(self._db, self.credentials)
 
         # A server side Patron was created from the PatronData.

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -823,15 +823,14 @@ class TestAuthenticationProvider(AuthenticatorTest):
     credentials = dict(username='user', password='')
     
     def test_authenticated_patron_passes_on_none(self):
-        provider = MockBasic(library=self._default_library, patrondata=None)
+        provider = self.mock_basic(patrondata=None)
         patron = provider.authenticated_patron(
             self._db, self.credentials
         )
         eq_(None, patron)
     
     def test_authenticated_patron_passes_on_problem_detail(self):
-        provider = MockBasic(
-            library=self._default_library,
+        provider = self.mock_basic(
             patrondata=UNSUPPORTED_AUTHENTICATION_MECHANISM
         )
         patron = provider.authenticated_patron(
@@ -847,9 +846,10 @@ class TestAuthenticationProvider(AuthenticatorTest):
 
         expired = PatronData(permanent_id="1", authorization_identifier="2",
                              authorization_expires=yesterday)
-        provider = MockBasic(library=self._default_library,
+        provider = self.mock_basic(
                              patrondata=expired,
-                             remote_patron_lookup_patrondata=expired)
+                             remote_patron_lookup_patrondata=expired
+        )
         patron = provider.authenticated_patron(
             self._db, self.credentials
         )
@@ -878,8 +878,7 @@ class TestAuthenticationProvider(AuthenticatorTest):
             username=username, complete=True
         )
         
-        provider = MockBasic(
-            library=self._default_library,
+        provider = self.mock_basic(
             patrondata=incomplete_data,
             remote_patron_lookup_patrondata=complete_data
         )
@@ -1140,9 +1139,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
     def test_failure_when_remote_authentication_returns_problemdetail(self):
         patron = self._patron()
         patrondata = PatronData(permanent_id=patron.external_identifier)
-        provider = MockBasic(
-            self._default_library, UNSUPPORTED_AUTHENTICATION_MECHANISM
-        )
+        provider = self.mock_basic(UNSUPPORTED_AUTHENTICATION_MECHANISM)
         eq_(UNSUPPORTED_AUTHENTICATION_MECHANISM,
             provider.authenticate(self._db, self.credentials))
 
@@ -1156,8 +1153,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
     def test_server_side_validation_runs(self):
         patron = self._patron()
         patrondata = PatronData(permanent_id=patron.external_identifier)
-        provider = MockBasic(
-            self._default_library,
+        provider = self.mock_basic(
             patrondata, identifier_regular_expression="foo",
             password_regular_expression="bar"
         )
@@ -1475,7 +1471,7 @@ class TestOAuthController(AuthenticatorTest):
                 return self.token, self.patron, self.patrondata
             
         patron = self._patron()
-        self.basic = MockBasic(library=self._default_library)
+        self.basic = self.mock_basic()
         self.oauth1 = MockOAuthWithExternalAuthenticateURL(
             self._default_library, self._db, "http://oauth1.com/", patron
         )

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -50,11 +50,14 @@ class TestCirculationAPI(DatabaseTest):
 
     def setup(self):
         super(TestCirculationAPI, self).setup()
-        self._default_collection.protocol = Collection.BIBLIOTHECA
-        edition, self.pool = self._edition(with_license_pool=True)
+        self.collection = MockBibliothecaAPI.mock_collection(self._db)
+        edition, self.pool = self._edition(
+            data_source_name=DataSource.BIBLIOTHECA,
+            identifier_type=Identifier.BIBLIOTHECA_ID,
+            with_license_pool=True, collection=self.collection
+        )
         self.pool.open_access = False
         self.identifier = self.pool.identifier
-        self.identifier.type = Identifier.BIBLIOTHECA_ID
         [self.delivery_mechanism] = self.pool.delivery_mechanisms
         self.patron = self._patron()
         self.circulation = MockCirculationAPI(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -204,7 +204,7 @@ class CirculationControllerTest(ControllerTest):
     def setup(self):
         super(CirculationControllerTest, self).setup()
         for (variable_name, title, author, language, fiction) in self.BOOKS:
-            work = self._work(title, author, language, fiction=fiction,
+            work = self._work(title, author, language=language, fiction=fiction,
                               with_open_access_download=True)
             setattr(self, variable_name, work)
             work.license_pools[0].collection = self.collection

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -135,8 +135,12 @@ class ControllerTest(DatabaseTest, MockAdobeConfiguration):
 
         # Create the patron used by the dummy authentication mechanism.
         self.default_patron, ignore = get_one_or_create(
-            _db, Patron, authorization_identifier="unittestuser",
-            create_method_kwargs=dict(external_identifier="unittestuser")
+            _db, Patron,
+            library=self._default_library,
+            authorization_identifier="unittestuser",
+            create_method_kwargs=dict(
+                external_identifier="unittestuser"
+            )
         )
 
         self.initialize_library(_db)
@@ -169,7 +173,7 @@ class ControllerTest(DatabaseTest, MockAdobeConfiguration):
             }
             lanes = make_lanes_default(_db)
             self.manager = TestCirculationManager(
-                _db, lanes=lanes, testing=True
+                self._default_library, lanes=lanes, testing=True
             )
             self.authdata = AuthdataUtility.from_config(_db)
             app.manager = self.manager

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -173,7 +173,7 @@ class ControllerTest(DatabaseTest, MockAdobeConfiguration):
             }
             lanes = make_lanes_default(_db)
             self.manager = TestCirculationManager(
-                self._default_library, lanes=lanes, testing=True
+                _db, lanes=lanes, testing=True
             )
             self.authdata = AuthdataUtility.from_config(_db)
             app.manager = self.manager
@@ -2306,7 +2306,6 @@ class TestScopedSession(ControllerTest):
 
     def setup(self):
         from api.app import _db
-        set_trace()
         super(TestScopedSession, self).setup(_db)
 
     @contextmanager

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1727,12 +1727,6 @@ class TestWorkController(CirculationControllerTest):
             expected_contributor_link = urllib.quote('contributor/John Bull/eng/')
             eq_(True, href.endswith(expected_contributor_link))
 
-        # The original book is listed in all three feeds.
-        title_to_link_ending = {
-            'Around the World' : expected_series_link,
-            'John Bull' : expected_contributor_link
-        }
-
         # The book for which we got recommendations is itself listed in the
         # series feed and in the 'books by this author' feed.
         eq_(set(["John Bull", "Around the World"]),

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -195,16 +195,14 @@ class ControllerTest(DatabaseTest, MockAdobeConfiguration):
 
 class CirculationControllerTest(ControllerTest):
 
+    # These tests generally need at least one Work created,
+    # but some need more.
     BOOKS = [
         ["english_1", "Quite British", "John Bull", "eng", True],
     ]
     
     def setup(self):
         super(CirculationControllerTest, self).setup()
-
-        # TODO: This is a prime candidate for optimization. A lot of
-        # tests don't need these books, and they take over 1 second to
-        # create.
         for (variable_name, title, author, language, fiction) in self.BOOKS:
             work = self._work(title, author, language, fiction=fiction,
                               with_open_access_download=True)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2306,6 +2306,7 @@ class TestScopedSession(ControllerTest):
 
     def setup(self):
         from api.app import _db
+        set_trace()
         super(TestScopedSession, self).setup(_db)
 
     @contextmanager

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -43,6 +43,7 @@ from core.model import (
     Edition,
     Identifier,
     Complaint,
+    Library,
     SessionManager,
     CachedFeed,
     Work,
@@ -123,7 +124,10 @@ class ControllerTest(DatabaseTest, MockAdobeConfiguration):
         from api.app import app
         self.app = app
         del os.environ['AUTOINITIALIZE']
-        self.library = self._default_library
+
+        # We can't use self._default_library, since that Library
+        # might be associated with a different 
+        self.library = Library.instance(_db)
 
         # PRESERVE_CONTEXT_ON_EXCEPTION needs to be off in tests
         # to prevent one test failure from breaking later tests as well.
@@ -136,7 +140,7 @@ class ControllerTest(DatabaseTest, MockAdobeConfiguration):
         # Create the patron used by the dummy authentication mechanism.
         self.default_patron, ignore = get_one_or_create(
             _db, Patron,
-            library=self._default_library,
+            library=self.library,
             authorization_identifier="unittestuser",
             create_method_kwargs=dict(
                 external_identifier="unittestuser"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -195,29 +195,22 @@ class ControllerTest(DatabaseTest, MockAdobeConfiguration):
 
 class CirculationControllerTest(ControllerTest):
 
+    BOOKS = [
+        ["english_1", "Quite British", "John Bull", "eng", True],
+        ["english_2", "Totally American", "Uncle Sam", "eng", False],
+    ]
+    
     def setup(self):
         super(CirculationControllerTest, self).setup()
 
         # TODO: This is a prime candidate for optimization. A lot of
         # tests don't need these books, and they take over 1 second to
         # create.
-
-        # Create two English books and a French book.
-        self.english_1 = self._work(
-            "Quite British", "John Bull", language="eng", fiction=True,
-            with_open_access_download=True
-        )
-        self.english_2 = self._work(
-            "Totally American", "Uncle Sam", language="eng", fiction=False,
-            with_open_access_download=True
-        )
-        self.french_1 = self._work(
-            u"Très Français", "Marianne", language="fre", fiction=False,
-            with_open_access_download=True
-        )
-        for w in self.english_1, self.english_2, self.french_1:
-            w.license_pools[0].collection = self.collection
-
+        for (variable_name, title, author, language, fiction) in self.BOOKS:
+            work = self._work(title, author, language, fiction=fiction,
+                              with_open_access_download=True)
+            setattr(self, variable_name, work)
+            work.license_pools[0].collection = self.collection
 
 
 class TestBaseController(CirculationControllerTest):
@@ -1880,6 +1873,10 @@ class TestWorkController(CirculationControllerTest):
 
 class TestFeedController(CirculationControllerTest):
 
+    BOOKS = list(CirculationControllerTest.BOOKS) + [
+        ["french_1", u"Très Français", "Marianne", "fre", False],
+    ]
+    
     def test_feed(self):
         SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context("/"):

--- a/tests/test_firstbook.py
+++ b/tests/test_firstbook.py
@@ -38,7 +38,7 @@ class TestFirstBook(DatabaseTest):
             FirstBookAuthenticationAPI.SECRET_KEY : "the_key",
         }
         api = FirstBookAuthenticationAPI.from_config(
-            self._default_library, config
+            self._default_library.id, config
         )
 
         # Verify that the configuration details were stored properly.
@@ -56,7 +56,7 @@ class TestFirstBook(DatabaseTest):
             FirstBookAuthenticationAPI.SECRET_KEY : "the_key",
         }
         api = FirstBookAuthenticationAPI.from_config(
-            self._default_library, config
+            self._default_library.id, config
         )
         eq_('http://example.com/?foo=bar&key=the_key', api.root)
         

--- a/tests/test_firstbook.py
+++ b/tests/test_firstbook.py
@@ -22,9 +22,13 @@ from api.circulation_exceptions import (
     RemoteInitiatedServerError
 )
 
-class TestFirstBook(object):
+from . import DatabaseTest
+
+
+class TestFirstBook(DatabaseTest):
     
     def setup(self):
+        super(TestFirstBook, self).setup()
         self.api = MockFirstBookAuthenticationAPI(dict(ABCD="1234"))
 
     def test_from_config(self):
@@ -33,7 +37,9 @@ class TestFirstBook(object):
             Configuration.URL : "http://example.com/",
             FirstBookAuthenticationAPI.SECRET_KEY : "the_key",
         }
-        api = FirstBookAuthenticationAPI.from_config(config)
+        api = FirstBookAuthenticationAPI.from_config(
+            self._default_library, config
+        )
 
         # Verify that the configuration details were stored properly.
         eq_('http://example.com/?key=the_key', api.root)
@@ -49,7 +55,9 @@ class TestFirstBook(object):
             Configuration.URL : "http://example.com/?foo=bar",
             FirstBookAuthenticationAPI.SECRET_KEY : "the_key",
         }
-        api = FirstBookAuthenticationAPI.from_config(config)
+        api = FirstBookAuthenticationAPI.from_config(
+            self._default_library, config
+        )
         eq_('http://example.com/?foo=bar&key=the_key', api.root)
         
     def test_authentication_success(self):

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -22,8 +22,8 @@ class MockResponse(object):
 
 class MockAPI(MilleniumPatronAPI):
 
-    def __init__(self, library, url="http://test-url/", *args, **kwargs):
-        super(MockAPI, self).__init__(library, url, *args, **kwargs)
+    def __init__(self, library_id, url="http://test-url/", *args, **kwargs):
+        super(MockAPI, self).__init__(library_id, url, *args, **kwargs)
         self.queue = []
         self.requests_made = []
         
@@ -46,7 +46,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
     def setup(self):
         super(TestMilleniumPatronAPI, self).setup()
         self.api = MockAPI(
-            self._default_library, identifier_regular_expression=None
+            self._default_library.id, identifier_regular_expression=None
         )
 
     def test_from_config(self):
@@ -55,7 +55,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
             Configuration.URL : "http://example.com",
             Configuration.AUTHORIZATION_IDENTIFIER_BLACKLIST : ["a", "b"],
         }
-        api = MilleniumPatronAPI.from_config(self._default_library, config)
+        api = MilleniumPatronAPI.from_config(self._default_library.id, config)
         eq_("http://example.com/", api.root)
         eq_(["a", "b"], [x.pattern for x in api.blacklist])
         
@@ -340,7 +340,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         eq_("SECOND_barcode", patrondata.authorization_identifier)
 
         api = MockAPI(
-            self._default_library, authorization_identifier_blacklist=["second"]
+            self._default_library.id, authorization_identifier_blacklist=["second"]
         )
         patrondata = api.patron_dump_to_patrondata('alice', content)
         eq_("FIRST_barcode", patrondata.authorization_identifier)
@@ -350,7 +350,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         because they're all blacklisted.
         """
         api = MockAPI(
-            self._default_library,
+            self._default_library.id,
             authorization_identifier_blacklist=["barcode"]
         )
         content = api.sample_data("dump.two_barcodes.html")
@@ -366,7 +366,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         config = {
             Configuration.URL : "http://example.com",
         }
-        api = MilleniumPatronAPI.from_config(self._default_library, config)
+        api = MilleniumPatronAPI.from_config(self._default_library.id, config)
         eq_(True, api.verify_certificate)
         
         # But we can turn it off.
@@ -374,13 +374,13 @@ class TestMilleniumPatronAPI(DatabaseTest):
             Configuration.URL : "http://example.com",
             MilleniumPatronAPI.VERIFY_CERTIFICATE : False,
         }
-        api = MilleniumPatronAPI.from_config(self._default_library, config)
+        api = MilleniumPatronAPI.from_config(self._default_library.id, config)
         eq_(False, api.verify_certificate)
 
         # Test that the value of verify_certificate becomes the
         # 'verify' argument when _modify_request_kwargs() is called.
         kwargs = dict(verify=False)
-        api = MockAPI(self._default_library, verify_certificate = "yes please")
+        api = MockAPI(self._default_library.id, verify_certificate = "yes please")
         api._update_request_kwargs(kwargs)
         eq_("yes please", kwargs['verify'])
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -68,12 +68,12 @@ class TestServiceStatusMonitor(DatabaseTest):
     def mock_auth(self):
         library = self._default_library
         provider = MockAuthenticationProvider(
-            library,
+            library.id,
             patrons={"user": "pass"},
             test_username="user",
             test_password="pass",
         )
-        return Authenticator(library, provider)
+        return Authenticator(self._db, library, provider)
 
     def test_test_patron(self):
         """Verify that test_patron() returns credentials determined

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -68,6 +68,7 @@ class TestServiceStatusMonitor(DatabaseTest):
     def mock_auth(self):
         library = self._default_library
         provider = MockAuthenticationProvider(
+            library,
             patrons={"user": "pass"},
             test_username="user",
             test_password="pass",


### PR DESCRIPTION
This branch ensures that AuthenticationProviders are always created in the context of a particular Library--the library whose patrons they are authenticating.

The majority of this work is changing all the AuthenticationProviders to take a library_id in their constructors, and then changing all the constructor calls in tests. We take a library_id instead of a Library because these objects are going to be instantiated in the context of a scoped session and used across requests. We can't store any data model objects inside them.

I'm a little concerned about performance implications--this might add an extra database lookup on every request, or even more than one--but data integrity is more important. We can profile the completed system and find the problems.

This is for https://github.com/NYPL-Simplified/circulation/issues/487.