### PR TITLE
Made posting an annotation return the created or modified annotation.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -823,7 +823,11 @@ class AnnotationController(CirculationManagerController):
         if isinstance(annotation, ProblemDetail):
             return annotation
 
-        return Response(status=200, headers=headers)
+        content = json.dumps(AnnotationWriter.detail(annotation))
+        status_code = 200
+        headers['Link'] = '<http://www.w3.org/ns/ldp#Resource>; rel="type"'
+        headers['Content-Type'] = AnnotationWriter.CONTENT_TYPE
+        return Response(content, status_code, headers)
 
     def container_for_work(self, identifier_type, identifier):
         id_obj, ignore = Identifier.for_foreign_id(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1131,6 +1131,11 @@ class TestAnnotationController(CirculationControllerTest):
             selector = json.loads(annotation.target).get("http://www.w3.org/ns/oa#hasSelector")[0].get('@id')
             eq_(data['target']['selector'], selector)
 
+            # The response contains the annotation in the db.
+            item = json.loads(response.data)
+            assert str(annotation.id) in item['id']
+            eq_(annotation.motivation, item['motivation'])
+
     def test_detail(self):
         self.pool.loan_to(self.default_patron)
 


### PR DESCRIPTION
Aferdita wanted this so she could get the id of a newly created annotation without having to sync all of them.