### PR TITLE
Library short name in urls

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -211,11 +211,11 @@ class WorkController(CirculationManagerController):
         This includes relevant links for editing the book.
         """
 
-        work = self.load_work(self.library, identifier_type, identifier)
+        work = self.load_work(flask.request.library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
-        annotator = AdminAnnotator(self.circulation)
+        annotator = AdminAnnotator(self.circulation, flask.request.library)
         return entry_response(
             AcquisitionFeed.single_entry(self._db, work, annotator)
         )
@@ -224,7 +224,7 @@ class WorkController(CirculationManagerController):
         """Return detailed complaint information for admins."""
         
         
-        work = self.load_work(self.library, identifier_type, identifier)
+        work = self.load_work(flask.request.library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -242,7 +242,7 @@ class WorkController(CirculationManagerController):
     def edit(self, identifier_type, identifier):
         """Edit a work's metadata."""
 
-        work = self.load_work(self.library, identifier_type, identifier)
+        work = self.load_work(flask.request.library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -325,7 +325,7 @@ class WorkController(CirculationManagerController):
     def suppress(self, identifier_type, identifier):
         """Suppress the license pool associated with a book."""
         # Turn source + identifier into a LicensePool
-        pools = self.load_licensepools(self.library, identifier_type, identifier)
+        pools = self.load_licensepools(flask.request.library, identifier_type, identifier)
         if isinstance(pools, ProblemDetail):
             # Something went wrong.
             return pools
@@ -345,7 +345,7 @@ class WorkController(CirculationManagerController):
         LicensePoool.
         """
         # Turn source + identifier into a group of LicensePools
-        pools = self.load_licensepools(self.library, identifier_type, identifier)
+        pools = self.load_licensepools(flask.request.library, identifier_type, identifier)
         if isinstance(pools, ProblemDetail):
             # Something went wrong.
             return pools
@@ -360,7 +360,7 @@ class WorkController(CirculationManagerController):
         if not provider:
             provider = MetadataWranglerCoverageProvider(self._db)
 
-        work = self.load_work(self.library, identifier_type, identifier)
+        work = self.load_work(flask.request.library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -386,7 +386,7 @@ class WorkController(CirculationManagerController):
     def resolve_complaints(self, identifier_type, identifier):
         """Resolve all complaints for a particular license pool and complaint type."""
 
-        work = self.load_work(self.library, identifier_type, identifier)
+        work = self.load_work(flask.request.library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -411,7 +411,7 @@ class WorkController(CirculationManagerController):
     def classifications(self, identifier_type, identifier):
         """Return list of this work's classifications."""
 
-        work = self.load_work(self.library, identifier_type, identifier)
+        work = self.load_work(flask.request.library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -444,7 +444,7 @@ class WorkController(CirculationManagerController):
     def edit_classifications(self, identifier_type, identifier):
         """Edit a work's audience, target age, fiction status, and genres."""
         
-        work = self.load_work(self.library, identifier_type, identifier)
+        work = self.load_work(flask.request.library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -608,7 +608,7 @@ class FeedController(CirculationManagerController):
 
     def complaints(self):
         this_url = self.url_for('complaints')
-        annotator = AdminAnnotator(self.circulation)
+        annotator = AdminAnnotator(self.circulation, flask.request.library)
         pagination = load_pagination_from_request()
         if isinstance(pagination, ProblemDetail):
             return pagination
@@ -621,7 +621,7 @@ class FeedController(CirculationManagerController):
 
     def suppressed(self):
         this_url = self.url_for('suppressed')
-        annotator = AdminAnnotator(self.circulation)
+        annotator = AdminAnnotator(self.circulation, flask.request.library)
         pagination = load_pagination_from_request()
         if isinstance(pagination, ProblemDetail):
             return pagination
@@ -765,7 +765,7 @@ class DashboardController(CirculationManagerController):
         )
 
     def circulation_events(self):
-        annotator = AdminAnnotator(self.circulation)
+        annotator = AdminAnnotator(self.circulation, flask.request.library)
         num = min(int(flask.request.args.get("num", "100")), 500)
 
         results = self._db.query(CirculationEvent) \
@@ -884,7 +884,8 @@ class SettingsController(CirculationManagerController):
         else:
             library, is_new = get_one_or_create(
                 self._db, Library, create_method_kwargs=dict(
-                    uuid=str(uuid.uuid4())
+                    uuid=str(uuid.uuid4()),
+                    short_name=short_name,
                 )
             )
 

--- a/api/admin/opds.py
+++ b/api/admin/opds.py
@@ -7,8 +7,8 @@ from core.opds import AcquisitionFeed
 
 class AdminAnnotator(CirculationManagerAnnotator):
 
-    def __init__(self, circulation, test_mode=False):
-        super(AdminAnnotator, self).__init__(circulation, None, test_mode=test_mode)
+    def __init__(self, circulation, library, test_mode=False):
+        super(AdminAnnotator, self).__init__(circulation, None, library, test_mode=test_mode)
         self.opds_cache_field = None
 
     def annotate_work_entry(self, work, active_license_pool, edition, identifier, feed, entry):

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -82,7 +82,8 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
         """Generate the Link Template that explains how to deregister
         a specific DRM device ID.
         """
-        url = url_for("adobe_drm_device", device_id="{id}", _external=True)
+        library = flask.request.library
+        url = url_for("adobe_drm_device", library_short_name=library.short_name, device_id="{id}", _external=True)
         # The curly brackets in {id} were escaped. Un-escape them to
         # get a Link Template.
         url = url.replace("%7Bid%7D", "{id}")

--- a/api/annotations.py
+++ b/api/annotations.py
@@ -59,9 +59,10 @@ class AnnotationWriter(object):
             url = url_for('annotations_for_work',
                           identifier_type=identifier.type,
                           identifier=identifier.identifier,
+                          library_short_name=patron.library.short_name,
                           _external=True)
         else:
-            url = url_for("annotations", _external=True)
+            url = url_for("annotations", library_short_name=patron.library.short_name, _external=True)
         annotations = cls.annotations_for(patron, identifier=identifier)
 
         latest_timestamp = None
@@ -85,9 +86,10 @@ class AnnotationWriter(object):
             url = url_for('annotations_for_work',
                           identifier_type=identifier.type,
                           identifier=identifier.identifier,
+                          library_short_name=patron.library.short_name,
                           _external=True)
         else:
-            url = url_for("annotations", _external=True)
+            url = url_for("annotations", library_short_name=patron.library.short_name, _external=True)
         annotations = cls.annotations_for(patron, identifier=identifier)
         details = [cls.detail(annotation, with_context=with_context) for annotation in annotations]
 
@@ -104,7 +106,9 @@ class AnnotationWriter(object):
         item = dict()
         if with_context:
             item["@context"] = cls.JSONLD_CONTEXT
-        item["id"] = url_for("annotation_detail", annotation_id=annotation.id, _external=True)
+        item["id"] = url_for("annotation_detail", annotation_id=annotation.id,
+                             library_short_name=annotation.patron.library.short_name,
+                             _external=True)
         item["type"] = "Annotation"
         item["motivation"] = annotation.motivation
         item["body"] = annotation.content

--- a/api/app.py
+++ b/api/app.py
@@ -29,6 +29,19 @@ app.config['BABEL_DEFAULT_LOCALE'] = LanguageCodes.three_to_two[Configuration.lo
 app.config['BABEL_TRANSLATION_DIRECTORIES'] = "../translations"
 babel = Babel(app)
 
+url = Configuration.integration_url(
+    Configuration.CIRCULATION_MANAGER_INTEGRATION, required=True)
+scheme, netloc, path, parameters, query, fragment = urlparse.urlparse(url)
+if ':' in netloc:
+    host, port = netloc.split(':')
+    port = int(port)
+else:
+    host = netloc
+    port = 80
+
+# Required for subdomain support.
+app.config['SERVER_NAME'] = netloc
+
 import routes
 if Configuration.get(Configuration.INCLUDE_ADMIN_INTERFACE):
     import admin.routes
@@ -40,15 +53,6 @@ app.debug = debug
 
 def run():
     debug = True
-    url = Configuration.integration_url(
-        Configuration.CIRCULATION_MANAGER_INTEGRATION, required=True)
-    scheme, netloc, path, parameters, query, fragment = urlparse.urlparse(url)
-    if ':' in netloc:
-        host, port = netloc.split(':')
-        port = int(port)
-    else:
-        host = netloc
-        port = 80
 
     # Workaround for a "Resource temporarily unavailable" error when
     # running in debug mode with the global socket timeout set by isbnlib

--- a/api/app.py
+++ b/api/app.py
@@ -29,19 +29,6 @@ app.config['BABEL_DEFAULT_LOCALE'] = LanguageCodes.three_to_two[Configuration.lo
 app.config['BABEL_TRANSLATION_DIRECTORIES'] = "../translations"
 babel = Babel(app)
 
-url = Configuration.integration_url(
-    Configuration.CIRCULATION_MANAGER_INTEGRATION, required=True)
-scheme, netloc, path, parameters, query, fragment = urlparse.urlparse(url)
-if ':' in netloc:
-    host, port = netloc.split(':')
-    port = int(port)
-else:
-    host = netloc
-    port = 80
-
-# Required for subdomain support.
-app.config['SERVER_NAME'] = netloc
-
 import routes
 if Configuration.get(Configuration.INCLUDE_ADMIN_INTERFACE):
     import admin.routes
@@ -52,6 +39,19 @@ app.config['DEBUG'] = debug
 app.debug = debug
 
 def run():
+    url = Configuration.integration_url(
+        Configuration.CIRCULATION_MANAGER_INTEGRATION, required=True)
+    scheme, netloc, path, parameters, query, fragment = urlparse.urlparse(url)
+    if ':' in netloc:
+        host, port = netloc.split(':')
+        port = int(port)
+    else:
+        host = netloc
+        port = 80
+
+    # Required for subdomain support.
+    app.config['SERVER_NAME'] = netloc
+
     debug = True
 
     # Workaround for a "Resource temporarily unavailable" error when

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -335,23 +335,48 @@ class PatronData(object):
         self.authorization_identifiers = authorization_identifiers
 
 class Authenticator(object):
+    """Route requests to the appropriate LibraryAuthenticator.
+    """
+
+    def __init__(self, _db):
+        self.library_authenticators = {}
+
+        for library in _db.query(Library):
+            self.library_authenticators[library.short_name] = LibraryAuthenticator.from_config(_db, library)
+
+    def authenticated_patron(self, _db, header):
+        short_name = flask.request.library.short_name
+        if short_name not in self.library_authenticators:
+            return LIBRARY_NOT_FOUND
+        return self.library_authenticators[short_name].authenticated_patron(_db, header)
+
+    def create_authentication_document(self):
+        short_name = flask.request.library.short_name
+        if short_name not in self.library_authenticators:
+            return LIBRARY_NOT_FOUND
+        return self.library_authenticators[short_name].create_authentication_document()
+
+    def create_authentication_headers(self):
+        short_name = flask.request.library.short_name
+        if short_name not in self.library_authenticators:
+            return LIBRARY_NOT_FOUND
+        return self.library_authenticators[short_name].create_authentication_headers()
+
+    def get_credential_from_header(self, header):
+        short_name = flask.request.library.short_name
+        if short_name not in self.library_authenticators:
+            return LIBRARY_NOT_FOUND
+        return self.library_authenticators[short_name].get_credential_from_header(header)
+
+class LibraryAuthenticator(object):
     """Use the registered AuthenticationProviders to turn incoming
     credentials into Patron objects.
     """    
 
     @classmethod
-    def from_config(cls, _db):
+    def from_config(cls, _db, library):
         """Initialize an Authenticator from site configuration.
         """
-        # TODO: This needs to change to get _all_ libraries
-        # and instantiate an Authenticator for each, or else
-        # a single Authenticator that can handle all of them.
-        library = Library.instance(_db)
-        
-        # Commit just in case this is the first time the Library has
-        # ever been loaded.
-        _db.commit()
-        
         authentication_policy = Configuration.policy("authentication")
         if not authentication_policy:
             raise CannotLoadConfiguration(
@@ -402,14 +427,13 @@ class Authenticator(object):
     def __init__(self, _db, library, basic_auth_provider=None,
                  oauth_providers=None,
                  bearer_token_signing_secret=None):
-        """Initialize an Authenticator from a list of AuthenticationProviders.
+        """Initialize a LibraryAuthenticator from a list of AuthenticationProviders.
 
         :param _db: A database session (probably a scoped session, which is
             why we can't derive it from `library`)
 
-        :param library: The Library to which this Authenticator guards
-        access. TODO: This paramater will disappear if we decide that
-        an Authenticator guards access to _all_ libraries.
+        :param library: The Library to which this LibraryAuthenticator guards
+        access.
 
         :param basic_auth_provider: The AuthenticatonProvider that handles
         HTTP Basic Auth requests.
@@ -434,7 +458,7 @@ class Authenticator(object):
         self.assert_ready_for_oauth()
         
     def assert_ready_for_oauth(self):
-        """If this Authenticator has OAuth providers, ensure that it
+        """If this LibraryAuthenticator has OAuth providers, ensure that it
         also has a secret it can use to sign bearer tokens.
         """
         if self.oauth_providers_by_name and not self.bearer_token_signing_secret:
@@ -621,11 +645,6 @@ class Authenticator(object):
         """
         base_opds_document = Configuration.base_opds_authentication_document()
 
-        circulation_manager_url = Configuration.integration_url(
-            Configuration.CIRCULATION_MANAGER_INTEGRATION, required=True)
-        scheme, netloc, path, parameters, query, fragment = (
-            urlparse.urlparse(circulation_manager_url))
-
         links = {}
         for rel, value in (
                 ("terms-of-service", Configuration.terms_of_service_url()),
@@ -639,7 +658,7 @@ class Authenticator(object):
 
         library_name = self.library_name or unicode(_("Library"))
         doc = OPDSAuthenticationDocument.fill_in(
-            base_opds_document, list(self.providers),
+            base_opds_document, list(self.providers), self._db,
             name=library_name, id=self.library_uuid, links=links,
         )
         return json.dumps(doc)
@@ -769,7 +788,7 @@ class AuthenticationProvider(object):
             patron_or_patrondata
         )       
     
-    def authentication_provider_document(self):
+    def authentication_provider_document(self, _db):
         """Create a stanza for use in an Authentication for OPDS document.
 
         :return: A dictionary that can be associated with the
@@ -1071,8 +1090,7 @@ class BasicAuthenticationProvider(AuthenticationProvider):
     def authentication_header(self):
         return 'Basic realm="%s"' % self.AUTHENTICATION_REALM
     
-    @property
-    def authentication_provider_document(self):
+    def authentication_provider_document(self, _db):
         """Create a stanza for use in an Authentication for OPDS document.
 
         Example:
@@ -1215,7 +1233,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
         """
         return None
 
-    def external_authenticate_url(self, state):
+    def external_authenticate_url(self, state, _db):
         """Generate the URL provided by the OAuth provider which will present
         the patron with a login form.
 
@@ -1223,18 +1241,19 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
         callback.
         """
         template = self.EXTERNAL_AUTHENTICATE_URL
-        arguments = self.external_authenticate_url_parameters(state)
+        arguments = self.external_authenticate_url_parameters(state, _db)
         return template % arguments
 
-    def external_authenticate_url_parameters(self, state):
+    def external_authenticate_url_parameters(self, state, _db):
         """Arguments used to fill in the template EXTERNAL_AUTHENTICATE_URL.
         """
+        library_short_name = self.library(_db).short_name
         return dict(
             client_id=self.client_id,
             state=state,
             # When the patron finishes logging in to the OAuth provider,
             # we want them to send the patron to this URL.
-            oauth_callback_url=OAuthController.oauth_authentication_callback_url()
+            oauth_callback_url=OAuthController.oauth_authentication_callback_url(library_short_name)
         )
 
 
@@ -1261,7 +1280,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
         # Ask the OAuth provider to verify the code that was passed
         # in.  This will give us an access token we can use to look up
         # detailed patron information.
-        token = self.remote_exchange_code_for_access_token(code)
+        token = self.remote_exchange_code_for_access_token(_db, code)
         if isinstance(token, ProblemDetail):
             return token
         
@@ -1280,7 +1299,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
         credential, is_new = self.create_token(_db, patron, token)
         return credential, patron, patrondata
 
-    def remote_exchange_authorization_code_for_access_token(self, code):
+    def remote_exchange_authorization_code_for_access_token(self, _db, code):
         """Ask the OAuth provider to convert a code (passed in to the OAuth
         callback) into a bearer token.
 
@@ -1302,16 +1321,15 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
         """
         raise NotImplementedError()
     
-    def _internal_authenticate_url(self):
+    def _internal_authenticate_url(self, _db):
         """A patron who wants to log in should hit this URL on the circulation
         manager. They'll be redirected to the OAuth provider, which will 
         take care of it.
         """
         return url_for('oauth_authenticate', _external=True,
-                       provider=self.NAME)
+                       provider=self.NAME, library_short_name=self.library(_db).short_name)
 
-    @property
-    def authentication_provider_document(self):
+    def authentication_provider_document(self, _db):
         """Create a stanza for use in an Authentication for OPDS document.
 
         Example:
@@ -1325,7 +1343,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
             }
         }
         """
-        method_doc = dict(links=dict(authenticate=self._internal_authenticate_url()))
+        method_doc = dict(links=dict(authenticate=self._internal_authenticate_url(_db)))
         methods = {}
         methods[self.METHOD] = method_doc
         return dict(name=self.NAME, methods=methods)
@@ -1346,7 +1364,7 @@ class OAuthController(object):
         self.authenticator = authenticator
 
     @classmethod
-    def oauth_authentication_callback_url(cls):
+    def oauth_authentication_callback_url(cls, library_short_name):
         """The URL to the oauth_authentication_callback controller.
 
         This is its own method because sometimes an
@@ -1354,9 +1372,9 @@ class OAuthController(object):
         provider to demonstrate that it knows which URL a patron was
         redirected to.
         """
-        return url_for('oauth_callback', _external=True)
+        return url_for('oauth_callback', library_short_name=library_short_name, _external=True)
         
-    def oauth_authentication_redirect(self, params):
+    def oauth_authentication_redirect(self, params, _db):
         """Redirect an unauthenticated patron to the authentication URL of the
         appropriate OAuth provider.
 
@@ -1374,7 +1392,7 @@ class OAuthController(object):
         )
         state = json.dumps(state)
         state = urllib.quote(state)
-        return redirect(provider.external_authenticate_url(state))
+        return redirect(provider.external_authenticate_url(state, _db))
 
     def oauth_authentication_callback(self, _db, params):
         """Create a Patron object and a bearer token for a patron who has just

--- a/api/base_controller.py
+++ b/api/base_controller.py
@@ -4,7 +4,7 @@ from core.util.problem_detail import ProblemDetail
 from circulation_exceptions import *
 from problem_details import *
 from flask.ext.babel import lazy_gettext as _
-from core.model import Library
+from core.model import Library, get_one
 
 class BaseCirculationManagerController(object):
     """Define minimal standards for a circulation manager controller,
@@ -19,16 +19,6 @@ class BaseCirculationManagerController(object):
         self.url_for = self.manager.url_for
         self.cdn_url_for = self.manager.cdn_url_for
 
-    @property
-    def library(self):
-        """Set flask.request.library.
-
-        TODO: This is a stopgap which will need to be modified once
-        we actually support more than one library.
-        """
-        flask.request.library = Library.instance(self._db)
-        return flask.request.library
-        
     def authorization_header(self):
         """Get the authentication header."""
 
@@ -85,9 +75,21 @@ class BaseCirculationManagerController(object):
 
     def authenticate(self):
         """Sends a 401 response that demands authentication."""
-        if not self.manager.opds_authentication_document:
-            self.manager.opds_authentication_document = self.manager.auth.create_authentication_document()
+        library_short_name = flask.request.library.short_name
+        if library_short_name not in self.manager.opds_authentication_documents:
+            self.manager.opds_authentication_documents[library_short_name] = self.manager.auth.create_authentication_document()
 
-        data = self.manager.opds_authentication_document
+        data = self.manager.opds_authentication_documents[library_short_name]
         headers = self.manager.auth.create_authentication_headers()
         return Response(data, 401, headers)
+
+    def library_from_request(self, library_short_name):
+        if library_short_name:
+            library = get_one(self._db, Library, short_name=library_short_name)
+        else:
+            library = Library.instance(self._db)
+        
+        if not library:
+            return LIBRARY_NOT_FOUND
+        flask.request.library = library
+        return library

--- a/api/base_controller.py
+++ b/api/base_controller.py
@@ -83,7 +83,7 @@ class BaseCirculationManagerController(object):
         headers = self.manager.auth.create_authentication_headers()
         return Response(data, 401, headers)
 
-    def library_from_request(self, library_short_name):
+    def library_for_request(self, library_short_name):
         if library_short_name:
             library = get_one(self._db, Library, short_name=library_short_name)
         else:

--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -4,7 +4,6 @@ import base64
 import json
 import os
 import datetime
-from flask import url_for
 from flask.ext.babel import lazy_gettext as _
 
 from core.util.problem_detail import ProblemDetail
@@ -93,7 +92,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
         # Ask the OAuth provider to verify the code that was passed
         # in.  This will give us a bearer token we can use to look up
         # detailed patron information.
-        token = self.remote_exchange_code_for_bearer_token(code)
+        token = self.remote_exchange_code_for_bearer_token(_db, code)
         if isinstance(token, ProblemDetail):
             return token
         
@@ -113,7 +112,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
     # End implementations of OAuthAuthenticationProvider abstract
     # methods.
 
-    def remote_exchange_code_for_bearer_token(self, code):
+    def remote_exchange_code_for_bearer_token(self, _db, code):
         """Ask the OAuth provider to convert a code (passed in to the OAuth
         callback) into a bearer token.
 
@@ -127,7 +126,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
         payload = dict(
             code=code,
             grant_type='authorization_code',
-            redirect_uri=OAuthController.oauth_authentication_callback_url()
+            redirect_uri=OAuthController.oauth_authentication_callback_url(_db)
         )
         authorization = base64.b64encode(
             self.client_id + ":" + self.client_secret

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -253,3 +253,10 @@ NO_ANNOTATION = pd(
     title=_("No annotation."),
     detail=_("The annotation you requested does not exist."),
 )
+
+LIBRARY_NOT_FOUND = pd(
+    "http://librarysimplified.org/terms/problem/library-not-found",
+    status_code=404,
+    title=_("Library not found."),
+    detail=_("The requested library short name does not exist."),
+)

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -258,5 +258,5 @@ LIBRARY_NOT_FOUND = pd(
     "http://librarysimplified.org/terms/problem/library-not-found",
     status_code=404,
     title=_("Library not found."),
-    detail=_("The requested library short name does not exist."),
+    detail=_("No library with the requested name on this server."),
 )

--- a/api/routes.py
+++ b/api/routes.py
@@ -210,6 +210,7 @@ def lane_search(languages, lane_name):
     return app.manager.opds_feeds.search(languages, lane_name)
 
 @library_route('/preload')
+@has_library
 @allows_patron_web()
 @returns_problem_detail
 def preload():

--- a/api/routes.py
+++ b/api/routes.py
@@ -118,9 +118,41 @@ h = ErrorHandler(app, app.config['DEBUG'])
 def exception_handler(exception):
     return h.handle(exception)
 
-def dir_route(path, *args, **kwargs):
-    """Decorator to create routes that work with or without a trailing slash."""
+def has_library(f):
+    """Decorator to extract the library short name from the arguments."""
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if 'library_short_name' in kwargs:
+            library_short_name = kwargs.pop("library_short_name")
+        else:
+            library_short_name = None
+        library = app.manager.index_controller.library_from_request(library_short_name)
+        if isinstance(library, ProblemDetail):
+            return library.response
+        else:
+            return f(*args, **kwargs)
+    return decorated
 
+def library_route(path, *args, **kwargs):
+    """Decorator to creates routes that have a library short name in either
+    a subdomain or a url path prefix. If not used with @has_library, the view function
+    must have a library_short_name argument.
+    """
+    def decorator(f):
+        # This sets up routes for both the subdomain and the url path prefix.
+        # The order of these determines which one will be used by url_for -
+        # in this case it's the prefix route.
+        # We may want to have a configuration option to specify whether to
+        # use a subdomain or a url path prefix.
+        prefix_route = app.route("/<library_short_name>" + path, *args, **kwargs)(f)
+        subdomain_route = app.route(path, subdomain="<library_short_name>", *args, **kwargs)(prefix_route)
+        default_library_route = app.route(path, *args, **kwargs)(subdomain_route)
+        return default_library_route
+    return decorator
+
+def library_dir_route(path, *args, **kwargs):
+    """Decorator to create library routes that work with or without a
+    trailing slash."""
     if path.endswith("/"):
         path_without_slash = path[:-1]
     else:
@@ -133,169 +165,195 @@ def dir_route(path, *args, **kwargs):
         # This is important for CORS because the redirects are not processed
         # by the CORS decorator and won't be valid CORS responses.
 
-        # Decorate f with two routes, with and without the slash.
-        g = app.route(path_without_slash + "/", strict_slashes=False, *args, **kwargs)(f)
-        h = app.route(path_without_slash, *args, **kwargs)(g)
-        return h
+        # Decorate f with four routes, with and without the slash, with a prefix or subdomain
+        prefix_slash = app.route("/<library_short_name>" + path_without_slash + "/", strict_slashes=False, *args, **kwargs)(f)
+        prefix_no_slash = app.route("/<library_short_name>" + path_without_slash, *args, **kwargs)(prefix_slash)
+        subdomain_slash = app.route(path_without_slash + "/", strict_slashes=False, subdomain="<library_short_name>", *args, **kwargs)(prefix_no_slash)
+        subdomain_no_slash = app.route(path_without_slash, subdomain="<library_short_name>", *args, **kwargs)(subdomain_slash)
+        default_library_slash = app.route(path_without_slash, *args, **kwargs)(subdomain_no_slash)
+        default_library_no_slash = app.route(path_without_slash + "/", *args, **kwargs)(default_library_slash)
+        return default_library_no_slash
     return decorator
 
-@app.route('/')
+@library_route("/")
+@has_library
 @allows_patron_web()
 @returns_problem_detail
 def index():
     return app.manager.index_controller()
 
-@dir_route('/groups', defaults=dict(lane_name=None, languages=None))
-@dir_route('/groups/<languages>', defaults=dict(lane_name=None))
-@app.route('/groups/<languages>/<lane_name>')
+@library_dir_route('/groups', defaults=dict(lane_name=None, languages=None))
+@library_dir_route('/groups/<languages>', defaults=dict(lane_name=None))
+@library_route('/groups/<languages>/<lane_name>')
+@has_library
 @allows_patron_web()
 @returns_problem_detail
 def acquisition_groups(languages, lane_name):
     return app.manager.opds_feeds.groups(languages, lane_name)
 
-@dir_route('/feed', defaults=dict(lane_name=None, languages=None))
-@dir_route('/feed/<languages>', defaults=dict(lane_name=None))
-@app.route('/feed/<languages>/<lane_name>')
+@library_dir_route('/feed', defaults=dict(lane_name=None, languages=None))
+@library_dir_route('/feed/<languages>', defaults=dict(lane_name=None))
+@library_route('/feed/<languages>/<lane_name>')
+@has_library
 @allows_patron_web()
 @returns_problem_detail
 def feed(languages, lane_name):
     return app.manager.opds_feeds.feed(languages, lane_name)
 
-@dir_route('/search', defaults=dict(lane_name=None, languages=None))
-@dir_route('/search/<languages>', defaults=dict(lane_name=None))
-@app.route('/search/<languages>/<lane_name>')
+@library_dir_route('/search', defaults=dict(lane_name=None, languages=None))
+@library_dir_route('/search/<languages>', defaults=dict(lane_name=None))
+@library_route('/search/<languages>/<lane_name>')
+@has_library
 @allows_patron_web()
 @returns_problem_detail
 def lane_search(languages, lane_name):
     return app.manager.opds_feeds.search(languages, lane_name)
 
-@app.route('/preload')
+@library_route('/preload')
 @allows_patron_web()
 @returns_problem_detail
 def preload():
     return app.manager.opds_feeds.preload()
 
-@dir_route('/patrons/me', methods=['GET', 'PUT'])
+@library_dir_route('/patrons/me', methods=['GET', 'PUT'])
+@has_library
 @allows_patron_web()
 @requires_auth
 @returns_problem_detail
 def patron_profile():
     return app.manager.profiles.protocol()
 
-@dir_route('/loans', methods=['GET', 'HEAD'])
+@library_dir_route('/loans', methods=['GET', 'HEAD'])
+@has_library
 @allows_patron_web()
 @requires_auth
 @returns_problem_detail
 def active_loans():
     return app.manager.loans.sync()
 
-@app.route('/annotations/', methods=['HEAD', 'GET', 'POST'])
+@library_route('/annotations/', methods=['HEAD', 'GET', 'POST'])
+@has_library
 @allows_patron_web()
 @requires_auth
 @returns_problem_detail
 def annotations():
     return app.manager.annotations.container()
 
-@app.route('/annotations/<annotation_id>', methods=['HEAD', 'GET', 'DELETE'])
+@library_route('/annotations/<annotation_id>', methods=['HEAD', 'GET', 'DELETE'])
+@has_library
 @allows_patron_web()
 @requires_auth
 @returns_problem_detail
 def annotation_detail(annotation_id):
     return app.manager.annotations.detail(annotation_id)
 
-@app.route('/annotations/<identifier_type>/<path:identifier>/', methods=['GET'])
+@library_route('/annotations/<identifier_type>/<path:identifier>/', methods=['GET'])
+@has_library
 @allows_patron_web()
 @requires_auth
 @returns_problem_detail
 def annotations_for_work(identifier_type, identifier):
     return app.manager.annotations.container_for_work(identifier_type, identifier)
 
-@app.route('/works/<identifier_type>/<path:identifier>/borrow', methods=['GET', 'PUT'])
-@app.route('/works/<identifier_type>/<path:identifier>/borrow/<mechanism_id>', 
+@library_route('/works/<identifier_type>/<path:identifier>/borrow', methods=['GET', 'PUT'])
+@library_route('/works/<identifier_type>/<path:identifier>/borrow/<mechanism_id>', 
            methods=['GET', 'PUT'])
+@has_library
 @allows_patron_web()
 @requires_auth
 @returns_problem_detail
 def borrow(identifier_type, identifier, mechanism_id=None):
     return app.manager.loans.borrow(identifier_type, identifier, mechanism_id)
 
-@app.route('/works/<license_pool_id>/fulfill')
-@app.route('/works/<license_pool_id>/fulfill/<mechanism_id>')
+@library_route('/works/<license_pool_id>/fulfill')
+@library_route('/works/<license_pool_id>/fulfill/<mechanism_id>')
+@has_library
 @allows_patron_web()
 @requires_auth
 @returns_problem_detail
 def fulfill(license_pool_id, mechanism_id=None):
     return app.manager.loans.fulfill(license_pool_id, mechanism_id)
 
-@app.route('/loans/<license_pool_id>/revoke', methods=['GET', 'PUT'])
+@library_route('/loans/<license_pool_id>/revoke', methods=['GET', 'PUT'])
+@has_library
 @allows_patron_web()
 @requires_auth
 @returns_problem_detail
 def revoke_loan_or_hold(license_pool_id):
     return app.manager.loans.revoke(license_pool_id)
 
-@app.route('/loans/<identifier_type>/<path:identifier>', methods=['GET', 'DELETE'])
+@library_route('/loans/<identifier_type>/<path:identifier>', methods=['GET', 'DELETE'])
+@has_library
 @allows_patron_web()
 @requires_auth
 @returns_problem_detail
 def loan_or_hold_detail(identifier_type, identifier):
     return app.manager.loans.detail(identifier_type, identifier)
 
-@dir_route('/works')
+@library_dir_route('/works')
+@has_library
 @allows_patron_web()
 @returns_problem_detail
 def work():
     annotator = CirculationManagerAnnotator(app.manager.circulation, None)
     return app.manager.urn_lookup.work_lookup(annotator, 'work')
 
-@dir_route('/works/contributor/<contributor_name>', defaults=dict(languages=None, audiences=None))
-@dir_route('/works/contributor/<contributor_name>/<languages>', defaults=dict(audiences=None))
-@app.route('/works/contributor/<contributor_name>/<languages>/<audiences>')
+@library_dir_route('/works/contributor/<contributor_name>', defaults=dict(languages=None, audiences=None))
+@library_dir_route('/works/contributor/<contributor_name>/<languages>', defaults=dict(audiences=None))
+@library_route('/works/contributor/<contributor_name>/<languages>/<audiences>')
+@has_library
 @allows_patron_web()
 @returns_problem_detail
 def contributor(contributor_name, languages, audiences):
     return app.manager.work_controller.contributor(contributor_name, languages, audiences)
 
-@dir_route('/works/series/<series_name>', defaults=dict(languages=None, audiences=None))
-@dir_route('/works/series/<series_name>/<languages>', defaults=dict(audiences=None))
-@app.route('/works/series/<series_name>/<languages>/<audiences>')
+@library_dir_route('/works/series/<series_name>', defaults=dict(languages=None, audiences=None))
+@library_dir_route('/works/series/<series_name>/<languages>', defaults=dict(audiences=None))
+@library_route('/works/series/<series_name>/<languages>/<audiences>')
+@has_library
 @allows_patron_web()
 @returns_problem_detail
 def series(series_name, languages, audiences):
     return app.manager.work_controller.series(series_name, languages, audiences)
 
-@app.route('/works/<identifier_type>/<path:identifier>')
+@library_route('/works/<identifier_type>/<path:identifier>')
+@has_library
 @allows_patron_web()
 @returns_problem_detail
 def permalink(identifier_type, identifier):
     return app.manager.work_controller.permalink(identifier_type, identifier)
 
-@app.route('/works/<identifier_type>/<path:identifier>/recommendations')
+@library_route('/works/<identifier_type>/<path:identifier>/recommendations')
+@has_library
 @allows_patron_web()
 @returns_problem_detail
 def recommendations(identifier_type, identifier):
     return app.manager.work_controller.recommendations(identifier_type, identifier)
 
-@app.route('/works/<identifier_type>/<path:identifier>/related_books')
+@library_route('/works/<identifier_type>/<path:identifier>/related_books')
+@has_library
 @allows_patron_web()
 @returns_problem_detail
 def related_books(identifier_type, identifier):
     return app.manager.work_controller.related(identifier_type, identifier)
 
-@app.route('/works/<identifier_type>/<path:identifier>/report', methods=['GET', 'POST'])
+@library_route('/works/<identifier_type>/<path:identifier>/report', methods=['GET', 'POST'])
+@has_library
 @allows_patron_web()
 @returns_problem_detail
 def report(identifier_type, identifier):
     return app.manager.work_controller.report(identifier_type, identifier)
 
-@app.route('/analytics/<identifier_type>/<path:identifier>/<event_type>')
+@library_route('/analytics/<identifier_type>/<path:identifier>/<event_type>')
+@has_library
 @allows_patron_web()
 @returns_problem_detail
 def track_analytics_event(identifier_type, identifier, event_type):
     return app.manager.analytics_controller.track_event(identifier_type, identifier, event_type)
 
 # Adobe Vendor ID implementation
-@app.route('/AdobeAuth/authdata')
+@library_route('/AdobeAuth/authdata')
+@has_library
 @requires_auth
 @returns_problem_detail
 def adobe_vendor_id_get_token():
@@ -317,26 +375,30 @@ def adobe_vendor_id_status():
     return app.manager.adobe_vendor_id.status_handler()
 
 # DRM Device Management Protocol implementation for ACS.
-@app.route('/AdobeAuth/devices', methods=['GET', 'POST'])
+@library_route('/AdobeAuth/devices', methods=['GET', 'POST'])
+@has_library
 @requires_auth
 @returns_problem_detail
 def adobe_drm_devices():
     return app.manager.adobe_device_management.device_id_list_handler()
 
-@app.route('/AdobeAuth/devices/<device_id>', methods=['DELETE'])
+@library_route('/AdobeAuth/devices/<device_id>', methods=['DELETE'])
+@has_library
 @requires_auth
 @returns_problem_detail
 def adobe_drm_device(device_id):
     return app.manager.adobe_device_management.device_id_handler(device_id)
     
 # Route that redirects to the authentication URL for an OAuth provider
-@app.route('/oauth_authenticate')
+@library_route('/oauth_authenticate')
+@has_library
 @returns_problem_detail
 def oauth_authenticate():
     return app.manager.oauth_controller.oauth_authentication_redirect(flask.request.args)
 
 # Redirect URI for OAuth providers, eg. Clever
-@app.route('/oauth_callback')
+@library_route('/oauth_callback')
+@has_library
 @returns_problem_detail
 def oauth_callback():
     return app.manager.oauth_controller.oauth_authentication_callback(app.manager._db, flask.request.args)

--- a/api/routes.py
+++ b/api/routes.py
@@ -126,7 +126,7 @@ def has_library(f):
             library_short_name = kwargs.pop("library_short_name")
         else:
             library_short_name = None
-        library = app.manager.index_controller.library_from_request(library_short_name)
+        library = app.manager.index_controller.library_for_request(library_short_name)
         if isinstance(library, ProblemDetail):
             return library.response
         else:

--- a/api/services.py
+++ b/api/services.py
@@ -11,7 +11,7 @@ from core.scripts import (
 from core.util.problem_detail import ProblemDetail
 
 from config import Configuration
-from authenticator import Authenticator
+from authenticator import LibraryAuthenticator
 from overdrive import OverdriveAPI
 from bibliotheca import BibliothecaAPI
 from axis import Axis360API
@@ -27,7 +27,7 @@ class ServiceStatus(object):
     def __init__(self, library, auth=None, api_map=None):
         self._db = Session.object_session(library)
         self.circulation = CirculationAPI(library, api_map)
-        self.auth = auth or Authenticator.from_config(self._db)
+        self.auth = auth or LibraryAuthenticator.from_config(self._db, library)
 
     @property
     def test_patron(self):

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -62,8 +62,7 @@ class TestWorkController(AdminControllerTest):
         [lp] = self.english_1.license_pools
 
         lp.suppressed = False
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             response = self.manager.admin_work_controller.details(
                 lp.identifier.type, lp.identifier.identifier
             )
@@ -79,8 +78,7 @@ class TestWorkController(AdminControllerTest):
             assert lp.identifier.identifier in suppress_links[0]
 
         lp.suppressed = True
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             response = self.manager.admin_work_controller.details(
                 lp.identifier.type, lp.identifier.identifier
             )
@@ -107,8 +105,7 @@ class TestWorkController(AdminControllerTest):
                 ) \
                 .count()
 
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             flask.request.form = ImmutableMultiDict([
                 ("title", "New title"),
                 ("subtitle", "New subtitle"),
@@ -132,8 +129,7 @@ class TestWorkController(AdminControllerTest):
             assert "&lt;p&gt;New summary&lt;/p&gt;" in self.english_1.simple_opds_entry
             eq_(1, staff_edition_count())
 
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             # Change the summary again
             flask.request.form = ImmutableMultiDict([
                 ("title", "New title"),
@@ -150,8 +146,7 @@ class TestWorkController(AdminControllerTest):
             assert 'New summary' not in self.english_1.simple_opds_entry
             eq_(1, staff_edition_count())
 
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             # Now delete the subtitle and series and summary entirely
             flask.request.form = ImmutableMultiDict([
                 ("title", "New title"),
@@ -174,8 +169,7 @@ class TestWorkController(AdminControllerTest):
             assert 'abcd' not in self.english_1.simple_opds_entry
             eq_(1, staff_edition_count())
 
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             # Set the fields one more time
             flask.request.form = ImmutableMultiDict([
                 ("title", "New title"),
@@ -198,8 +192,7 @@ class TestWorkController(AdminControllerTest):
             assert "&lt;p&gt;Final summary&lt;/p&gt;" in self.english_1.simple_opds_entry
             eq_(1, staff_edition_count())
 
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             # Set the series position to a non-numerical value
             flask.request.form = ImmutableMultiDict([
                 ("title", "New title"),
@@ -239,8 +232,7 @@ class TestWorkController(AdminControllerTest):
         work.genres = [genre1, genre2]
 
         # make no changes
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             flask.request.form = MultiDict([
                 ("audience", "Adult"),
                 ("fiction", "fiction"),
@@ -274,8 +266,7 @@ class TestWorkController(AdminControllerTest):
         eq_(True, work.fiction)
 
         # remove all genres
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             flask.request.form = MultiDict([
                 ("audience", "Adult"),
                 ("fiction", "fiction")
@@ -303,8 +294,7 @@ class TestWorkController(AdminControllerTest):
         eq_(True, work.fiction)
 
         # completely change genres
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             flask.request.form = MultiDict([
                 ("audience", "Adult"),
                 ("fiction", "fiction"),
@@ -326,8 +316,7 @@ class TestWorkController(AdminControllerTest):
         eq_(True, work.fiction)
 
         # remove some genres and change audience and target age
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             flask.request.form = MultiDict([
                 ("audience", "Young Adult"),
                 ("target_age_min", 16),
@@ -352,8 +341,7 @@ class TestWorkController(AdminControllerTest):
         previous_genres = new_genre_names
 
         # try to add a nonfiction genre
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             flask.request.form = MultiDict([
                 ("audience", "Young Adult"),
                 ("target_age_min", 16),
@@ -375,8 +363,7 @@ class TestWorkController(AdminControllerTest):
         eq_(True, work.fiction)
 
         # try to add Erotica
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             flask.request.form = MultiDict([
                 ("audience", "Young Adult"),
                 ("target_age_min", 16),
@@ -399,8 +386,7 @@ class TestWorkController(AdminControllerTest):
 
         # try to set min target age greater than max target age
         # othe edits should not go through
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             flask.request.form = MultiDict([
                 ("audience", "Young Adult"),
                 ("target_age_min", 16),
@@ -419,8 +405,7 @@ class TestWorkController(AdminControllerTest):
         eq_(True, work.fiction)        
 
         # change to nonfiction with nonfiction genres and new target age
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             flask.request.form = MultiDict([
                 ("audience", "Young Adult"),
                 ("target_age_min", 15),
@@ -441,8 +426,7 @@ class TestWorkController(AdminControllerTest):
         eq_(False, work.fiction)
 
         # set to Adult and make sure that target ages is set automatically
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             flask.request.form = MultiDict([
                 ("audience", "Adult"),
                 ("fiction", "nonfiction"),
@@ -460,8 +444,7 @@ class TestWorkController(AdminControllerTest):
     def test_suppress(self):
         [lp] = self.english_1.license_pools
 
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             response = self.manager.admin_work_controller.suppress(
                 lp.identifier.type, lp.identifier.identifier
             )
@@ -486,8 +469,7 @@ class TestWorkController(AdminControllerTest):
             "blah", "blah"
         )
 
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             response = self.manager.admin_work_controller.unsuppress(
                 lp.identifier.type, lp.identifier.identifier
             )
@@ -509,8 +491,7 @@ class TestWorkController(AdminControllerTest):
             DATA_SOURCE_NAME = wrangler.name
         failure_provider = NeverSuccessfulMetadataProvider(self._db)
 
-        with self.app.test_request_context('/'):
-            flask.request.library = self._default_library
+        with self.request_context_with_library('/'):
             [lp] = self.english_1.license_pools
             response = self.manager.admin_work_controller.refresh_metadata(
                 lp.identifier.type, lp.identifier.identifier, provider=success_provider
@@ -554,8 +535,7 @@ class TestWorkController(AdminControllerTest):
         SessionManager.refresh_materialized_views(self._db)
         [lp] = work.license_pools
 
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             response = self.manager.admin_work_controller.complaints(
                 lp.identifier.type, lp.identifier.identifier
             )
@@ -589,8 +569,7 @@ class TestWorkController(AdminControllerTest):
         [lp] = work.license_pools
 
         # first attempt to resolve complaints of the wrong type
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             flask.request.form = ImmutableMultiDict([("type", type2)])
             response = self.manager.admin_work_controller.resolve_complaints(
                 lp.identifier.type, lp.identifier.identifier
@@ -600,8 +579,7 @@ class TestWorkController(AdminControllerTest):
             eq_(len(unresolved_complaints), 2)
 
         # then attempt to resolve complaints of the correct type
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             flask.request.form = ImmutableMultiDict([("type", type1)])
             response = self.manager.admin_work_controller.resolve_complaints(
                 lp.identifier.type, lp.identifier.identifier
@@ -612,8 +590,7 @@ class TestWorkController(AdminControllerTest):
             eq_(len(unresolved_complaints), 0)
 
         # then attempt to resolve the already-resolved complaints of the correct type
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             flask.request.form = ImmutableMultiDict([("type", type1)])
             response = self.manager.admin_work_controller.resolve_complaints(
                 lp.identifier.type, lp.identifier.identifier
@@ -645,8 +622,7 @@ class TestWorkController(AdminControllerTest):
         SessionManager.refresh_materialized_views(self._db)
         [lp] = work.license_pools
 
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             response = self.manager.admin_work_controller.classifications(
                 lp.identifier.type, lp.identifier.identifier)
             eq_(response['book']['identifier_type'], lp.identifier.type)
@@ -797,8 +773,7 @@ class TestFeedController(AdminControllerTest):
             "complaint detail 3")
 
         SessionManager.refresh_materialized_views(self._db)
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             response = self.manager.admin_feed_controller.complaints()
             feed = feedparser.parse(response.data)
             entries = feed['entries']
@@ -812,8 +787,7 @@ class TestFeedController(AdminControllerTest):
         unsuppressed_work = self._work()
 
         SessionManager.refresh_materialized_views(self._db)
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             response = self.manager.admin_feed_controller.suppressed()
             feed = feedparser.parse(response.data)
             entries = feed['entries']
@@ -852,8 +826,7 @@ class TestDashboardController(AdminControllerTest):
                 foreign_patron_id=patron_id)
             time += timedelta(minutes=1)
 
-        with self.app.test_request_context("/"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/"):
             response = self.manager.admin_dashboard_controller.circulation_events()
             url = AdminAnnotator(self.manager.circulation, self._default_library).permalink_for(self.english_1, lp, lp.identifier)
 
@@ -864,8 +837,7 @@ class TestDashboardController(AdminControllerTest):
         eq_([patron_id]*len(types), [event['patron_id'] for event in events])
 
         # request fewer events
-        with self.app.test_request_context("/?num=2"):
-            flask.request.library = self._default_library
+        with self.request_context_with_library("/?num=2"):
             response = self.manager.admin_dashboard_controller.circulation_events()
             url = AdminAnnotator(self.manager.circulation, self._default_library).permalink_for(self.english_1, lp, lp.identifier)
 

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -63,6 +63,7 @@ class TestWorkController(AdminControllerTest):
 
         lp.suppressed = False
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             response = self.manager.admin_work_controller.details(
                 lp.identifier.type, lp.identifier.identifier
             )
@@ -79,6 +80,7 @@ class TestWorkController(AdminControllerTest):
 
         lp.suppressed = True
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             response = self.manager.admin_work_controller.details(
                 lp.identifier.type, lp.identifier.identifier
             )
@@ -106,6 +108,7 @@ class TestWorkController(AdminControllerTest):
                 .count()
 
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             flask.request.form = ImmutableMultiDict([
                 ("title", "New title"),
                 ("subtitle", "New subtitle"),
@@ -130,6 +133,7 @@ class TestWorkController(AdminControllerTest):
             eq_(1, staff_edition_count())
 
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             # Change the summary again
             flask.request.form = ImmutableMultiDict([
                 ("title", "New title"),
@@ -147,6 +151,7 @@ class TestWorkController(AdminControllerTest):
             eq_(1, staff_edition_count())
 
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             # Now delete the subtitle and series and summary entirely
             flask.request.form = ImmutableMultiDict([
                 ("title", "New title"),
@@ -170,6 +175,7 @@ class TestWorkController(AdminControllerTest):
             eq_(1, staff_edition_count())
 
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             # Set the fields one more time
             flask.request.form = ImmutableMultiDict([
                 ("title", "New title"),
@@ -193,6 +199,7 @@ class TestWorkController(AdminControllerTest):
             eq_(1, staff_edition_count())
 
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             # Set the series position to a non-numerical value
             flask.request.form = ImmutableMultiDict([
                 ("title", "New title"),
@@ -233,6 +240,7 @@ class TestWorkController(AdminControllerTest):
 
         # make no changes
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             flask.request.form = MultiDict([
                 ("audience", "Adult"),
                 ("fiction", "fiction"),
@@ -267,6 +275,7 @@ class TestWorkController(AdminControllerTest):
 
         # remove all genres
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             flask.request.form = MultiDict([
                 ("audience", "Adult"),
                 ("fiction", "fiction")
@@ -295,6 +304,7 @@ class TestWorkController(AdminControllerTest):
 
         # completely change genres
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             flask.request.form = MultiDict([
                 ("audience", "Adult"),
                 ("fiction", "fiction"),
@@ -317,6 +327,7 @@ class TestWorkController(AdminControllerTest):
 
         # remove some genres and change audience and target age
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             flask.request.form = MultiDict([
                 ("audience", "Young Adult"),
                 ("target_age_min", 16),
@@ -342,6 +353,7 @@ class TestWorkController(AdminControllerTest):
 
         # try to add a nonfiction genre
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             flask.request.form = MultiDict([
                 ("audience", "Young Adult"),
                 ("target_age_min", 16),
@@ -364,6 +376,7 @@ class TestWorkController(AdminControllerTest):
 
         # try to add Erotica
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             flask.request.form = MultiDict([
                 ("audience", "Young Adult"),
                 ("target_age_min", 16),
@@ -387,6 +400,7 @@ class TestWorkController(AdminControllerTest):
         # try to set min target age greater than max target age
         # othe edits should not go through
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             flask.request.form = MultiDict([
                 ("audience", "Young Adult"),
                 ("target_age_min", 16),
@@ -406,6 +420,7 @@ class TestWorkController(AdminControllerTest):
 
         # change to nonfiction with nonfiction genres and new target age
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             flask.request.form = MultiDict([
                 ("audience", "Young Adult"),
                 ("target_age_min", 15),
@@ -427,6 +442,7 @@ class TestWorkController(AdminControllerTest):
 
         # set to Adult and make sure that target ages is set automatically
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             flask.request.form = MultiDict([
                 ("audience", "Adult"),
                 ("fiction", "nonfiction"),
@@ -445,6 +461,7 @@ class TestWorkController(AdminControllerTest):
         [lp] = self.english_1.license_pools
 
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             response = self.manager.admin_work_controller.suppress(
                 lp.identifier.type, lp.identifier.identifier
             )
@@ -470,6 +487,7 @@ class TestWorkController(AdminControllerTest):
         )
 
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             response = self.manager.admin_work_controller.unsuppress(
                 lp.identifier.type, lp.identifier.identifier
             )
@@ -492,6 +510,7 @@ class TestWorkController(AdminControllerTest):
         failure_provider = NeverSuccessfulMetadataProvider(self._db)
 
         with self.app.test_request_context('/'):
+            flask.request.library = self._default_library
             [lp] = self.english_1.license_pools
             response = self.manager.admin_work_controller.refresh_metadata(
                 lp.identifier.type, lp.identifier.identifier, provider=success_provider
@@ -536,6 +555,7 @@ class TestWorkController(AdminControllerTest):
         [lp] = work.license_pools
 
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             response = self.manager.admin_work_controller.complaints(
                 lp.identifier.type, lp.identifier.identifier
             )
@@ -570,6 +590,7 @@ class TestWorkController(AdminControllerTest):
 
         # first attempt to resolve complaints of the wrong type
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             flask.request.form = ImmutableMultiDict([("type", type2)])
             response = self.manager.admin_work_controller.resolve_complaints(
                 lp.identifier.type, lp.identifier.identifier
@@ -580,6 +601,7 @@ class TestWorkController(AdminControllerTest):
 
         # then attempt to resolve complaints of the correct type
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             flask.request.form = ImmutableMultiDict([("type", type1)])
             response = self.manager.admin_work_controller.resolve_complaints(
                 lp.identifier.type, lp.identifier.identifier
@@ -591,6 +613,7 @@ class TestWorkController(AdminControllerTest):
 
         # then attempt to resolve the already-resolved complaints of the correct type
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             flask.request.form = ImmutableMultiDict([("type", type1)])
             response = self.manager.admin_work_controller.resolve_complaints(
                 lp.identifier.type, lp.identifier.identifier
@@ -623,6 +646,7 @@ class TestWorkController(AdminControllerTest):
         [lp] = work.license_pools
 
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             response = self.manager.admin_work_controller.classifications(
                 lp.identifier.type, lp.identifier.identifier)
             eq_(response['book']['identifier_type'], lp.identifier.type)
@@ -774,6 +798,7 @@ class TestFeedController(AdminControllerTest):
 
         SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             response = self.manager.admin_feed_controller.complaints()
             feed = feedparser.parse(response.data)
             entries = feed['entries']
@@ -788,6 +813,7 @@ class TestFeedController(AdminControllerTest):
 
         SessionManager.refresh_materialized_views(self._db)
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             response = self.manager.admin_feed_controller.suppressed()
             feed = feedparser.parse(response.data)
             entries = feed['entries']
@@ -827,8 +853,9 @@ class TestDashboardController(AdminControllerTest):
             time += timedelta(minutes=1)
 
         with self.app.test_request_context("/"):
+            flask.request.library = self._default_library
             response = self.manager.admin_dashboard_controller.circulation_events()
-            url = AdminAnnotator(self.manager.circulation).permalink_for(self.english_1, lp, lp.identifier)
+            url = AdminAnnotator(self.manager.circulation, self._default_library).permalink_for(self.english_1, lp, lp.identifier)
 
         events = response['circulation_events']
         eq_(types[::-1], [event['type'] for event in events])
@@ -838,8 +865,9 @@ class TestDashboardController(AdminControllerTest):
 
         # request fewer events
         with self.app.test_request_context("/?num=2"):
+            flask.request.library = self._default_library
             response = self.manager.admin_dashboard_controller.circulation_events()
-            url = AdminAnnotator(self.manager.circulation).permalink_for(self.english_1, lp, lp.identifier)
+            url = AdminAnnotator(self.manager.circulation, self._default_library).permalink_for(self.english_1, lp, lp.identifier)
 
         eq_(2, len(response['circulation_events']))
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -877,11 +877,11 @@ class TestLibraryAuthenticator(AuthenticatorTest):
                 # right position.
                 providers = doc['providers']
                 basic_doc = providers[basic.URI]
-                expect_basic = basic.authentication_provider_document(self._db)
+                expect_basic = basic.authentication_provider_document(library.short_name)
                 eq_(expect_basic, basic_doc)
             
                 oauth_doc = providers[oauth.URI]
-                expect_oauth = oauth.authentication_provider_document(self._db)
+                expect_oauth = oauth.authentication_provider_document(library.short_name)
                 eq_(expect_oauth, oauth_doc)
 
                 # We also need to test that the library's name and UUID

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -404,7 +404,16 @@ class TestAuthenticator(ControllerTest):
         l1, ignore = create(self._db, Library, short_name="l1")
         l2, ignore = create(self._db, Library, short_name="l2")
 
-        auth = Authenticator(self._db)
+        with temp_config() as config:
+            config[Configuration.POLICIES] = {
+                Configuration.AUTHENTICATION_POLICY: {
+                    "providers": [
+                        {"module": 'api.millenium_patron',
+                         Configuration.URL: "http://url"}
+                    ]
+                }
+            }
+            auth = Authenticator(self._db)
         auth.library_authenticators['l1'] = MockLibraryAuthenticator("l1")
         auth.library_authenticators['l2'] = MockLibraryAuthenticator("l2")
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -497,18 +497,18 @@ class TestBaseController(CirculationControllerTest):
             problem = self.controller.apply_borrowing_policy(patron, pool)
             eq_(FORBIDDEN_BY_POLICY.uri, problem.uri)
 
-    def test_library_from_request(self):
+    def test_library_for_request(self):
         with self.app.test_request_context("/"):
-            value = self.controller.library_from_request("not-a-library")
+            value = self.controller.library_for_request("not-a-library")
             eq_(LIBRARY_NOT_FOUND, value)
 
         with self.app.test_request_context("/"):
-            value = self.controller.library_from_request(self._default_library.short_name)
+            value = self.controller.library_for_request(self._default_library.short_name)
             eq_(self._default_library, value)
             eq_(self._default_library, flask.request.library)
 
         with self.app.test_request_context("/"):
-            value = self.controller.library_from_request(None)
+            value = self.controller.library_for_request(None)
             eq_(self._default_library, value)
             eq_(self._default_library, flask.request.library)
 

--- a/tests/test_firstbook.py
+++ b/tests/test_firstbook.py
@@ -100,6 +100,6 @@ class TestFirstBook(DatabaseTest):
         )
     
     def test_authentication_provider_document(self):
-        doc = self.api.authentication_provider_document
+        doc = self.api.authentication_provider_document(self._db)
         eq_(self.api.DISPLAY_NAME, doc['name'])
         assert self.api.METHOD in doc['methods']

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -5,6 +5,7 @@ from nose.tools import (
 
 import contextlib
 import datetime
+import flask
 
 from api.adobe_vendor_id import (
     AdobeVendorIDModel,
@@ -212,6 +213,7 @@ class TestCacheFacetListsPerLane(TestLaneScript):
                 testing=True
             )
             with script.app.test_request_context("/"):
+                flask.request.library = self._default_library
                 cached_feeds = script.process_lane(lane)
                 # 2 availabilities * 2 collections * 1 order * 1 page = 4 feeds
                 eq_(4, len(cached_feeds))

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -13,7 +13,7 @@ from api.config import (
 )
 
 from api.authenticator import (
-    Authenticator
+    LibraryAuthenticator
 )
 from api.mock_authentication import (
     MockAuthenticationProvider
@@ -73,7 +73,7 @@ class TestServiceStatusMonitor(DatabaseTest):
             test_username="user",
             test_password="pass",
         )
-        return Authenticator(self._db, library, provider)
+        return LibraryAuthenticator(self._db, library, provider)
 
     def test_test_patron(self):
         """Verify that test_patron() returns credentials determined


### PR DESCRIPTION
This branch adds the library short name to all urls that are library-specific. It works with either a subdomain prefix or a url path prefix, and if there's no library in the url, it can use a default library which is currently Library.instance(). This is done with a few new decorators in api/routes. Library.short_name is no longer nullable since it's used to create urls.

Most of the changes are adding the library short name to calls to url_for, and setting flask.request.library in tests. Maybe there's a better way to handle that so it doesn't need to happen in so many places.

The admin interface will need a new design for multiple libraries, but for now it shows you the default library.