### PR TITLE
Move (some) configuration settings from the JSON configuration and into the database

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -976,7 +976,7 @@ class SettingsController(CirculationManagerController):
 
         for setting in settings:
             value = flask.request.form.get(setting['key'], None)
-            ConfigurationSetting.for_library(self._db, setting['key'], library).value = value
+            ConfigurationSetting.for_library(setting['key'], library).value = value
 
         if is_new:
             return Response(unicode(_("Success")), 201)

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -8,12 +8,15 @@ from flask import (
 )
 import os
 
-from api.app import app
+from api.app import app, _db
 from api.config import Configuration
 
 from core.util.problem_detail import ProblemDetail
 from core.app_server import returns_problem_detail
-from core.model import Library
+from core.model import (
+    ConfigurationSetting,
+    Library,
+)
 
 from controller import setup_admin_controllers
 from templates import (
@@ -31,7 +34,9 @@ import urllib
 from datetime import timedelta
 
 # The secret key is used for signing cookies for admin login
-app.secret_key = Configuration.get(Configuration.SECRET_KEY)
+app.secret_key = ConfigurationSetting.sitewide_secret(
+    _db, Configuration.SECRET_KEY
+)
 
 # An admin's session will expire after this amount of time and
 # the admin will have to log in again.

--- a/api/app.py
+++ b/api/app.py
@@ -30,8 +30,7 @@ app.config['BABEL_TRANSLATION_DIRECTORIES'] = "../translations"
 babel = Babel(app)
 
 import routes
-if Configuration.get(Configuration.INCLUDE_ADMIN_INTERFACE):
-    import admin.routes
+import admin.routes
 
 debug = Configuration.logging_policy().get("level") == 'DEBUG'
 logging.getLogger().info("Application debug mode==%r" % debug)

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -431,6 +431,7 @@ class LibraryAuthenticator(object):
         self.library_uuid = library.uuid
         self.library_name = library.name
         self.library_short_name = library.short_name
+
         self.basic_auth_provider = basic_auth_provider
         self.oauth_providers_by_name = dict()
         self.bearer_token_signing_secret = bearer_token_signing_secret
@@ -482,7 +483,7 @@ class LibraryAuthenticator(object):
             raise CannotLoadConfiguration(
                 "Loaded module %s but could not find a class called AuthenticationProvider inside." % module_name
             )
-        provider = provider_class.from_config(self.library_id, integration)
+        provider = provider_class(self.library, integration)
         if issubclass(provider_class, BasicAuthenticationProvider):
             self.register_basic_auth_provider(provider)
             # TODO: Run a self-test, or at least check that we have
@@ -579,7 +580,7 @@ class LibraryAuthenticator(object):
                 break
             
         return credential
-    
+
     def oauth_provider_lookup(self, provider_name):
         """Look up the OAuthAuthenticationProvider with the given name. If that
         doesn't work, return an appropriate ProblemDetail.
@@ -623,14 +624,14 @@ class LibraryAuthenticator(object):
         return jwt.encode(
             payload, self.bearer_token_signing_secret, algorithm='HS256'
         )
-    
+
     def decode_bearer_token_from_header(self, header):
         """Extract auth provider name and access token from an Authenticate
         header value.
         """
         simplified_token = header.split(' ')[1]
         return self.decode_bearer_token(simplified_token)
-    
+
     def decode_bearer_token(self, token):
         """Extract auth provider name and access token from JSON web token."""
         decoded = jwt.decode(token, self.bearer_token_signing_secret,
@@ -638,7 +639,7 @@ class LibraryAuthenticator(object):
         provider_name = decoded['iss']
         token = decoded['token']
         return (provider_name, token)
-    
+
     def create_authentication_document(self):
         """Create the OPDS authentication document to be used when
         a request comes in with no authentication.
@@ -687,24 +688,52 @@ class AuthenticationProvider(object):
     # used to create the name of the log channel used by this
     # subclass, used to distinguish between tokens from different
     # OAuth providers, etc.
-    
+
     # Each subclass MUST define a value for URI. This is used in the
     # Authentication for OPDS document to distinguish between
     # different types of authentication.
     URI = None
 
-    def __init__(self, library_id):
+    # Each library and authentication mechanism may have a regular
+    # expression for deriving a patron's external type from their
+    # authentication identifier.
+    EXTERNAL_TYPE_REGULAR_EXPRESSION = 'external_type_regular_expression'
+    
+    def __init__(self, library, externalintegration):
         """Basic constructor.
         
-        :param library_id: The database ID of the Library to be managed 
-        by this AuthenticationProvider.
+        :param library: Patrons authenticated through this provider
+        are associated with this Library. Don't store this object!
+        It's associated with a scoped database session. Just pull
+        normal Python objects out of it.
+
+        :param externalintegration: The ExternalIntegration that
+        configures this AuthenticationProvider. Don't store this
+        object! It's associated with a scoped database session. Just
+        pull normal Python objects out of it.
         """
-        if not isinstance(library_id, int):
+        if not isinstance(library, Library):
             raise Exception(
-                "Expected library_id to be an integer, got %r" % library_id
+                "Expected library to be a Library, got %r" % library
             )
-        self.library_id = library_id
-    
+        if not isinstance(integration, ExternalIntegration):
+            raise Exception(
+                "Expected integration to be an ExternalIntegration, got %r" % integration
+            )
+
+        self.library_id = library.id
+
+        # If there's a regular expression that maps authorization
+        # identifier to external type, find it now.
+        regexp = ConfigurationSetting.for_library_and_externalintegration(
+            self.EXTERNAL_TYPE_REGULAR_EXPRESSION, library, external_integration
+        ).value
+        if regexp:
+            regexp = re.compile(regexp)
+        self.external_type_regular_expression = regexp
+
+        self.log = logging.getLogger(self.NAME)
+            
     def library(self, _db):
         return get_one(_db, Library, self.library_id)
     
@@ -723,6 +752,8 @@ class AuthenticationProvider(object):
             return patron
         if PatronUtility.needs_external_sync(patron):
             self.update_patron_metadata(patron)
+        if self.external_type_regular_expression:
+            self.update_patron_external_type(patron)
         return patron
 
     def update_patron_metadata(self, patron):
@@ -733,6 +764,34 @@ class AuthenticationProvider(object):
         remote_patron_info = self.remote_patron_lookup(patron)
         if isinstance(remote_patron_info, PatronData):
             remote_patron_info.apply(patron)
+
+    def update_patron_external_type(self, patron):
+        """Make sure the patron's external type reflects
+        what external_type_regular_expression says.
+        """
+        if not self.external_type_regular_expression:
+            # External type is not determined by a regular expression.
+            return
+        if not patron.authorization_identifier:
+            # Patron has no authorization identifier. Leave their
+            # external_type alone.
+            return
+
+        match = self.external_type_regular_expression.search(
+            patron.authorization_identifier
+        )
+        if not match:
+            # Patron's authorization identifier doesn't match the
+            # regular expression at all. Leave their external_type
+            # alone.
+            return
+        groups = match.groups()
+        if not groups:
+            # The regular expression matched but didn't contain any groups.
+            # This is a configuration error; do nothing.
+            return
+            
+        patron.external_type = groups[0]
 
     def authenticate(self, _db, header):
         """Authenticate a patron based on a WWW-Authenticate header
@@ -862,29 +921,25 @@ class BasicAuthenticationProvider(AuthenticationProvider):
     TEST_IDENTIFIER = 'test_identifier'
     TEST_PASSWORD = 'test_password'
     
-    @classmethod
-    def from_config(cls, library_id, integration):
-        """Load a BasicAuthenticationProvider from an ExternalIntegration."""
-        return cls(library_id, integration)
-
     # Used in the constructor to signify that the default argument
     # value for the class should be used (as distinct from None, which
     # indicates that no value should be used.)
     class_default = object()
     
-    def __init__(self, library_id, integration):
+    def __init__(self, library, integration):
         """Create a BasicAuthenticationProvider.
 
-        :param library_id: Patrons authenticated through this provider
-            are associated with the Library with the given ID. We don't
-            pass the Library object to avoid contaminating with
-            an object from a non-scoped session.
+        :param library: Patrons authenticated through this provider
+        are associated with this Library. Don't store this object!
+        It's associated with a scoped database session. Just pull
+        normal Python objects out of it.
 
-        :param integration: An ExternalIntegration that configures
-            this authentication mechanism. Don't store this object--just
-            pull normal Python objects out of it.
+        :param externalintegration: The ExternalIntegration that
+        configures this AuthenticationProvider. Don't store this
+        object! It's associated with a scoped database session. Just
+        pull normal Python objects out of it.
         """
-        super(BasicAuthenticationProvider, self).__init__(library_id)
+        super(BasicAuthenticationProvider, self).__init__(library)
         identifier_regular_expression = integration.setting(
             self.IDENTIFIER_REGULAR_EXPRESSION
         ).value or self.DEFAULT_IDENTIFIER_REGULAR_EXPRESSION
@@ -906,7 +961,6 @@ class BasicAuthenticationProvider(AuthenticationProvider):
 
         self.test_username = integration.setting(self.TEST_IDENTIFIER).value
         self.test_password = integration.setting(self.TEST_PASSWORD).value
-        self.log = logging.getLogger(self.NAME)
         
     def testing_patron(self, _db):
         """Look up a Patron object reserved for testing purposes.
@@ -1143,7 +1197,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
     # Each subclass MUST define an attribute called
     # NAME, which is the name used to configure that
     # subclass in the configuration file. Failure to define this
-    # attribute will result in an error in .from_config().
+    # attribute will result in an error in the constructor.
     #
     # Each subclass MUST define an attribute called TOKEN_TYPE, which
     # is the name used in the database to distinguish this provider's
@@ -1191,23 +1245,18 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
         return ConfigurationSetting.sitewide_secret(
             _db, cls.BEARER_TOKEN_SIGNING_SECRET
         )
-    
-    @classmethod
-    def from_config(cls, library_id, integration):
-        """Load this OAuthAuthenticationProvider from an ExternalIntegration.
-        """
-        client_id = integration.username
-        client_secret = integration.password
-        token_expiration_days = integration.setting(
-            cls.OAUTH_TOKEN_EXPIRATION_DAYS
-        ).int_value or cls.DEFAULT_TOKEN_EXPIRATION_DAYS
-        return cls(library_id, client_id, client_secret, token_expiration_days)
-    
-    def __init__(self, library_id, client_id, client_secret, token_expiration_days):
+        
+    def __init__(self, library, integration):
         """Initialize this OAuthAuthenticationProvider.
 
         :param library: Patrons authenticated through this provider
-            are associated with the given Library.
+            are associated with this Library. Don't store this object!
+            It's associated with a scoped database session. Just pull
+            normal Python objects out of it.
+        :param externalintegration: The ExternalIntegration that
+            configures this AuthenticationProvider. Don't store this
+            object! It's associated with a scoped database session. Just
+            pull normal Python objects out of it.
         :param client_id: An ID given to us by the OAuth provider, used
             to distinguish between us and its other clients.
         :param client_secret: A secret key given to us by the OAuth 
@@ -1216,11 +1265,14 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
             we ask the patron to go through the OAuth validation
             process again.
         """
-        super(OAuthAuthenticationProvider, self).__init__(library_id)
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self.token_expiration_days = token_expiration_days
-        self.log = logging.getLogger(self.NAME)
+        super(OAuthAuthenticationProvider, self).__init__(
+            library, integration
+        )
+        self.client_id = integration.username
+        self.client_secret = integration.password
+        self.token_expiration_days = integration.setting(
+            cls.OAUTH_TOKEN_EXPIRATION_DAYS
+        ).int_value or cls.DEFAULT_TOKEN_EXPIRATION_DAYS
         
     def authenticated_patron(self, _db, token):
         """Go from an OAuth provider token to an authenticated Patron.

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -722,7 +722,7 @@ class AuthenticationProvider(object):
             )
 
         self.library_id = library.id
-
+        self.log = logging.getLogger(self.NAME)
         # If there's a regular expression that maps authorization
         # identifier to external type, find it now.
         _db = Session.object_session(library)
@@ -730,10 +730,15 @@ class AuthenticationProvider(object):
             _db, self.EXTERNAL_TYPE_REGULAR_EXPRESSION, library, integration
         ).value
         if regexp:
-            regexp = re.compile(regexp)
+            try:
+                regexp = re.compile(regexp)
+            except Exception, e:
+                self.log.error(
+                    "Could not configure external type regular expression: %r", e
+                )
+                regexp = None
         self.external_type_regular_expression = regexp
 
-        self.log = logging.getLogger(self.NAME)
             
     def library(self, _db):
         return get_one(_db, Library, self.library_id)

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -187,7 +187,7 @@ class PatronData(object):
         # identifier.
         self.set_value(patron, 'external_identifier', self.permanent_id)
         self.set_value(patron, 'username', self.username)
-        self.set_value(patron, '_external_type', self.external_type)
+        self.set_value(patron, 'external_type', self.external_type)
         self.set_value(patron, 'authorization_expires',
                        self.authorization_expires)
         self.set_value(patron, 'fines', self.fines)
@@ -753,8 +753,6 @@ class AuthenticationProvider(object):
             return patron
         if PatronUtility.needs_external_sync(patron):
             self.update_patron_metadata(patron)
-        if self.external_type_regular_expression:
-            self.update_patron_external_type(patron)
         return patron
 
     def update_patron_metadata(self, patron):
@@ -765,6 +763,8 @@ class AuthenticationProvider(object):
         remote_patron_info = self.remote_patron_lookup(patron)
         if isinstance(remote_patron_info, PatronData):
             remote_patron_info.apply(patron)
+        if self.external_type_regular_expression:
+            self.update_patron_external_type(patron)
 
     def update_patron_external_type(self, patron):
         """Make sure the patron's external type reflects

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -648,7 +648,7 @@ class LibraryAuthenticator(object):
         links = {}
         library = get_one(self._db, Library, self.library_id)
         for rel in CirculationManagerAnnotator.CONFIGURATION_LINKS:
-            setting = ConfigurationSetting.for_library(self._db, rel, library)
+            setting = ConfigurationSetting.for_library(rel, library)
             if setting.value:
                 links[rel] = dict(href=setting.value, type="text/html")
 
@@ -1188,14 +1188,9 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
     @classmethod
     def bearer_token_signing_secret(cls, _db):
         """Find or generate the site-wide bearer token signing secret."""
-        secret = ConfigurationSetting.sitewide(
+        secret = ConfigurationSetting.sitewide_secret(
             _db, cls.BEARER_TOKEN_SIGNING_SECRET
         )
-        if not secret.value:
-            secret.value = os.urandom(24).encode('hex')
-            # Commit to get this in the database ASAP.
-            _db.commit()
-        return secret.value
     
     @classmethod
     def from_config(cls, library_id, integration):

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1188,7 +1188,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
     @classmethod
     def bearer_token_signing_secret(cls, _db):
         """Find or generate the site-wide bearer token signing secret."""
-        secret = ConfigurationSetting.sitewide_secret(
+        return ConfigurationSetting.sitewide_secret(
             _db, cls.BEARER_TOKEN_SIGNING_SECRET
         )
     

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -853,7 +853,7 @@ class BaseCirculationAPI(object):
         of changes?
         """
         return ConfigurationSetting.for_library(
-            cls.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, patron.library
+            self.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, patron.library
         ).value
 
     def checkin(self, patron, pin, licensepool):

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -853,7 +853,7 @@ class BaseCirculationAPI(object):
         of changes?
         """
         return ConfigurationSetting.for_library(
-            self.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, patron.library
+            Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, patron.library
         ).value
 
     def checkin(self, patron, pin, licensepool):

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -30,8 +30,6 @@ from config import Configuration
 
 class CirculationInfo(object):
 
-    DEFAULT_NOTIFICATION_EMAIL_ADDRESS = "default_notification_email_address"
-    
     def __init__(self, collection, data_source_name, identifier_type,
                  identifier):
         """A loan, hold, or whatever.

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -14,6 +14,7 @@ from core.model import (
     CirculationEvent,
     Collection,
     CollectionMissing,
+    ConfigurationSetting,
     ExternalIntegration,
     Identifier,
     DataSource,

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -283,7 +283,7 @@ class CirculationAPI(object):
         internal_format = api.internal_format(delivery_mechanism)
 
         if patron.fines:
-            max_fines = Configuration.max_outstanding_fines()
+            max_fines = Configuration.max_outstanding_fines(patron.library)
             if patron.fines >= max_fines.amount:
                 raise OutstandingFines()
 

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -29,6 +29,8 @@ from config import Configuration
 
 class CirculationInfo(object):
 
+    DEFAULT_NOTIFICATION_EMAIL_ADDRESS = "default_notification_email_address"
+    
     def __init__(self, collection, data_source_name, identifier_type,
                  identifier):
         """A loan, hold, or whatever.
@@ -849,8 +851,9 @@ class BaseCirculationAPI(object):
         """What email address should be used to notify this patron
         of changes?
         """
-        return Configuration.default_notification_email_address()
-
+        return ConfigurationSetting.for_library(
+            cls.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, patron.library
+        ).value
 
     def checkin(self, patron, pin, licensepool):
         """  Return a book early.  

--- a/api/config.py
+++ b/api/config.py
@@ -9,10 +9,11 @@ from core.config import (
     temp_config as core_temp_config,
 )
 from core.util import MoneyUtility
+from core.model import ConfigurationSetting
+
 
 class Configuration(CoreConfiguration):
 
-    INCLUDE_ADMIN_INTERFACE = "include_admin_interface"
     LENDING_POLICY = "lending"
     LANGUAGE_POLICY = "languages"
     LARGE_COLLECTION_LANGUAGES = "large_collections"
@@ -23,21 +24,19 @@ class Configuration(CoreConfiguration):
 
     ROOT_LANE_POLICY = "root_lane"
 
-    MAX_OUTSTANDING_FINES = "max_outstanding_fines"
-
-    PRELOADED_CONTENT = "preloaded_content"
-
     ADOBE_VENDOR_ID_INTEGRATION = u"Adobe Vendor ID"
     ADOBE_VENDOR_ID = u"vendor_id"
     ADOBE_VENDOR_ID_NODE_VALUE = u"node_value"
 
-    SECRET_KEY = "secret_key"
-
-    STAFF_PICKS_INTEGRATION = u"Staff Picks"
     PATRON_WEB_CLIENT_INTEGRATION = u"Patron Web Client"
 
-    LIST_FIELDS = "fields"
-   
+    # The name of the sitewide secret used to sign cookies for admin login.
+    SECRET_KEY = "secret_key"
+
+    # The name of the per-library setting that sets the maximum amount
+    # of fines a patron can have before losing lending privileges.
+    MAX_OUTSTANDING_FINES = "max_outstanding_fines"
+    
     @classmethod
     def lending_policy(cls):
         return cls.policy(cls.LENDING_POLICY)
@@ -88,7 +87,7 @@ class Configuration(CoreConfiguration):
     @classmethod
     def max_outstanding_fines(cls, library):
         max_fines = ConfigurationSetting.for_library(
-            self.MAX_OUTSTANDING_FINES, library
+            cls.MAX_OUTSTANDING_FINES, library
         ).value
         return MoneyUtility.parse(max_fines)
     

--- a/api/config.py
+++ b/api/config.py
@@ -15,7 +15,6 @@ class Configuration(CoreConfiguration):
     INCLUDE_ADMIN_INTERFACE = "include_admin_interface"
     LENDING_POLICY = "lending"
     LANGUAGE_POLICY = "languages"
-    LANGUAGE_FORCE = "force"
     LARGE_COLLECTION_LANGUAGES = "large_collections"
     SMALL_COLLECTION_LANGUAGES = "small_collections"
     TINY_COLLECTION_LANGUAGES = "tiny_collections"
@@ -90,22 +89,16 @@ class Configuration(CoreConfiguration):
         return [[x] for x in value.split(',')]
 
     @classmethod
-    def force_language(cls, language):
-        """Override normal language settings to deliver a particular
-        collection no matter what.
-        """
-        policy = cls.language_policy()
-        return policy.get(cls.LANGUAGE_FORCE, language)
-
-    @classmethod
     def default_notification_email_address(cls):
-        return cls.required(cls.DEFAULT_NOTIFICATION_EMAIL_ADDRESS)
+        return ConfigurationSetting.for_library(
+            cls.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, library
+        )
 
     @classmethod
-    def max_outstanding_fines(cls):
-        max_fines = Configuration.policy(
-            Configuration.MAX_OUTSTANDING_FINES
-        )
+    def max_outstanding_fines(cls, library):
+        max_fines = ConfigurationSetting.for_library(
+            self.MAX_OUTSTANDING_FINES, library
+        ).value
         return MoneyUtility.parse(max_fines)
     
     @classmethod

--- a/api/config.py
+++ b/api/config.py
@@ -22,7 +22,6 @@ class Configuration(CoreConfiguration):
     DEFAULT_OPDS_FORMAT = "simple_opds_entry"
 
     ROOT_LANE_POLICY = "root_lane"
-    EXTERNAL_TYPE_REGULAR_EXPRESSION = "external_type_regular_expression"
 
     MAX_OUTSTANDING_FINES = "max_outstanding_fines"
 
@@ -89,10 +88,10 @@ class Configuration(CoreConfiguration):
         return [[x] for x in value.split(',')]
 
     @classmethod
-    def default_notification_email_address(cls):
+    def default_notification_email_address(cls, library):
         return ConfigurationSetting.for_library(
             cls.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, library
-        )
+        ).value
 
     @classmethod
     def max_outstanding_fines(cls, library):

--- a/api/config.py
+++ b/api/config.py
@@ -36,6 +36,10 @@ class Configuration(CoreConfiguration):
     # The name of the per-library setting that sets the maximum amount
     # of fines a patron can have before losing lending privileges.
     MAX_OUTSTANDING_FINES = "max_outstanding_fines"
+
+    # The name of the per-library setting that sets the default email
+    # address to use when notifying patrons of changes.
+    DEFAULT_NOTIFICATION_EMAIL_ADDRESS = "default_notification_email_address"
     
     @classmethod
     def lending_policy(cls):

--- a/api/config.py
+++ b/api/config.py
@@ -38,8 +38,6 @@ class Configuration(CoreConfiguration):
 
     LIST_FIELDS = "fields"
    
-    DEFAULT_NOTIFICATION_EMAIL_ADDRESS = "default_notification_email_address"
-
     @classmethod
     def lending_policy(cls):
         return cls.policy(cls.LENDING_POLICY)
@@ -86,12 +84,6 @@ class Configuration(CoreConfiguration):
         if isinstance(value, list):
             return value
         return [[x] for x in value.split(',')]
-
-    @classmethod
-    def default_notification_email_address(cls, library):
-        return ConfigurationSetting.for_library(
-            cls.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, library
-        ).value
 
     @classmethod
     def max_outstanding_fines(cls, library):

--- a/api/controller.py
+++ b/api/controller.py
@@ -509,16 +509,6 @@ class OPDSFeedController(CirculationManagerController):
         )
         return feed_response(opds_feed)
 
-    def preload(self):
-        this_url = url_for("preload", library_short_name=flask.request.library.short_name, _external=True)
-
-        annotator = self.manager.annotator(None)
-        opds_feed = PreloadFeed.page(
-            self._db, "Content to Preload", this_url,
-            annotator=annotator,
-        )
-        return feed_response(opds_feed)
-
 
 class LoanController(CirculationManagerController):
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -84,7 +84,6 @@ from circulation_exceptions import *
 from opds import (
     CirculationManagerAnnotator,
     CirculationManagerLoanAndHoldAnnotator,
-    PreloadFeed,
 )
 from annotations import (
   AnnotationWriter,

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -64,8 +64,8 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         PIN_AUTHENTICATION_MODE, FAMILY_NAME_AUTHENTICATION_MODE
     ]
     
-    def __init__(self, library_id, integration):
-        super(MilleniumPatronAPI, self).__init__(library_id, integration)
+    def __init__(self, library, integration):
+        super(MilleniumPatronAPI, self).__init__(library, integration)
         url = integration.url
         if not url:
             raise CannotLoadConfiguration(

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -67,10 +67,14 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
             )
         )
 
-        num_days = int(self.ebook_loan_length)
-        self.ebook_expiration_default = datetime.timedelta(days=num_days)
-        num_days = int(self.eaudio_loan_length)
-        self.eaudio_expiration_default = datetime.timedelta(days=num_days)
+        # TODO: We need a general system for tracking default loan
+        # durations for different media types. However it doesn't
+        # matter much because the license sources generally tell us
+        # when specific loans expire.
+        self.ebook_expiration_default = datetime.timedelta(
+            self.collection.default_reservation_period
+        )
+        self.eaudio_expiration_default = self.ebook_expiration_default
 
 
     def checkin(self, patron, pin, licensepool):

--- a/api/opds.py
+++ b/api/opds.py
@@ -430,14 +430,6 @@ class CirculationManagerAnnotator(Annotator):
         )
         feed.add_link_to_feed(feed.feed, **search_link)
 
-        # Add preload link
-        preload_url = dict(
-            rel='http://librarysimplified.org/terms/rel/preload',
-            type='application/atom+xml;profile=opds-catalog;kind=acquisition',
-            href=self.url_for('preload', library_short_name=self.library.short_name, _external=True),
-        )
-        feed.add_link_to_feed(feed.feed, **preload_url)
-
         shelf_link = dict(
             rel="http://opds-spec.org/shelf",
             type=OPDSFeed.ACQUISITION_FEED_TYPE,
@@ -927,39 +919,3 @@ class CirculationManagerLoanAndHoldAnnotator(CirculationManagerAnnotator):
             tags.append(self.user_profile_management_protocol_link)
             for tag in tags:
                 feed.feed.append(tag)
-
-class PreloadFeed(AcquisitionFeed):
-
-    @classmethod
-    def page(cls, _db, title, url, annotator=None,
-             use_materialized_works=True):
-
-        """Create a feed of content to preload on devices."""
-        configured_content = Configuration.policy(Configuration.PRELOADED_CONTENT)
-
-        identifiers = [Identifier.parse_urn(_db, urn)[0] for urn in configured_content]
-        identifier_ids = [identifier.id for identifier in identifiers]
-
-        if use_materialized_works:
-            from core.model import MaterializedWork
-            q = _db.query(MaterializedWork)
-            q = q.filter(MaterializedWork.primary_identifier_id.in_(identifier_ids))
-
-            # Avoid eager loading of objects that are contained in the 
-            # materialized view.
-            q = q.options(
-                lazyload(MaterializedWork.license_pool, LicensePool.data_source),
-                lazyload(MaterializedWork.license_pool, LicensePool.identifier),
-                lazyload(MaterializedWork.license_pool, LicensePool.presentation_edition),
-            )
-        else:
-            q = _db.query(Work).join(Work.presentation_edition)
-            q = q.filter(Edition.primary_identifier_id.in_(identifier_ids))
-
-        works = q.all()
-        feed = cls(_db, title, url, works, annotator)
-
-        annotator.annotate_feed(feed, None)
-        content = unicode(feed)
-        return content
-        

--- a/api/opds.py
+++ b/api/opds.py
@@ -455,7 +455,7 @@ class CirculationManagerAnnotator(Annotator):
     def add_configuration_links(self, feed):
         _db = Session.object_session(self.library)
         for rel in self.CONFIGURATION_LINKS:
-            setting = ConfigurationSetting.for_library(_db, rel, self.library)
+            setting = ConfigurationSetting.for_library(rel, self.library)
             if setting.value:
                 d = dict(href=setting.value, type="text/html", rel=rel)
                 if isinstance(feed, OPDSFeed):

--- a/api/routes.py
+++ b/api/routes.py
@@ -209,13 +209,6 @@ def feed(languages, lane_name):
 def lane_search(languages, lane_name):
     return app.manager.opds_feeds.search(languages, lane_name)
 
-@library_route('/preload')
-@has_library
-@allows_patron_web()
-@returns_problem_detail
-def preload():
-    return app.manager.opds_feeds.preload()
-
 @library_dir_route('/patrons/me', methods=['GET', 'PUT'])
 @has_library
 @allows_patron_web()

--- a/api/services.py
+++ b/api/services.py
@@ -4,6 +4,7 @@ import logging
 from nose.tools import set_trace
 from sqlalchemy.orm.session import Session
 
+from core.model import ConfigurationSetting
 from core.scripts import (
     Script,
     IdentifierInputScript,
@@ -114,10 +115,16 @@ class ServiceStatus(object):
                 license_pool.collection.name, identifier
             )
             api = self.circulation.api_for_license_pool(license_pool)
+
+            address = ConfigurationSetting.for_library(
+                Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS,
+                patron.library
+            )
+            
             def do_checkout():
                 loan, hold, is_new = api.borrow(
                     patron, password, license_pool, delivery_mechanism,
-                    Configuration.default_notification_email_address()
+                    address,
                 )
                 if loan:
                     loans.append(loan)

--- a/api/simple_authentication.py
+++ b/api/simple_authentication.py
@@ -18,9 +18,9 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
     """
     NAME = "Simple Authentication Provider"
 
-    def __init__(self, library_id, integration):
+    def __init__(self, library, integration):
         super(SimpleAuthenticationProvider, self).__init__(
-            library_id, integration,
+            library, integration,
         )
         self.test_identifier = integration.setting(self.TEST_IDENTIFIER).value
         self.test_password = integration.setting(self.TEST_PASSWORD).value

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -31,7 +31,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         SIPClient.EXCESSIVE_FEES : PatronData.EXCESSIVE_FINES,
     }
 
-    def __init__(self, library_id, integration, client=None, connect=True):
+    def __init__(self, library, integration, client=None, connect=True):
         """An object capable of communicating with a SIP server.
 
         :param server: Hostname of the SIP server.
@@ -66,7 +66,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         during testing.
         """
         super(SIP2AuthenticationProvider, self).__init__(
-            library_id, integration
+            library, integration
         )
         try:
             server = None

--- a/api/util/patron.py
+++ b/api/util/patron.py
@@ -65,7 +65,7 @@ class PatronUtility(object):
             raise AuthorizationExpired()
 
         if patron.fines:
-            max_fines = Configuration.max_outstanding_fines()
+            max_fines = Configuration.max_outstanding_fines(patron.library)
             if patron.fines >= max_fines.amount:
                 raise OutstandingFines()
 

--- a/migration/20170609-1-move-library-configuration-to-configurationsettings.py
+++ b/migration/20170609-1-move-library-configuration-to-configurationsettings.py
@@ -22,91 +22,10 @@ from core.model import (
 )
 
 from api.config import Configuration
-from api.millenium_patron import MilleniumPatronAPI
-from api.sip import SIP2AuthenticationProvider
-from api.authenticator import (
-    BasicAuthenticationProvider,
-    OAuthAuthenticationProvider,
-)
 
-log = logging.getLogger(name="Circulation manager library configuration import")
-
-def log_import(service_name):
-    log.info("Importing configuration for %s" % service_name)
-
-def make_patron_auth_integration(_db, provider):
-    integration, ignore = get_one_or_create(
-        _db, ExternalIntegration, protocol=provider.get('module'),
-        goal=ExternalIntegration.PATRON_AUTH_GOAL
-    )
-
-    # If any of the common Basic Auth-type settings were provided, set them
-    # as ConfigurationSettings on the ExternalIntegration.
-    test_identifier = provider.get('test_username')
-    test_password = provider.get('test_password')
-    if test_identifier:
-        integration.setting(BasicAuthenticationProvider.TEST_IDENTIFIER).value = test_identifier
-    if test_password:
-        integration.setting(BasicAuthenticationProvider.TEST_PASSWORD).value = test_password
-    identifier_re = provider.get('identifier_regular_expression')
-    password_re = provider.get('password_regular_expression')
-    if identifier_re:
-        integration.setting(BasicAuthenticationProvider.IDENTIFIER_REGULAR_EXPRESSION).value = identifier_re
-    if password_re:
-        integration.setting(BasicAuthenticationProvider.PASSWORD_REGULAR_EXPRESSION).value = password_re
-    
-    return integration
-        
-def convert_millenium(_db, integration, provider):
-
-    # Cross-check MilleniumPatronAPI.__init__ to see how these values
-    # are pulled from the ExternalIntegration.
-    integration.url = provider.get('url')
-    auth_mode = provider.get('auth_mode')
-    blacklist = provider.get('authorization_identifier_blacklist')
-    if blacklist:
-        integration.setting(MilleniumPatronAPI.IDENTIFIER_BLACKLIST
-        ).value = json.dumps(blacklist)
-    if auth_mode:
-        integration.setting(MilleniumPatronAPI.AUTHENTICATION_MODE
-        ).value = auth_mode
-    
-def convert_sip(_db, integration, provider):
-    # Cross-check SIP2AuthenticationProvider.__init__ to see how these values
-    # are pulled from the ExternalIntegration.
-    integration.url = provider.get('server')
-    integration.username = provider.get('login_user_id')
-    integration.password = provider.get('login_password')
-    SAP = SIP2AuthenticationProvider
-    port = provider.get('port')
-    if port:
-        integration.setting(SAP.PORT).value = port
-    location_code = provider.get('location_code')
-    if location_code:
-        integration.setting(SAP.LOCATION_CODE).value = location_code
-    field_separator = provider.get('field_separator')
-    if field_separator:
-        integration.setting(SAP.FIELD_SEPARATOR).value = field_separator
-
-def convert_firstbook(_db, integration, provider):
-    # Cross-check FirstBookAuthenticationAPI.__init__ to see how these values
-    # are pulled from the ExternalIntegration.    
-    integration.url = provider.get('url')
-    integration.password = provider.get('key')
-
-def convert_clever(_db, integration, provider):
-    # Cross-check OAuthAuthenticationProvider.from_config to see how
-    # these values are pulled from the ExternalIntegration.
-    integration.username = provider.get('client_id')
-    integration.password = provider.get('client_secret')
-    expiration_days = provider.get('token_expiration_days')
-    if expiration_days:
-        integration.setting(OAuthAuthenticationProvider.TOKEN_EXPIRATION_DAYS
-        ).value = expiration_days
-    
+_db = production_session()
 try:
     Configuration.load()
-    _db = production_session()
     integrations = []
 
     # If the secret key is set, make it a sitewide setting.

--- a/migration/20170609-1-move-library-configuration-to-configurationsettings.py
+++ b/migration/20170609-1-move-library-configuration-to-configurationsettings.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+"""Move per-library settings from the Configuration file
+into the database as ConfigurationSettings.
+"""
+import os
+import sys
+import json
+import logging
+from nose.tools import set_trace
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from core.model import (
+    ConfigurationSetting,
+    ExternalIntegration,
+    get_one_or_create,
+    production_session,
+    Library,
+    create,
+)
+
+from api.config import Configuration
+from api.millenium_patron import MilleniumPatronAPI
+from api.sip import SIP2AuthenticationProvider
+from api.authenticator import (
+    BasicAuthenticationProvider,
+    OAuthAuthenticationProvider,
+)
+
+log = logging.getLogger(name="Circulation manager library configuration import")
+
+def log_import(service_name):
+    log.info("Importing configuration for %s" % service_name)
+
+def make_patron_auth_integration(_db, provider):
+    integration, ignore = get_one_or_create(
+        _db, ExternalIntegration, protocol=provider.get('module'),
+        goal=ExternalIntegration.PATRON_AUTH_GOAL
+    )
+
+    # If any of the common Basic Auth-type settings were provided, set them
+    # as ConfigurationSettings on the ExternalIntegration.
+    test_identifier = provider.get('test_username')
+    test_password = provider.get('test_password')
+    if test_identifier:
+        integration.setting(BasicAuthenticationProvider.TEST_IDENTIFIER).value = test_identifier
+    if test_password:
+        integration.setting(BasicAuthenticationProvider.TEST_PASSWORD).value = test_password
+    identifier_re = provider.get('identifier_regular_expression')
+    password_re = provider.get('password_regular_expression')
+    if identifier_re:
+        integration.setting(BasicAuthenticationProvider.IDENTIFIER_REGULAR_EXPRESSION).value = identifier_re
+    if password_re:
+        integration.setting(BasicAuthenticationProvider.PASSWORD_REGULAR_EXPRESSION).value = password_re
+    
+    return integration
+        
+def convert_millenium(_db, integration, provider):
+
+    # Cross-check MilleniumPatronAPI.__init__ to see how these values
+    # are pulled from the ExternalIntegration.
+    integration.url = provider.get('url')
+    auth_mode = provider.get('auth_mode')
+    blacklist = provider.get('authorization_identifier_blacklist')
+    if blacklist:
+        integration.setting(MilleniumPatronAPI.IDENTIFIER_BLACKLIST
+        ).value = json.dumps(blacklist)
+    if auth_mode:
+        integration.setting(MilleniumPatronAPI.AUTHENTICATION_MODE
+        ).value = auth_mode
+    
+def convert_sip(_db, integration, provider):
+    # Cross-check SIP2AuthenticationProvider.__init__ to see how these values
+    # are pulled from the ExternalIntegration.
+    integration.url = provider.get('server')
+    integration.username = provider.get('login_user_id')
+    integration.password = provider.get('login_password')
+    SAP = SIP2AuthenticationProvider
+    port = provider.get('port')
+    if port:
+        integration.setting(SAP.PORT).value = port
+    location_code = provider.get('location_code')
+    if location_code:
+        integration.setting(SAP.LOCATION_CODE).value = location_code
+    field_separator = provider.get('field_separator')
+    if field_separator:
+        integration.setting(SAP.FIELD_SEPARATOR).value = field_separator
+
+def convert_firstbook(_db, integration, provider):
+    # Cross-check FirstBookAuthenticationAPI.__init__ to see how these values
+    # are pulled from the ExternalIntegration.    
+    integration.url = provider.get('url')
+    integration.password = provider.get('key')
+
+def convert_clever(_db, integration, provider):
+    # Cross-check OAuthAuthenticationProvider.from_config to see how
+    # these values are pulled from the ExternalIntegration.
+    integration.username = provider.get('client_id')
+    integration.password = provider.get('client_secret')
+    expiration_days = provider.get('token_expiration_days')
+    if expiration_days:
+        integration.setting(OAuthAuthenticationProvider.TOKEN_EXPIRATION_DAYS
+        ).value = expiration_days
+    
+try:
+    Configuration.load()
+    _db = production_session()
+    integrations = []
+
+    # If the secret key is set, make it a sitewide setting.
+    secret_key = Configuration.get('secret_key')
+    if secret_key:
+        secret_setting = ConfigurationSetting.sitewide(
+            _db, OAuthAuthenticationProvider.BEARER_TOKEN_SIGNING_SECRET
+        )
+        secret_setting.value = secret_key
+    
+    library = Library.instance(_db)
+    libraries = _db.query(Library).all()
+    
+    # Copy default email address into each library.
+    key = 'default_notification_email_address'
+    value = Configuration.get(key)
+    if value:
+        for library in libraries:
+            ConfigurationSetting.for_library(key, library).value = value
+
+    # Copy maximum fines into each library.
+    key = 'max_outstanding_fines'
+    value = Configuration.policy(key)
+    if value:
+        for library in libraries:
+            ConfigurationSetting.for_library(key, library).value = value
+
+    # Copy external type regular expression into each collection for each
+    # library.
+    key = 'external_type_regular_expression'
+    value = Configuration.policy(key)
+    if value:
+        for library in libraries:
+            for collection in library.collections:
+                integration = collection.external_integration
+                if not integration:
+                    continue
+                ConfigurationSetting.for_library_and_externalintegration(
+                    _db, key, library, integration).value = value
+                
+finally:
+    _db.commit()
+    _db.close()

--- a/migration/20170609-1-move-library-configuration-to-configurationsettings.py
+++ b/migration/20170609-1-move-library-configuration-to-configurationsettings.py
@@ -113,7 +113,7 @@ try:
     secret_key = Configuration.get('secret_key')
     if secret_key:
         secret_setting = ConfigurationSetting.sitewide(
-            _db, OAuthAuthenticationProvider.BEARER_TOKEN_SIGNING_SECRET
+            _db, Configuration.SECRET_KEY
         )
         secret_setting.value = secret_key
     

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -20,6 +20,7 @@ from core.model import (
     Classification,
     Collection,
     Complaint,
+    ConfigurationSetting,
     CoverageRecord,
     create,
     DataSource,
@@ -48,13 +49,9 @@ from datetime import date, datetime, timedelta
 class AdminControllerTest(CirculationControllerTest):
 
     def setup(self):
-        with temp_config() as config:
-            config[Configuration.INCLUDE_ADMIN_INTERFACE] = True
-            config[Configuration.SECRET_KEY] = "a secret"
-
-            super(AdminControllerTest, self).setup()
-
-            setup_admin_controllers(self.manager)
+        super(AdminControllerTest, self).setup()
+        ConfigurationSetting.sitewide(self._db, Configuration.SECRET_KEY).value = "a secret"
+        setup_admin_controllers(self.manager)
 
 class TestWorkController(AdminControllerTest):
 

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -47,7 +47,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         integration.password = "pass1"
         integration.setting(p.FIELD_SEPARATOR).value = "\t"
 
-        provider = p(self._default_library.id, integration, connect=False)
+        provider = p(self._default_library, integration, connect=False)
 
         # A SIPClient was initialized based on the integration values.
         client = provider.client
@@ -61,14 +61,14 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
 
         # Try again, specifying a port.
         integration.setting(p.PORT).value = "1234"
-        provider = p(self._default_library.id, integration, connect=False)
+        provider = p(self._default_library, integration, connect=False)
         eq_(1234, provider.client.target_port)
         
     def test_remote_authenticate(self):
         integration = self._external_integration(self._str)
         client = MockSIPClient()
         auth = SIP2AuthenticationProvider(
-            self._default_library.id, integration, client=client
+            self._default_library, integration, client=client
         )
 
         # Some examples taken from a Sierra SIP API.
@@ -183,7 +183,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
             RemoteIntegrationException,
             "Error accessing unknown server: Doom!",
             SIP2AuthenticationProvider,
-            self._default_library.id, integration, client=CannotConnect
+            self._default_library, integration, client=CannotConnect
         )
 
     def test_ioerror_during_send_becomes_remoteintegrationexception(self):
@@ -197,7 +197,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
 
         integration = self._external_integration(self._str)
         provider = SIP2AuthenticationProvider(
-            self._default_library.id, integration, client=client
+            self._default_library, integration, client=client
         )
         provider.client.target_server = 'server.local'
         assert_raises_regexp(

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -66,7 +66,7 @@ class TestVendorIDModel(VendorIDTest):
         integration.setting(provider.TEST_IDENTIFIER).value = "validpatron"
         integration.setting(provider.TEST_PASSWORD).value = "password"
         self.authenticator = SimpleAuthenticationProvider(
-            self._default_library.id, integration
+            self._default_library, integration
         )
         
         self.model = AdobeVendorIDModel(self._db, self.authenticator,

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -893,7 +893,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
 
         # Set up configuration settings for links.
         for rel, value in link_config.iteritems():
-            ConfigurationSetting.for_library(self._db, rel, self._default_library).value = value
+            ConfigurationSetting.for_library(rel, self._default_library).value = value
 
         with temp_config() as config:
             config[Configuration.INTEGRATIONS][

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -9,6 +9,7 @@ from nose.tools import (
 )
 
 from core.model import (
+    ConfigurationSetting,
     DataSource,
     Edition,
     Identifier,
@@ -120,15 +121,16 @@ class TestAxis360API(Axis360Test):
         data = self.sample_data("place_hold_success.xml")
         self.api.queue_response(200, content=data)
         patron = self._patron()
-        with temp_config() as config:
-            config['default_notification_email_address'] = "notifications@example.com"
-            response = self.api.place_hold(patron, 'pin', pool, None)
-            eq_(1, response.hold_position)
-            eq_(response.identifier_type, pool.identifier.type)
-            eq_(response.identifier, pool.identifier.identifier)
-            [request] = self.api.requests
-            params = request[-1]['params']
-            eq_('notifications@example.com', params['email'])
+        ConfigurationSetting.for_library(
+            Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS,
+            self._default_library).value = "notifications@example.com"
+        response = self.api.place_hold(patron, 'pin', pool, None)
+        eq_(1, response.hold_position)
+        eq_(response.identifier_type, pool.identifier.type)
+        eq_(response.identifier, pool.identifier.identifier)
+        [request] = self.api.requests
+        params = request[-1]['params']
+        eq_('notifications@example.com', params['email'])
 
 class TestCirculationMonitor(Axis360Test):
 

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -27,6 +27,7 @@ from api.circulation import (
 from core.analytics import Analytics
 from core.model import (
     CirculationEvent,
+    ConfigurationSetting,
     DataSource,
     DeliveryMechanism,
     ExternalIntegration,
@@ -367,11 +368,10 @@ class TestCirculationAPI(DatabaseTest):
         old_fines = self.patron.fines
         self.patron.fines = 1000
 
-        with temp_config() as config:
-            config[Configuration.POLICIES] = {
-                Configuration.MAX_OUTSTANDING_FINES : "$0.50"
-            }
-            assert_raises(OutstandingFines, self.borrow)
+        ConfigurationSetting.for_library(
+            Configuration.MAX_OUTSTANDING_FINES,
+            self._default_library).value = "$0.50"
+        assert_raises(OutstandingFines, self.borrow)
         self.patron.fines = old_fines
 
     def test_borrow_with_block_fails(self):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -538,12 +538,15 @@ class TestIndexController(CirculationControllerTest):
                 eq_("http://cdn/default/groups/", response.headers['location'])
 
     def test_authenticated_patron_root_lane(self):
+        ConfigurationSetting.for_library(
+            Library.EXTERNAL_TYPE_REGULAR_EXPRESSION,
+            self._default_library
+        ).value = "^(unittest)"
         with temp_config() as config:
             # Patrons whose authorization identifiers start with 'unittest'
             # get sent to the Adult Fiction lane.
             config[Configuration.POLICIES] = {
                 Configuration.ROOT_LANE_POLICY : { "unittest": ["eng", "Adult Fiction"]},
-                Configuration.EXTERNAL_TYPE_REGULAR_EXPRESSION : "^(unittest)",
             }
             with self.request_context_with_library(
                 "/", headers=dict(Authorization=self.invalid_auth)):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2019,9 +2019,10 @@ class TestFeedController(CirculationControllerTest):
             )            
 
     def test_groups(self):
+        ConfigurationSetting.sitewide(
+            self._db, AcquisitionFeed.GROUPED_MAX_AGE_POLICY).value = 10
         with temp_config() as config:
             config[Configuration.POLICIES] = {
-                Configuration.GROUPS_MAX_AGE_POLICY : 10,
                 Configuration.MINIMUM_FEATURED_QUALITY: 0,
                 Configuration.FEATURED_LANE_SIZE: 2,
             }

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1952,7 +1952,7 @@ class TestFeedController(CirculationControllerTest):
                            (CirculationManagerAnnotator.COPYRIGHT, "c"),
                            (CirculationManagerAnnotator.ABOUT, "d"),
                            ]:
-            ConfigurationSetting.for_library(self._db, rel, self._default_library).value = value
+            ConfigurationSetting.for_library(rel, self._default_library).value = value
 
         with self.request_context_with_library("/"):
             response = self.manager.opds_feeds.feed(
@@ -2077,21 +2077,6 @@ class TestFeedController(CirculationControllerTest):
             previous_links = [link for link in feed['feed']['links'] if link.rel == 'previous']
             eq_(1, len(previous_links))
 
-    def test_preload(self):
-        SessionManager.refresh_materialized_views(self._db)
-
-        with temp_config() as config:
-            urn = self.english_2.presentation_edition.primary_identifier.urn
-            config[Configuration.POLICIES] = {
-                Configuration.PRELOADED_CONTENT : [urn]
-            }
-
-            with self.request_context_with_library("/"):
-                response = self.manager.opds_feeds.preload()
-
-                assert self.english_1.title not in response.data
-                assert self.english_2.title in response.data
-                assert self.french_1.author not in response.data
 
 class TestAnalyticsController(CirculationControllerTest):
     def setup(self):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -502,10 +502,10 @@ class TestBaseController(CirculationControllerTest):
                 }
             )
 
-            patron._external_type = '10'
+            patron.external_type = '10'
             eq_(None, self.controller.apply_borrowing_policy(patron, pool))
 
-            patron._external_type = '152'
+            patron.external_type = '152'
             problem = self.controller.apply_borrowing_policy(patron, pool)
             eq_(FORBIDDEN_BY_POLICY.uri, problem.uri)
 
@@ -538,15 +538,12 @@ class TestIndexController(CirculationControllerTest):
                 eq_("http://cdn/default/groups/", response.headers['location'])
 
     def test_authenticated_patron_root_lane(self):
-        ConfigurationSetting.for_library(
-            Library.EXTERNAL_TYPE_REGULAR_EXPRESSION,
-            self._default_library
-        ).value = "^(unittest)"
+        self.default_patron.external_type = "1"
         with temp_config() as config:
-            # Patrons whose authorization identifiers start with 'unittest'
-            # get sent to the Adult Fiction lane.
+            # Patrons of external type '1' get sent to the Adult
+            # Fiction lane.
             config[Configuration.POLICIES] = {
-                Configuration.ROOT_LANE_POLICY : { "unittest": ["eng", "Adult Fiction"]},
+                Configuration.ROOT_LANE_POLICY : { "1": ["eng", "Adult Fiction"]},
             }
             with self.request_context_with_library(
                 "/", headers=dict(Authorization=self.invalid_auth)):
@@ -560,7 +557,7 @@ class TestIndexController(CirculationControllerTest):
                 eq_("http://cdn/default/groups/eng/Adult%20Fiction", response.headers['location'])
 
             # Now those patrons get sent to the top-level lane.
-            config['policies'][Configuration.ROOT_LANE_POLICY] = { "unittest": None }
+            config['policies'][Configuration.ROOT_LANE_POLICY] = { "1": None }
             with self.request_context_with_library(
                 "/", headers=dict(Authorization=self.valid_auth)):
                 response = self.manager.index_controller()

--- a/tests/test_firstbook.py
+++ b/tests/test_firstbook.py
@@ -36,7 +36,7 @@ class TestFirstBook(DatabaseTest):
         integration = self._external_integration(self._str)
         integration.url = "http://example.com/"
         integration.password = "the_key"
-        api = FirstBookAuthenticationAPI(self._default_library.id, integration)
+        api = FirstBookAuthenticationAPI(self._default_library, integration)
 
         # Verify that the configuration details were stored properly.
         eq_('http://example.com/?key=the_key', api.root)
@@ -49,7 +49,7 @@ class TestFirstBook(DatabaseTest):
 
         # Try another case where the root URL has multiple arguments.
         integration.url = "http://example.com/?foo=bar"
-        api = FirstBookAuthenticationAPI(self._default_library.id, integration)
+        api = FirstBookAuthenticationAPI(self._default_library, integration)
         eq_('http://example.com/?foo=bar&key=the_key', api.root)
         
     def test_authentication_success(self):

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -52,7 +52,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         integration.setting(MilleniumPatronAPI.VERIFY_CERTIFICATE).value = json.dumps(verify_certificate)
         if auth_mode:
             integration.setting(MilleniumPatronAPI.AUTHENTICATION_MODE).value = auth_mode
-        return MockAPI(self._default_library.id, integration)
+        return MockAPI(self._default_library, integration)
     
     def setup(self):
         super(TestMilleniumPatronAPI, self).setup()

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -114,7 +114,7 @@ class TestCirculationManagerAnnotator(WithVendorIDTest):
 
         # Set up configuration settings for links.
         for rel, value in link_config.iteritems():
-            ConfigurationSetting.for_library(self._db, rel, self._default_library).value = value
+            ConfigurationSetting.for_library(rel, self._default_library).value = value
 
         self.annotator.add_configuration_links(mock_feed)
 
@@ -678,17 +678,6 @@ class TestOPDS(WithVendorIDTest):
         assert "simplified:username" in raw
         eq_(patron.username, feed_details['simplified_patron']['simplified:username'])
         eq_(u'987654321', feed_details['simplified_patron']['simplified:authorizationidentifier'])
-
-    def test_loans_feed_includes_preload_link(self):
-        patron = self._patron()
-        feed_obj = CirculationManagerLoanAndHoldAnnotator.active_loans_for(
-            None, patron, test_mode=True)
-        raw = unicode(feed_obj)
-        feed = feedparser.parse(raw)['feed']
-        links = feed['links']
-
-        [preload_link] = [x for x in links if x['rel'] == 'http://librarysimplified.org/terms/rel/preload']
-        assert '/preload' in preload_link['href']
         
     def test_loans_feed_includes_annotations_link(self):
         patron = self._patron()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -20,6 +20,7 @@ from api.simple_authentication import (
 )
 
 from core.model import (
+    ConfigurationSetting,
     DataSource,
     ExternalIntegration,
     Library,
@@ -178,7 +179,8 @@ class TestServiceStatusMonitor(DatabaseTest):
         edition, lp = self._edition(
             with_license_pool=True, collection=overdrive_collection
         )
-        self._default_library.collections.append(overdrive_collection)
+        library = self._default_library
+        library.collections.append(overdrive_collection)
 
         # Test a scenario where we get information for every
         # relevant collection in the library.
@@ -204,12 +206,11 @@ class TestServiceStatusMonitor(DatabaseTest):
         everything_succeeds = {ExternalIntegration.OVERDRIVE : CheckoutSuccess}
 
         auth = self.mock_auth
-        status = ServiceStatus(
-            self._default_library, auth=auth, api_map=everything_succeeds
-        )
-        with temp_config() as config:
-            config[Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS] = "a@b"
-            response = status.checkout_status(lp.identifier)
+        status = ServiceStatus(library, auth=auth, api_map=everything_succeeds)
+        ConfigurationSetting.for_library(
+            Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, library
+        ).value = "a@b"
+        response = status.checkout_status(lp.identifier)
 
         # The ServiceStatus object was able to run its test.
         for value in response.values():
@@ -230,12 +231,8 @@ class TestServiceStatusMonitor(DatabaseTest):
                 "Oops! We put the book on hold instead of borrowing it."
                 return None, object(), True
         no_loan_created = {ExternalIntegration.OVERDRIVE : NoLoanCreated}
-        status = ServiceStatus(
-            self._default_library, auth=auth, api_map=no_loan_created
-        )            
-        with temp_config() as config:
-            config[Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS] = "a@b"
-            response = status.checkout_status(lp.identifier)
+        status = ServiceStatus(library, auth=auth, api_map=no_loan_created)
+        response = status.checkout_status(lp.identifier)
         assert 'FAILURE: No loan created during checkout' in response.values()
 
         # Next: The 'revoke' operation fails on an API level.
@@ -244,12 +241,8 @@ class TestServiceStatusMonitor(DatabaseTest):
                 "Simulate an error during loan revocation."
                 raise Exception("Doomed to fail!")
         revoke_fail = {ExternalIntegration.OVERDRIVE : RevokeFail}
-        status = ServiceStatus(
-            self._default_library, auth=auth, api_map=revoke_fail
-        )            
-        with temp_config() as config:
-            config[Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS] = "a@b"
-            response = status.checkout_status(lp.identifier)
+        status = ServiceStatus(library, auth=auth, api_map=revoke_fail)
+        response = status.checkout_status(lp.identifier)
         assert 'FAILURE: Doomed to fail!' in response.values()
 
         # But at least we got through the borrow and fulfill steps.

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -71,7 +71,7 @@ class TestServiceStatusMonitor(DatabaseTest):
         provider = SimpleAuthenticationProvider
         integration.setting(provider.TEST_IDENTIFIER).value = "validpatron"
         integration.setting(provider.TEST_PASSWORD).value = "password"
-        self.authenticator = provider(library.id, integration)
+        self.authenticator = provider(library, integration)
         return LibraryAuthenticator(self._db, library, self.authenticator)
 
     def test_test_patron(self):

--- a/tests/test_simple_auth.py
+++ b/tests/test_simple_auth.py
@@ -25,7 +25,7 @@ class TestSimpleAuth(DatabaseTest):
         assert_raises_regexp(
             CannotLoadConfiguration,
             "Test identifier and password not set.",
-            p, self._default_library.id, integration
+            p, self._default_library, integration
         )
 
         integration.setting(p.TEST_IDENTIFIER).value = "barcode"

--- a/tests/test_simple_auth.py
+++ b/tests/test_simple_auth.py
@@ -30,7 +30,7 @@ class TestSimpleAuth(DatabaseTest):
 
         integration.setting(p.TEST_IDENTIFIER).value = "barcode"
         integration.setting(p.TEST_PASSWORD).value = "pass"
-        provider = p(self._default_library.id, integration)
+        provider = p(self._default_library, integration)
 
         eq_(None, provider.remote_authenticate("user", "wrongpass"))
         eq_(None, provider.remote_authenticate("user", None))


### PR DESCRIPTION
The focus of this branch is on configuration settings that are sitewide or library-specific. Courteney is handling settings that are related to configuring some external piece of software.

* The SECRET_KEY used to sign admin cookies has become a site-wide secret, just like the bearer token signing secret.
* INCLUDE_ADMIN_INTERFACE has been removed. The admin interface has become so important to site configuration that it's now required.
* I removed the preloaded content feature. We ended up not using it and it's easier to remove it than to convert its configuration.
* I removed the 'force language' setting, which as far as I can tell is not used.
* The default email address to use for patron book availability notifications is now a per-library setting.
* The maximum amount of fines before a patron loses lending privileges is now a per-library setting.
* The regular expression used to derive `Patron.external_integration` from `Patron.authorization_identifier` is now a per-library per-integration setting.

Since instantiating an AuthenticationProvider now requires both a Library and an ExternalIntegration, I changed the constructor to take a Library instead of a Library_id. This meant a lot of tiny changes to tests.