### PR TITLE
Moved url, username, and password on ExternalIntegration to settings, and fixed a CSRF token problem

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1008,16 +1008,16 @@ class SettingsController(CirculationManagerController):
             "fields": [
                 { "key": "external_account_id", "label": _("Library ID") },
                 { "key": "website_id", "label": _("Website ID") },
-                { "key": "username", "label": _("Client Key") },
-                { "key": "password", "label": _("Client Secret") },
+                { "key": ExternalIntegration.USERNAME, "label": _("Client Key") },
+                { "key": ExternalIntegration.PASSWORD, "label": _("Client Secret") },
             ],
         })
 
         protocols.append({
             "name": ExternalIntegration.BIBLIOTHECA,
             "fields": [
-                { "key": "username", "label": _("Account ID") },
-                { "key": "password", "label": _("Account Key") },
+                { "key": ExternalIntegration.USERNAME, "label": _("Account ID") },
+                { "key": ExternalIntegration.PASSWORD, "label": _("Account Key") },
                 { "key": "external_account_id", "label": _("Library ID") },
             ],
         })
@@ -1025,21 +1025,19 @@ class SettingsController(CirculationManagerController):
         protocols.append({
             "name": ExternalIntegration.AXIS_360,
             "fields": [
-                { "key": "username", "label": _("Username") },
-                { "key": "password", "label": _("Password") },
+                { "key": ExternalIntegration.USERNAME, "label": _("Username") },
+                { "key": ExternalIntegration.PASSWORD, "label": _("Password") },
                 { "key": "external_account_id", "label": _("Library ID") },
-                { "key": "url", "label": _("Server") },
+                { "key": ExternalIntegration.URL, "label": _("Server") },
             ],
         })
 
         protocols.append({
             "name": ExternalIntegration.ONE_CLICK,
             "fields": [
-                { "key": "password", "label": _("Basic Token") },
+                { "key": ExternalIntegration.PASSWORD, "label": _("Basic Token") },
                 { "key": "external_account_id", "label": _("Library ID") },
-                { "key": "url", "label": _("URL") },
-                { "key": "ebook_loan_length", "label": _("eBook Loan Length") },
-                { "key": "eaudio_loan_length", "label": _("eAudio Loan Length") },
+                { "key": ExternalIntegration.URL, "label": _("URL") },
             ],
         })
 
@@ -1051,9 +1049,6 @@ class SettingsController(CirculationManagerController):
                     protocol=c.protocol,
                     libraries=[library.short_name for library in c.libraries],
                     external_account_id=c.external_account_id,
-                    url=c.external_integration.url,
-                    username=c.external_integration.username,
-                    password=c.external_integration.password,
                 )
                 if c.protocol in [p.get("name") for p in protocols]:
                     [protocol] = [p for p in protocols if p.get("name") == c.protocol]
@@ -1108,12 +1103,6 @@ class SettingsController(CirculationManagerController):
 
             if key == "external_account_id":
                 collection.external_account_id = value
-            elif key == "username":
-                collection.external_integration.username = value
-            elif key == "password":
-                collection.external_integration.password = value
-            elif key == "url":
-                collection.external_integration.url = value
             else:
                 collection.external_integration.setting(key).value = value
 
@@ -1274,12 +1263,6 @@ class SettingsController(CirculationManagerController):
                     libraries.append(library_info)
 
                 settings = { setting.key: setting.value for setting in auth_service.settings if setting.library_id == None}
-                if auth_service.url:
-                    settings["url"] = auth_service.url
-                if auth_service.username:
-                    settings["username"] = auth_service.username
-                if auth_service.password:
-                    settings["password"] = auth_service.password
 
                 auth_services.append(
                     dict(
@@ -1335,14 +1318,7 @@ class SettingsController(CirculationManagerController):
                 return INCOMPLETE_PATRON_AUTH_SERVICE_CONFIGURATION.detailed(
                     _("The patron authentication service is missing a required field: %(field)s",
                       field=field.get("label")))
-            if key == "url":
-                auth_service.url = value
-            elif key == "username":
-                auth_service.username = value
-            elif key == "password":
-                auth_service.password = value
-            else:
-                auth_service.setting(key).value = value
+            auth_service.setting(key).value = value
 
 
         auth_service.libraries = []

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1010,6 +1010,8 @@ class SettingsController(CirculationManagerController):
                 { "key": "website_id", "label": _("Website ID") },
                 { "key": ExternalIntegration.USERNAME, "label": _("Client Key") },
                 { "key": ExternalIntegration.PASSWORD, "label": _("Client Secret") },
+                { "key": "default_loan_period", "label": _("Default Loan Period") },
+                { "key": "default_reservation_period", "label": _("Default Reservation Period") },
             ],
         })
 
@@ -1019,6 +1021,8 @@ class SettingsController(CirculationManagerController):
                 { "key": ExternalIntegration.USERNAME, "label": _("Account ID") },
                 { "key": ExternalIntegration.PASSWORD, "label": _("Account Key") },
                 { "key": "external_account_id", "label": _("Library ID") },
+                { "key": "default_loan_period", "label": _("Default Loan Period") },
+                { "key": "default_reservation_period", "label": _("Default Reservation Period") },
             ],
         })
 
@@ -1029,6 +1033,8 @@ class SettingsController(CirculationManagerController):
                 { "key": ExternalIntegration.PASSWORD, "label": _("Password") },
                 { "key": "external_account_id", "label": _("Library ID") },
                 { "key": ExternalIntegration.URL, "label": _("Server") },
+                { "key": "default_loan_period", "label": _("Default Loan Period") },
+                { "key": "default_reservation_period", "label": _("Default Reservation Period") },
             ],
         })
 
@@ -1038,6 +1044,8 @@ class SettingsController(CirculationManagerController):
                 { "key": ExternalIntegration.PASSWORD, "label": _("Basic Token") },
                 { "key": "external_account_id", "label": _("Library ID") },
                 { "key": ExternalIntegration.URL, "label": _("URL") },
+                { "key": "default_loan_period", "label": _("Default Loan Period") },
+                { "key": "default_reservation_period", "label": _("Default Reservation Period") },
             ],
         })
 

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -379,7 +379,7 @@ def admin_view(collection=None, book=None, **kwargs):
     else:
         home_url = None
 
-    csrf_token = app.manager.admin_sign_in_controller.generate_csrf_token()
+    csrf_token = flask.request.cookies.get("csrf_token") or app.manager.admin_sign_in_controller.generate_csrf_token()
 
     show_circ_events_download = (
         "core.local_analytics_provider" in (Configuration.policy("analytics") or [])

--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -19,6 +19,7 @@ from core.model import (
     get_one_or_create,
     Credential,
     DataSource,
+    ExternalIntegration,
     Patron,
 )
 from core.util.http import HTTP
@@ -60,8 +61,8 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
         OAuth provider.""")
 
     SETTINGS = [
-        { "key": "username", "label": _("Client ID") },
-        { "key": "password", "label": _("Client Secret") },
+        { "key": ExternalIntegration.USERNAME, "label": _("Client ID") },
+        { "key": ExternalIntegration.PASSWORD, "label": _("Client Secret") },
     ] + OAuthAuthenticationProvider.SETTINGS
 
     # Unlike other authentication providers, external type regular expression

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -15,6 +15,7 @@ import urlparse
 import urllib
 from core.model import (
     get_one_or_create,
+    ExternalIntegration,
     Patron,
 )
 
@@ -39,8 +40,8 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
     DEFAULT_PASSWORD_REGULAR_EXPRESSION = '^[0-9]+$'
     
     SETTINGS = [
-        { "key": "url", "label": _("URL") },
-        { "key": "password", "label": _("Key") },
+        { "key": ExternalIntegration.URL, "label": _("URL") },
+        { "key": ExternalIntegration.PASSWORD, "label": _("Key") },
     ] + BasicAuthenticationProvider.SETTINGS
     
     log = logging.getLogger("First Book authentication API")

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -8,6 +8,7 @@ from api.authenticator import (
 from api.sip.client import SIPClient
 from core.util.http import RemoteIntegrationException
 from core.util import MoneyUtility
+from core.model import ExternalIntegration
 
 class SIP2AuthenticationProvider(BasicAuthenticationProvider):
 
@@ -21,10 +22,10 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
     FIELD_SEPARATOR = "field separator"
     
     SETTINGS = [
-        { "key": "url", "label": _("URL") },
+        { "key": ExternalIntegration.URL, "label": _("URL") },
         { "key": PORT, "label": _("Port") },
-        { "key": "username", "label": _("Login User ID") },
-        { "key": "password", "label": _("Login Password") },
+        { "key": ExternalIntegration.USERNAME, "label": _("Login User ID") },
+        { "key": ExternalIntegration.PASSWORD, "label": _("Login Password") },
         { "key": LOCATION_CODE, "label": _("Location Code") },
         { "key": FIELD_SEPARATOR, "label": _("Field Separator") },
     ] + BasicAuthenticationProvider.SETTINGS

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1414,6 +1414,8 @@ class TestSettingsController(AdminControllerTest):
                 ("username", "username"),
                 ("password", "password"),
                 ("website_id", "1234"),
+                ("default_loan_period", "14"),
+                ("default_reservation_period", "3"),
             ])
             response = self.manager.admin_settings_controller.collections()
             eq_(response.status_code, 201)
@@ -1430,10 +1432,18 @@ class TestSettingsController(AdminControllerTest):
         eq_([collection], l2.collections)
         eq_([], l3.collections)
 
-        # One additional setting was set on the collection.
+        # Additional settings were set on the collection.
         setting = collection.external_integration.setting("website_id")
         eq_("website_id", setting.key)
         eq_("1234", setting.value)
+
+        setting = collection.external_integration.setting("default_loan_period")
+        eq_("default_loan_period", setting.key)
+        eq_("14", setting.value)
+
+        setting = collection.external_integration.setting("default_reservation_period")
+        eq_("default_reservation_period", setting.key)
+        eq_("3", setting.value)
 
     def test_collections_post_edit(self):
         # The collection exists.
@@ -1455,6 +1465,8 @@ class TestSettingsController(AdminControllerTest):
                 ("password", "password"),
                 ("website_id", "1234"),
                 ("libraries", json.dumps(["L1"])),
+                ("default_loan_period", "14"),
+                ("default_reservation_period", "3"),
             ])
             response = self.manager.admin_settings_controller.collections()
             eq_(response.status_code, 200)
@@ -1465,10 +1477,18 @@ class TestSettingsController(AdminControllerTest):
         # A library now has access to the collection.
         eq_([collection], l1.collections)
 
-        # One additional setting was set on the collection.
+        # Additional settings were set on the collection.
         setting = collection.external_integration.setting("website_id")
         eq_("website_id", setting.key)
         eq_("1234", setting.value)
+
+        setting = collection.external_integration.setting("default_loan_period")
+        eq_("default_loan_period", setting.key)
+        eq_("14", setting.value)
+
+        setting = collection.external_integration.setting("default_reservation_period")
+        eq_("default_reservation_period", setting.key)
+        eq_("3", setting.value)
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
@@ -1478,6 +1498,8 @@ class TestSettingsController(AdminControllerTest):
                 ("username", "user2"),
                 ("password", "password"),
                 ("website_id", "1234"),
+                ("default_loan_period", "14"),
+                ("default_reservation_period", "3"),
                 ("libraries", json.dumps([])),
             ])
             response = self.manager.admin_settings_controller.collections()

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1430,8 +1430,8 @@ class TestSettingsController(AdminControllerTest):
         eq_([collection], l2.collections)
         eq_([], l3.collections)
 
-        # One CollectionSetting was set on the collection.
-        [setting] = collection.external_integration.settings
+        # One additional setting was set on the collection.
+        setting = collection.external_integration.setting("website_id")
         eq_("website_id", setting.key)
         eq_("1234", setting.value)
 
@@ -1465,8 +1465,8 @@ class TestSettingsController(AdminControllerTest):
         # A library now has access to the collection.
         eq_([collection], l1.collections)
 
-        # One CollectionSetting was set on the collection.
-        [setting] = collection.external_integration.settings
+        # One additional setting was set on the collection.
+        setting = collection.external_integration.setting("website_id")
         eq_("website_id", setting.key)
         eq_("1234", setting.value)
 
@@ -1582,7 +1582,7 @@ class TestSettingsController(AdminControllerTest):
         eq_("username", auth_service.username)
         eq_("password", auth_service.password)
 
-        [setting] = auth_service.settings
+        setting = auth_service.setting("domains")
         eq_("domains", setting.key)
         eq_(["nypl.org", "gmail.com"], json.loads(setting.value))
 
@@ -1611,7 +1611,7 @@ class TestSettingsController(AdminControllerTest):
 
         eq_("url2", auth_service.url)
         eq_("user2", auth_service.username)
-        [setting] = auth_service.settings
+        setting = auth_service.setting("domains")
         eq_("domains", setting.key)
         eq_(["library2.org"], json.loads(setting.value))
 
@@ -1758,10 +1758,10 @@ class TestSettingsController(AdminControllerTest):
             protocol=SIP2AuthenticationProvider.__module__,
             goal=ExternalIntegration.PATRON_AUTH_GOAL
         )
-        auth_service.setting("url").value = "url"
+        auth_service.url = "url"
         auth_service.setting(SIP2AuthenticationProvider.PORT).value = "1234"
-        auth_service.setting("username").value = "user"
-        auth_service.setting("password").value = "pass"
+        auth_service.username = "user"
+        auth_service.password = "pass"
         auth_service.setting(SIP2AuthenticationProvider.LOCATION_CODE).value = "5"
         auth_service.setting(SIP2AuthenticationProvider.FIELD_SEPARATOR).value = ","
 
@@ -1777,10 +1777,10 @@ class TestSettingsController(AdminControllerTest):
 
             eq_(auth_service.id, service.get("id"))
             eq_(SIP2AuthenticationProvider.__module__, service.get("protocol"))
-            eq_("url", service.get("settings").get("url"))
+            eq_("url", service.get("settings").get(ExternalIntegration.URL))
             eq_("1234", service.get("settings").get(SIP2AuthenticationProvider.PORT))
-            eq_("user", service.get("settings").get("username"))
-            eq_("pass", service.get("settings").get("password"))
+            eq_("user", service.get("settings").get(ExternalIntegration.USERNAME))
+            eq_("pass", service.get("settings").get(ExternalIntegration.PASSWORD))
             eq_("5", service.get("settings").get(SIP2AuthenticationProvider.LOCATION_CODE))
             eq_(",", service.get("settings").get(SIP2AuthenticationProvider.FIELD_SEPARATOR))
             [library] = service.get("libraries")
@@ -1793,8 +1793,8 @@ class TestSettingsController(AdminControllerTest):
             protocol=FirstBookAuthenticationAPI.__module__,
             goal=ExternalIntegration.PATRON_AUTH_GOAL
         )
-        auth_service.setting("url").value = "url"
-        auth_service.setting("password").value = "pass"
+        auth_service.url = "url"
+        auth_service.password = "pass"
         auth_service.libraries += [self._default_library]
         ConfigurationSetting.for_library_and_externalintegration(
             self._db, AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION,
@@ -1807,8 +1807,8 @@ class TestSettingsController(AdminControllerTest):
 
             eq_(auth_service.id, service.get("id"))
             eq_(FirstBookAuthenticationAPI.__module__, service.get("protocol"))
-            eq_("url", service.get("settings").get("url"))
-            eq_("pass", service.get("settings").get("password"))
+            eq_("url", service.get("settings").get(ExternalIntegration.URL))
+            eq_("pass", service.get("settings").get(ExternalIntegration.PASSWORD))
             [library] = service.get("libraries")
             eq_(self._default_library.short_name, library.get("short_name"))
             eq_("^(u)", library.get(AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION))
@@ -1819,8 +1819,8 @@ class TestSettingsController(AdminControllerTest):
             protocol=CleverAuthenticationAPI.__module__,
             goal=ExternalIntegration.PATRON_AUTH_GOAL
         )
-        auth_service.setting("username").value = "user"
-        auth_service.setting("password").value = "pass"
+        auth_service.username = "user"
+        auth_service.password = "pass"
         auth_service.libraries += [self._default_library]
 
         with self.app.test_request_context("/"):
@@ -1829,8 +1829,8 @@ class TestSettingsController(AdminControllerTest):
 
             eq_(auth_service.id, service.get("id"))
             eq_(CleverAuthenticationAPI.__module__, service.get("protocol"))
-            eq_("user", service.get("settings").get("username"))
-            eq_("pass", service.get("settings").get("password"))
+            eq_("user", service.get("settings").get(ExternalIntegration.USERNAME))
+            eq_("pass", service.get("settings").get(ExternalIntegration.PASSWORD))
             [library] = service.get("libraries")
             eq_(self._default_library.short_name, library.get("short_name"))
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -154,8 +154,8 @@ class MockOAuth(OAuthAuthenticationProvider):
         integration, ignore = create(
             _db, ExternalIntegration, protocol="OAuth",
             goal=ExternalIntegration.PATRON_AUTH_GOAL,
-            username=name
         )
+        integration.username = name
         integration.password = ""
         integration.setting(self.OAUTH_TOKEN_EXPIRATION_DAYS).value = 20
         super(MockOAuth, self).__init__(library, integration)
@@ -472,8 +472,8 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         # Only a basic auth provider.
         millenium = self._external_integration(
             "api.millenium_patron", ExternalIntegration.PATRON_AUTH_GOAL,
-            url="http://url/"
         )
+        millenium.url = "http://url/"
         self._default_library.integrations.append(millenium)
 
         auth = LibraryAuthenticator.from_config(self._db, self._default_library)
@@ -487,14 +487,16 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         # A basic auth provider and an oauth provider.
         firstbook = self._external_integration(
             "api.firstbook", ExternalIntegration.PATRON_AUTH_GOAL,
-            url="http://url/", password="secret"
         )
+        firstbook.url = "http://url/"
+        firstbook.password = "secret"
         library.integrations.append(firstbook)
         
         oauth = self._external_integration(
             "api.clever", ExternalIntegration.PATRON_AUTH_GOAL,
-            username="client_id", password="client_secret"
         )
+        oauth.username = "client_id"
+        oauth.password = "client_secret"
         library.integrations.append(oauth)
 
         auth = LibraryAuthenticator.from_config(self._db, library)
@@ -560,8 +562,9 @@ class TestLibraryAuthenticator(AuthenticatorTest):
     def test_register_provider_basic_auth(self):
         firstbook = self._external_integration(
             "api.firstbook", ExternalIntegration.PATRON_AUTH_GOAL,
-            url="http://url/", password="secret"
         )
+        firstbook.url = "http://url/"
+        firstbook.password = "secret"
         self._default_library.integrations.append(firstbook)
         auth = LibraryAuthenticator(_db=self._db, library=self._default_library)
         auth.register_provider(firstbook)
@@ -572,8 +575,9 @@ class TestLibraryAuthenticator(AuthenticatorTest):
     def test_register_oauth_provider(self):
         oauth = self._external_integration(
             "api.clever", ExternalIntegration.PATRON_AUTH_GOAL,
-            username="client_id", password="client_secret"
         )
+        oauth.username = "client_id"
+        oauth.password = "client_secret"
         self._default_library.integrations.append(oauth)
         auth = LibraryAuthenticator(_db=self._db, library=self._default_library)
         auth.register_provider(oauth)


### PR DESCRIPTION
This simplifies the admin interface code using https://github.com/NYPL-Simplified/server_core/pull/528.

I also fixed an admin interface bug I noticed due to the CSRF token changing on every page load. When you opened a second tab, and then went back to the first tab and tried to submit a form, you'd get a CSRF token error since that tab's html still had the old token, but your cookie had the new token.