### PR TITLE
Fix to family name authentication

### DIFF
--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -101,10 +101,11 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
             url = self.root + path
             response = self.request(url)
             data = dict(self._extract_text_nodes(response.content))
-            dump_name = data.get(self.PERSONAL_NAME_FIELD)
-            dump_name = dump_name.split(',')[0]
-            if dump_name.upper() == password.upper():
-              return PatronData(authorization_identifier=username, complete=False)
+            if data.get('REDCOD') == '0':
+              dump_name = data.get(self.PERSONAL_NAME_FIELD)
+              dump_name = dump_name.split(',')[0]
+              if dump_name.upper() == password.upper():
+                return PatronData(authorization_identifier=username, complete=False)
             return False
 
     def remote_patron_lookup(self, patron_or_patrondata):

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -101,7 +101,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
             url = self.root + path
             response = self.request(url)
             data = dict(self._extract_text_nodes(response.content))
-            if data.get('REDCOD') == '0':
+            if data.get('ERROR_MESSAGE_FIELD') is None:
               dump_name = data.get(self.PERSONAL_NAME_FIELD)
               dump_name = dump_name.split(',')[0]
               if dump_name.upper() == password.upper():

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -400,7 +400,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         self.api.enqueue("dump.success.html")
         eq_(False, self.api.remote_authenticate("44444444444447", "wrong name"))
 
-    def test_remote_patron_lookup_no_such_patron(self):
+    def test_remote_patron_lookup_last_name_no_such_patron(self):
         """Test for no such patron using last name authentication"""
         self.api = MockAPI(auth_mode = "family_name")
         self.api.enqueue("dump.no such barcode.html")

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -399,3 +399,10 @@ class TestMilleniumPatronAPI(DatabaseTest):
         self.api = MockAPI(auth_mode = "family_name")
         self.api.enqueue("dump.success.html")
         eq_(False, self.api.remote_authenticate("44444444444447", "wrong name"))
+
+    def test_remote_patron_lookup_no_such_patron(self):
+        """Test for no such patron using last name authentication"""
+        self.api = MockAPI(auth_mode = "family_name")
+        self.api.enqueue("dump.no such barcode.html")
+        patrondata = PatronData(authorization_identifier="bad barcode")
+        eq_(None, self.api.remote_patron_lookup(patrondata))


### PR DESCRIPTION
Previously, a generic error was thrown when an invalid barcode was entered.
Now, the client will display the correct invalid barcode/PIN message.