### PR TITLE
Implement patron identifier prefix

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -719,6 +719,10 @@ class AuthenticationProvider(object):
     # authenticate with the ILS but not be considered a patron of
     # _this_ library. This setting contains the rule for determining
     # whether an identifier is valid for a specific library.
+    #
+    # Usually this is a prefix string which is compared against the
+    # patron's identifiers, but if the string starts with a carat (^)
+    # it will be interpreted as a regular expression.
     PATRON_IDENTIFIER_RESTRICTION = 'patron_identifier_restriction'
     
     LIBRARY_SETTINGS = [
@@ -727,7 +731,7 @@ class AuthenticationProvider(object):
           "optional": True,
         },
         { "key": PATRON_IDENTIFIER_RESTRICTION,
-          "label": _("Patron identifier restriction"),
+          "label": _("Patron identifier prefix"),
           "optional": True,
         }
     ]

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1182,7 +1182,7 @@ class BasicAuthenticationProvider(AuthenticationProvider):
                 self.password_re.match(password) is not None
             )
         if not self.patron_identifier_restriction_matches(username):
-            value = PATRON_OF_ANOTHER_LIBRARY
+            valid = PATRON_OF_ANOTHER_LIBRARY
         return valid
     
     def remote_authenticate(self, username, password):

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -714,10 +714,20 @@ class AuthenticationProvider(object):
     # expression for deriving a patron's external type from their
     # authentication identifier.
     EXTERNAL_TYPE_REGULAR_EXPRESSION = 'external_type_regular_expression'
+
+    # When multiple libraries share an ILS, a person may be able to
+    # authenticate with the ILS but not be considered a patron of
+    # _this_ library. This setting contains the rule for determining
+    # whether an identifier is valid for a specific library.
+    PATRON_IDENTIFIER_RESTRICTION = 'patron_identifier_restriction'
     
     LIBRARY_SETTINGS = [
         { "key": EXTERNAL_TYPE_REGULAR_EXPRESSION,
           "label": _("External Type Regular Expression"),
+          "optional": True,
+        },
+        { "key": PATRON_IDENTIFIER_RESTRICTION,
+          "label": _("Patron identifier restriction"),
           "optional": True,
         }
     ]
@@ -762,7 +772,50 @@ class AuthenticationProvider(object):
                 regexp = None
         self.external_type_regular_expression = regexp
 
-            
+        restriction = ConfigurationSetting.for_library_and_externalintegration(
+            _db, self.PATRON_IDENTIFIER_RESTRICTION, library, integration
+        ).value
+        if restriction and restriction.startswith("^"):
+            # Interpret the value a regular expression
+            try:
+                restriction = re.compile(restriction)
+            except Exception, e:
+                self.log.error(
+                    "Could not interpret identifier restriction as a regular expression: %r", e
+                )
+        self.patron_identifier_restriction = restriction
+
+    @classmethod
+    def _restriction_matches(cls, identifier, restriction):
+        """Does the given patron identifier match the given 
+        patron identifier restriction?
+        """
+        if not restriction:
+            # No restriction -- anything matches.
+            return True
+        if not identifier:
+            # No identifier -- it won't match any restriction.
+            return False
+        if isinstance(restriction, basestring):
+            # It's a prefix string.
+            if not identifier.startswith(restriction):
+                # The prefix doesn't match.
+                return False
+        else:
+            # It's a regexp.
+            if not restriction.search(identifier):
+                # The regex doesn't match.
+                return False
+        return True
+        
+    def patron_identifier_restriction_matches(self, identifier):
+        """Does the given patron identifier match the configured
+        patron identifier restriction?
+        """
+        return self._restriction_matches(
+            identifier, self.patron_identifier_restriction
+        )
+    
     def library(self, _db):
         return get_one(_db, Library, self.library_id)
     
@@ -1019,10 +1072,17 @@ class BasicAuthenticationProvider(AuthenticationProvider):
         """
         username = credentials.get('username')
         password = credentials.get('password')
-        if not self.server_side_validation(username, password):
+        server_side_validation_result = self.server_side_validation(
+            username, password
+        )
+        if not server_side_validation_result:
+            # False => None
+            server_side_validation_result = None
+        if (not server_side_validation_result
+            or isinstance(server_side_validation_result, ProblemDetail)):
             # The credentials are prima facie invalid and do not
             # need to be checked with the source of truth.
-            return None
+            return server_side_validation_result
 
         # Check these credentials with the source of truth.
         patrondata = self.remote_authenticate(username, password)
@@ -1117,8 +1177,10 @@ class BasicAuthenticationProvider(AuthenticationProvider):
             valid = valid and password is not None and (
                 self.password_re.match(password) is not None
             )
+        if not self.patron_identifier_restriction_matches(username):
+            value = PATRON_OF_ANOTHER_LIBRARY
         return valid
-        
+    
     def remote_authenticate(self, username, password):
         """Does the source of truth approve of these credentials?
 
@@ -1412,7 +1474,16 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
         patrondata = self.remote_patron_lookup(token)
         if isinstance(patrondata, ProblemDetail):
             return patrondata
-        
+
+        for identifier in patrondata.authorization_identifiers:
+            if self.patron_identifier_restriction_matches(identifier):
+                break
+        else:
+            # None of the patron's authorization identifiers match.
+            # This patron was able to validate with the OAuth provider,
+            # but they are not a patron of _this_ library.
+            return PATRON_OF_ANOTHER_LIBRARY
+            
         # Convert the PatronData into a Patron object.
         patron, is_new = patrondata.get_or_create_patron(
             _db, self.library_id

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -260,3 +260,10 @@ LIBRARY_NOT_FOUND = pd(
     title=_("Library not found."),
     detail=_("No library with the requested name on this server."),
 )
+
+PATRON_OF_ANOTHER_LIBRARY = pd(
+    "http://librarysimplified.org/terms/problem/patron-of-another-library",
+    status_code=404,
+    title=_("Wrong library"),
+    detail=_("You are not a patron of the selected library."),
+)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1167,7 +1167,9 @@ class TestAuthenticationProvider(AuthenticatorTest):
         eq_(True, m(None, None))
         eq_(True, m("12345a", "1234"))
         eq_(True, m("a1234", re.compile("1234")))
-
+        eq_(True, m("123", re.compile("^(12|34)")))
+        eq_(True, m("345", re.compile("^(12|34)")))
+        
         eq_(False, m(None, "1234"))
         eq_(False, m(None, re.compile(".*")))
         eq_(False, m("a1234", "1234"))


### PR DESCRIPTION
This branch implements the most commonly used per-library configuration setting: a "barcode prefix" used to exclude people who might be able to authenticate with the ILS, but who are patrons of a different library that shares an ILS with this library.

If the patron identifier prefix starts with a carat, it's treated as a regular expression. Otherwise, it's treated as a prefix string. This lets us handle all possible restrictions of this type, while keeping things simple for the "barcode prefix" case, which is by far the most common.

This is different from the "identifier_regular_expression" in two ways. First, it applies to all AuthenticationProviders, not only BasicAuthenticationProviders. Second, the goal of identifier_regular_expression is to filter out people who typed in junk, rather than people who have valid credentials for a different library.