### PR TITLE
Metadata services in admin interface

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -90,6 +90,7 @@ from api.oneclick import OneClickAPI
 
 from api.nyt import NYTBestSellerAPI
 from api.novelist import NoveListAPI
+from core.opds_import import MetadataWranglerOPDSLookup
 
 def setup_admin_controllers(manager):
     """Set up all the controllers that will be used by the admin parts of the web app."""
@@ -1393,6 +1394,7 @@ class SettingsController(CirculationManagerController):
 
         for provider in [NYTBestSellerAPI,
                          NoveListAPI,
+                         MetadataWranglerOPDSLookup,
                         ]:
             protocols.append({
                 "name": provider.PROTOCOL,

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.22"
+    "simplified-circulation-web": "0.0.23"
   }
 }

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -135,25 +135,25 @@ MISSING_COLLECTION_NAME = pd(
     detail=_("You must identify the collection by its name."),
 )
 
-NO_PROTOCOL_FOR_NEW_COLLECTION = pd(
-    "http://librarysimplified.org/terms/problem/no-protocol-for-new-collection",
+NO_PROTOCOL_FOR_NEW_SERVICE = pd(
+    "http://librarysimplified.org/terms/problem/no-protocol-for-new-service",
     status_code=400,
-    title=_("No protocol for new collection"),
-    detail=_("The specified collection doesn't exist. You can create it, but you must specify a protocol."),
+    title=_("No protocol for new service"),
+    detail=_("The specified service doesn't exist. You can create it, but you must specify a protocol."),
 )
 
-UNKNOWN_COLLECTION_PROTOCOL = pd(
-    "http://librarysimplified.org/terms/problem/unknown-collection-protocol",
+UNKNOWN_PROTOCOL = pd(
+    "http://librarysimplified.org/terms/problem/unknown-protocol",
     status_code=400,
-    title=_("Unknown collection protocol"),
+    title=_("Unknown protocol"),
     detail=_("The protocol is not one of the known protocols."),
 )
 
-CANNOT_CHANGE_COLLECTION_PROTOCOL = pd(
-    "http://librarysimplified.org/terms/problem/cannot-change-collection-protocol",
+CANNOT_CHANGE_PROTOCOL = pd(
+    "http://librarysimplified.org/terms/problem/cannot-change-protocol",
     status_code=400,
-    title=_("Cannot change collection protocol"),
-    detail=_("A collection's protocol can't be changed once it has been set."),
+    title=_("Cannot change protocol"),
+    detail=_("A protocol can't be changed once it has been set."),
 )
 
 NO_SUCH_LIBRARY = pd(
@@ -163,39 +163,11 @@ NO_SUCH_LIBRARY = pd(
     detail=_("One of the libraries you attempted to add the collection to does not exist."),
 )
 
-INCOMPLETE_COLLECTION_CONFIGURATION = pd(
-    "http://librarysimplified.org/terms/problem/incomplete-collection-configuration",
+INCOMPLETE_CONFIGURATION = pd(
+    "http://librarysimplified.org/terms/problem/incomplete-configuration",
     status_code=400,
-    title=_("Incomplete collection configuration"),
-    detail=_("The collection's configuration is missing a required field."),
-)
-
-UNKNOWN_ADMIN_AUTH_SERVICE_PROVIDER = pd(
-    "http://librarysimplified.org/terms/problem/unknown-admin-auth-service-provider",
-    status_code=400,
-    title=_("Unknown admin authentication service provider"),
-    detail=_("The provider is not one of the known admin authentication service providers."),
-)
-
-CANNOT_CHANGE_ADMIN_AUTH_SERVICE_PROVIDER = pd(
-    "http://librarysimplified.org/terms/problem/cannot-change-admin-auth-service-provider",
-    status_code=400,
-    title=_("Cannot change admin authentication service provider"),
-    detail=_("An admin authentication service's provider can't be changed once it has been set."),
-)
-
-NO_PROVIDER_FOR_NEW_ADMIN_AUTH_SERVICE = pd(
-    "http://librarysimplified.org/terms/problem/no-provider-for-new-admin-auth-service",
-    status_code=400,
-    title=_("No provider for new admin authentication service"),
-    detail=_("The specified admin authentication service doesn't exist. You can create it, but you must specify a provider."),
-)
-
-INCOMPLETE_ADMIN_AUTH_SERVICE_CONFIGURATION = pd(
-    "http://librarysimplified.org/terms/problem/incomplete-admin-auth-service-configuration",
-    status_code=400,
-    title=_("Incomplete admin authentication service configuration"),
-    detail=_("The admin authentication service's configuration is missing a required field."),
+    title=_("Incomplete configuration"),
+    detail=_("The configuration is missing a required field."),
 )
 
 INVALID_ADMIN_AUTH_DOMAIN_LIST = pd(
@@ -203,13 +175,6 @@ INVALID_ADMIN_AUTH_DOMAIN_LIST = pd(
     status_code=400,
     title=_("Invalid admin authentication domain list"),
     detail=_("The admin authentication domain list isn't in a valid format."),
-)
-
-INVALID_INDIVIDUAL_ADMIN_CONFIGURATION = pd(
-    "http://librarysimplified.org/terms/problem/invalid-individual-admin-configuration",
-    status_code=400,
-    title=_("Incomplete individual admin configuration"),
-    detail=_("The individual admin's configuration is missing a required field."),
 )
 
 MISSING_PGCRYPTO_EXTENSION = pd(
@@ -226,39 +191,11 @@ MISSING_PATRON_AUTH_SERVICE = pd(
     detail=_("The specific patron authentication service does not exist."),
 )
 
-UNKNOWN_PATRON_AUTH_SERVICE_PROTOCOL = pd(
-    "http://librarysimplified.org/terms/problem/unknown-patron-auth-service-protocol",
+INVALID_CONFIGURATION_OPTION = pd(
+    "http://librarysimplified.org/terms/problem/invalid-configuration-option",
     status_code=400,
-    title=_("Unknown patron authentication service protocol"),
-    detail=_("The protocol is not one of the known patron authentication service protocols."),
-)
-
-CANNOT_CHANGE_PATRON_AUTH_SERVICE_PROTOCOL = pd(
-    "http://librarysimplified.org/terms/problem/cannot-change-patron-auth-service-protocol",
-    status_code=400,
-    title=_("Cannot change patron authentication service protocol"),
-    detail=_("A patron authentication service's protocol can't be changed once it has been set."),
-)
-
-NO_PROTOCOL_FOR_NEW_PATRON_AUTH_SERVICE = pd(
-    "http://librarysimplified.org/terms/problem/no-protocol-for-new-patron-auth-service",
-    status_code=400,
-    title=_("No protocol for new patron authentication service"),
-    detail=_("The specified patron authentication service doesn't exist. You can create it, but you must specify a protocol."),
-)
-
-INCOMPLETE_PATRON_AUTH_SERVICE_CONFIGURATION = pd(
-    "http://librarysimplified.org/terms/problem/incomplete-patron-auth-service-configuration",
-    status_code=400,
-    title=_("Incomplete patron authentication service configuration"),
-    detail=_("The patron authentication service's configuration is missing a required field."),
-)
-
-INVALID_PATRON_AUTH_SERVICE_CONFIGURATION_OPTION = pd(
-    "http://librarysimplified.org/terms/problem/invalid-patron-auth-service-configuration-option",
-    status_code=400,
-    title=_("Invalid patron authentication service configuration option"),
-    detail=_("The patron authentication service's configuration has an invalid value."),
+    title=_("Invalid configuration option"),
+    detail=_("The configuration has an invalid value."),
 )
 
 INVALID_EXTERNAL_TYPE_REGULAR_EXPRESSION = pd(
@@ -287,4 +224,11 @@ MISSING_SITEWIDE_SETTING_VALUE = pd(
     status_code=400,
     title=_("Missing sitewide setting value"),
     detail=_("A value is required to change a sitewide setting."),
+)
+
+MISSING_METADATA_SERVICE = pd(
+    "http://librarysimplified.org/terms/problem/missing-metadata-service",
+    status_code=404,
+    title=_("Missing metadata service"),
+    detail=_("The specified metadata service does not exist."),
 )

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -339,6 +339,18 @@ def patron_auth_services():
         return data
     return flask.jsonify(**data)
 
+@app.route("/admin/metadata_services", methods=['GET', 'POST'])
+@returns_problem_detail
+@requires_admin
+@requires_csrf_token
+def metadata_services():
+    data = app.manager.admin_settings_controller.metadata_services()
+    if isinstance(data, ProblemDetail):
+        return data
+    if isinstance(data, Response):
+        return data
+    return flask.jsonify(**data)
+
 @app.route("/admin/sitewide_settings", methods=['GET', 'POST'])
 @returns_problem_detail
 @requires_admin

--- a/api/novelist.py
+++ b/api/novelist.py
@@ -3,6 +3,7 @@ import logging
 import urllib
 from collections import Counter
 from nose.tools import set_trace
+from flask.ext.babel import lazy_gettext as _
 
 from core.config import Configuration
 from core.coverage import (
@@ -30,6 +31,18 @@ from core.model import (
 from core.util import TitleProcessor
 
 class NoveListAPI(object):
+
+    PROTOCOL = ExternalIntegration.NOVELIST
+    NAME = _("Novelist API")
+
+    SETTINGS = [
+        { "key": ExternalIntegration.USERNAME, "label": _("Profile") },
+        { "key": ExternalIntegration.PASSWORD, "label": _("Password") },
+    ]
+
+    # Different libraries may have different NoveList integrations
+    # on the same circulation manager.
+    SITEWIDE = False
 
     IS_CONFIGURED = None
     _configuration_library_id = None

--- a/api/nyt.py
+++ b/api/nyt.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm.session import Session
 from sqlalchemy.orm.exc import (
     NoResultFound,
 )
+from flask.ext.babel import lazy_gettext as _
 
 from config import CannotLoadConfiguration
 
@@ -44,6 +45,16 @@ class NYTAPI(object):
 
 class NYTBestSellerAPI(NYTAPI):
     
+    PROTOCOL = ExternalIntegration.NYT
+    NAME = _("NYT Best Seller API")
+
+    SETTINGS = [
+        { "key": ExternalIntegration.PASSWORD, "label": _("API key") },
+    ]
+
+    # An NYT integration is shared by all libraries in a circulation manager.
+    SITEWIDE = True
+
     BASE_URL = "http://api.nytimes.com/svc/books/v3/lists"
 
     LIST_NAMES_URL = BASE_URL + "/names.json"

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -54,6 +54,7 @@ from api.sip import SIP2AuthenticationProvider
 from api.firstbook import FirstBookAuthenticationAPI
 from api.clever import CleverAuthenticationAPI
 
+from api.novelist import NoveListAPI
 
 class AdminControllerTest(CirculationControllerTest):
 
@@ -1402,7 +1403,7 @@ class TestSettingsController(AdminControllerTest):
                 ("name", "collection"),
             ])
             response = self.manager.admin_settings_controller.collections()
-            eq_(response, NO_PROTOCOL_FOR_NEW_COLLECTION)
+            eq_(response, NO_PROTOCOL_FOR_NEW_SERVICE)
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
@@ -1410,7 +1411,7 @@ class TestSettingsController(AdminControllerTest):
                 ("protocol", "Unknown"),
             ])
             response = self.manager.admin_settings_controller.collections()
-            eq_(response, UNKNOWN_COLLECTION_PROTOCOL)
+            eq_(response, UNKNOWN_PROTOCOL)
 
         collection = self._collection(
             name="Collection 1",
@@ -1423,7 +1424,7 @@ class TestSettingsController(AdminControllerTest):
                 ("protocol", "Bibliotheca"),
             ])
             response = self.manager.admin_settings_controller.collections()
-            eq_(response, CANNOT_CHANGE_COLLECTION_PROTOCOL)
+            eq_(response, CANNOT_CHANGE_PROTOCOL)
 
 
         with self.app.test_request_context("/", method="POST"):
@@ -1442,7 +1443,7 @@ class TestSettingsController(AdminControllerTest):
                 ("protocol", "OPDS Import"),
             ])
             response = self.manager.admin_settings_controller.collections()
-            eq_(response.uri, INCOMPLETE_COLLECTION_CONFIGURATION.uri)
+            eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
@@ -1453,7 +1454,7 @@ class TestSettingsController(AdminControllerTest):
                 ("password", "password"),
             ])
             response = self.manager.admin_settings_controller.collections()
-            eq_(response.uri, INCOMPLETE_COLLECTION_CONFIGURATION.uri)
+            eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
@@ -1463,7 +1464,7 @@ class TestSettingsController(AdminControllerTest):
                 ("password", "password"),
             ])
             response = self.manager.admin_settings_controller.collections()
-            eq_(response.uri, INCOMPLETE_COLLECTION_CONFIGURATION.uri)
+            eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
@@ -1473,7 +1474,7 @@ class TestSettingsController(AdminControllerTest):
                 ("password", "password"),
             ])
             response = self.manager.admin_settings_controller.collections()
-            eq_(response.uri, INCOMPLETE_COLLECTION_CONFIGURATION.uri)
+            eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
@@ -1483,7 +1484,7 @@ class TestSettingsController(AdminControllerTest):
                 ("password", "password"),
             ])
             response = self.manager.admin_settings_controller.collections()
-            eq_(response.uri, INCOMPLETE_COLLECTION_CONFIGURATION.uri)
+            eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
 
     def test_collections_post_create(self):
         l1, ignore = create(
@@ -1640,12 +1641,12 @@ class TestSettingsController(AdminControllerTest):
                 ("provider", "Unknown"),
             ])
             response = self.manager.admin_settings_controller.admin_auth_services()
-            eq_(response, UNKNOWN_ADMIN_AUTH_SERVICE_PROVIDER)
+            eq_(response, UNKNOWN_PROTOCOL)
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([])
             response = self.manager.admin_settings_controller.admin_auth_services()
-            eq_(response, NO_PROVIDER_FOR_NEW_ADMIN_AUTH_SERVICE)
+            eq_(response, NO_PROTOCOL_FOR_NEW_SERVICE)
 
     def test_admin_auth_services_post_errors_google_oauth(self):
         auth_service, ignore = create(
@@ -1657,14 +1658,14 @@ class TestSettingsController(AdminControllerTest):
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([])
             response = self.manager.admin_settings_controller.admin_auth_services()
-            eq_(response, CANNOT_CHANGE_ADMIN_AUTH_SERVICE_PROVIDER)
+            eq_(response, CANNOT_CHANGE_PROTOCOL)
         
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
                 ("provider", "Google OAuth"),
             ])
             response = self.manager.admin_settings_controller.admin_auth_services()
-            eq_(response.uri, INCOMPLETE_ADMIN_AUTH_SERVICE_CONFIGURATION.uri)
+            eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
@@ -1747,7 +1748,7 @@ class TestSettingsController(AdminControllerTest):
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([])
             response = self.manager.admin_settings_controller.individual_admins()
-            eq_(response.uri, INVALID_INDIVIDUAL_ADMIN_CONFIGURATION.uri)
+            eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
 
     def test_individual_admins_post_create(self):
         with self.app.test_request_context("/", method="POST"):
@@ -1953,12 +1954,12 @@ class TestSettingsController(AdminControllerTest):
                 ("protocol", "Unknown"),
             ])
             response = self.manager.admin_settings_controller.patron_auth_services()
-            eq_(response, UNKNOWN_PATRON_AUTH_SERVICE_PROTOCOL)
+            eq_(response, UNKNOWN_PROTOCOL)
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([])
             response = self.manager.admin_settings_controller.patron_auth_services()
-            eq_(response, NO_PROTOCOL_FOR_NEW_PATRON_AUTH_SERVICE)
+            eq_(response, NO_PROTOCOL_FOR_NEW_SERVICE)
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
@@ -1979,7 +1980,7 @@ class TestSettingsController(AdminControllerTest):
                 ("protocol", SIP2AuthenticationProvider.__module__),
             ])
             response = self.manager.admin_settings_controller.patron_auth_services()
-            eq_(response, CANNOT_CHANGE_PATRON_AUTH_SERVICE_PROTOCOL)
+            eq_(response, CANNOT_CHANGE_PROTOCOL)
 
         auth_service, ignore = create(
             self._db, ExternalIntegration,
@@ -1994,7 +1995,7 @@ class TestSettingsController(AdminControllerTest):
                 (MilleniumPatronAPI.AUTHENTICATION_MODE, "Invalid mode"),
             ])
             response = self.manager.admin_settings_controller.patron_auth_services()
-            eq_(response.uri, INVALID_PATRON_AUTH_SERVICE_CONFIGURATION_OPTION.uri)
+            eq_(response.uri, INVALID_CONFIGURATION_OPTION.uri)
 
         auth_service, ignore = create(
             self._db, ExternalIntegration,
@@ -2008,7 +2009,7 @@ class TestSettingsController(AdminControllerTest):
                 ("protocol", SimpleAuthenticationProvider.__module__),
             ])
             response = self.manager.admin_settings_controller.patron_auth_services()
-            eq_(response.uri, INCOMPLETE_PATRON_AUTH_SERVICE_CONFIGURATION.uri)
+            eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
@@ -2214,4 +2215,157 @@ class TestSettingsController(AdminControllerTest):
 
         # The setting was changed.
         eq_("20", setting.value)
+
+    def test_metadata_services_get_with_no_services(self):
+        with self.app.test_request_context("/"):
+            response = self.manager.admin_settings_controller.metadata_services()
+            eq_(response.get("metadata_services"), [])
+            protocols = response.get("protocols")
+            assert NoveListAPI.NAME in [p.get("label") for p in protocols]
+            assert "fields" in protocols[0]
+        
+    def test_metadata_services_get_with_one_service(self):
+        novelist_service, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=ExternalIntegration.NOVELIST,
+            goal=ExternalIntegration.METADATA_GOAL,
+        )
+        novelist_service.username = "user"
+        novelist_service.password = "pass"
+
+        with self.app.test_request_context("/"):
+            response = self.manager.admin_settings_controller.metadata_services()
+            [service] = response.get("metadata_services")
+
+            eq_(novelist_service.id, service.get("id"))
+            eq_(ExternalIntegration.NOVELIST, service.get("protocol"))
+            eq_("user", service.get("settings").get(ExternalIntegration.USERNAME))
+            eq_("pass", service.get("settings").get(ExternalIntegration.PASSWORD))
+
+        novelist_service.libraries += [self._default_library]
+        with self.app.test_request_context("/"):
+            response = self.manager.admin_settings_controller.metadata_services()
+            [service] = response.get("metadata_services")
+
+            eq_("user", service.get("settings").get(ExternalIntegration.USERNAME))
+            [library] = service.get("libraries")
+            eq_(self._default_library.short_name, library)
+        
+    def test_metadata_services_post_errors(self):
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("protocol", "Unknown"),
+            ])
+            response = self.manager.admin_settings_controller.metadata_services()
+            eq_(response, UNKNOWN_PROTOCOL)
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([])
+            response = self.manager.admin_settings_controller.metadata_services()
+            eq_(response, NO_PROTOCOL_FOR_NEW_SERVICE)
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("id", "123"),
+            ])
+            response = self.manager.admin_settings_controller.metadata_services()
+            eq_(response, MISSING_METADATA_SERVICE)
+
+        service, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=ExternalIntegration.NOVELIST,
+            goal=ExternalIntegration.METADATA_GOAL,
+        )
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("id", service.id),
+                ("protocol", ExternalIntegration.NYT),
+            ])
+            response = self.manager.admin_settings_controller.metadata_services()
+            eq_(response, CANNOT_CHANGE_PROTOCOL)
+
+        service, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=ExternalIntegration.NOVELIST,
+            goal=ExternalIntegration.METADATA_GOAL,
+        )
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("id", service.id),
+                ("protocol", ExternalIntegration.NOVELIST),
+            ])
+            response = self.manager.admin_settings_controller.metadata_services()
+            eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
+
+        service, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=ExternalIntegration.NOVELIST,
+            goal=ExternalIntegration.METADATA_GOAL,
+        )
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("id", service.id),
+                ("protocol", ExternalIntegration.NOVELIST),
+                (ExternalIntegration.USERNAME, "user"),
+                (ExternalIntegration.PASSWORD, "pass"),
+                ("libraries", json.dumps(["not-a-library"])),
+            ])
+            response = self.manager.admin_settings_controller.metadata_services()
+            eq_(response.uri, NO_SUCH_LIBRARY.uri)
+
+    def test_metadata_services_post_create(self):
+        library, ignore = create(
+            self._db, Library, name="Library", short_name="L",
+        )
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("protocol", ExternalIntegration.NOVELIST),
+                (ExternalIntegration.USERNAME, "user"),
+                (ExternalIntegration.PASSWORD, "pass"),
+                ("libraries", json.dumps(["L"])),
+            ])
+            response = self.manager.admin_settings_controller.metadata_services()
+            eq_(response.status_code, 201)
+
+        service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.METADATA_GOAL)
+        eq_(ExternalIntegration.NOVELIST, service.protocol)
+        eq_("user", service.username)
+        eq_("pass", service.password)
+        eq_([library], service.libraries)
+
+    def test_metadata_services_post_edit(self):
+        l1, ignore = create(
+            self._db, Library, name="Library 1", short_name="L1",
+        )
+        l2, ignore = create(
+            self._db, Library, name="Library 2", short_name="L2",
+        )
+
+        novelist_service, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=ExternalIntegration.NOVELIST,
+            goal=ExternalIntegration.METADATA_GOAL,
+        )
+        novelist_service.username = "olduser"
+        novelist_service.password = "oldpass"
+        novelist_service.libraries = [l1]
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("id", novelist_service.id),
+                ("protocol", ExternalIntegration.NOVELIST),
+                (ExternalIntegration.USERNAME, "user"),
+                (ExternalIntegration.PASSWORD, "pass"),
+                ("libraries", json.dumps(["L2"])),
+            ])
+            response = self.manager.admin_settings_controller.metadata_services()
+            eq_(response.status_code, 200)
+
+        eq_(ExternalIntegration.NOVELIST, novelist_service.protocol)
+        eq_("user", novelist_service.username)
+        eq_("pass", novelist_service.password)
+        eq_([l2], novelist_service.libraries)
 


### PR DESCRIPTION
This branch adds metadata service editing to the admin interface, with NYT and NoveList as the supported protocols. I also consolidated a bunch of similar problem details.

I tried to follow the pattern I started with patron auth services, where the constants that control the admin interface form are defined in the individual API classes. Unlike patron auth services, though, metadata services don't share a base class, so maybe it doesn't make as much sense. I wasn't sure what to do for the metadata wrangler protocol, since it doesn't have an API class. That still needs to be added. Other than metadata wrangler, I think the remaining protocols aren't used in the circ manager and don't need to be in the admin interface, but let me know if I missed anything.