### PR TITLE
Autoreload configuration

### DIFF
--- a/api/base_controller.py
+++ b/api/base_controller.py
@@ -83,6 +83,14 @@ class BaseCirculationManagerController(object):
         return Response(data, 401, headers)
 
     def library_for_request(self, library_short_name):
+        """Look up the library the user is trying to access.
+
+        Since this is called on pretty much every request, it's also
+        an appropriate time to check whether the site configuration
+        has been changed and needs to be updated.
+        """
+        self.manager.reload_settings_if_changed()
+        
         if library_short_name:
             library = get_one(self._db, Library, short_name=library_short_name)
         else:

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -733,7 +733,7 @@ class BibliothecaEventMonitor(CollectionMonitor):
 
         The command line date argument should have the format YYYY-MM-DD.
         """
-        initialized = get_one(_db, Timestamp, self.service_name)
+        initialized = get_one(_db, Timestamp, service=self.service_name)
         default_start_time = datetime.datetime.utcnow() - self.DEFAULT_START_TIME
 
         if cli_date:

--- a/api/controller.py
+++ b/api/controller.py
@@ -154,7 +154,7 @@ class CirculationManager(object):
         """If the site configuration has been updated, reload the
         CirculationManager's configuration from the database.
         """
-        last_update = Configuration.site_configuration_last_update(self._db, timeout=0)
+        last_update = Configuration.site_configuration_last_update(self._db)
         if last_update > self.site_configuration_last_update:
             self.load_settings()
             self.site_configuration_last_update = last_update

--- a/api/controller.py
+++ b/api/controller.py
@@ -146,6 +146,13 @@ class CirculationManager(object):
         self.lane_descriptions = lanes
         self.setup_one_time_controllers()
         self.load_settings()
+
+    def reload_settings_if_changed(self):
+        """If the site configuration has been updated, reload the
+        CirculationManager's configuration from the database.
+        """
+        if Configuration.check_for_site_configuration_update(self._db):
+            self.load_settings()
         
     def load_settings(self):
         """Load all necessary configuration settings and external

--- a/api/controller.py
+++ b/api/controller.py
@@ -143,16 +143,21 @@ class CirculationManager(object):
                 sys.exit()
 
         self.testing = testing
+        self.site_configuration_last_update = (
+            Configuration.site_configuration_last_update(self._db, timeout=0)
+        )
         self.lane_descriptions = lanes
         self.setup_one_time_controllers()
         self.load_settings()
-
+        
     def reload_settings_if_changed(self):
         """If the site configuration has been updated, reload the
         CirculationManager's configuration from the database.
         """
-        if Configuration.check_for_site_configuration_update(self._db):
+        last_update = Configuration.site_configuration_last_update(self._db, timeout=0)
+        if last_update > self.site_configuration_last_update:
             self.load_settings()
+            self.site_configuration_last_update = last_update
         
     def load_settings(self):
         """Load all necessary configuration settings and external

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -622,33 +622,35 @@ class TestBaseController(CirculationControllerTest):
             )
 
     def test_library_for_request_reloads_settings_if_necessary(self):
-
+        
         # We're about to change the shortname of the default library.
         new_name = "newname" + self._str
 
         # Before we make the change, a request to the library's new name
         # will fail.
         assert new_name not in self.manager.auth.library_authenticators
-        with self.app.test_request_context("/"):
-            problem = self.controller.library_for_request(new_name)
-            eq_(LIBRARY_NOT_FOUND, problem)
+        with self.default_config():
+            with self.app.test_request_context("/"):
+                problem = self.controller.library_for_request(new_name)
+                eq_(LIBRARY_NOT_FOUND, problem)
 
-        # Make the change, and the configuration settings are
-        # automatically reloaded to take the library's new name into
-        # account.
+        # Make the change.
         self._default_library.short_name = new_name
         self._db.commit()
 
-        # Now we can use the same Controller and the same
-        # CirculationManager to call the library by its new name.
-        assert new_name in self.manager.auth.library_authenticators
-        with self.app.test_request_context("/"):
-            value = self.controller.library_for_request(
-                self._default_library.short_name
-            )
-            eq_(self._default_library, value)
-            eq_(self._default_library, flask.request.library)
+        # Just making the change was not enough to update the
+        # CirculationManager's settings.
+        assert new_name not in self.manager.auth.library_authenticators
         
+        # But the first time we make a request that calls the library
+        # by its new name, those settings are reloaded.
+        with self.default_config():
+            with self.app.test_request_context("/"):
+                value = self.controller.library_for_request(new_name)
+
+                # An assertion that would have failed before works now.
+                assert new_name in self.manager.auth.library_authenticators
+
 
 class FullLaneSetupTest(CirculationControllerTest):
     """Most lane-based tests don't need the full multi-tier setup of lanes

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -39,6 +39,7 @@ from core.app_server import (
 )
 from core.external_search import DummyExternalSearchIndex
 from core.metadata_layer import Metadata
+from core import model
 from core.model import (
     Annotation,
     Collection,
@@ -620,9 +621,9 @@ class TestBaseController(CirculationControllerTest):
             assert_raises(
                 ValueError, self.controller.library_for_request, None
             )
-
+            
     def test_library_for_request_reloads_settings_if_necessary(self):
-        
+
         # We're about to change the shortname of the default library.
         new_name = "newname" + self._str
 
@@ -634,11 +635,17 @@ class TestBaseController(CirculationControllerTest):
                 problem = self.controller.library_for_request(new_name)
                 eq_(LIBRARY_NOT_FOUND, problem)
 
+
         # Make the change.
         self._default_library.short_name = new_name
         self._db.commit()
 
-        # Just making the change was not enough to update the
+        # Bypass the 1-second timeout and make sure the site knows
+        # the configuration has actually changed.
+        model.site_configuration_has_changed(self._db, timeout=0)        
+        
+        # Just making the change and calling
+        # site_configuration_has_changed was not enough to update the
         # CirculationManager's settings.
         assert new_name not in self.manager.auth.library_authenticators
         
@@ -647,7 +654,8 @@ class TestBaseController(CirculationControllerTest):
         with self.default_config():
             with self.app.test_request_context("/"):
                 value = self.controller.library_for_request(new_name)
-
+                eq_(self._default_library, value)
+                
                 # An assertion that would have failed before works now.
                 assert new_name in self.manager.auth.library_authenticators
 


### PR DESCRIPTION
This branch changes the `CirculationManager` to keep track of the last time it saw a site configuration change. If it detects a change, it calls `load_settings()` to reload the configuration. This should make sure any `CirculationManager` gets reloaded within 61 seconds of a change to any configuration item, even in a clustered scenario.

The check happens in `library_for_request`, which seems like the earliest code that runs on almost every request. The test illustrates a case where the name of a library changes immediately before a request comes in for the library under the new name.