### PR TITLE
Catch configuration exceptions

### DIFF
--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -707,7 +707,7 @@ class AuthdataUtility(object):
             or not library_short_name or not secret
         ):
             raise CannotLoadConfiguration(
-                "Library Registry configuration is incomplete. "
+                "Short Client Token configuration is incomplete. "
                 "vendor_id, username, password and "
                 "Library website_url must all be defined.")
         if '|' in library_short_name:

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -392,8 +392,11 @@ class LibraryAuthenticator(object):
         # Turn each such ExternalIntegration into an
         # AuthenticationProvider.
         for integration in integrations:
-            authenticator.register_provider(integration)
-
+            try:
+                authenticator.register_provider(integration)
+            except CannotLoadConfiguration, e:
+                authenticator.initialization_errors[integration.id] = e
+                
         if authenticator.oauth_providers_by_name:
             # NOTE: this will immediately commit the database session,
             # which may not be what you want during a test. To avoid
@@ -435,6 +438,7 @@ class LibraryAuthenticator(object):
         self.basic_auth_provider = basic_auth_provider
         self.oauth_providers_by_name = dict()
         self.bearer_token_signing_secret = bearer_token_signing_secret
+        self.initialization_errors = dict()
         if oauth_providers:
             for provider in oauth_providers:
                 self.oauth_providers_by_name[provider.NAME] = provider

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -394,8 +394,10 @@ class LibraryAuthenticator(object):
         for integration in integrations:
             try:
                 authenticator.register_provider(integration)
-            except CannotLoadConfiguration, e:
-                authenticator.initialization_errors[integration.id] = e
+            except (ImportError, CannotLoadConfiguration), e:
+                # These are the two types of error that might be caused
+                # by misconfiguration, as opposed to bad code.
+                authenticator.initialization_exceptions[integration.id] = e
                 
         if authenticator.oauth_providers_by_name:
             # NOTE: this will immediately commit the database session,
@@ -438,7 +440,7 @@ class LibraryAuthenticator(object):
         self.basic_auth_provider = basic_auth_provider
         self.oauth_providers_by_name = dict()
         self.bearer_token_signing_secret = bearer_token_signing_secret
-        self.initialization_errors = dict()
+        self.initialization_exceptions = dict()
         if oauth_providers:
             for provider in oauth_providers:
                 self.oauth_providers_by_name[provider.NAME] = provider

--- a/api/controller.py
+++ b/api/controller.py
@@ -182,7 +182,7 @@ class CirculationManager(object):
         
         self.adobe_vendor_id = None
         self.adobe_device_management = None
-        self.short_client_token_initialization_exception = dict()
+        self.short_client_token_initialization_exceptions = dict()
         for library in self._db.query(Library):
             lanes = make_lanes(library, self.lane_descriptions)
             
@@ -348,11 +348,10 @@ class CirculationManager(object):
         if registry:
             try:
                 authdata = AuthdataUtility.from_config(library)
-                self.short_client_token_initialization_exception = None
             except CannotLoadConfiguration, e:
-                self.short_client_token_initialization_exception[library.id] = e
+                self.short_client_token_initialization_exceptions[library.id] = e
                 self.log.error(
-                    "Short Client Token configuration for %s is present but not working. This may be cause for concern. Original error: %s" %
+                    "Short Client Token configuration for %s is present but not working. This may be cause for concern. Original error: %s",
                     library.name, e
                 )
         return authdata
@@ -368,7 +367,19 @@ class CirculationManager(object):
             top_level_title='All Books', *args, **kwargs
         )
 
+    def initialization_exceptions(self):
+        """Consolidate the exceptions that happened upon initialization.
 
+        These exceptions can be displayed to an administrator.
+        """
+        return dict(
+            external_search=self.external_search_initialization_exception,
+            short_client_tokens=self.short_client_token_initialization_exceptions,
+            authenticators=self.auth.initialization_exceptions,
+            collections=self.circulation.initialization_exceptions,
+        )
+        
+    
 class CirculationManagerController(BaseCirculationManagerController):
 
     @property

--- a/api/controller.py
+++ b/api/controller.py
@@ -366,18 +366,6 @@ class CirculationManager(object):
             self.circulation_apis[library.id], lane, library,
             top_level_title='All Books', *args, **kwargs
         )
-
-    def initialization_exceptions(self):
-        """Consolidate the exceptions that happened upon initialization.
-
-        These exceptions can be displayed to an administrator.
-        """
-        return dict(
-            external_search=self.external_search_initialization_exception,
-            short_client_tokens=self.short_client_token_initialization_exceptions,
-            authenticators=self.auth.initialization_exceptions,
-            collections=self.circulation.initialization_exceptions,
-        )
         
     
 class CirculationManagerController(BaseCirculationManagerController):

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -557,8 +557,8 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         # Both integrations have left their trace in
         # initialization_exceptions.
         not_configured = auth.initialization_exceptions[misconfigured.id]
-        assert isinstance(not_found, CannotLoadConfiguration)
-        eq_('First Book server not configured.', not_found.message)
+        assert isinstance(not_configured, CannotLoadConfiguration)
+        eq_('First Book server not configured.', not_configured.message)
 
         not_found = auth.initialization_exceptions[unknown.id]
         assert isinstance(not_found, ImportError)


### PR DESCRIPTION
This branch catches `CannotLoadConfiguration` exceptions (and `ImportError`s in one case) that happen when initializing things from site configuration and `ExternalIntegration`s, and stores the exceptions in objects associated with the `CirculationManager`. This fixes https://github.com/NYPL-Simplified/circulation/issues/532 in that it stops a configuration problem from making the site (which you need to use to fix the configuration problem) unusable. But the exceptions are in places that, although conveniently near the bit of code where the exception happened, are a little tough to gather in one place when you want to show a person what has gone wrong.

I have some preliminary code (see the issue) for consolidating the exceptions, but it's on hold until we figure out what the user interface should look like.