### PR TITLE
Allow Millenium-using libraries to customize which MBLOCK[56] values actually block a patron

### DIFF
--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -208,26 +208,26 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
     def _patron_block_reason(cls, block_types, mblock_value):
         """Turn a value of the MBLOCK[56] field into a block type."""
 
-        if self.block_types and mblock_value in self.block_types:
+        if block_types and mblock_value in block_types:
             # We are looking for a specific value, and we found it
             return PatronData.UNKNOWN_BLOCK
 
-        if not self.block_types:        
+        if not block_types:        
             # Apply the default rules.
             if not mblock_value or mblock_value.strip() in ('', '-'):
                 # This patron is not blocked at all.
-                return None
+                return PatronData.NO_VALUE
             else:
                 # This patron is blocked for an unknown reason.
                 return PatronData.UNKNOWN_BLOCK
 
         # We have specific types that mean the patron is blocked.
-        if mblock_value in self.block_types:
+        if mblock_value in block_types:
             # The patron has one of those types.
             return PatronData.UNKNOWN_BLOCK
 
         # The patron does not have one of those types, so is not blocked.
-        return None
+        return PatronData.NO_VALUE
         
     def patron_dump_to_patrondata(self, current_identifier, content):
         """Convert an HTML patron dump to a PatronData object.

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -223,7 +223,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
 
         # We have specific types that mean the patron is blocked.
         if mblock_value in block_types:
-            # The patron has one of those types.
+            # The patron has one of those types. They are blocked.
             return PatronData.UNKNOWN_BLOCK
 
         # The patron does not have one of those types, so is not blocked.

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -61,6 +61,10 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
     AUTHENTICATION_MODE = 'auth_mode'
     PIN_AUTHENTICATION_MODE = 'pin'
     FAMILY_NAME_AUTHENTICATION_MODE = 'family_name'
+
+    # The field to use when seeing which values of MBLOCK[p56] mean a patron
+    # is blocked. By default, any value other than '-' indicates a block.
+    BLOCK_TYPES = 'block_types'
     
     AUTHENTICATION_MODES = [
         PIN_AUTHENTICATION_MODE, FAMILY_NAME_AUTHENTICATION_MODE
@@ -74,6 +78,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
               { "key": "false", "label": _("Ignore Certificate Problems (For temporary testing only)") },
           ]
         },
+        { "key": BLOCK_TYPES, "label": _("Block types"), "optional": True },
         { "key": IDENTIFIER_BLACKLIST, "label": _("Identifier Blacklist"), "optional": True },
         { "key": AUTHENTICATION_MODE, "label": _("Authentication Mode"),
           "type": "select",
@@ -118,6 +123,8 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
                 "Unrecognized Millenium Patron API authentication mode: %s." % auth_mode
             )
         self.auth_mode = auth_mode
+
+        self.block_types = integration.setting(self.BLOCK_TYPES).value or None
         
     # Begin implementation of BasicAuthenticationProvider abstract
     # methods.
@@ -196,7 +203,32 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         configuration, in a testable way.
         """
         kwargs['verify'] = self.verify_certificate
-    
+
+    @classmethod
+    def _patron_block_reason(cls, block_types, mblock_value):
+        """Turn a value of the MBLOCK[56] field into a block type."""
+
+        if self.block_types and mblock_value in self.block_types:
+            # We are looking for a specific value, and we found it
+            return PatronData.UNKNOWN_BLOCK
+
+        if not self.block_types:        
+            # Apply the default rules.
+            if not mblock_value or mblock_value.strip() in ('', '-'):
+                # This patron is not blocked at all.
+                return None
+            else:
+                # This patron is blocked for an unknown reason.
+                return PatronData.UNKNOWN_BLOCK
+
+        # We have specific types that mean the patron is blocked.
+        if mblock_value in self.block_types:
+            # The patron has one of those types.
+            return PatronData.UNKNOWN_BLOCK
+
+        # The patron does not have one of those types, so is not blocked.
+        return None
+        
     def patron_dump_to_patrondata(self, current_identifier, content):
         """Convert an HTML patron dump to a PatronData object.
         
@@ -245,12 +277,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
                     )
                     fines = Money("0", "USD")
             elif k == self.BLOCK_FIELD:
-                if v != '-':
-                    # '-' always seems to mean the absence of a block
-                    # on a patron's record. Any other value for this
-                    # field means the patron is blocked for a
-                    # library-specific reason.
-                    block_reason = PatronData.UNKNOWN_BLOCK
+                block_reason = self._patron_block_reason(self.block_types, v)
             elif k == self.EXPIRATION_FIELD:
                 try:
                     expires = datetime.datetime.strptime(

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -378,6 +378,25 @@ class TestMilleniumPatronAPI(DatabaseTest):
         # calls _modify_request_kwargs() because request() is the
         # method we override for mock purposes.
 
+    def test_patron_block_reason(self):
+        m = MilleniumPatronAPI._patron_block_reason
+        blocked = PatronData.UNKNOWN_BLOCK
+        unblocked = PatronData.NO_VALUE
+
+        # Our default behavior.
+        eq_(blocked, m(None, "a"))
+        eq_(unblocked, m(None, None))
+        eq_(unblocked, m(None, "-"))
+        eq_(unblocked, m(None, " "))
+        
+        # Behavior with custom block values.
+        eq_(blocked, m("abcd", "b"))
+        eq_(unblocked, m("abcd", "e"))
+        eq_(unblocked, m("", "-"))
+        
+        # This is unwise but allowed.
+        eq_(blocked, m("ab-c", "-"))
+        
     def test_family_name_match(self):
         m = MilleniumPatronAPI.family_name_match
         eq_(False, m(None, None))
@@ -396,8 +415,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
             self.mock_api,
             auth_mode = 'nosuchauthmode'
         )
-            
-        
+
     def test_authorization_family_name_success(self):
         """Test authenticating against the patron's family name, given the
         correct name (case insensitive)


### PR DESCRIPTION
Different libraries have different rules about which values for the MBLOCK[56] field mean a patron is actually denied borrowing privileges. This branch adds a configuration setting that lets the library administrator enter a list of values which indicate a patron is blocked if they show up in MBLOCK[56].

The lack of a value means we use the default: "-" or the empty string means you're okay, any other value means you're blocked. It's not yet clear whether this is a Sierra default or an NYPL+Brooklyn default.