### PR TITLE
Make CirculationAPI database-session-safe

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -271,7 +271,7 @@ class CirculationManager(object):
             cls = MockCirculationAPI
         else:
             cls = CirculationAPI
-        return cls(library)
+        return cls(self._db, library)
         
     def setup_one_time_controllers(self):
         """Set up all the controllers that will be used by the web app.

--- a/api/controller.py
+++ b/api/controller.py
@@ -1323,7 +1323,9 @@ class ServiceStatusController(CirculationManagerController):
 """
 
     def __call__(self):
-        service_status = ServiceStatus(self._db, flask.request.library)
+        library = flask.request.library
+        circulation = self.manager.circulation_apis[library.id]
+        service_status = ServiceStatus(circulation)
         timings = service_status.loans_status(response=True)
         statuses = []
         for k, v in sorted(timings.items()):

--- a/api/services.py
+++ b/api/services.py
@@ -25,9 +25,18 @@ class ServiceStatus(object):
 
     SUCCESS_MSG = re.compile('^SUCCESS: ([0-9]+.[0-9]+)sec')
 
-    def __init__(self, library, auth=None, api_map=None):
-        self._db = Session.object_session(library)
-        self.circulation = CirculationAPI(library, api_map)
+    def __init__(self, circulation, auth=None):
+        """Constructor.
+
+        :param circulation: A CirculationAPI for the library whose status
+        we're checking.
+
+        :param auth: A LibraryAuthenticator object to use when authenticating
+        the sample patron.
+        """
+        self._db = circulation._db
+        self.circulation = circulation
+        library = circulation.library
         self.auth = auth or LibraryAuthenticator.from_config(self._db, library)
 
     @property

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -152,7 +152,7 @@ class TestBibliothecaAPI(BibliothecaAPITest):
 
     def test_sync_bookshelf(self):
         patron = self._patron()
-        circulation = CirculationAPI(self._default_library, api_map={
+        circulation = CirculationAPI(self._db, self._default_library, api_map={
             self.collection.protocol : MockBibliothecaAPI
         })
 

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -63,7 +63,7 @@ class TestCirculationAPI(DatabaseTest):
         [self.delivery_mechanism] = self.pool.delivery_mechanisms
         self.patron = self._patron()
         self.circulation = MockCirculationAPI(
-            self._default_library, api_map = {
+            self._db, self._default_library, api_map = {
                 ExternalIntegration.BIBLIOTHECA : MockBibliothecaAPI
             }
         )
@@ -650,7 +650,7 @@ class TestCirculationAPI(DatabaseTest):
                 return [], [], False
 
         circulation = IncompleteCirculationAPI(
-            self._default_library,
+            self._db, self._default_library,
             api_map={ExternalIntegration.BIBLIOTHECA : MockBibliothecaAPI})
         circulation.sync_bookshelf(self.patron, "1234")
 
@@ -667,7 +667,7 @@ class TestCirculationAPI(DatabaseTest):
                 return [], [], True
 
         circulation = CompleteCirculationAPI(
-            self._default_library,
+            self._db, self._default_library,
             api_map={ExternalIntegration.BIBLIOTHECA : MockBibliothecaAPI})
         circulation.sync_bookshelf(self.patron, "1234")
 
@@ -677,7 +677,8 @@ class TestCirculationAPI(DatabaseTest):
 
     def test_patron_activity(self):
         # Get a CirculationAPI that doesn't mock out its API's patron activity.
-        circulation = CirculationAPI(self._default_library, api_map={
+        circulation = CirculationAPI(
+            self._db, self._default_library, api_map={
             ExternalIntegration.BIBLIOTHECA : MockBibliothecaAPI
         })
         mock_bibliotheca = circulation.api_for_collection[self.collection]
@@ -711,7 +712,9 @@ class TestConfigurationFailures(DatabaseTest):
         CirculationAPI rather than being propagated.
         """
         api_map = {self._default_collection.protocol : self.MisconfiguredAPI}
-        circulation = CirculationAPI(self._default_library, api_map=api_map)
+        circulation = CirculationAPI(
+            self._db, self._default_library, api_map=api_map
+        )
 
         # Although the CirculationAPI was created, it has no functioning
         # APIs.

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -45,7 +45,7 @@ class OverdriveAPITest(DatabaseTest):
         library = self._default_library
         self.collection = MockOverdriveAPI.mock_collection(self._db)
         self.circulation = CirculationAPI(
-            library, {ExternalIntegration.OVERDRIVE:MockOverdriveAPI}
+            self._db, library, {ExternalIntegration.OVERDRIVE:MockOverdriveAPI}
         )
         self.api = self.circulation.api_for_collection[self.collection]
         


### PR DESCRIPTION
This branch changes CirculationAPI to take a database session as a constructor argument instead of deriving it from the Library object. In the web app, using Session.object_session will give a database session that's only good for the active request, and CirculationAPI needs to stick around for multiple requests.

This branch also changes `ServiceStatus` to take a `CirculationAPI` as an argument instead of trying to create one. I think `ServiceStatus` is going away soon but this is the easiest way to solve the `CirculationAPI` constructor problem.