### PR TITLE
Use default library when no library is specified in incoming request

### DIFF
--- a/api/base_controller.py
+++ b/api/base_controller.py
@@ -94,9 +94,7 @@ class BaseCirculationManagerController(object):
         if library_short_name:
             library = get_one(self._db, Library, short_name=library_short_name)
         else:
-            # TODO: It should be possible to designate one library
-            # as the default.
-            raise ValueError("No library_short_name provided!")
+            library = Library.default(self._db)
         
         if not library:
             return LIBRARY_NOT_FOUND

--- a/migration/20170224-copy-collection-configuration-into-database.py
+++ b/migration/20170224-copy-collection-configuration-into-database.py
@@ -5,6 +5,7 @@ into Collection objects.
 
 import os
 import sys
+import uuid
 from pdb import set_trace
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, u"..")
@@ -132,8 +133,17 @@ def convert_content_server(_db, library):
     )
     library.collections.append(collection)
     collection.url = url
-    
-library = Library.instance(_db)
+
+# This is the point in the migration where we first create a Library
+# for this system.
+library = get_one_or_create(
+    _db, Library,
+    create_method_kwargs=dict(
+        name="Default Library",
+        short_name="default",
+        uuid=unicode(uuid.uuid4())
+    )
+)
 copy_library_registry_information(_db, library)
 convert_overdrive(_db, library)
 convert_bibliotheca(_db, library)

--- a/migration/20170605-move-configuration-links-into-db.py
+++ b/migration/20170605-move-configuration-links-into-db.py
@@ -19,7 +19,7 @@ from api.config import Configuration
 
 Configuration.load()
 _db = production_session()
-library = Library.instance(_db)
+library = Library.default(_db)
 
 for rel, value in (
         ("terms-of-service", Configuration.get('links', {}).get('terms_of_service', None)),

--- a/migration/20170606-1-move-authentication-configuration-to-external-integrations.py
+++ b/migration/20170606-1-move-authentication-configuration-to-external-integrations.py
@@ -133,7 +133,7 @@ try:
         integrations.append(integration)
         
     # Add each integration to each library.
-    library = Library.instance(_db)
+    library = Library.default(_db)
     for library in _db.query(Library):
         for integration in integrations:
             if integration not in library.integrations:

--- a/migration/20170609-1-move-library-configuration-to-configurationsettings.py
+++ b/migration/20170609-1-move-library-configuration-to-configurationsettings.py
@@ -36,7 +36,6 @@ try:
         )
         secret_setting.value = secret_key
     
-    library = Library.instance(_db)
     libraries = _db.query(Library).all()
     
     # Copy default email address into each library.

--- a/migration/20170616-2-move-third-party-config-to-external-integrations.py
+++ b/migration/20170616-2-move-third-party-config-to-external-integrations.py
@@ -31,7 +31,7 @@ def log_import(integration_or_setting):
 try:
     Configuration.load()
     _db = production_session()
-    LIBRARIES = _db.query(Library).all() or [Library.instance(_db)]
+    LIBRARIES = _db.query(Library).all()
 
     # Import Circulation Manager base url.
     circ_manager_conf = Configuration.integration('Circulation Manager')
@@ -85,7 +85,7 @@ try:
         other_libraries = adobe_conf.get('other_libraries')
 
         if node_value:
-            node_library = Library.instance(_db)
+            node_library = Library.default(_db)
             integration = EI(protocol=EI.ADOBE_VENDOR_ID, goal=EI.DRM_GOAL)
             _db.add(integration)
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -917,10 +917,10 @@ class TestLibraryAuthenticator(AuthenticatorTest):
 
     def test_create_authentication_document(self):
         integration = self._external_integration(self._str)
-        basic = MockBasicAuthenticationProvider(self._default_library, integration)
-        oauth = MockOAuthAuthenticationProvider(self._default_library, "oauth")
+        library = self._default_library
+        basic = MockBasicAuthenticationProvider(library, integration)
+        oauth = MockOAuthAuthenticationProvider(library, "oauth")
         oauth.URI = "http://example.org/"
-        library = Library.instance(self._db)
         expect_uuid = library.uuid
         library.name = "A Fabulous Library"
         authenticator = LibraryAuthenticator(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -659,10 +659,12 @@ class TestBaseController(CirculationControllerTest):
             eq_(self._default_library, value)
             eq_(self._default_library, flask.request.library)
 
+        # If you don't specify a library, the default library is used.
         with self.app.test_request_context("/"):
-            assert_raises(
-                ValueError, self.controller.library_for_request, None
-            )
+            value = self.controller.library_for_request(None)
+            expect_default = Library.default(self._db)
+            eq_(expect_default, value)
+            eq_(expect_default, flask.request.library)
             
     def test_library_for_request_reloads_settings_if_necessary(self):
 


### PR DESCRIPTION
This branch uses `Library.default` to pick a library to use as the request library, instead of raising a ValueError when none is specified.

This will work for multi-library setups but it's mainly intended for single-library setups, where naming a library in the URL is redundant.