### PR TITLE
Moved analytics config into the database and added it to the admin interface

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -92,6 +92,9 @@ from api.nyt import NYTBestSellerAPI
 from api.novelist import NoveListAPI
 from core.opds_import import MetadataWranglerOPDSLookup
 
+from api.google_analytics_provider import GoogleAnalyticsProvider
+from core.local_analytics_provider import LocalAnalyticsProvider
+
 def setup_admin_controllers(manager):
     """Set up all the controllers that will be used by the admin parts of the web app."""
     if not manager.testing:
@@ -1248,12 +1251,12 @@ class SettingsController(CirculationManagerController):
         auth_service = ExternalIntegration.admin_authentication(self._db)
         if auth_service:
             if id and id != auth_service.id:
-                return MISSING_ADMIN_AUTH_SERVICE
+                return MISSING_SERVICE
             if protocol != auth_service.protocol:
                 return CANNOT_CHANGE_PROTOCOL
         else:
             if id:
-                return MISSING_ADMIN_AUTH_SERVICE
+                return MISSING_SERVICE
 
             if protocol:
                 auth_service, is_new = get_one_or_create(
@@ -1366,7 +1369,7 @@ class SettingsController(CirculationManagerController):
         if id:
             auth_service = get_one(self._db, ExternalIntegration, id=id, goal=ExternalIntegration.PATRON_AUTH_GOAL)
             if not auth_service:
-                return MISSING_PATRON_AUTH_SERVICE
+                return MISSING_SERVICE
             if protocol != auth_service.protocol:
                 return CANNOT_CHANGE_PROTOCOL
         else:
@@ -1480,7 +1483,7 @@ class SettingsController(CirculationManagerController):
         if id:
             service = get_one(self._db, ExternalIntegration, id=id, goal=ExternalIntegration.METADATA_GOAL)
             if not service:
-                return MISSING_METADATA_SERVICE
+                return MISSING_SERVICE
             if protocol != service.protocol:
                 return CANNOT_CHANGE_PROTOCOL
         else:
@@ -1488,6 +1491,88 @@ class SettingsController(CirculationManagerController):
                 service, is_new = create(
                     self._db, ExternalIntegration, protocol=protocol,
                     goal=ExternalIntegration.METADATA_GOAL
+                )
+            else:
+                return NO_PROTOCOL_FOR_NEW_SERVICE
+
+        name = flask.request.form.get("name")
+        if name:
+            if service.name != name:
+                service_with_name = get_one(self._db, ExternalIntegration, name=name)
+                if service_with_name:
+                    self._db.rollback()
+                    return INTEGRATION_NAME_ALREADY_IN_USE
+            service.name = name
+
+        [protocol] = [p for p in protocols if p.get("name") == protocol]
+        result = self._set_integration_settings_and_libraries(service, protocol)
+        if isinstance(result, ProblemDetail):
+            return result
+
+        if is_new:
+            return Response(unicode(_("Success")), 201)
+        else:
+            return Response(unicode(_("Success")), 200)
+
+    def analytics_services(self):
+        provider_apis = [GoogleAnalyticsProvider,
+                         LocalAnalyticsProvider,
+                        ]
+        protocols = self._get_integration_protocols(provider_apis)
+
+        if flask.request.method == 'GET':
+            services = []
+            for service in self._db.query(ExternalIntegration).filter(
+                ExternalIntegration.goal==ExternalIntegration.ANALYTICS_GOAL):
+
+                [protocol] = [p for p in protocols if p.get("name") == service.protocol]
+                libraries = []
+                for library in service.libraries:
+                    library_info = dict(short_name=library.short_name)
+                    for setting in protocol.get("library_settings"):
+                        key = setting.get("key")
+                        value = ConfigurationSetting.for_library_and_externalintegration(
+                            self._db, key, library, service
+                        ).value
+                        if value:
+                            library_info[key] = value
+                    libraries.append(library_info)
+
+                settings = { setting.key: setting.value for setting in service.settings if setting.library_id == None}
+
+                services.append(
+                    dict(
+                        id=service.id,
+                        name=service.name,
+                        protocol=service.protocol,
+                        settings=settings,
+                        libraries=libraries,
+                    )
+                )
+
+            return dict(
+                analytics_services=services,
+                protocols=protocols,
+            )
+
+        id = flask.request.form.get("id")
+
+        protocol = flask.request.form.get("protocol")
+        if protocol and protocol not in [p.get("name") for p in protocols]:
+            return UNKNOWN_PROTOCOL
+
+        is_new = False
+        if id:
+            service = get_one(self._db, ExternalIntegration, id=id, goal=ExternalIntegration.ANALYTICS_GOAL)
+            if not service:
+                return MISSING_SERVICE
+            if protocol != service.protocol:
+                return CANNOT_CHANGE_PROTOCOL
+        else:
+            if protocol:
+                service, is_new = create(
+                    self._db, ExternalIntegration, protocol=protocol,
+                    goal=ExternalIntegration.ANALYTICS_GOAL
                 )
             else:
                 return NO_PROTOCOL_FOR_NEW_SERVICE

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1529,7 +1529,7 @@ class SettingsController(CirculationManagerController):
                 libraries = []
                 for library in service.libraries:
                     library_info = dict(short_name=library.short_name)
-                    for setting in protocol.get("library_settings"):
+                    for setting in protocol.get("library_settings", []):
                         key = setting.get("key")
                         value = ConfigurationSetting.for_library_and_externalintegration(
                             self._db, key, library, service

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.26"
+    "simplified-circulation-web": "0.0.27"
   }
 }

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -198,18 +198,11 @@ MISSING_PGCRYPTO_EXTENSION = pd(
     detail=_("You tried to store a password for an individual admin, but the database does not have the pgcrypto extension installed."),
 )
 
-MISSING_ADMIN_AUTH_SERVICE = pd(
-    "http://librarysimplified.org/terms/problem/missing-admin-auth-service",
+MISSING_SERVICE = pd(
+    "http://librarysimplified.org/terms/problem/missing-service",
     status_code=404,
-    title=_("Missing admin authentication service"),
-    detail=_("The specified admin authentication service does not exist."),
-)
-
-MISSING_PATRON_AUTH_SERVICE = pd(
-    "http://librarysimplified.org/terms/problem/missing-patron-auth-service",
-    status_code=404,
-    title=_("Missing patron authentication service"),
-    detail=_("The specified patron authentication service does not exist."),
+    title=_("Missing service"),
+    detail=_("The specified service does not exist."),
 )
 
 INVALID_CONFIGURATION_OPTION = pd(
@@ -245,11 +238,4 @@ MISSING_SITEWIDE_SETTING_VALUE = pd(
     status_code=400,
     title=_("Missing sitewide setting value"),
     detail=_("A value is required to change a sitewide setting."),
-)
-
-MISSING_METADATA_SERVICE = pd(
-    "http://librarysimplified.org/terms/problem/missing-metadata-service",
-    status_code=404,
-    title=_("Missing metadata service"),
-    detail=_("The specified metadata service does not exist."),
 )

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -395,6 +395,7 @@ def admin_sign_in_again():
 @app.route('/admin/web/<path:etc>') # catchall for single-page URLs
 def admin_view(collection=None, book=None, **kwargs):
     setting_up = (app.manager.admin_sign_in_controller.auth == None)
+    home_url = None
     if not setting_up:
         admin = app.manager.admin_sign_in_controller.authenticated_admin_from_request()
         if isinstance(admin, ProblemDetail):
@@ -416,8 +417,6 @@ def admin_view(collection=None, book=None, **kwargs):
         if libraries:
             library = libraries[0]
             home_url = app.manager.url_for('acquisition_groups', library_short_name=library.short_name)
-        else:
-            home_url = None
 
     csrf_token = flask.request.cookies.get("csrf_token") or app.manager.admin_sign_in_controller.generate_csrf_token()
 

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -351,6 +351,18 @@ def metadata_services():
         return data
     return flask.jsonify(**data)
 
+@app.route("/admin/analytics_services", methods=['GET', 'POST'])
+@returns_problem_detail
+@requires_admin
+@requires_csrf_token
+def analytics_services():
+    data = app.manager.admin_settings_controller.analytics_services()
+    if isinstance(data, ProblemDetail):
+        return data
+    if isinstance(data, Response):
+        return data
+    return flask.jsonify(**data)
+
 @app.route("/admin/sitewide_settings", methods=['GET', 'POST'])
 @returns_problem_detail
 @requires_admin

--- a/api/config.py
+++ b/api/config.py
@@ -59,6 +59,10 @@ class Configuration(CoreConfiguration):
             "key": SECRET_KEY,
             "label": _("Internal secret key for admin interface cookies"),
         },
+        {
+            "key": PATRON_WEB_CLIENT_URL,
+            "label": _("URL of the web catalog for patrons"),
+        },
     ]
 
     LIBRARY_SETTINGS = CoreConfiguration.LIBRARY_SETTINGS + [

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -46,8 +46,8 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
     
     log = logging.getLogger("First Book authentication API")
 
-    def __init__(self, library_id, integration):
-        super(FirstBookAuthenticationAPI, self).__init__(library_id, integration)
+    def __init__(self, library_id, integration, analytics=None):
+        super(FirstBookAuthenticationAPI, self).__init__(library_id, integration, analytics)
         url = integration.url
         key = integration.password
         if not (url and key):

--- a/api/google_analytics_provider.py
+++ b/api/google_analytics_provider.py
@@ -3,24 +3,45 @@ import uuid
 import unicodedata
 import urllib
 import re
+from flask.ext.babel import lazy_gettext as _
 from core.util.http import HTTP
+from core.model import (
+    ConfigurationSetting,
+    ExternalIntegration,
+    Session,
+    get_one,
+)
 
 class GoogleAnalyticsProvider(object):
-    INTEGRATION_NAME = "Google Analytics"
+    NAME = _("Google Analytics")
+
+    TRACKING_ID = "tracking_id"
+    DEFAULT_URL = "http://www.google-analytics.com/collect"
+
+    SETTINGS = [
+        { "key": ExternalIntegration.URL, "label": _("URL"), "default": DEFAULT_URL },
+    ]
+
+    LIBRARY_SETTINGS = [
+        { "key": TRACKING_ID, "label": _("Tracking ID") },
+    ]
     
-    @classmethod
-    def from_config(cls, config):
-        tracking_id = config[Configuration.INTEGRATIONS][cls.INTEGRATION_NAME]['tracking_id']
-        return cls(tracking_id)
+    def __init__(self, integration):
+        url_setting = ConfigurationSetting.for_externalintegration(ExternalIntegration.URL, integration)
+        self.url = url_setting.value or self.DEFAULT_URL
+        self.integration_id = integration.id
 
-    def __init__(self, tracking_id):
-        self.tracking_id = tracking_id
+    def collect_event(self, library, license_pool, event_type, time, **kwargs):
+        _db = Session.object_session(library)
+        integration = get_one(_db, ExternalIntegration, id=self.integration_id)
+        tracking_id = ConfigurationSetting.for_library_and_externalintegration(
+            _db, self.TRACKING_ID, library, integration,
+        ).value
 
-    def collect_event(self, _db, license_pool, event_type, time, **kwargs):
         client_id = uuid.uuid4()
         fields = {
             'v': 1,
-            'tid': self.tracking_id,
+            'tid': tracking_id,
             'cid': client_id,
             'aip': 1, # anonymize IP
             'ds': "Circulation Manager",
@@ -54,7 +75,7 @@ class GoogleAnalyticsProvider(object):
         fields = {k: unicodedata.normalize("NFKD", unicode(v)).encode("utf8") for k, v in fields.iteritems()}
         
         params = re.sub(r"=None(&?)", r"=\1", urllib.urlencode(fields))
-        self.post("http://www.google-analytics.com/collect", params)
+        self.post(self.url, params)
 
     def post(self, url, params):
         response = HTTP.post_with_timeout(url, params)

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -89,8 +89,8 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         }
     ] + BasicAuthenticationProvider.SETTINGS
     
-    def __init__(self, library, integration):
-        super(MilleniumPatronAPI, self).__init__(library, integration)
+    def __init__(self, library, integration, analytics=None):
+        super(MilleniumPatronAPI, self).__init__(library, integration, analytics)
         url = integration.url
         if not url:
             raise CannotLoadConfiguration(

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -842,6 +842,7 @@ class OverdriveCirculationMonitor(CollectionMonitor):
         self.maximum_consecutive_unchanged_books = (
             self.MAXIMUM_CONSECUTIVE_UNCHANGED_BOOKS
         )
+        self.analytics = Analytics(_db)
         
     def recently_changed_ids(self, start, cutoff):
         return self.api.recently_changed_ids(start, cutoff)
@@ -863,8 +864,9 @@ class OverdriveCirculationMonitor(CollectionMonitor):
             license_pool, is_new, is_changed = self.api.update_licensepool(book)
             # Log a circulation event for this work.
             if is_new:
-                Analytics.collect_event(
-                    _db, license_pool, CirculationEvent.DISTRIBUTOR_TITLE_ADD, license_pool.last_checked)
+                for library in self.collection.libraries:
+                    self.analytics.collect_event(
+                        library, license_pool, CirculationEvent.DISTRIBUTOR_TITLE_ADD, license_pool.last_checked)
 
             _db.commit()
 

--- a/api/simple_authentication.py
+++ b/api/simple_authentication.py
@@ -24,9 +24,9 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
         This is useful for testing a circulation manager before connecting
         it to an ILS.""")
 
-    def __init__(self, library, integration):
+    def __init__(self, library, integration, analytics=None):
         super(SimpleAuthenticationProvider, self).__init__(
-            library, integration,
+            library, integration, analytics
         )
         self.test_identifier = integration.setting(self.TEST_IDENTIFIER).value
         self.test_password = integration.setting(self.TEST_PASSWORD).value

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -42,7 +42,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         SIPClient.EXCESSIVE_FEES : PatronData.EXCESSIVE_FINES,
     }
 
-    def __init__(self, library, integration, client=None, connect=True):
+    def __init__(self, library, integration, analytics=None, client=None, connect=True):
         """An object capable of communicating with a SIP server.
 
         :param server: Hostname of the SIP server.
@@ -77,7 +77,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         during testing.
         """
         super(SIP2AuthenticationProvider, self).__init__(
-            library, integration
+            library, integration, analytics
         )
         try:
             server = None

--- a/migration/20170616-2-move-third-party-config-to-external-integrations.py
+++ b/migration/20170616-2-move-third-party-config-to-external-integrations.py
@@ -117,7 +117,7 @@ try:
 
             library_url = adobe_conf.get('library_uri')
             ConfigurationSetting.for_library(
-                Library.WEBSITE_KEY, library).value = library_url
+                Configuration.WEBSITE_URL, library).value = library_url
 
             integration.libraries.append(library)
 
@@ -145,6 +145,28 @@ try:
             _db, Configuration.PATRON_WEB_CLIENT_URL)
         setting.value = patron_web_client_url
         log_import(setting)
+
+    # Import analytics configuration.
+    policies = Configuration.get(u"policies", {})
+    analytics_modules = policies.get(u"analytics", ["core.local_analytics_provider"])
+
+    if "api.google_analytics_provider" in analytics_modules:
+        google_analytics_conf = Configuration.integration(u"Google Analytics Provider", {})
+        tracking_id = google_analytics_conf.get(u"tracking_id")
+
+        integration = EI(protocol=u"api.google_analytics_provider", goal=EI.ANALYTICS_GOAL)
+        _db.add(integration)
+        integration.url = "http://www.google-analytics.com/collect"
+
+        for library in LIBRARIES:
+            ConfigurationSetting.for_library_and_externalintegration(
+                _db, u"tracking_id", library, integration).value = tracking_id
+            library.integrations += [integration]
+
+    if "core.local_analytics_provider" in analytics_modules:
+        integration = EI(protocol=u"core.local_analytics_provider", goal=EI.ANALYTICS_GOAL)
+        _db.add(integration)
+
 finally:
     _db.commit()
     _db.close()

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1362,9 +1362,10 @@ class TestSettingsController(AdminControllerTest):
             response = self.manager.admin_settings_controller.collections()
             eq_(response.get("collections"), [])
 
-            # All the protocols in ExternalIntegration.LICENSE_PROTOCOLS are supported by the admin interface.
-            eq_(sorted([p.get("name") for p in response.get("protocols")]),
-                sorted(ExternalIntegration.LICENSE_PROTOCOLS))
+
+            names = [p.get("name") for p in response.get("protocols")]
+            assert ExternalIntegration.OVERDRIVE in names
+            assert ExternalIntegration.OPDS_IMPORT in names
 
     def test_collections_get_with_multiple_collections(self):
 

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -56,6 +56,8 @@ from api.clever import CleverAuthenticationAPI
 
 from api.novelist import NoveListAPI
 
+from api.google_analytics_provider import GoogleAnalyticsProvider
+
 class AdminControllerTest(CirculationControllerTest):
 
     def setup(self):
@@ -1683,7 +1685,7 @@ class TestSettingsController(AdminControllerTest):
                 ("id", "1234"),
             ])
             response = self.manager.admin_settings_controller.admin_auth_services()
-            eq_(response, MISSING_ADMIN_AUTH_SERVICE)
+            eq_(response, MISSING_SERVICE)
 
         auth_service, ignore = create(
             self._db, ExternalIntegration,
@@ -2000,7 +2002,7 @@ class TestSettingsController(AdminControllerTest):
                 ("id", "123"),
             ])
             response = self.manager.admin_settings_controller.patron_auth_services()
-            eq_(response, MISSING_PATRON_AUTH_SERVICE)
+            eq_(response, MISSING_SERVICE)
 
         auth_service, ignore = create(
             self._db, ExternalIntegration,
@@ -2321,7 +2323,7 @@ class TestSettingsController(AdminControllerTest):
                 ("id", "123"),
             ])
             response = self.manager.admin_settings_controller.metadata_services()
-            eq_(response, MISSING_METADATA_SERVICE)
+            eq_(response, MISSING_SERVICE)
 
         service, ignore = create(
             self._db, ExternalIntegration,
@@ -2435,4 +2437,190 @@ class TestSettingsController(AdminControllerTest):
         eq_("user", novelist_service.username)
         eq_("pass", novelist_service.password)
         eq_([l2], novelist_service.libraries)
+
+    def test_analytics_services_get_with_no_services(self):
+        with self.app.test_request_context("/"):
+            response = self.manager.admin_settings_controller.analytics_services()
+            eq_(response.get("analytics_services"), [])
+            protocols = response.get("protocols")
+            assert GoogleAnalyticsProvider.NAME in [p.get("label") for p in protocols]
+            assert "settings" in protocols[0]
+        
+    def test_analytics_services_get_with_one_service(self):
+        ga_service, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=GoogleAnalyticsProvider.__module__,
+            goal=ExternalIntegration.ANALYTICS_GOAL,
+        )
+        ga_service.url = self._str
+
+        with self.app.test_request_context("/"):
+            response = self.manager.admin_settings_controller.analytics_services()
+            [service] = response.get("analytics_services")
+
+            eq_(ga_service.id, service.get("id"))
+            eq_(ga_service.protocol, service.get("protocol"))
+            eq_(ga_service.url, service.get("settings").get(ExternalIntegration.URL))
+
+        ga_service.libraries += [self._default_library]
+        ConfigurationSetting.for_library_and_externalintegration(
+            self._db, GoogleAnalyticsProvider.TRACKING_ID, self._default_library, ga_service
+        ).value = "trackingid"
+        with self.app.test_request_context("/"):
+            response = self.manager.admin_settings_controller.analytics_services()
+            [service] = response.get("analytics_services")
+
+            [library] = service.get("libraries")
+            eq_(self._default_library.short_name, library.get("short_name"))
+            eq_("trackingid", library.get(GoogleAnalyticsProvider.TRACKING_ID))
+        
+    def test_analytics_services_post_errors(self):
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("protocol", "Unknown"),
+            ])
+            response = self.manager.admin_settings_controller.analytics_services()
+            eq_(response, UNKNOWN_PROTOCOL)
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([])
+            response = self.manager.admin_settings_controller.analytics_services()
+            eq_(response, NO_PROTOCOL_FOR_NEW_SERVICE)
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("id", "123"),
+            ])
+            response = self.manager.admin_settings_controller.analytics_services()
+            eq_(response, MISSING_SERVICE)
+
+        service, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=GoogleAnalyticsProvider.__module__,
+            goal=ExternalIntegration.ANALYTICS_GOAL,
+            name="name",
+        )
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("name", service.name),
+                ("protocol", GoogleAnalyticsProvider.__module__),
+            ])
+            response = self.manager.admin_settings_controller.analytics_services()
+            eq_(response, INTEGRATION_NAME_ALREADY_IN_USE)
+
+        service, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=GoogleAnalyticsProvider.__module__,
+            goal=ExternalIntegration.ANALYTICS_GOAL,
+        )
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("id", service.id),
+                ("protocol", "core.local_analytics_provider"),
+            ])
+            response = self.manager.admin_settings_controller.analytics_services()
+            eq_(response, CANNOT_CHANGE_PROTOCOL)
+
+        service, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=GoogleAnalyticsProvider.__module__,
+            goal=ExternalIntegration.ANALYTICS_GOAL,
+        )
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("id", service.id),
+                ("protocol", GoogleAnalyticsProvider.__module__),
+            ])
+            response = self.manager.admin_settings_controller.analytics_services()
+            eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
+
+        service, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=GoogleAnalyticsProvider.__module__,
+            goal=ExternalIntegration.ANALYTICS_GOAL,
+        )
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("id", service.id),
+                ("protocol", GoogleAnalyticsProvider.__module__),
+                (ExternalIntegration.URL, "url"),
+                ("libraries", json.dumps([{"short_name": "not-a-library"}])),
+            ])
+            response = self.manager.admin_settings_controller.analytics_services()
+            eq_(response.uri, NO_SUCH_LIBRARY.uri)
+
+        service, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=GoogleAnalyticsProvider.__module__,
+            goal=ExternalIntegration.ANALYTICS_GOAL,
+        )
+        library, ignore = create(
+            self._db, Library, name="Library", short_name="L",
+        )
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("id", service.id),
+                ("protocol", GoogleAnalyticsProvider.__module__),
+                (ExternalIntegration.URL, "url"),
+                ("libraries", json.dumps([{"short_name": library.short_name}])),
+            ])
+            response = self.manager.admin_settings_controller.analytics_services()
+            eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
+
+    def test_analytics_services_post_create(self):
+        library, ignore = create(
+            self._db, Library, name="Library", short_name="L",
+        )
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("protocol", GoogleAnalyticsProvider.__module__),
+                (ExternalIntegration.URL, "url"),
+                ("libraries", json.dumps([{"short_name": "L", "tracking_id": "trackingid"}])),
+            ])
+            response = self.manager.admin_settings_controller.analytics_services()
+            eq_(response.status_code, 201)
+
+        service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.ANALYTICS_GOAL)
+        eq_(GoogleAnalyticsProvider.__module__, service.protocol)
+        eq_("url", service.url)
+        eq_([library], service.libraries)
+        eq_("trackingid", ConfigurationSetting.for_library_and_externalintegration(
+                self._db, GoogleAnalyticsProvider.TRACKING_ID, library, service).value)
+
+    def test_analytics_services_post_edit(self):
+        l1, ignore = create(
+            self._db, Library, name="Library 1", short_name="L1",
+        )
+        l2, ignore = create(
+            self._db, Library, name="Library 2", short_name="L2",
+        )
+
+        ga_service, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=GoogleAnalyticsProvider.__module__,
+            goal=ExternalIntegration.ANALYTICS_GOAL,
+        )
+        ga_service.url = "oldurl"
+        ga_service.libraries = [l1]
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("id", ga_service.id),
+                ("protocol", GoogleAnalyticsProvider.__module__),
+                (ExternalIntegration.URL, "url"),
+                ("libraries", json.dumps([{"short_name": "L2", "tracking_id": "l2id"}])),
+            ])
+            response = self.manager.admin_settings_controller.analytics_services()
+            eq_(response.status_code, 200)
+
+        eq_(GoogleAnalyticsProvider.__module__, ga_service.protocol)
+        eq_("url", ga_service.url)
+        eq_([l2], ga_service.libraries)
+        eq_("l2id", ConfigurationSetting.for_library_and_externalintegration(
+                self._db, GoogleAnalyticsProvider.TRACKING_ID, l2, ga_service).value)
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2341,32 +2341,28 @@ class TestAnalyticsController(CirculationControllerTest):
         self.identifier = self.lp.identifier
 
     def test_track_event(self):
-        with temp_config() as config:
-            config = {
-                Configuration.POLICIES : {
-                    Configuration.ANALYTICS_POLICY : ["core.local_analytics_provider"],
-                }
-            }
+        integration, ignore = create(
+            self._db, ExternalIntegration,
+            goal=ExternalIntegration.ANALYTICS_GOAL,
+            protocol="core.local_analytics_provider",
+        )
+        self.manager.analytics = Analytics(self._db)
 
-            analytics = Analytics.initialize(
-                ['core.local_analytics_provider'], config
-            )            
+        with self.request_context_with_library("/"):
+            response = self.manager.analytics_controller.track_event(self.identifier.type, self.identifier.identifier, "invalid_type")
+            eq_(400, response.status_code)
+            eq_(INVALID_ANALYTICS_EVENT_TYPE.uri, response.uri)
 
-            with self.request_context_with_library("/"):
-                response = self.manager.analytics_controller.track_event(self.identifier.type, self.identifier.identifier, "invalid_type")
-                eq_(400, response.status_code)
-                eq_(INVALID_ANALYTICS_EVENT_TYPE.uri, response.uri)
-
-            with self.request_context_with_library("/"):
-                response = self.manager.analytics_controller.track_event(self.identifier.type, self.identifier.identifier, "open_book")
-                eq_(200, response.status_code)
-
-                circulation_event = get_one(
-                    self._db, CirculationEvent,
-                    type="open_book",
-                    license_pool=self.lp
-                )
-                assert circulation_event != None
+        with self.request_context_with_library("/"):
+            response = self.manager.analytics_controller.track_event(self.identifier.type, self.identifier.identifier, "open_book")
+            eq_(200, response.status_code)
+            
+            circulation_event = get_one(
+                self._db, CirculationEvent,
+                type="open_book",
+                license_pool=self.lp
+            )
+            assert circulation_event != None
 
 
 class TestDeviceManagementProtocolController(ControllerTest):

--- a/tests/test_google_analytics_provider.py
+++ b/tests/test_google_analytics_provider.py
@@ -11,8 +11,11 @@ from api.google_analytics_provider import GoogleAnalyticsProvider
 from . import DatabaseTest
 from core.model import (
     get_one_or_create,
+    create,
     CirculationEvent,
+    ConfigurationSetting,
     DataSource,
+    ExternalIntegration,
     LicensePool
 )
 import unicodedata
@@ -29,19 +32,33 @@ class MockGoogleAnalyticsProvider(GoogleAnalyticsProvider):
 
 class TestGoogleAnalyticsProvider(DatabaseTest):
 
-    def test_from_config(self):        
-        config = {
-            Configuration.INTEGRATIONS: {
-                GoogleAnalyticsProvider.INTEGRATION_NAME: {
-                    "tracking_id": "faketrackingid"
-                }
-            }
-        }        
-        ga = GoogleAnalyticsProvider.from_config(config)
-        eq_("faketrackingid", ga.tracking_id)
+    def test_init(self):
+        integration, ignore = create(
+            self._db, ExternalIntegration,
+            goal=ExternalIntegration.ANALYTICS_GOAL,
+            protocol="api.google_analytics_provider",
+        )
+        ga = GoogleAnalyticsProvider(integration)
+        eq_(GoogleAnalyticsProvider.DEFAULT_URL, ga.url)
+        eq_(integration.id, ga.integration_id)
+
+        integration.url = self._str
+        ga = GoogleAnalyticsProvider(integration)
+        eq_(integration.url, ga.url)
+        eq_(integration.id, ga.integration_id)
 
     def test_collect_event_with_work(self):
-        ga = MockGoogleAnalyticsProvider("faketrackingid")
+        integration, ignore = create(
+            self._db, ExternalIntegration,
+            goal=ExternalIntegration.ANALYTICS_GOAL,
+            protocol="api.google_analytics_provider",
+        )
+        integration.url = self._str
+        ConfigurationSetting.for_library_and_externalintegration(
+            self._db, GoogleAnalyticsProvider.TRACKING_ID, self._default_library, integration
+        ).value = "faketrackingid"
+        ga = MockGoogleAnalyticsProvider(integration)
+
         work = self._work(
             title=u"pi\u00F1ata", authors=u"chlo\u00E9", fiction=True,
             audience="audience", language="lang", 
@@ -52,11 +69,11 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
         work.target_age = NumericRange(10, 15)
         [lp] = work.license_pools
         now = datetime.datetime.utcnow()
-        ga.collect_event(self._db, lp, CirculationEvent.DISTRIBUTOR_CHECKIN, now)
+        ga.collect_event(self._default_library, lp, CirculationEvent.DISTRIBUTOR_CHECKIN, now)
         params = urlparse.parse_qs(ga.params)
 
         eq_(1, ga.count)
-        eq_("http://www.google-analytics.com/collect", ga.url)
+        eq_(integration.url, ga.url)
         eq_("faketrackingid", params['tid'][0])
         eq_("event", params['t'][0])
         eq_("circulation", params['ec'][0])
@@ -77,7 +94,16 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
         eq_("true", params['cd12'][0])
 
     def test_collect_event_without_work(self):
-        ga = MockGoogleAnalyticsProvider("faketrackingid")
+        integration, ignore = create(
+            self._db, ExternalIntegration,
+            goal=ExternalIntegration.ANALYTICS_GOAL,
+            protocol="api.google_analytics_provider",
+        )
+        integration.url = self._str
+        ConfigurationSetting.for_library_and_externalintegration(
+            self._db, GoogleAnalyticsProvider.TRACKING_ID, self._default_library, integration
+        ).value = "faketrackingid"
+        ga = MockGoogleAnalyticsProvider(integration)
 
         identifier = self._identifier()
         source = DataSource.lookup(self._db, DataSource.GUTENBERG)
@@ -88,11 +114,11 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
         )
 
         now = datetime.datetime.utcnow()
-        ga.collect_event(self._db, pool, CirculationEvent.DISTRIBUTOR_CHECKIN, now)
+        ga.collect_event(self._default_library, pool, CirculationEvent.DISTRIBUTOR_CHECKIN, now)
         params = urlparse.parse_qs(ga.params)
 
         eq_(1, ga.count)
-        eq_("http://www.google-analytics.com/collect", ga.url)
+        eq_(integration.url, ga.url)
         eq_("faketrackingid", params['tid'][0])
         eq_("event", params['t'][0])
         eq_("circulation", params['ec'][0])
@@ -111,14 +137,23 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
         eq_(None, params.get('cd12'))
 
     def test_collect_event_without_license_pool(self):
-        ga = MockGoogleAnalyticsProvider('faketrackingid')
+        integration, ignore = create(
+            self._db, ExternalIntegration,
+            goal=ExternalIntegration.ANALYTICS_GOAL,
+            protocol="api.google_analytics_provider",
+        )
+        integration.url = self._str
+        ConfigurationSetting.for_library_and_externalintegration(
+            self._db, GoogleAnalyticsProvider.TRACKING_ID, self._default_library, integration
+        ).value = "faketrackingid"
+        ga = MockGoogleAnalyticsProvider(integration)
 
         now = datetime.datetime.utcnow()
-        ga.collect_event(self._db, None, CirculationEvent.NEW_PATRON, now)
+        ga.collect_event(self._default_library, None, CirculationEvent.NEW_PATRON, now)
         params = urlparse.parse_qs(ga.params)
 
         eq_(1, ga.count)
-        eq_("http://www.google-analytics.com/collect", ga.url)
+        eq_(integration.url, ga.url)
         eq_("faketrackingid", params['tid'][0])
         eq_("event", params['t'][0])
         eq_("circulation", params['ec'][0])

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -45,7 +45,7 @@ class OverdriveAPITest(DatabaseTest):
         library = self._default_library
         self.collection = MockOverdriveAPI.mock_collection(self._db)
         self.circulation = CirculationAPI(
-            self._db, library, {ExternalIntegration.OVERDRIVE:MockOverdriveAPI}
+            self._db, library, api_map={ExternalIntegration.OVERDRIVE:MockOverdriveAPI}
         )
         self.api = self.circulation.api_for_collection[self.collection]
         


### PR DESCRIPTION
This fixes #539 
It uses https://github.com/NYPL-Simplified/circulation-web/pull/93 and https://github.com/NYPL-Simplified/server_core/pull/551

It moves the analytics configuration into the database, and changes Analytics to be initialized by the CirculationManager, instead of a global singleton. When scripts need it, they have to create their own. It also adds an admin route for editing analytics configuration.
