### PR TITLE
Short client token changes and drm services in admin interface

### DIFF
--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.27"
+    "simplified-circulation-web": "0.0.28"
   }
 }

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -114,20 +114,6 @@ LIBRARY_SHORT_NAME_ALREADY_IN_USE = pd(
     detail=_("The library short name must be unique, and there's already a library with the specified short name."),
 )
 
-CANNOT_SET_BOTH_RANDOM_AND_SPECIFIC_SECRET = pd(
-    "http://librarysimplified.org/terms/problem/cannot-set-both-random-and-specific-secret",
-    status_code=400,
-    title=_("Cannot set both random and specific secret"),
-    detail=_("You can't set the shared secret to a random value and a specific value at the same time"),
-)
-
-CANNOT_REPLACE_EXISTING_SECRET_WITH_RANDOM_SECRET = pd(
-    "http://librarysimplified.org/terms/problem/cannot-replace-existing-secret-with-random-secret",
-    status_code=400,
-    title=_("Cannot replace existing secret with random secret"),
-    detail=_("You can't overwrite an existing shared secret with a random value"),
-)
-
 MISSING_COLLECTION = pd(
     "http://librarysimplified.org/terms/problem/missing-collection",
     status_code=404,

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -363,6 +363,18 @@ def analytics_services():
         return data
     return flask.jsonify(**data)
 
+@app.route("/admin/drm_services", methods=["GET", "POST"])
+@returns_problem_detail
+@requires_admin
+@requires_csrf_token
+def drm_services():
+    data = app.manager.admin_settings_controller.drm_services()
+    if isinstance(data, ProblemDetail):
+        return data
+    if isinstance(data, Response):
+        return data
+    return flask.jsonify(**data)
+
 @app.route("/admin/sitewide_settings", methods=['GET', 'POST'])
 @returns_problem_detail
 @requires_admin

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -668,6 +668,17 @@ class AuthdataUtility(object):
     VENDOR_ID_KEY = u'vendor_id'
     OTHER_LIBRARIES_KEY = u'other_libraries'
 
+    NAME = ExternalIntegration.SHORT_CLIENT_TOKEN
+
+    SETTINGS = [
+        { "key": VENDOR_ID_KEY, "label": _("Vendor ID") },
+    ]
+
+    LIBRARY_SETTINGS = [
+        { "key": ExternalIntegration.USERNAME, "label": _("Short name for library registry") },
+        { "key": ExternalIntegration.PASSWORD, "label": _("Shared secret for library registry"), "randomizable": True },
+    ]
+
     @classmethod
     def from_config(cls, library):
         """Initialize an AuthdataUtility from site configuration.
@@ -691,8 +702,12 @@ class AuthdataUtility(object):
             return None
 
         vendor_id = short_client_token.setting(cls.VENDOR_ID_KEY).value
-        library_short_name = short_client_token.username
-        secret = short_client_token.password
+        library_short_name = ConfigurationSetting.for_library_and_externalintegration(
+            _db, ExternalIntegration.USERNAME, library, short_client_token
+        ).value
+        secret = ConfigurationSetting.for_library_and_externalintegration(
+            _db, ExternalIntegration.PASSWORD, library, short_client_token
+        ).value
 
         other_libraries = None
         adobe_integration = ExternalIntegration.lookup(

--- a/migration/20170616-2-move-third-party-config-to-external-integrations.py
+++ b/migration/20170616-2-move-third-party-config-to-external-integrations.py
@@ -98,22 +98,26 @@ try:
             integration.libraries.append(node_library)
             log_import(integration)
 
-        for library in LIBRARIES:
-            integration = EI(protocol=EI.SHORT_CLIENT_TOKEN, goal=EI.DRM_GOAL)
-            _db.add(integration)
+        # Import short client token configuration.
+        integration = EI(protocol=EI.SHORT_CLIENT_TOKEN, goal=EI.DRM_GOAL)
+        _db.add(integration)
+        integration.set_setting(
+            AuthdataUtility.VENDOR_ID_KEY, vendor_id
+        )
 
+        for library in LIBRARIES:
             short_name = library.library_registry_short_name
             short_name = short_name or adobe_conf.get('library_short_name')
             if short_name:
-                integration.username = short_name.upper()
+                ConfigurationSetting.for_library_and_externalintegration(
+                    _db, EI.USERNAME, library, integration
+                ).value = short_name
 
             shared_secret = library.library_registry_shared_secret
             shared_secret = shared_secret or adobe_conf.get('authdata_secret')
-            integration.password = shared_secret
-
-            integration.set_setting(
-                AuthdataUtility.VENDOR_ID_KEY, vendor_id
-            )
+            ConfigurationSetting.for_library_and_externalintegration(
+                _db, EI.PASSWORD, library, integration
+            ).value = shared_secret
 
             library_url = adobe_conf.get('library_uri')
             ConfigurationSetting.for_library(

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -565,7 +565,9 @@ class TestOPDS(VendorIDTest):
         eq_(self.adobe_vendor_id.username,
             licensor.attrib['{http://librarysimplified.org/terms/drm}vendor'])
         [client_token, device_management_link] = licensor.getchildren()
-        expected = self.short_client_token[self._default_library].username.upper()
+        expected = ConfigurationSetting.for_library_and_externalintegration(
+            self._db, ExternalIntegration.USERNAME, self._default_library, self.short_client_token
+        ).value.upper()
         assert client_token.text.startswith(expected)
         assert adobe_patron_identifier in client_token.text
         eq_("{http://www.w3.org/2005/Atom}link",


### PR DESCRIPTION
This fixes #553 and fixes #538.

This uses https://github.com/NYPL-Simplified/circulation-web/pull/94.


