### PR TITLE
Made Lane constructor take db argument.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -185,11 +185,11 @@ class CirculationManager(object):
         self.adobe_device_management = None
         self.short_client_token_initialization_exceptions = dict()
         for library in self._db.query(Library):
-            lanes = make_lanes(library, self.lane_descriptions)
+            lanes = make_lanes(self._db, library, self.lane_descriptions)
             
             self.top_level_lanes[library.id] = (
                 self.create_top_level_lane(
-                    library, lanes
+                    self._db, library, lanes
                 )
             )
 
@@ -227,9 +227,10 @@ class CirculationManager(object):
                 self.external_search_initialization_exception = e
         return self.__external_search
 
-    def create_top_level_lane(self, library, lanelist):
+    def create_top_level_lane(self, _db, library, lanelist):
         name = 'All Books'
         return Lane(
+            _db,
             library, name,
             display_name=name,
             parent=None,
@@ -1086,7 +1087,7 @@ class WorkController(CirculationManagerController):
         languages, audiences = self._lane_details(languages, audiences)
 
         lane = ContributorLane(
-            library, contributor_name, languages=languages, audiences=audiences
+            self._db, library, contributor_name, languages=languages, audiences=audiences
         )
 
         annotator = self.manager.annotator(lane)
@@ -1143,7 +1144,7 @@ class WorkController(CirculationManagerController):
                 work.title, work.author
             )
             lane = RelatedBooksLane(
-                library, work, lane_name, novelist_api=novelist_api
+                self._db, library, work, lane_name, novelist_api=novelist_api
             )
         except ValueError, e:
             # No related books were found.
@@ -1178,7 +1179,7 @@ class WorkController(CirculationManagerController):
         lane_name = "Recommendations for %s by %s" % (work.title, work.author)
         try:
             lane = RecommendationLane(
-                library, work, lane_name, novelist_api=novelist_api
+                self._db, library, work, lane_name, novelist_api=novelist_api
             )
         except ValueError, e:
             # NoveList isn't configured.
@@ -1235,7 +1236,7 @@ class WorkController(CirculationManagerController):
             return NO_SUCH_LANE.detailed(_("No series provided"))
 
         languages, audiences = self._lane_details(languages, audiences)
-        lane = SeriesLane(library, series_name=series_name,
+        lane = SeriesLane(self._db, library, series_name=series_name,
                           languages=languages, audiences=audiences
         )
         annotator = self.manager.annotator(lane)

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -30,18 +30,18 @@ from core.model import (
 from core.util import LanguageCodes
 from novelist import NoveListAPI
 
-def make_lanes(library, definitions=None):
+def make_lanes(_db, library, definitions=None):
 
-    lanes = core_make_lanes(library, definitions)
+    lanes = core_make_lanes(_db, library, definitions)
     if lanes:
         return lanes
 
     # There was no configuration to create the lanes,
     # so go with  the default configuration instead.
-    lanes = make_lanes_default(library)
-    return LaneList.from_description(library, None, lanes)
+    lanes = make_lanes_default(_db, library)
+    return LaneList.from_description(_db, library, None, lanes)
 
-def make_lanes_default(library):
+def make_lanes_default(_db, library):
     """Create the default layout of lanes for the server configuration."""
 
     # The top-level LaneList includes a hidden lane for each
@@ -69,20 +69,20 @@ def make_lanes_default(library):
     for language_set in Configuration.large_collection_languages():
         languages = language_list(language_set)
         seen_languages = seen_languages.union(set(languages))
-        top_level_lanes.extend(lanes_for_large_collection(library, language_set))
+        top_level_lanes.extend(lanes_for_large_collection(_db, library, language_set))
 
     for language_set in Configuration.small_collection_languages():
         languages = language_list(language_set)
         seen_languages = seen_languages.union(set(languages))
-        top_level_lanes.append(lane_for_small_collection(library, language_set))
+        top_level_lanes.append(lane_for_small_collection(_db, library, language_set))
 
-    other_languages_lane = lane_for_other_languages(library, seen_languages)
+    other_languages_lane = lane_for_other_languages(_db, library, seen_languages)
     if other_languages_lane:
         top_level_lanes.append(other_languages_lane)
 
-    return LaneList.from_description(library, None, top_level_lanes)
+    return LaneList.from_description(_db, library, None, top_level_lanes)
 
-def lanes_from_genres(library, genres, **extra_args):
+def lanes_from_genres(_db, library, genres, **extra_args):
     """Turn genre info into a list of Lane objects."""
 
     genre_lane_instructions = {
@@ -111,10 +111,10 @@ def lanes_from_genres(library, genres, **extra_args):
                 lane_args['display_name']=instructions.get('display_name')
             if "invisible" in instructions:
                 lane_args['invisible']=instructions.get("invisible")
-        lanes.append(genredata.to_lane(library, **lane_args))
+        lanes.append(genredata.to_lane(_db, library, **lane_args))
     return lanes
 
-def lanes_for_large_collection(library, languages):
+def lanes_for_large_collection(_db, library, languages):
 
     YA = Classifier.AUDIENCE_YOUNG_ADULT
     CHILDREN = Classifier.AUDIENCE_CHILDREN
@@ -126,10 +126,10 @@ def lanes_for_large_collection(library, languages):
     )
 
     adult_fiction = Lane(
-        library, full_name="Adult Fiction", display_name="Fiction",
+        _db, library, full_name="Adult Fiction", display_name="Fiction",
         genres=None,
         sublanes=lanes_from_genres(
-            library, fiction_genres, languages=languages,
+            _db, library, fiction_genres, languages=languages,
             audiences=Classifier.AUDIENCES_ADULT,
         ),
         fiction=True, 
@@ -137,10 +137,10 @@ def lanes_for_large_collection(library, languages):
         **common_args
     )
     adult_nonfiction = Lane(
-        library, full_name="Adult Nonfiction", display_name="Nonfiction",
+        _db, library, full_name="Adult Nonfiction", display_name="Nonfiction",
         genres=None,
         sublanes=lanes_from_genres(
-            library, nonfiction_genres, languages=languages,
+            _db, library, nonfiction_genres, languages=languages,
             audiences=Classifier.AUDIENCES_ADULT,
         ),
         fiction=False, 
@@ -154,39 +154,39 @@ def lanes_for_large_collection(library, languages):
     )
 
     ya_fiction = Lane(
-        library, full_name="Young Adult Fiction", genres=None, fiction=True,
+        _db, library, full_name="Young Adult Fiction", genres=None, fiction=True,
         include_best_sellers=True,
         include_staff_picks=True,        
         sublanes=[
-            Lane(library, full_name="YA Dystopian",
+            Lane(_db, library, full_name="YA Dystopian",
                  display_name="Dystopian", genres=[genres.Dystopian_SF],
                  **ya_common_args),
-            Lane(library, full_name="YA Fantasy", display_name="Fantasy",
+            Lane(_db, library, full_name="YA Fantasy", display_name="Fantasy",
                  genres=[genres.Fantasy], 
                  subgenre_behavior=Lane.IN_SAME_LANE, **ya_common_args),
-            Lane(library, full_name="YA Graphic Novels",
+            Lane(_db, library, full_name="YA Graphic Novels",
                  display_name="Comics & Graphic Novels",
                  genres=[genres.Comics_Graphic_Novels], **ya_common_args),
-            Lane(library, full_name="YA Literary Fiction",
+            Lane(_db, library, full_name="YA Literary Fiction",
                  display_name="Contemporary Fiction",
                  genres=[genres.Literary_Fiction], **ya_common_args),
-            Lane(library, full_name="YA LGBTQ Fiction", 
+            Lane(_db, library, full_name="YA LGBTQ Fiction", 
                  display_name="LGBTQ Fiction",
                  genres=[genres.LGBTQ_Fiction],
                  **ya_common_args),
-            Lane(library, full_name="Mystery & Thriller",
+            Lane(_db, library, full_name="Mystery & Thriller",
                  genres=[genres.Suspense_Thriller, genres.Mystery],
                  subgenre_behavior=Lane.IN_SAME_LANE, **ya_common_args),
-            Lane(library, full_name="YA Romance", display_name="Romance",
+            Lane(_db, library, full_name="YA Romance", display_name="Romance",
                  genres=[genres.Romance],
                  subgenre_behavior=Lane.IN_SAME_LANE, **ya_common_args),
-            Lane(library, full_name="YA Science Fiction",
+            Lane(_db, library, full_name="YA Science Fiction",
                  display_name="Science Fiction",
                  genres=[genres.Science_Fiction],
                  subgenre_behavior=Lane.IN_SAME_LANE,
                  exclude_genres=[genres.Dystopian_SF, genres.Steampunk],
                  **ya_common_args),
-            Lane(library, full_name="YA Steampunk", genres=[genres.Steampunk],
+            Lane(_db, library, full_name="YA Steampunk", genres=[genres.Steampunk],
                  subgenre_behavior=Lane.IN_SAME_LANE,
                  display_name="Steampunk", **ya_common_args),
             # TODO:
@@ -196,27 +196,27 @@ def lanes_for_large_collection(library, languages):
     )
 
     ya_nonfiction = Lane(
-        library, full_name="Young Adult Nonfiction", genres=None, fiction=False,
+        _db, library, full_name="Young Adult Nonfiction", genres=None, fiction=False,
         include_best_sellers=True,
         include_staff_picks=True,
         sublanes=[
-            Lane(library, full_name="YA Biography", 
+            Lane(_db, library, full_name="YA Biography", 
                  genres=genres.Biography_Memoir,
                  display_name="Biography",
                  **ya_common_args
                  ),
-            Lane(library, full_name="YA History",
+            Lane(_db, library, full_name="YA History",
                  genres=[genres.History, genres.Social_Sciences],
                  display_name="History & Sociology", 
                  subgenre_behavior=Lane.IN_SAME_LANE,
                  **ya_common_args
              ),
-            Lane(library, full_name="YA Life Strategies",
+            Lane(_db, library, full_name="YA Life Strategies",
                  display_name="Life Strategies",
                  genres=[genres.Life_Strategies], 
                  **ya_common_args
                  ),
-            Lane(library, full_name="YA Religion & Spirituality", 
+            Lane(_db, library, full_name="YA Religion & Spirituality", 
                  display_name="Religion & Spirituality",
                  genres=genres.Religion_Spirituality,
                  subgenre_behavior=Lane.IN_SAME_LANE,
@@ -232,65 +232,65 @@ def lanes_for_large_collection(library, languages):
     )
 
     children = Lane(
-        library, full_name="Children and Middle Grade", genres=None,
+        _db, library, full_name="Children and Middle Grade", genres=None,
         fiction=Lane.BOTH_FICTION_AND_NONFICTION,
         include_best_sellers=True,
         include_staff_picks=True,
         searchable=True,
         sublanes=[
-            Lane(library, full_name="Picture Books", age_range=[0,1,2,3,4],
+            Lane(_db, library, full_name="Picture Books", age_range=[0,1,2,3,4],
                  genres=None, fiction=Lane.BOTH_FICTION_AND_NONFICTION,
                  **children_common_args
              ),
-            Lane(library, full_name="Easy readers", age_range=[5,6,7,8],
+            Lane(_db, library, full_name="Easy readers", age_range=[5,6,7,8],
                  genres=None, fiction=Lane.BOTH_FICTION_AND_NONFICTION,
                  **children_common_args
              ),
-            Lane(library, full_name="Chapter books", age_range=[9,10,11,12],
+            Lane(_db, library, full_name="Chapter books", age_range=[9,10,11,12],
                  genres=None, fiction=Lane.BOTH_FICTION_AND_NONFICTION,
                  **children_common_args
              ),
-            Lane(library, full_name="Children's Poetry", 
+            Lane(_db, library, full_name="Children's Poetry", 
                  display_name="Poetry books", genres=[genres.Poetry],
                  **children_common_args
              ),
-            Lane(library, full_name="Children's Folklore", display_name="Folklore",
+            Lane(_db, library, full_name="Children's Folklore", display_name="Folklore",
                  genres=[genres.Folklore],
                  subgenre_behavior=Lane.IN_SAME_LANE,
                  **children_common_args
              ),
-            Lane(library, full_name="Children's Fantasy", display_name="Fantasy",
+            Lane(_db, library, full_name="Children's Fantasy", display_name="Fantasy",
                  fiction=True,
                  genres=[genres.Fantasy], 
                  subgenre_behavior=Lane.IN_SAME_LANE,
                  **children_common_args
              ),
-            Lane(library, full_name="Children's SF", display_name="Science Fiction",
+            Lane(_db, library, full_name="Children's SF", display_name="Science Fiction",
                  fiction=True, genres=[genres.Science_Fiction],
                  subgenre_behavior=Lane.IN_SAME_LANE,
                  **children_common_args
              ),
-            Lane(library, full_name="Realistic fiction", 
+            Lane(_db, library, full_name="Realistic fiction", 
                  fiction=True, genres=[genres.Literary_Fiction],
                  subgenre_behavior=Lane.IN_SAME_LANE,
                  **children_common_args
              ),
-            Lane(library, full_name="Children's Graphic Novels",
+            Lane(_db, library, full_name="Children's Graphic Novels",
                  display_name="Comics & Graphic Novels",
                  genres=[genres.Comics_Graphic_Novels],
                  **children_common_args
              ),
-            Lane(library, full_name="Biography", 
+            Lane(_db, library, full_name="Biography", 
                  genres=[genres.Biography_Memoir],
                  subgenre_behavior=Lane.IN_SAME_LANE,
                  **children_common_args
              ),
-            Lane(library, full_name="Historical fiction", 
+            Lane(_db, library, full_name="Historical fiction", 
                  genres=[genres.Historical_Fiction],
                  subgenre_behavior=Lane.IN_SAME_LANE, 
                  **children_common_args
              ),
-            Lane(library, full_name="Informational books", genres=None,
+            Lane(_db, library, full_name="Informational books", genres=None,
                  fiction=False, exclude_genres=[genres.Biography_Memoir],
                  subgenre_behavior=Lane.IN_SAME_LANE,
                  **children_common_args
@@ -301,7 +301,7 @@ def lanes_for_large_collection(library, languages):
 
     name = LanguageCodes.name_for_languageset(languages)
     lane = Lane(
-        library, full_name=name,
+        _db, library, full_name=name,
         genres=None,
         sublanes=[adult_fiction, adult_nonfiction, ya_fiction, ya_nonfiction, children],
         fiction=Lane.BOTH_FICTION_AND_NONFICTION,
@@ -312,7 +312,7 @@ def lanes_for_large_collection(library, languages):
 
     return [lane]
 
-def lane_for_small_collection(library, languages):
+def lane_for_small_collection(_db, library, languages):
 
     YA = Classifier.AUDIENCE_YOUNG_ADULT
     CHILDREN = Classifier.AUDIENCE_CHILDREN
@@ -325,14 +325,14 @@ def lane_for_small_collection(library, languages):
     )
 
     adult_fiction = Lane(
-        library, full_name="Adult Fiction",
+        _db, library, full_name="Adult Fiction",
         display_name="Fiction",
         fiction=True, 
         audiences=Classifier.AUDIENCES_ADULT,
         **common_args
     )
     adult_nonfiction = Lane(
-        library, full_name="Adult Nonfiction", 
+        _db, library, full_name="Adult Nonfiction", 
         display_name="Nonfiction",
         fiction=False, 
         audiences=Classifier.AUDIENCES_ADULT,
@@ -340,7 +340,7 @@ def lane_for_small_collection(library, languages):
     )
 
     ya_children = Lane(
-        library, 
+        _db, library, 
         full_name="Children & Young Adult", 
         fiction=Lane.BOTH_FICTION_AND_NONFICTION,
         audiences=[YA, CHILDREN],
@@ -349,14 +349,14 @@ def lane_for_small_collection(library, languages):
 
     name = LanguageCodes.name_for_languageset(languages)
     lane = Lane(
-        library, full_name=name, languages=languages, 
+        _db, library, full_name=name, languages=languages, 
         sublanes=[adult_fiction, adult_nonfiction, ya_children],
         searchable=True
     )
     lane.default_for_language = True
     return lane
 
-def lane_for_other_languages(library, exclude_languages):
+def lane_for_other_languages(_db, library, exclude_languages):
     """Make a lane for all books not in one of the given languages."""
 
     language_lanes = []
@@ -368,7 +368,7 @@ def lane_for_other_languages(library, exclude_languages):
     for language_set in other_languages:
         name = LanguageCodes.name_for_languageset(language_set)
         language_lane = Lane(
-            library, full_name=name,
+            _db, library, full_name=name,
             genres=None,
             fiction=Lane.BOTH_FICTION_AND_NONFICTION,
             searchable=True,
@@ -377,7 +377,7 @@ def lane_for_other_languages(library, exclude_languages):
         language_lanes.append(language_lane)
 
     lane = Lane(
-        library, 
+        _db, library, 
         full_name="Other Languages", 
         sublanes=language_lanes,
         exclude_languages=exclude_languages,
@@ -394,7 +394,7 @@ class WorkBasedLane(QueryGeneratedLane):
     DISPLAY_NAME = None
     ROUTE = None
 
-    def __init__(self, library, work, full_name, display_name=None,
+    def __init__(self, _db, library, work, full_name, display_name=None,
                  sublanes=[], invisible=False, **kwargs):
         self.work = work
         self.edition = work.presentation_edition
@@ -407,7 +407,7 @@ class WorkBasedLane(QueryGeneratedLane):
         display_name = display_name or self.DISPLAY_NAME
 
         super(WorkBasedLane, self).__init__(
-            library, full_name, display_name=display_name, sublanes=sublanes,
+            _db, library, full_name, display_name=display_name, sublanes=sublanes,
             languages=languages, audiences=audiences, **kwargs
         )
 
@@ -442,36 +442,36 @@ class RelatedBooksLane(WorkBasedLane):
     DISPLAY_NAME = "Related Books"
     ROUTE = 'related_books'
 
-    def __init__(self, library, work, full_name, display_name=None,
+    def __init__(self, _db, library, work, full_name, display_name=None,
                  novelist_api=None):
         super(RelatedBooksLane, self).__init__(
-            library, work, full_name, display_name=display_name,
+            _db, library, work, full_name, display_name=display_name,
             invisible=True, searchable=False,
         )
-        sublanes = self._get_sublanes(novelist_api)
+        sublanes = self._get_sublanes(_db, novelist_api)
         if not sublanes:
             raise ValueError(
                 "No related books for %s by %s" % (self.work.title, self.work.author)
             )
         self.set_sublanes(self.library, sublanes, [])
 
-    def _get_sublanes(self, novelist_api):
+    def _get_sublanes(self, _db, novelist_api):
         sublanes = list()
 
-        for contributor_lane in self._contributor_sublanes():
+        for contributor_lane in self._contributor_sublanes(_db):
             sublanes.append(contributor_lane)
 
-        for recommendation_lane in self._recommendation_sublane(novelist_api):
+        for recommendation_lane in self._recommendation_sublane(_db, novelist_api):
             sublanes.append(recommendation_lane)
 
         # Create a series sublane.
         series_name = self.edition.series
         if series_name:
-            sublanes.append(SeriesLane(self.library, series_name, parent=self))
+            sublanes.append(SeriesLane(_db, self.library, series_name, parent=self))
 
         return sublanes
 
-    def _contributor_sublanes(self):
+    def _contributor_sublanes(self, _db):
         """Create contributor sublanes"""
         viable_contributors = list()
         roles_by_priority = list(Contributor.author_contributor_tiers())[1:]
@@ -492,18 +492,18 @@ class RelatedBooksLane(WorkBasedLane):
                 contributor_name = contributor.sort_name
 
             contributor_lane = ContributorLane(
-                self.library, contributor_name, parent=self
+                _db, self.library, contributor_name, parent=self
             )
             yield contributor_lane
 
-    def _recommendation_sublane(self, novelist_api):
+    def _recommendation_sublane(self, _db, novelist_api):
         """Create a recommendations sublane."""
         try:
             lane_name = "Recommendations for %s by %s" % (
                 self.work.title, self.work.author
             )
             recommendation_lane = RecommendationLane(
-                self.library, self.work, lane_name, novelist_api=novelist_api,
+                _db, self.library, self.work, lane_name, novelist_api=novelist_api,
                 parent=self
             )
             if recommendation_lane.recommendations:
@@ -525,10 +525,10 @@ class RecommendationLane(WorkBasedLane):
     ROUTE = "recommendations"
     MAX_CACHE_AGE = 7*24*60*60      # one week
 
-    def __init__(self, library, work, full_name, display_name=None,
+    def __init__(self, _db, library, work, full_name, display_name=None,
                  novelist_api=None, parent=None):
         super(RecommendationLane, self).__init__(
-            library, work, full_name, display_name=display_name,
+            _db, library, work, full_name, display_name=display_name,
             parent=parent, searchable=False,
         )
         self.api = novelist_api or NoveListAPI.from_config(library)
@@ -561,7 +561,7 @@ class SeriesLane(QueryGeneratedLane):
     ROUTE = 'series'
     MAX_CACHE_AGE = 48*60*60    # 48 hours
 
-    def __init__(self, library, series_name, parent=None, languages=None,
+    def __init__(self, _db, library, series_name, parent=None, languages=None,
                  audiences=None):
         if not series_name:
             raise ValueError("SeriesLane can't be created without series")
@@ -574,7 +574,7 @@ class SeriesLane(QueryGeneratedLane):
             audiences = [parent.source_audience]
 
         super(SeriesLane, self).__init__(
-            library, full_name, parent=parent, display_name=display_name,
+            _db, library, full_name, parent=parent, display_name=display_name,
             audiences=audiences, languages=languages, searchable=False,
         )
 
@@ -618,7 +618,7 @@ class ContributorLane(QueryGeneratedLane):
     ROUTE = 'contributor'
     MAX_CACHE_AGE = 48*60*60    # 48 hours
 
-    def __init__(self, library, contributor_name,
+    def __init__(self, _db, library, contributor_name,
                  parent=None, languages=None, audiences=None):
         if not contributor_name:
             raise ValueError("ContributorLane can't be created without contributor")
@@ -626,7 +626,7 @@ class ContributorLane(QueryGeneratedLane):
         self.contributor_name = contributor_name
         full_name = display_name = contributor_name
         super(ContributorLane, self).__init__(
-            library, full_name, display_name=display_name, parent=parent,
+            _db, library, full_name, display_name=display_name, parent=parent,
             audiences=audiences, languages=languages, searchable=False,
         )
         self.contributors = self._db.query(Contributor)\

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -42,7 +42,7 @@ class TestLaneCreation(DatabaseTest):
 
     def test_lanes_for_large_collection(self):
         languages = ['eng', 'spa']
-        lanes = lanes_for_large_collection(self._default_library, languages)
+        lanes = lanes_for_large_collection(self._db, self._default_library, languages)
         [lane] = lanes
 
         # We have one top-level lane for English & Spanish
@@ -92,7 +92,7 @@ class TestLaneCreation(DatabaseTest):
         eq_(True, children.searchable)
 
     def test_lane_for_small_collection(self):
-        lane = lane_for_small_collection(self._default_library, ['eng', 'spa', 'chi'])
+        lane = lane_for_small_collection(self._db, self._default_library, ['eng', 'spa', 'chi'])
         eq_(u"English/español/Chinese", lane.display_name)
         sublanes = lane.sublanes.lanes
         eq_(
@@ -119,7 +119,7 @@ class TestLaneCreation(DatabaseTest):
             }
 
             exclude = ['eng', 'spa']
-            lane = lane_for_other_languages(self._default_library, exclude)
+            lane = lane_for_other_languages(self._db, self._default_library, exclude)
             eq_(None, lane.languages)
             eq_(exclude, lane.exclude_languages)
             eq_("Other Languages", lane.name)
@@ -141,7 +141,7 @@ class TestLaneCreation(DatabaseTest):
             }
 
             exclude = ['eng', 'spa']
-            lane = lane_for_other_languages(self._default_library, exclude)
+            lane = lane_for_other_languages(self._db, self._default_library, exclude)
             eq_(None, lane)
 
     def test_make_lanes_default(self):
@@ -153,7 +153,7 @@ class TestLaneCreation(DatabaseTest):
                     Configuration.TINY_COLLECTION_LANGUAGES : 'ger,fre,ita'
                 }
             }
-            lane_list = make_lanes_default(self._default_library)
+            lane_list = make_lanes_default(self._db, self._default_library)
 
             assert isinstance(lane_list, LaneList)
             lanes = lane_list.lanes
@@ -180,19 +180,19 @@ class TestWorkBasedLane(DatabaseTest):
         work = self._work(with_license_pool=True)
 
         work.audience = Classifier.AUDIENCE_CHILDREN
-        children_lane = WorkBasedLane(self._default_library, work, '')
+        children_lane = WorkBasedLane(self._db, self._default_library, work, '')
         eq_(set([Classifier.AUDIENCE_CHILDREN]), children_lane.audiences)
 
         work.audience = Classifier.AUDIENCE_YOUNG_ADULT
-        ya_lane = WorkBasedLane(self._default_library, work, '')
+        ya_lane = WorkBasedLane(self._db, self._default_library, work, '')
         eq_(sorted(Classifier.AUDIENCES_JUVENILE), sorted(ya_lane.audiences))
 
         work.audience = Classifier.AUDIENCE_ADULT
-        adult_lane = WorkBasedLane(self._default_library, work, '')
+        adult_lane = WorkBasedLane(self._db, self._default_library, work, '')
         eq_(sorted(Classifier.AUDIENCES), sorted(adult_lane.audiences))
 
         work.audience = Classifier.AUDIENCE_ADULTS_ONLY
-        adults_only_lane = WorkBasedLane(self._default_library, work, '')
+        adults_only_lane = WorkBasedLane(self._db, self._default_library, work, '')
         eq_(sorted(Classifier.AUDIENCES), sorted(adults_only_lane.audiences))
 
 
@@ -217,14 +217,14 @@ class TestRelatedBooksLane(DatabaseTest):
         self._db.commit()
 
         assert_raises(
-            ValueError, RelatedBooksLane, self._default_library, self.work, ""
+            ValueError, RelatedBooksLane, self._db, self._default_library, self.work, ""
         )
 
         # A book with a contributor initializes a RelatedBooksLane.
         luthor, i = self._contributor('Luthor, Lex')
         self.edition.add_contributor(luthor, [Contributor.EDITOR_ROLE])
 
-        result = RelatedBooksLane(self._default_library, self.work, '')
+        result = RelatedBooksLane(self._db, self._default_library, self.work, '')
         eq_(self.work, result.work)
         [sublane] = result.sublanes
         eq_(True, isinstance(sublane, ContributorLane))
@@ -232,7 +232,7 @@ class TestRelatedBooksLane(DatabaseTest):
 
         # As does a book in a series.
         self.edition.series = "All By Myself"
-        result = RelatedBooksLane(self._default_library, self.work, "")
+        result = RelatedBooksLane(self._db, self._default_library, self.work, "")
         eq_(2, len(result.sublanes))
         [contributor, series] = result.sublanes
         eq_(True, isinstance(series, SeriesLane))
@@ -249,7 +249,7 @@ class TestRelatedBooksLane(DatabaseTest):
             self.edition.data_source, recommendations=[self._identifier()]
         )
         mock_api.setup(response)
-        result = RelatedBooksLane(self._default_library, self.work, "", novelist_api=mock_api)
+        result = RelatedBooksLane(self._db, self._default_library, self.work, "", novelist_api=mock_api)
         eq_(3, len(result.sublanes))
 
         # The book's language and audience list is passed down to all sublanes.
@@ -274,7 +274,7 @@ class TestRelatedBooksLane(DatabaseTest):
 
         # Lex Luthor doesn't show up because he's only an editor,
         # and an author is listed.
-        result = RelatedBooksLane(self._default_library, self.work, '')
+        result = RelatedBooksLane(self._db, self._default_library, self.work, '')
         eq_(1, len(result.sublanes))
         [sublane] = result.sublanes
         eq_([original], sublane.contributors)
@@ -283,7 +283,7 @@ class TestRelatedBooksLane(DatabaseTest):
         # ContributorLane sublanes.
         lane, i = self._contributor('Lane, Lois')
         self.edition.add_contributor(lane, Contributor.PRIMARY_AUTHOR_ROLE)
-        result = RelatedBooksLane(self._default_library, self.work, '')
+        result = RelatedBooksLane(self._db, self._default_library, self.work, '')
         eq_(2, len(result.sublanes))
         sublane_contributors = list()
         [sublane_contributors.extend(c.contributors) for c in result.sublanes]
@@ -296,7 +296,7 @@ class TestRelatedBooksLane(DatabaseTest):
                 self._db.delete(contribution)
         self._db.commit()
 
-        result = RelatedBooksLane(self._default_library, self.work, '')
+        result = RelatedBooksLane(self._db, self._default_library, self.work, '')
         eq_(1, len(result.sublanes))
         [sublane] = result.sublanes
         eq_([luthor], sublane.contributors)
@@ -305,7 +305,7 @@ class TestRelatedBooksLane(DatabaseTest):
         """RelatedBooksLane is an invisible, groups lane without works."""
 
         self.edition.series = "All By Myself"
-        lane = RelatedBooksLane(self._default_library, self.work, "")
+        lane = RelatedBooksLane(self._db, self._default_library, self.work, "")
         eq_(None, lane.works())
         eq_(None, lane.materialized_works())
 
@@ -360,7 +360,7 @@ class TestRecommendationLane(LaneTest):
         mock_api = self.generate_mock_api()
 
         # With an empty recommendation result, the lane is empty.
-        lane = RecommendationLane(self._default_library, self.work, '', novelist_api=mock_api)
+        lane = RecommendationLane(self._db, self._default_library, self.work, '', novelist_api=mock_api)
         eq_(None, lane.works())
         eq_(None, lane.materialized_works())
 
@@ -392,7 +392,7 @@ class TestRecommendationLane(LaneTest):
 
             mock_api = self.generate_mock_api()
             lane = RecommendationLane(
-                self._default_library, self.work, '', novelist_api=mock_api
+                self._db, self._default_library, self.work, '', novelist_api=mock_api
             )
             lane.recommendations = recommendations
             self.assert_works_queries(lane, results)
@@ -411,7 +411,7 @@ class TestRecommendationLane(LaneTest):
 
         # But only the work that matches the source work is included.
         mock_api = self.generate_mock_api()
-        lane = RecommendationLane(self._default_library, self.work, '', novelist_api=mock_api)
+        lane = RecommendationLane(self._db, self._default_library, self.work, '', novelist_api=mock_api)
         lane.recommendations = recommendations
         self.assert_works_queries(lane, [eng])
 
@@ -419,7 +419,7 @@ class TestRecommendationLane(LaneTest):
         self.work.presentation_edition.language = 'fre'
         SessionManager.refresh_materialized_views(self._db)
         mock_api = self.generate_mock_api()
-        lane = RecommendationLane(self._default_library, self.work, '', novelist_api=mock_api)
+        lane = RecommendationLane(self._db, self._default_library, self.work, '', novelist_api=mock_api)
         lane.recommendations = recommendations
         self.assert_works_queries(lane, [fre])
 
@@ -429,16 +429,16 @@ class TestSeriesLane(LaneTest):
     def test_initialization(self):
         # An error is raised if SeriesLane is created with an empty string.
         assert_raises(
-            ValueError, SeriesLane, self._default_library, ''
+            ValueError, SeriesLane, self._db, self._default_library, ''
         )
 
-        lane = SeriesLane(self._default_library, 'Alrighty Then')
+        lane = SeriesLane(self._db, self._default_library, 'Alrighty Then')
         eq_('Alrighty Then', lane.series)
 
     def test_works_query(self):
         # If there are no works with the series name, no works are returned.
         series_name = "Like As If Whatever Mysteries"
-        lane = SeriesLane(self._default_library, series_name)
+        lane = SeriesLane(self._db, self._default_library, series_name)
         self.assert_works_queries(lane, [])
 
         # Works in the series are returned as expected.
@@ -485,7 +485,7 @@ class TestSeriesLane(LaneTest):
 
         # SeriesLane only returns works that match a given audience.
         children_lane = SeriesLane(
-            self._default_library, series_name, audiences=[Classifier.AUDIENCE_CHILDREN]
+            self._db, self._default_library, series_name, audiences=[Classifier.AUDIENCE_CHILDREN]
         )
         self.assert_works_queries(children_lane, [children])
 
@@ -493,12 +493,12 @@ class TestSeriesLane(LaneTest):
         # A request for adult material, only returns Adult material, not
         # Adults Only material.
         adult_lane = SeriesLane(
-            self._default_library, series_name, audiences=[Classifier.AUDIENCE_ADULT]
+            self._db, self._default_library, series_name, audiences=[Classifier.AUDIENCE_ADULT]
         )
         self.assert_works_queries(adult_lane, [adult])
 
         adult_lane = SeriesLane(
-            self._default_library, series_name, audiences=[Classifier.AUDIENCE_ADULTS_ONLY]
+            self._db, self._default_library, series_name, audiences=[Classifier.AUDIENCE_ADULTS_ONLY]
         )
         self.assert_works_queries(adult_lane, [adults_only])
 
@@ -514,7 +514,7 @@ class TestContributorLane(LaneTest):
     def test_initialization(self):
         # An error is raised if ContributorLane is created without
         # at least a name.
-        assert_raises(ValueError, ContributorLane, self._default_library, '')
+        assert_raises(ValueError, ContributorLane, self._db, self._default_library, '')
 
     def test_works_query(self):
         # A work by someone else.
@@ -527,7 +527,7 @@ class TestContributorLane(LaneTest):
         SessionManager.refresh_materialized_views(self._db)
 
         # The work with a matching name is found in the contributor lane.
-        lane = ContributorLane(self._default_library, 'Lois Lane')
+        lane = ContributorLane(self._db, self._default_library, 'Lois Lane')
         self.assert_works_queries(lane, [w2])
 
         # And when we add some additional works, like:
@@ -553,7 +553,7 @@ class TestContributorLane(LaneTest):
             main_contribution.contributor = self.contributor
         SessionManager.refresh_materialized_views(self._db)
 
-        lane = ContributorLane(self._default_library, 'Lois Lane', languages=['eng'])
+        lane = ContributorLane(self._db, self._default_library, 'Lois Lane', languages=['eng'])
         self.assert_works_queries(lane, [w3, w4, w2])
 
         lane.languages = ['fre', 'spa']
@@ -571,12 +571,12 @@ class TestContributorLane(LaneTest):
         # Only childrens works are available in a ContributorLane with a
         # Children audience source
         children_lane = ContributorLane(
-            self._default_library, 'Lois Lane', audiences=[Classifier.AUDIENCE_CHILDREN]
+            self._db, self._default_library, 'Lois Lane', audiences=[Classifier.AUDIENCE_CHILDREN]
         )
         self.assert_works_queries(children_lane, [children])
 
         # When more than one audience is requested, all are included.
         ya_lane = ContributorLane(
-            self._default_library, 'Lois Lane', audiences=list(Classifier.AUDIENCES_JUVENILE)
+            self._db, self._default_library, 'Lois Lane', audiences=list(Classifier.AUDIENCES_JUVENILE)
         )
         self.assert_works_queries(ya_lane, [children, ya])

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -138,7 +138,7 @@ class TestCirculationManagerAnnotator(VendorIDTest):
 
     def test_group_uri_with_flattened_lane(self):
         spanish_lane = Lane(
-            self._default_library, "Spanish", languages="spa"
+            self._db, self._default_library, "Spanish", languages="spa"
         )
         flat_spanish_lane = dict({
             "lane": spanish_lane,
@@ -159,16 +159,16 @@ class TestCirculationManagerAnnotator(VendorIDTest):
 
     def test_lane_url(self):
         everything_lane = Lane(
-            self._default_library, "Everything", fiction=Lane.BOTH_FICTION_AND_NONFICTION)
+            self._db, self._default_library, "Everything", fiction=Lane.BOTH_FICTION_AND_NONFICTION)
 
         fantasy_lane_with_sublanes = Lane(
-            self._default_library, "Fantasy", genres=[Fantasy], languages="eng", 
+            self._db, self._default_library, "Fantasy", genres=[Fantasy], languages="eng", 
             subgenre_behavior=Lane.IN_SAME_LANE,
             sublanes=[Urban_Fantasy],
             parent=everything_lane)
 
         fantasy_lane_without_sublanes = Lane(
-            self._default_library, "Fantasy", genres=[Fantasy], languages="eng", 
+            self._db, self._default_library, "Fantasy", genres=[Fantasy], languages="eng", 
             subgenre_behavior=Lane.IN_SAME_LANE,
             parent=everything_lane)
 
@@ -285,8 +285,8 @@ class TestOPDS(VendorIDTest):
 
     def setup(self):
         super(TestOPDS, self).setup()
-        parent = Lane(self._default_library, "Fiction", languages=["eng"], fiction=True)
-        self.lane = Lane(self._default_library, "Fantasy", languages=["eng"], genres=[Fantasy], parent=parent)
+        parent = Lane(self._db, self._default_library, "Fiction", languages=["eng"], fiction=True)
+        self.lane = Lane(self._db, self._default_library, "Fantasy", languages=["eng"], genres=[Fantasy], parent=parent)
         self.annotator = CirculationManagerAnnotator(None, self.lane, self._default_library, test_mode=True)
 
         # Initialize library with Adobe Vendor ID details
@@ -294,7 +294,7 @@ class TestOPDS(VendorIDTest):
         self._default_library.library_registry_shared_secret = "s3cr3t5"
 
         # A QueryGeneratedLane to test code that handles it differently.
-        self.contributor_lane = ContributorLane(self._default_library, "Someone", languages=["eng"], audiences=None)
+        self.contributor_lane = ContributorLane(self._db, self._default_library, "Someone", languages=["eng"], audiences=None)
 
     def test_default_lane_url(self):
         default_lane_url = self.annotator.default_lane_url()
@@ -364,7 +364,7 @@ class TestOPDS(VendorIDTest):
 
     def get_parsed_feed(self, works, lane=None):
         if not lane:
-            lane = Lane(self._default_library, "Main Lane")
+            lane = Lane(self._db, self._default_library, "Main Lane")
         feed = AcquisitionFeed(
             self._db, "test", "url", works,
             CirculationManagerAnnotator(None, lane, self._default_library, test_mode=True)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -123,14 +123,14 @@ class TestRepresentationPerLane(TestLaneScript):
             )
             eq_(['fre', 'eng'], script.languages)
 
-            english_lane = Lane(self._default_library, self._str, languages=['eng'])
+            english_lane = Lane(self._db, self._default_library, self._str, languages=['eng'])
             eq_(True, script.should_process_lane(english_lane))
 
-            no_english_lane = Lane(self._default_library, self._str, exclude_languages=['eng'])
+            no_english_lane = Lane(self._db, self._default_library, self._str, exclude_languages=['eng'])
             eq_(True, script.should_process_lane(no_english_lane))
 
             no_english_or_french_lane = Lane(
-                self._default_library, self._str, exclude_languages=['eng', 'fre']
+                self._db, self._default_library, self._str, exclude_languages=['eng', 'fre']
             )
             eq_(False, script.should_process_lane(no_english_or_french_lane))
             
@@ -142,8 +142,8 @@ class TestRepresentationPerLane(TestLaneScript):
             )
             eq_(0, script.max_depth)
 
-            child = Lane(self._default_library, "sublane")
-            parent = Lane(self._default_library, "parent", sublanes=[child])
+            child = Lane(self._db, self._default_library, "sublane")
+            parent = Lane(self._db, self._default_library, "parent", sublanes=[child])
             eq_(True, script.should_process_lane(parent))
             eq_(False, script.should_process_lane(child))
 
@@ -183,7 +183,7 @@ class TestCacheFacetListsPerLane(TestLaneScript):
 
     def test_process_lane(self):
         with self.temp_config() as config:
-            lane = Lane(self._default_library, self._str)
+            lane = Lane(self._db, self._default_library, self._str)
 
             script = CacheFacetListsPerLane(
                 self._db, ["--availability=all", "--availability=always",


### PR DESCRIPTION
This goes with https://github.com/NYPL-Simplified/server_core/pull/560.

Having Lane._db come from the Library was causing a scoped session error when creating CachedFeeds, so Leonard suggested passing the db to the Lane constructor.

I'm not sure how to write a test for the problem I was seeing, but I verified that this fixed it. It happened when going to the root url and getting redirected after you'd already been to /groups.