### PR TITLE
Settings for opds document

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1379,7 +1379,6 @@ class SettingsController(CirculationManagerController):
                     return INTEGRATION_NAME_ALREADY_IN_USE
             auth_service.name = name
 
-        orig_protocol = protocol
         [protocol] = [p for p in protocols if p.get("name") == protocol]
         result = self._set_integration_settings_and_libraries(auth_service, protocol)
         if isinstance(result, ProblemDetail):

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1091,7 +1091,7 @@ class BasicAuthenticationProvider(AuthenticationProvider):
                 "label": _("Email address entry") },
               { "key": NUMBER_PAD, "label": _("Number pad") },
           ],
-          "optional": True,
+          "default": DEFAULT_KEYBOARD
         },
         { "key": PASSWORD_KEYBOARD,
           "label": _("Keyboard for password entry"),
@@ -1099,7 +1099,7 @@ class BasicAuthenticationProvider(AuthenticationProvider):
               { "key": DEFAULT_KEYBOARD, "label": _("System default") },
               { "key": NUMBER_PAD, "label": _("Number pad") },
           ],
-          "optional": True,
+          "default": DEFAULT_KEYBOARD
         },
         { "key": IDENTIFIER_MAXIMUM_LENGTH,
           "label": _("Maximum identifier length"),
@@ -1111,9 +1111,11 @@ class BasicAuthenticationProvider(AuthenticationProvider):
         },
         { "key": IDENTIFIER_LABEL,
           "label": _("Label for identifier entry"),
+          "optional": True,
         },
         { "key": PASSWORD_LABEL,
           "label": _("Label for password entry"),
+          "optional": True,
         },
     ] + AuthenticationProvider.SETTINGS
     

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1112,7 +1112,7 @@ class BasicAuthenticationProvider(AuthenticationProvider):
           "optional": True,
         },
         { "key": PASSWORD_MAXIMUM_LENGTH,
-          "label": _("Maximum passowrd length"),
+          "label": _("Maximum password length"),
           "optional": True,
         },
         { "key": IDENTIFIER_LABEL,

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -666,6 +666,12 @@ class LibraryAuthenticator(object):
             links.setdefault("help", []).append(link)
             if type:
                 link['type'] = type
+
+        # Find the URL for the library itself.
+        library_uri = ConfigurationSetting.for_library(
+            Configuration.WEBSITE_URL, library).value
+        if library_uri:
+            links['alternate'] = dict(type="text/html", href=library_uri)
                 
         library_name = self.library_name or unicode(_("Library"))
         doc = OPDSAuthenticationDocument.fill_in(

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1052,7 +1052,7 @@ class BasicAuthenticationProvider(AuthenticationProvider):
     # expression.
     PASSWORD_REGULAR_EXPRESSION = 'password_regular_expression'
 
-    # The client should prefer one keyboard over another 
+    # The client should prefer one keyboard over another.
     IDENTIFIER_KEYBOARD = 'identifier_keyboard'
     PASSWORD_KEYBOARD = 'password_keyboard'
 
@@ -1312,7 +1312,7 @@ class BasicAuthenticationProvider(AuthenticationProvider):
             valid = valid and (len(username) <= self.identifier_maximum_length)
 
         if self.password_maximum_length:
-            valid = valid and (len(password) <= self.password_maximum_length)
+            valid = valid and password and (len(password) <= self.password_maximum_length)
         return valid
     
     def remote_authenticate(self, username, password):

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -691,6 +691,12 @@ class LibraryAuthenticator(object):
             _db=self._db, name=library_name, id=self.library_uuid, links=links
         )
 
+        # Add the library's color scheme, if it has one.
+        description = ConfigurationSetting.for_library(
+            Configuration.COLOR_SCHEME, library).value
+        if description:
+            doc['color_scheme'] = description        
+        
         # Add the description of the library as the OPDS feed's
         # service_description.
         description = ConfigurationSetting.for_library(

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -656,10 +656,16 @@ class LibraryAuthenticator(object):
 
         links = {}
         library = get_one(self._db, Library, self.library_id)
-        for rel in CirculationManagerAnnotator.CONFIGURATION_LINKS:
-            setting = ConfigurationSetting.for_library(rel, library)
-            if setting.value:
-                links[rel] = dict(href=setting.value, type="text/html")
+        for rel in (CirculationManagerAnnotator.CONFIGURATION_LINKS +
+                    Configuration.AUTHENTICATION_FOR_OPDS_LINKS):
+            value = ConfigurationSetting.for_library(rel, library).value
+            if not value:
+                continue
+            links[rel] = dict(href=value)
+            if any(value.startswith(x) for x in ('http:', 'https:')):
+                # We assume that HTTP URLs lead to HTML, but
+                # we don't assume anything about other sorts of URLs.
+                links[rel]['type'] = "text/html"
 
         for type, uri in Configuration.help_uris(library):
             link = dict(href=uri)

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1166,7 +1166,7 @@ class BasicAuthenticationProvider(AuthenticationProvider):
         self.identifier_keyboard = integration.setting(
             self.IDENTIFIER_KEYBOARD).value or self.DEFAULT_KEYBOARD
         self.password_keyboard = integration.setting(
-            self.IDENTIFIER_KEYBOARD).value or self.DEFAULT_KEYBOARD
+            self.PASSWORD_KEYBOARD).value or self.DEFAULT_KEYBOARD
         
         self.identifier_label = (
             integration.setting(self.IDENTIFIER_LABEL).value

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -687,9 +687,8 @@ class LibraryAuthenticator(object):
                 
         library_name = self.library_name or unicode(_("Library"))
         doc = OPDSAuthenticationDocument.fill_in(
-            base_opds_document, list(self.providers), short_name=self.library_short_name,
-            name=library_name, id=self.library_uuid, links=links,
-            _db=self._db,
+            base_opds_document, list(self.providers),
+            _db=self._db, name=library_name, id=self.library_uuid, links=links
         )
 
         # Add the description of the library as the OPDS feed's

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1037,7 +1037,7 @@ class BasicAuthenticationProvider(AuthenticationProvider):
     METHOD = "http://opds-spec.org/auth/basic"
     URI = "http://librarysimplified.org/terms/auth/library-barcode"
     NAME = 'Generic Basic Authentication provider'
-    
+   
     # By default, patron identifiers can only contain alphanumerics and
     # a few other characters. By default, there are no restrictions on
     # passwords.
@@ -1077,6 +1077,25 @@ class BasicAuthenticationProvider(AuthenticationProvider):
     PASSWORD_LABEL = 'password_label'
     DEFAULT_IDENTIFIER_LABEL = "Barcode"
     DEFAULT_PASSWORD_LABEL = "PIN"
+
+    # If the identifier label is one of these strings, it will be
+    # automatically localized. Otherwise, the same label will be displayed
+    # to everyone.
+    COMMON_IDENTIFIER_LABELS = {
+        "Barcode": _("Barcode"),
+        "Email Address": _("Email Address"),
+        "Username": _("Username"),
+        "Library Card": _("Library Card"),
+        "Card Number": _("Card Number"),
+    }
+
+    # If the password label is one of these strings, it will be
+    # automatically localized. Otherwise, the same label will be
+    # displayed to everyone.
+    COMMON_PASSWORD_LABELS = {
+        "Password": _("Password"),
+        "PIN": _("PIN"),
+    }
     
     # These identifier and password are supposed to be valid
     # credentials.  If there's a problem using them, there's a problem
@@ -1423,9 +1442,18 @@ class BasicAuthenticationProvider(AuthenticationProvider):
         if self.password_maximum_length:
             login_inputs['maximum_length'] = self.password_maximum_length
 
+        # Localize the labels if possible.
+        localized_identifier_label = self.COMMON_IDENTIFIER_LABELS.get(
+            self.identifier_label,
+            self.identifier_label
+        )
+        localized_password_label = self.COMMON_PASSWORD_LABELS.get(
+            self.password_label,
+            self.password_label
+        )
         method_doc = dict(
-            labels=dict(login=unicode(_(self.identifier_label)),
-                        password=unicode(_(self.password_label))),
+            labels=dict(login=unicode(localized_identifier_label),
+                        password=unicode(_(localized_password_label))),
             inputs = dict(login=login_inputs,
                           password=password_inputs)
         )

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1453,7 +1453,7 @@ class BasicAuthenticationProvider(AuthenticationProvider):
         )
         method_doc = dict(
             labels=dict(login=unicode(localized_identifier_label),
-                        password=unicode(_(localized_password_label))),
+                        password=unicode(localized_password_label)),
             inputs = dict(login=login_inputs,
                           password=password_inputs)
         )

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -672,6 +672,16 @@ class LibraryAuthenticator(object):
             name=library_name, id=self.library_uuid, links=links,
             _db=self._db,
         )
+
+        # Add feature flags.
+        enabled = []
+        disabled = []
+        if library.allow_holds:
+            bucket = enabled
+        else:
+            bucket = disabled
+        bucket.append(Configuration.RESERVATIONS_FEATURE)
+        doc['features'] = dict(enabled=enabled, disabled=disabled)
         return json.dumps(doc)
 
     def create_authentication_headers(self):

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -686,6 +686,12 @@ class LibraryAuthenticator(object):
             _db=self._db,
         )
 
+        # Add the service description
+        description = ConfigurationSetting.for_library(
+            Configuration.LIBRARY_DESCRIPTION, library).value
+        if description:
+            doc['service_description'] = description
+        
         # Add feature flags.
         enabled = []
         disabled = []

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -662,9 +662,10 @@ class LibraryAuthenticator(object):
                 links[rel] = dict(href=setting.value, type="text/html")
 
         for type, uri in Configuration.help_uris(library):
-            links[rel] = dict(href=uri)
+            link = dict(href=uri)
+            links.setdefault("help", []).append(link)
             if type:
-                links[rel]['type'] = type
+                link['type'] = type
                 
         library_name = self.library_name or unicode(_("Library"))
         doc = OPDSAuthenticationDocument.fill_in(

--- a/api/config.py
+++ b/api/config.py
@@ -53,7 +53,12 @@ class Configuration(CoreConfiguration):
     COPYRIGHT = 'copyright'
     ABOUT = 'about'
     LICENSE = 'license'
+    REGISTER = 'register'
 
+    # These are link relations that are valid in Authentication for
+    # OPDS documents but are not registered with IANA.
+    AUTHENTICATION_FOR_OPDS_LINKS = ['register']
+    
     # We support three different ways of integrating help processes.
     # All three of these will be sent out as links with rel='help'
     HELP_EMAIL = 'help-email'
@@ -121,6 +126,10 @@ class Configuration(CoreConfiguration):
         {
             "key": LICENSE,
             "label": _("License URL"),
+        },
+        {
+            "key": REGISTER,
+            "label": _("Patron registration URL"),
         },
         {
             "key": HELP_EMAIL,

--- a/api/config.py
+++ b/api/config.py
@@ -43,6 +43,10 @@ class Configuration(CoreConfiguration):
     # used to sign bearer tokens.
     BEARER_TOKEN_SIGNING_SECRET = "bearer_token_signing_secret"
 
+    # The client-side color scheme to use for this library.
+    COLOR_SCHEME = "color_scheme"
+    DEFAULT_COLOR_SCHEME = "blue"
+    
     # Names of the library-wide link settings.
     TERMS_OF_SERVICE = 'terms-of-service'
     PRIVACY_POLICY = 'privacy-policy'
@@ -50,6 +54,13 @@ class Configuration(CoreConfiguration):
     ABOUT = 'about'
     LICENSE = 'license'
 
+    # We support three different ways of integrating help processes.
+    # All three of these will be sent out as links with rel='help'
+    HELP_EMAIL = 'help-email'
+    HELP_WEB = 'help-web'
+    HELP_URI = 'help-uri'
+    HELP_LINKS = [HELP_EMAIL, HELP_WEB, HELP_URI]
+    
     SITEWIDE_SETTINGS = CoreConfiguration.SITEWIDE_SETTINGS + [
         {
             "key": BEARER_TOKEN_SIGNING_SECRET,
@@ -66,6 +77,19 @@ class Configuration(CoreConfiguration):
     ]
 
     LIBRARY_SETTINGS = CoreConfiguration.LIBRARY_SETTINGS + [
+        {
+            "key": COLOR_SCHEME,
+            "label": _("Color scheme"),
+            "options": [
+                { "key": "blue", "label": _("Blue") },
+                { "key": "red", "label": _("Red") },
+                { "key": "gray", "label": _("Gray") },
+                { "key": "gold", "label": _("Gold") },
+                { "key": "green", "label": _("Green") },
+                { "key": "teal", "label": _("Teal") },
+                { "key": "purple", "label": _("Purple") },
+            ],
+        },
         {
             "key": MAX_OUTSTANDING_FINES,
             "label": _("Maximum amount of fines a patron can have before losing lending privileges"),
@@ -93,6 +117,18 @@ class Configuration(CoreConfiguration):
         {
             "key": LICENSE,
             "label": _("License URL"),
+        },
+        {
+            "key": HELP_EMAIL,
+            "label": _("Patron support email address"),
+        },
+        {
+            "key": HELP_WEB,
+            "label": _("Patron support web site"),
+        },
+        {
+            "key": HELP_URI,
+            "label": _("Patron support custom integration URI")
         },
     ]
     
@@ -155,6 +191,26 @@ class Configuration(CoreConfiguration):
         CoreConfiguration.load(_db)
         cls.instance = CoreConfiguration.instance
 
+    @classmethod
+    def help_uris(cls, library):
+        """Find all the URIs that might help patrons get help from
+        this library.
+
+        :yield: A sequence of 2-tuples (media type, URL)
+        """
+        for name in self.HELP_LINKS:
+            setting = ConfigurationSetting.for_library(name, self.library)
+            value = setting.value
+            if not value:
+                continue
+            type = None
+            if name == self.HELP_EMAIL:
+                value = 'mailto:' + value
+            if name == self.HELP_WEB:
+                type = 'text/html'
+            yield type, value
+            
+        
 @contextlib.contextmanager
 def empty_config():
     with core_empty_config({}, [CoreConfiguration, Configuration]) as i:

--- a/api/config.py
+++ b/api/config.py
@@ -208,9 +208,9 @@ class Configuration(CoreConfiguration):
             if not value:
                 continue
             type = None
-            if name == self.HELP_EMAIL:
+            if name == cls.HELP_EMAIL:
                 value = 'mailto:' + value
-            if name == self.HELP_WEB:
+            if name == cls.HELP_WEB:
                 type = 'text/html'
             yield type, value
             

--- a/api/config.py
+++ b/api/config.py
@@ -31,6 +31,10 @@ class Configuration(CoreConfiguration):
     # The name of the sitewide secret used to sign cookies for admin login.
     SECRET_KEY = u"secret_key"
 
+    # A short description of the library, used in its Authentication
+    # for OPDS document.
+    LIBRARY_DESCRIPTION = 'library_description'
+    
     # The name of the per-library setting that sets the maximum amount
     # of fines a patron can have before losing lending privileges.
     MAX_OUTSTANDING_FINES = u"max_outstanding_fines"
@@ -86,6 +90,10 @@ class Configuration(CoreConfiguration):
     ]
 
     LIBRARY_SETTINGS = CoreConfiguration.LIBRARY_SETTINGS + [
+        {
+            "key": LIBRARY_DESCRIPTION,
+            "label": _("A short description of this library, shown to people who aren't sure they've chosen the right library."),
+        },
         {
             "key": COLOR_SCHEME,
             "label": _("Color scheme"),

--- a/api/config.py
+++ b/api/config.py
@@ -60,6 +60,10 @@ class Configuration(CoreConfiguration):
     HELP_WEB = 'help-web'
     HELP_URI = 'help-uri'
     HELP_LINKS = [HELP_EMAIL, HELP_WEB, HELP_URI]
+
+    # Features of an OPDS client which a library may want to enable or
+    # disable.
+    RESERVATIONS_FEATURE = "https://librarysimplified.org/rel/policy/reservations"
     
     SITEWIDE_SETTINGS = CoreConfiguration.SITEWIDE_SETTINGS + [
         {
@@ -198,8 +202,8 @@ class Configuration(CoreConfiguration):
 
         :yield: A sequence of 2-tuples (media type, URL)
         """
-        for name in self.HELP_LINKS:
-            setting = ConfigurationSetting.for_library(name, self.library)
+        for name in cls.HELP_LINKS:
+            setting = ConfigurationSetting.for_library(name, library)
             value = setting.value
             if not value:
                 continue

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -46,19 +46,21 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
     
     log = logging.getLogger("First Book authentication API")
 
-    def __init__(self, library_id, integration, analytics=None):
+    def __init__(self, library_id, integration, analytics=None, root=None):
         super(FirstBookAuthenticationAPI, self).__init__(library_id, integration, analytics)
-        url = integration.url
-        key = integration.password
-        if not (url and key):
-            raise CannotLoadConfiguration(
-                "First Book server not configured."
-            )
-        if '?' in url:
-            url += '&'
-        else:
-            url += '?'
-        self.root = url + 'key=' + key
+        if not root:
+            url = integration.url
+            key = integration.password
+            if not (url and key):
+                raise CannotLoadConfiguration(
+                    "First Book server not configured."
+                )
+            if '?' in url:
+                url += '&'
+            else:
+                url += '?'
+            root = url + 'key=' + key 
+        self.root = root
 
     # Begin implementation of BasicAuthenticationProvider abstract
     # methods.
@@ -120,15 +122,17 @@ class MockFirstBookAuthenticationAPI(FirstBookAuthenticationAPI):
     SUCCESS = '"Valid Code Pin Pair"'
     FAILURE = '{"code":404,"message":"Access Code Pin Pair not found"}'
 
-    def __init__(self, valid={}, bad_connection=False, 
+    def __init__(self, library, integration, valid={}, bad_connection=False, 
                  failure_status_code=None):
+        super(MockFirstBookAuthenticationAPI, self).__init__(
+            library, integration, root="http://example.com/"
+        )
         self.identifier_re = None
         self.password_re = None
-        self.root = "http://example.com/"
         self.valid = valid
         self.bad_connection = bad_connection
         self.failure_status_code = failure_status_code
-
+        
     def request(self, url):
         if self.bad_connection:
             # Simulate a bad connection.

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -76,7 +76,8 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
           "type": "select", "options": [
               { "key": "true", "label": _("Verify Certificate Normally (Required for production)") },
               { "key": "false", "label": _("Ignore Certificate Problems (For temporary testing only)") },
-          ]
+          ],
+          "default": "true"
         },
         { "key": BLOCK_TYPES, "label": _("Block types"), "optional": True },
         { "key": IDENTIFIER_BLACKLIST, "label": _("Identifier Blacklist"), "optional": True },
@@ -85,7 +86,8 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
           "options": [
               { "key": PIN_AUTHENTICATION_MODE, "label": _("PIN") },
               { "key": FAMILY_NAME_AUTHENTICATION_MODE, "label": _("Family Name") },
-          ]
+          ],
+          "default": PIN_AUTHENTICATION_MODE
         }
     ] + BasicAuthenticationProvider.SETTINGS
     

--- a/api/opds.py
+++ b/api/opds.py
@@ -58,7 +58,6 @@ class CirculationManagerAnnotator(Annotator):
         COPYRIGHT,
         ABOUT,
         LICENSE,
-        HELP,
     ]
 
     HELP_LINKS = [

--- a/api/opds.py
+++ b/api/opds.py
@@ -51,6 +51,7 @@ class CirculationManagerAnnotator(Annotator):
     COPYRIGHT = Configuration.COPYRIGHT
     ABOUT = Configuration.ABOUT
     LICENSE = Configuration.LICENSE
+    REGISTER = Configuration.REGISTER
     
     CONFIGURATION_LINKS = [
         TERMS_OF_SERVICE,

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -2094,7 +2094,7 @@ class TestSettingsController(AdminControllerTest):
                     "short_name": library.short_name,
                     AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION: "^(.)",
                 }])),
-            ] + common_args)
+            ] + self._common_basic_auth_arguments())
             response = self.manager.admin_settings_controller.patron_auth_services()
             eq_(response.status_code, 201)
 
@@ -2152,13 +2152,11 @@ class TestSettingsController(AdminControllerTest):
             flask.request.form = MultiDict([
                 ("id", auth_service.id),
                 ("protocol", SimpleAuthenticationProvider.__module__),
-                (BasicAuthenticationProvider.TEST_IDENTIFIER, "user"),
-                (BasicAuthenticationProvider.TEST_PASSWORD, "pass"),
                 ("libraries", json.dumps([{
                     "short_name": l2.short_name,
                     AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION: "^(.)",
                 }])),
-            ])
+            ] + self._common_basic_auth_arguments())
             response = self.manager.admin_settings_controller.patron_auth_services()
             eq_(response.status_code, 200)
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -942,6 +942,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             CirculationManagerAnnotator.COPYRIGHT: "http://copyright",
             CirculationManagerAnnotator.ABOUT: "http://about",
             CirculationManagerAnnotator.LICENSE: "http://license/",
+            CirculationManagerAnnotator.REGISTER: "custom-registration-hook://library/",
         }
 
         for rel, value in link_config.iteritems():
@@ -990,6 +991,15 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             eq_("http://copyright", links['copyright']['href'])
             eq_("http://about", links['about']['href'])
             eq_("http://license/", links['license']['href'])
+
+            # Most of the links have type='text/html'
+            eq_("text/html", links['about']['type'])
+
+            # The registration link doesn't have a type, because it
+            # uses a non-HTTP URI scheme.
+            register = links['register']
+            eq_({'href': 'custom-registration-hook://library/'},
+                links['register'])
 
             # We have three help links.
             uri, web, email = sorted(links['help'], key=lambda x: x['href'])

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -947,6 +947,11 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         for rel, value in link_config.iteritems():
             ConfigurationSetting.for_library(rel, self._default_library).value = value
 
+        # Set the URL to the library's web page.
+        ConfigurationSetting.for_library(
+            Configuration.WEBSITE_URL, library).value = "http://library/"
+
+            
         # Configure the various ways a patron can get help.
         ConfigurationSetting.for_library(
             Configuration.HELP_EMAIL, library).value = "help@library"
@@ -992,6 +997,13 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             eq_("http://library.help/", web['href'])
             eq_("text/html", web['type'])
             eq_("mailto:help@library", email['href'])
+
+            # The library's web page shows up as an HTML alternate
+            # to the OPDS server.
+            eq_(
+                dict(type="text/html", href="http://library/"),
+                links['alternate']
+            )
             
             # Features that are enabled for this library are communicated
             # through the 'features' item.

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -992,7 +992,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             eq_(expect_uuid, doc['id'])
 
             # The color scheme is correctly reported.
-            eq_("plain", doc['color_scheme'])
+            eq_("plaid", doc['color_scheme'])
             
             # We also need to test that the links got pulled in
             # from the configuration.

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -948,11 +948,14 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         for rel, value in link_config.iteritems():
             ConfigurationSetting.for_library(rel, self._default_library).value = value
 
+        ConfigurationSetting.for_library(
+            Configuration.LIBRARY_DESCRIPTION, library
+        ).value = "Just the best."
+            
         # Set the URL to the library's web page.
         ConfigurationSetting.for_library(
             Configuration.WEBSITE_URL, library).value = "http://library/"
-
-            
+        
         # Configure the various ways a patron can get help.
         ConfigurationSetting.for_library(
             Configuration.HELP_EMAIL, library).value = "help@library"
@@ -981,6 +984,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             # We also need to test that the library's name and UUID
             # were placed in the document.
             eq_("A Fabulous Library", doc['name'])
+            eq_("Just the best.", doc['service_description'])
             eq_(expect_uuid, doc['id'])
             
             # We also need to test that the links got pulled in

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1381,14 +1381,14 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         integration.setting(
             b.IDENTIFIER_KEYBOARD).value = b.EMAIL_ADDRESS_KEYBOARD
         integration.setting(b.PASSWORD_KEYBOARD).value = b.NUMBER_PAD
-        integration.setting(b.IDENTIFIER_LABEL).value = "Library Card"
+        integration.setting(b.IDENTIFIER_LABEL).value = "Your Library Card"
         integration.setting(b.PASSWORD_LABEL).value = 'Password'
         
         provider = b(self._default_library, integration)
 
         eq_(b.EMAIL_ADDRESS_KEYBOARD, provider.identifier_keyboard)
         eq_(b.NUMBER_PAD, provider.password_keyboard)
-        eq_("Library Card", provider.identifier_label)
+        eq_("Your Library Card", provider.identifier_label)
         eq_("Password", provider.password_label)
         
     def test_server_side_validation(self):

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -961,7 +961,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             eq_(expect_basic, basic_doc)
 
             oauth_doc = providers[oauth.URI]
-            expect_oauth = oauth.authentication_provider_document(library.short_name)
+            expect_oauth = oauth.authentication_provider_document(self._db)
             eq_(expect_oauth, oauth_doc)
 
             # We also need to test that the library's name and UUID
@@ -1414,18 +1414,20 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         eq_("foo", provider.get_credential_from_header(dict(password="foo")))
         
     def test_authentication_provider_document(self):
+        """Test the default authentication provider document."""
         provider = self.mock_basic()
         doc = provider.authentication_provider_document(self._db)
         eq_(_(provider.DISPLAY_NAME), doc['name'])
         methods = doc['methods']
         eq_([provider.METHOD], methods.keys())
         method = methods[provider.METHOD]
-        eq_(['labels'], method.keys())
+        eq_(['inputs', 'labels'], sorted(method.keys()))
         login = method['labels']['login']
         password = method['labels']['password']
-        eq_(provider.LOGIN_LABEL, login)
-        eq_(provider.PASSWORD_LABEL, password)
-
+        eq_(provider.identifier_label, login)
+        eq_(provider.password_label, password)
+        eq_(provider.DEFAULT_KEYBOARD, method['inputs']['login']['keyboard'])
+        eq_(provider.DEFAULT_KEYBOARD, method['inputs']['password']['keyboard'])
 
 class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
     """Test the complex BasicAuthenticationProvider.authenticate method."""

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1404,6 +1404,21 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         eq_(True, provider.server_side_validation("food", "barbecue"))
         eq_(True, provider.server_side_validation("a", None))
         eq_(False, provider.server_side_validation("!@#$", None))
+
+        # Test maximum length of identifier and password.
+        integration.setting(b.IDENTIFIER_MAXIMUM_LENGTH).value = "5"
+        integration.setting(b.PASSWORD_MAXIMUM_LENGTH).value = "10"
+        provider = b(self._default_library, integration)
+
+        eq_(True, provider.server_side_validation("a", "1234"))
+        eq_(False, provider.server_side_validation("a", "123456789012345"))
+        eq_(False, provider.server_side_validation("abcdefghijklmnop", "1234"))
+
+        # You can disable the password check altogether by setting maximum
+        # length to zero.
+        integration.setting(b.PASSWORD_MAXIMUM_LENGTH).value = "0"
+        provider = b(self._default_library, integration)
+        eq_(True, provider.server_side_validation("a", None))
         
     def test_local_patron_lookup(self):
         patron1 = self._patron("patron1_ext_id")

--- a/tests/test_firstbook.py
+++ b/tests/test_firstbook.py
@@ -23,13 +23,19 @@ from api.circulation_exceptions import (
 )
 
 from . import DatabaseTest
+from core.model import ExternalIntegration
 
 
 class TestFirstBook(DatabaseTest):
     
     def setup(self):
         super(TestFirstBook, self).setup()
-        self.api = MockFirstBookAuthenticationAPI(dict(ABCD="1234"))
+        integration = self._external_integration(
+            ExternalIntegration.PATRON_AUTH_GOAL)
+        self.api = MockFirstBookAuthenticationAPI(
+            self._default_library, integration,
+            dict(ABCD="1234")
+        )
 
     def test_from_config(self):
         api = None

--- a/tests/test_firstbook.py
+++ b/tests/test_firstbook.py
@@ -30,13 +30,17 @@ class TestFirstBook(DatabaseTest):
     
     def setup(self):
         super(TestFirstBook, self).setup()
-        integration = self._external_integration(
+        self.integration = self._external_integration(
             ExternalIntegration.PATRON_AUTH_GOAL)
-        self.api = MockFirstBookAuthenticationAPI(
-            self._default_library, integration,
-            dict(ABCD="1234")
-        )
+        self.api = self.mock_api(dict(ABCD="1234"))
 
+    def mock_api(self, *args, **kwargs):
+        "Create a MockFirstBookAuthenticationAPI."
+        return MockFirstBookAuthenticationAPI(
+            self._default_library, self.integration,
+            *args, **kwargs
+        )
+        
     def test_from_config(self):
         api = None
         integration = self._external_integration(self._str)
@@ -82,7 +86,7 @@ class TestFirstBook(DatabaseTest):
 
 
     def test_broken_service_remote_pin_test(self):
-        api = MockFirstBookAuthenticationAPI(failure_status_code=502)
+        api = self.mock_api(failure_status_code=502)
         assert_raises_regexp(
             RemoteInitiatedServerError, 
             "Got unexpected response code 502. Content: Error 502",
@@ -90,7 +94,7 @@ class TestFirstBook(DatabaseTest):
         )
     
     def test_bad_connection_remote_pin_test(self):
-        api = MockFirstBookAuthenticationAPI(bad_connection=True)
+        api = self.mock_api(bad_connection=True)
         assert_raises_regexp(
             RemoteInitiatedServerError, 
             "Could not connect!",


### PR DESCRIPTION
This branch adds a large number of configuration settings to each Library and to any ExternalIntegration that implements Basic Auth. These configuration settings are editable through the admin interface and are used to generate the Authentication for OPDS document, which I've extended to configure the behavior of a client in ways that are currently hard-coded in the SimplyE mobile app.

This fixes https://github.com/NYPL-Simplified/circulation/issues/561, https://github.com/NYPL-Simplified/circulation/issues/560, and https://github.com/NYPL-Simplified/circulation/issues/559. The only parts of those issues not addressed are the library icon and the barcode scanning format. I've split those issues into https://github.com/NYPL-Simplified/circulation/issues/566 and https://github.com/NYPL-Simplified/circulation/issues/565.

A library has the following new configuration options:

* Color scheme
* Description
* URL to the library web site (This is a preexisting configuration setting and all I did was start publishing it in the Authentication For OPDS feed.)
* Registration URL, i.e. where you go to get a library card.
* Feature flags. The only existing feature flag is "reservations".
* Three different types of "help" URL: an email address, a web page, and a custom integration using a custom URI scheme (designed for client-side API-based integrations such as HelpDesk).

An authentication mechanism has the following new configuration options:

* Keyboard to show when typing in patron identifier
* Keyboard to show when typing in patron password
* Maximum identifier length
* Maximum password length
* Label to use for identifier
* Label to use for password

The values of the labels are localized. It's a little unusual for us to localize the values of configuration settings, rather than constant strings, but I figure it will let us localize some common terms like "Barcode", "Library Card", "Email Address" and be able to handle them automatically. I don't know if there's a better way to do this, though.

Maximum identifier and password length are unique in this branch in that they also change the server-side behavior. `server_side_validation` enforces the maximum identifier and password lengths.