### PR TITLE
Moved admin interface view to a controller

### DIFF
--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.29"
+    "simplified-circulation-web": "0.0.30"
   }
 }

--- a/api/admin/templates.py
+++ b/api/admin/templates.py
@@ -11,7 +11,6 @@ admin = """
   <script>
     var circulationWeb = new CirculationWeb({
         csrfToken: \"{{ csrf_token }}\",
-        homeUrl: \"{{ home_url }}\",
         showCircEventsDownload: {{ "true" if show_circ_events_download else "false" }},
         settingUp: {{ "true" if setting_up else "false" }}
     });


### PR DESCRIPTION
This branch updates the admin interface to a version that lets you select a library instead of keeping you on the default library. The code now redirects you to the default library if you're not on a library yet, and there's no longer a home url. I also updated the code to check if the local analytics provider is configured, and moved everything into a controller so I could test it.