### PR TITLE
Language policy admin config

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1043,10 +1043,15 @@ class SettingsController(CirculationManagerController):
 
         for setting in Configuration.LIBRARY_SETTINGS:
             if setting.get("type") == "list":
-                value = []
-                for option in setting.get("options"):
-                    if setting["key"] + "_" + option["key"] in flask.request.form:
-                        value += [option["key"]]
+                if setting.get('options'):
+                    # Restrict to the values in 'options'.
+                    value = []
+                    for option in setting.get("options"):
+                        if setting["key"] + "_" + option["key"] in flask.request.form:
+                            value += [option["key"]]
+                else:
+                    # Allow any entered values.
+                    value = [item for item in flask.request.form.getlist(key) if item]
                 value = json.dumps(value)
             else:
                 value = flask.request.form.get(setting['key'], None)

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1051,7 +1051,7 @@ class SettingsController(CirculationManagerController):
                             value += [option["key"]]
                 else:
                     # Allow any entered values.
-                    value = [item for item in flask.request.form.getlist(key) if item]
+                    value = [item for item in flask.request.form.getlist(setting.get('key')) if item]
                 value = json.dumps(value)
             else:
                 value = flask.request.form.get(setting['key'], None)

--- a/api/app.py
+++ b/api/app.py
@@ -23,10 +23,15 @@ app = Flask(__name__)
 
 testing = 'TESTING' in os.environ
 db_url = Configuration.database_url(testing)
-SessionManager.initialize(db_url)
+# Initialize a new database session unless we were told not to
+# (e.g. because a script already initialized it).
+autoinitialize = os.environ.get('AUTOINITIALIZE') != 'False'
+if autoinitialize:
+    SessionManager.initialize(db_url)
 session_factory = SessionManager.sessionmaker(db_url)
 _db = flask_scoped_session(session_factory, app)
-SessionManager.initialize_data(_db)
+if autoinitialize:
+    SessionManager.initialize_data(_db)
 
 app.config['BABEL_DEFAULT_LOCALE'] = LanguageCodes.three_to_two[Configuration.localization_languages()[0]]
 app.config['BABEL_TRANSLATION_DIRECTORIES'] = "../translations"

--- a/api/config.py
+++ b/api/config.py
@@ -271,6 +271,13 @@ class Configuration(CoreConfiguration):
         small = []
         tiny = []
         result = [large, small, tiny]
+
+        if not works_by_language:
+            # In the absence of any information, assume we have an
+            # English collection and nothing else.
+            large.append('eng')
+            return result
+        
         # The single most common language always gets a large
         # collection.
         #
@@ -286,11 +293,6 @@ class Configuration(CoreConfiguration):
             else:
                 bucket = tiny
             bucket.append(language)
-
-        if not large:
-            # In the absence of any information, assume we have an
-            # English collection and nothing else.
-            large.append('eng')
             
         return result        
         

--- a/api/config.py
+++ b/api/config.py
@@ -164,6 +164,18 @@ class Configuration(CoreConfiguration):
             "key": HELP_URI,
             "label": _("Patron support custom integration URI")
         },
+        {
+            "key": LARGE_COLLECTION_LANGUAGES,
+            "label": _("The primary languages represented in this library's collection")
+        },
+        {
+            "key": SMALL_COLLECTION_LANGUAGES,
+            "label": _("Other major languages represented in this library's collection")
+        },        
+        {
+            "key": TINY_COLLECTION_LANGUAGES,
+            "label": _("Other languages in this library's collection")
+        },        
     ]
     
     @classmethod

--- a/api/config.py
+++ b/api/config.py
@@ -118,6 +118,7 @@ class Configuration(CoreConfiguration):
                 { "key": "teal", "label": _("Teal") },
                 { "key": "purple", "label": _("Purple") },
             ],
+            "type": "select",
         },
         {
             "key": MAX_OUTSTANDING_FINES,
@@ -166,14 +167,17 @@ class Configuration(CoreConfiguration):
         {
             "key": LARGE_COLLECTION_LANGUAGES,
             "label": _("The primary languages represented in this library's collection"),
+            "type": "list",
         },
         {
             "key": SMALL_COLLECTION_LANGUAGES,
             "label": _("Other major languages represented in this library's collection"),
+            "type": "list",
         },        
         {
             "key": TINY_COLLECTION_LANGUAGES,
             "label": _("Other languages in this library's collection"),
+            "type": "list",
         },        
     ]
     

--- a/api/config.py
+++ b/api/config.py
@@ -286,9 +286,9 @@ class Configuration(CoreConfiguration):
         for language, num_works in works_by_language.most_common():
             if not large:
                 bucket = large
-            elif num_works > cls.LARGE_COLLECTION_CUTOFF:
+            elif num_works >= cls.LARGE_COLLECTION_CUTOFF:
                 bucket = large
-            elif num_works > cls.SMALL_COLLECTION_CUTOFF:
+            elif num_works >= cls.SMALL_COLLECTION_CUTOFF:
                 bucket = small
             else:
                 bucket = tiny

--- a/api/config.py
+++ b/api/config.py
@@ -296,6 +296,7 @@ class Configuration(CoreConfiguration):
             
         return result        
         
+    @classmethod
     def help_uris(cls, library):
         """Find all the URIs that might help patrons get help from
         this library.

--- a/api/config.py
+++ b/api/config.py
@@ -193,12 +193,20 @@ class Configuration(CoreConfiguration):
         If the value is not set, estimate a value (and all related
         values) by looking at the library's collection.
         """
-        setting = ConfigurationSetting.for_library(
-            cls.LARGE_COLLECTION_LANGUAGES, library
-        )
-        if setting.value is None:
-            cls.estimate_language_collections_for_library()
-        return setting.json_value
+        setting = ConfigurationSetting.for_library(key, library)
+        value = None
+        try:
+            value = setting.json_value
+            if not isinstance(value, list):
+                value = None
+        except (TypeError, ValueError):
+            pass
+
+        if value is None:
+            # We have no value or a bad value. Estimate a better value.
+            cls.estimate_language_collections_for_library(library)
+            value = setting.json_value
+        return value
     
     @classmethod
     def large_collection_languages(cls, library):

--- a/api/config.py
+++ b/api/config.py
@@ -119,36 +119,36 @@ class Configuration(CoreConfiguration):
         return cls.policy(cls.ROOT_LANE_POLICY)
 
     @classmethod
-    def large_collection_languages(cls):
-        value = cls.language_policy().get(cls.LARGE_COLLECTION_LANGUAGES, 'eng')
-        if not value:
-            return []
-        if isinstance(value, list):
-            return value
-        return [[x] for x in value.split(',')]
+    def _collection_languages(cls, library, key):
+        """Look up a list of languages in a library configuration.
+
+        If the value is not set, estimate a value (and all related
+        values) by looking at the library's collection.
+        """
+        setting = ConfigurationSetting.for_library(
+            cls.LARGE_COLLECTION_LANGUAGES, library
+        )
+        if setting.value is None:
+            cls.estimate_language_collections_for_library()
+        return setting.json_value
+    
+    @classmethod
+    def large_collection_languages(cls, library):
+        return cls._collection_languages(
+            library, cls.LARGE_COLLECTION_LANGUAGES
+        )
 
     @classmethod
-    def small_collection_languages(cls):
-        import logging
-        value = cls.language_policy().get(cls.SMALL_COLLECTION_LANGUAGES, '')
-        if not value:
-            return []
-        if isinstance(value, list):
-            return value
-        return [[x] for x in value.split(',')]
+    def small_collection_languages(cls, library):
+        return cls._collection_languages(
+            library, cls.SMALL_COLLECTION_LANGUAGES
+        )
 
     @classmethod
-    def tiny_collection_languages(cls):
-        import logging
-        logging.info("In tiny_collection_languages.")
-        value = cls.language_policy().get(cls.TINY_COLLECTION_LANGUAGES, '')
-        logging.info("Language policy: %r" % cls.language_policy())
-        logging.info("Tiny collections: %r" % value)
-        if not value:
-            return []
-        if isinstance(value, list):
-            return value
-        return [[x] for x in value.split(',')]
+    def tiny_collection_languages(cls, library):
+        return cls._collection_languages(
+            library, cls.TINY_COLLECTION_LANGUAGES
+        )
 
     @classmethod
     def max_outstanding_fines(cls, library):

--- a/api/config.py
+++ b/api/config.py
@@ -44,7 +44,6 @@ class Configuration(CoreConfiguration):
     # used to sign bearer tokens.
     BEARER_TOKEN_SIGNING_SECRET = "bearer_token_signing_secret"
 
-
     # Names of per-library ConfigurationSettings that control
     # how detailed the lane configuration gets for various languages.
     LARGE_COLLECTION_LANGUAGES = "large_collections"
@@ -167,17 +166,14 @@ class Configuration(CoreConfiguration):
         {
             "key": LARGE_COLLECTION_LANGUAGES,
             "label": _("The primary languages represented in this library's collection"),
-            "type": "list",
         },
         {
             "key": SMALL_COLLECTION_LANGUAGES,
             "label": _("Other major languages represented in this library's collection"),
-            "type": "list",
         },        
         {
             "key": TINY_COLLECTION_LANGUAGES,
             "label": _("Other languages in this library's collection"),
-            "type": "list",
         },        
     ]
     

--- a/api/config.py
+++ b/api/config.py
@@ -1,3 +1,4 @@
+import json
 import re
 from nose.tools import set_trace
 import contextlib
@@ -16,10 +17,6 @@ from core.model import ConfigurationSetting
 class Configuration(CoreConfiguration):
 
     LENDING_POLICY = "lending"
-    LANGUAGE_POLICY = "languages"
-    LARGE_COLLECTION_LANGUAGES = "large_collections"
-    SMALL_COLLECTION_LANGUAGES = "small_collections"
-    TINY_COLLECTION_LANGUAGES = "tiny_collections"
 
     DEFAULT_OPDS_FORMAT = "simple_opds_entry"
 
@@ -43,6 +40,12 @@ class Configuration(CoreConfiguration):
     # used to sign bearer tokens.
     BEARER_TOKEN_SIGNING_SECRET = "bearer_token_signing_secret"
 
+    # Names of per-library ConfigurationSettings that control
+    # how detailed the lane configuration gets for various languages.
+    LARGE_COLLECTION_LANGUAGES = "large_collections"
+    SMALL_COLLECTION_LANGUAGES = "small_collections"
+    TINY_COLLECTION_LANGUAGES = "tiny_collections"
+    
     # Names of the library-wide link settings.
     TERMS_OF_SERVICE = 'terms-of-service'
     PRIVACY_POLICY = 'privacy-policy'
@@ -50,6 +53,17 @@ class Configuration(CoreConfiguration):
     ABOUT = 'about'
     LICENSE = 'license'
 
+    # A library with this many titles in a given language will be given
+    # a large, detailed lane configuration for that language.
+    LARGE_COLLECTION_CUTOFF = 10000
+
+    # A library with this many titles in a given language will be
+    # given separate fiction and nonfiction lanes for that language.
+    SMALL_COLLECTION_CUTOFF = 500
+
+    # A library with fewer titles than that will be given a single
+    # lane containing all books in that language.
+    
     SITEWIDE_SETTINGS = CoreConfiguration.SITEWIDE_SETTINGS + [
         {
             "key": BEARER_TOKEN_SIGNING_SECRET,
@@ -105,10 +119,6 @@ class Configuration(CoreConfiguration):
         return cls.policy(cls.ROOT_LANE_POLICY)
 
     @classmethod
-    def language_policy(cls):
-        return cls.policy(cls.LANGUAGE_POLICY, required=True)
-
-    @classmethod
     def large_collection_languages(cls):
         value = cls.language_policy().get(cls.LARGE_COLLECTION_LANGUAGES, 'eng')
         if not value:
@@ -120,10 +130,7 @@ class Configuration(CoreConfiguration):
     @classmethod
     def small_collection_languages(cls):
         import logging
-        logging.info("In small_collection_languages.")
         value = cls.language_policy().get(cls.SMALL_COLLECTION_LANGUAGES, '')
-        logging.info("Language policy: %r" % cls.language_policy())
-        logging.info("Small collections: %r" % value)
         if not value:
             return []
         if isinstance(value, list):
@@ -155,6 +162,63 @@ class Configuration(CoreConfiguration):
         CoreConfiguration.load(_db)
         cls.instance = CoreConfiguration.instance
 
+    @classmethod
+    def estimate_language_collections_for_library(cls, library):
+        """Guess at appropriate values for the given library for
+        LARGE_COLLECTION_LANGUAGES, SMALL_COLLECTION_LANGUAGES, and
+        TINY_COLLECTION_LANGUAGES. Set configuration values
+        appropriately, overriding any previous values.
+        """
+        holdings = library.estimated_holdings_by_language()
+        large, small, tiny = cls.classify_holdings(holdings)
+        for setting, value in (
+                (cls.LARGE_COLLECTION_LANGUAGES, large),
+                (cls.SMALL_COLLECTION_LANGUAGES, small),
+                (cls.TINY_COLLECTION_LANGUAGES, tiny),
+        ):
+            ConfigurationSetting.for_library(
+                setting, library).value = json.dumps(value)
+
+    @classmethod
+    def classify_holdings(cls, works_by_language):
+        """Divide languages into 'large', 'small', and 'tiny' colletions based
+        on the number of works available for each.
+
+        :param works_by_language: A Counter mapping languages to the
+        number of active works available for that language.  The
+        output of `Library.estimated_holdings_by_language` is a good
+        thing to pass in.
+
+        :return: a 3-tuple of lists (large, small, tiny).
+        """
+        large = []
+        small = []
+        tiny = []
+        result = [large, small, tiny]
+        # The single most common language always gets a large
+        # collection.
+        #
+        # Otherwise, it depends on how many works are in the
+        # collection.
+        for language, num_works in works_by_language.most_common():
+            if not large:
+                bucket = large
+            elif num_works > cls.LARGE_COLLECTION_CUTOFF:
+                bucket = large
+            elif num_works > cls.SMALL_COLLECTION_CUTOFF:
+                bucket = small
+            else:
+                bucket = tiny
+            bucket.append(language)
+
+        if not large:
+            # In the absence of any information, assume we have an
+            # English collection and nothing else.
+            large.append('eng')
+            
+        return result        
+        
+        
 @contextlib.contextmanager
 def empty_config():
     with core_empty_config({}, [CoreConfiguration, Configuration]) as i:

--- a/api/config.py
+++ b/api/config.py
@@ -166,15 +166,18 @@ class Configuration(CoreConfiguration):
         },
         {
             "key": LARGE_COLLECTION_LANGUAGES,
-            "label": _("The primary languages represented in this library's collection")
+            "label": _("The primary languages represented in this library's collection"),
+            "type": "list",
         },
         {
             "key": SMALL_COLLECTION_LANGUAGES,
-            "label": _("Other major languages represented in this library's collection")
+            "label": _("Other major languages represented in this library's collection"),
+            "type": "list",
         },        
         {
             "key": TINY_COLLECTION_LANGUAGES,
-            "label": _("Other languages in this library's collection")
+            "label": _("Other languages in this library's collection"),
+            "type": "list",
         },        
     ]
     

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -66,12 +66,12 @@ def make_lanes_default(_db, library):
             return x.split(',')
         return x
 
-    for language_set in Configuration.large_collection_languages():
+    for language_set in Configuration.large_collection_languages(library):
         languages = language_list(language_set)
         seen_languages = seen_languages.union(set(languages))
         top_level_lanes.extend(lanes_for_large_collection(_db, library, language_set))
 
-    for language_set in Configuration.small_collection_languages():
+    for language_set in Configuration.small_collection_languages(library):
         languages = language_list(language_set)
         seen_languages = seen_languages.union(set(languages))
         top_level_lanes.append(lane_for_small_collection(_db, library, language_set))
@@ -360,7 +360,7 @@ def lane_for_other_languages(_db, library, exclude_languages):
     """Make a lane for all books not in one of the given languages."""
 
     language_lanes = []
-    other_languages = Configuration.tiny_collection_languages()
+    other_languages = Configuration.tiny_collection_languages(library)
 
     if not other_languages:
         return None

--- a/migration/20170609-1-move-library-configuration-to-configurationsettings.py
+++ b/migration/20170609-1-move-library-configuration-to-configurationsettings.py
@@ -59,6 +59,17 @@ try:
         for library in libraries:
             library.setting("allow_holds").value = "False"
 
+    # Install the language policies used to configure the lanes.
+    language_policy = Configuration.policy('languages')
+    if language_policy:
+        for variable in [Configuration.LARGE_COLLECTION_LANGUAGES,
+                         Configuration.SMALL_COLLECTION_LANGUAGES,
+                         Configuration.TINY_COLLECTION_LANGUAGES]:
+            value = language_policy.get(variable)
+            if value:
+                for library in libraries:
+                    library.setting(variable).value = json.dumps(value)
+    
     # Copy facet configuration
     facet_policy = Configuration.policy("facets", default={})
     enabled = facet_policy.get("enabled", {})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,32 @@ from api.config import Configuration
 
 class TestConfiguration(DatabaseTest):
 
+    def test_collection_language_method_performs_estimate(self):
+        C = Configuration
+        library = self._default_library
+
+        # We haven't set any of these values.
+        for key in [C.LARGE_COLLECTION_LANGUAGES,
+                    C.SMALL_COLLECTION_LANGUAGES,
+                    C.TINY_COLLECTION_LANGUAGES]:
+            eq_(None, ConfigurationSetting.for_library(key, library).value)
+
+        # So how does this happen?
+        eq_(["eng"], C.large_collection_languages(library))
+        eq_([], C.small_collection_languages(library))
+        eq_([], C.tiny_collection_languages(library))
+
+        # It happens because the first time we call one of those
+        # *_collection_languages, it estimates values for all three
+        # configuration settings, based on the library's current
+        # holdings.
+        eq_(["eng"], ConfigurationSetting.for_library(
+            C.LARGE_COLLECTION_LANGUAGES, library).json_value)
+        eq_([], ConfigurationSetting.for_library(
+            C.SMALL_COLLECTION_LANGUAGES, library).json_value)
+        eq_([], ConfigurationSetting.for_library(
+            C.TINY_COLLECTION_LANGUAGES, library).json_value)
+        
     def test_estimate_language_collection_for_library(self):
 
         library = self._default_library

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,12 +32,26 @@ class TestConfiguration(DatabaseTest):
         # *_collection_languages, it estimates values for all three
         # configuration settings, based on the library's current
         # holdings.
-        eq_(["eng"], ConfigurationSetting.for_library(
-            C.LARGE_COLLECTION_LANGUAGES, library).json_value)
+        large_setting = ConfigurationSetting.for_library(
+            C.LARGE_COLLECTION_LANGUAGES, library
+        ) 
+        eq_(["eng"], large_setting.json_value)
         eq_([], ConfigurationSetting.for_library(
             C.SMALL_COLLECTION_LANGUAGES, library).json_value)
         eq_([], ConfigurationSetting.for_library(
             C.TINY_COLLECTION_LANGUAGES, library).json_value)
+
+        # We can change these values.
+        large_setting.value = json.dumps(["spa", "jpn"])
+        eq_(["spa", "jpn"], C.large_collection_languages(library))
+        
+        # If we enter an invalid value, or a value that's not a list,
+        # the estimate is re-calculated the next time we look.
+        large_setting.value = "this isn't json"
+        eq_(["eng"], C.large_collection_languages(library))
+
+        large_setting.value = '"this is json but it\'s not a list"'
+        eq_(["eng"], C.large_collection_languages(library))
         
     def test_estimate_language_collection_for_library(self):
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,68 @@
+from collections import Counter
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+import json
+
+from core.model import (
+    ConfigurationSetting
+)
+from . import DatabaseTest
+from api.config import Configuration
+
+class TestConfiguration(DatabaseTest):
+
+    def test_estimate_language_collection_for_library(self):
+
+        library = self._default_library
+
+        # We thought we'd have big collections.
+        old_settings = {
+            Configuration.LARGE_COLLECTION_LANGUAGES : ["spa", "fre"],
+            Configuration.SMALL_COLLECTION_LANGUAGES : ["chi"],
+            Configuration.TINY_COLLECTION_LANGUAGES : ["rus"],
+        }
+
+        for key, value in old_settings.items():
+            ConfigurationSetting.for_library(
+                key, library).value = json.dumps(value)
+
+        # But there's nothing in our database, so when we call
+        # Configuration.estimate_language_collections_for_library...
+        Configuration.estimate_language_collections_for_library(library)
+
+        # ...it gets reset to the default.
+        eq_(["eng"], ConfigurationSetting.for_library(
+            Configuration.LARGE_COLLECTION_LANGUAGES, library
+        ).json_value)
+        
+        eq_([], ConfigurationSetting.for_library(
+            Configuration.SMALL_COLLECTION_LANGUAGES, library
+        ).json_value)
+            
+        eq_([], ConfigurationSetting.for_library(
+            Configuration.TINY_COLLECTION_LANGUAGES, library
+        ).json_value)
+
+    def test_classify_holdings(self):
+
+        m = Configuration.classify_holdings
+        
+        # If there are no titles in the collection at all, we assume
+        # there will eventually be a large English collection.
+        eq_([["eng"], [], []], m(Counter()))
+
+        # The largest collection is given the 'large collection' treatment,
+        # even if it's very small.
+        very_small = Counter(rus=2, pol=1)
+        eq_([["rus"], [], ["pol"]], m(very_small))
+
+        # Otherwise, the classification of a collection depends on the
+        # sheer number of items in that collection. Within a
+        # classification, languages are ordered by holding size.
+        different_sizes = Counter(jpn=16000, fre=20000, spa=8000,
+                                  nav=6, ukr=4000, ira=1500)
+        eq_([['fre', 'jpn'], ['spa', 'ukr', 'ira'], ['nav']],
+            m(different_sizes))
+        

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -246,7 +246,6 @@ class ControllerTest(VendorIDTest):
             integration.setting(p.TEST_PASSWORD).value = "unittestpassword"
             library.integrations.append(integration)
 
-        # Set language collection policies.
         for k, v in [
                 (Configuration.LARGE_COLLECTION_LANGUAGES, []),
                 (Configuration.SMALL_COLLECTION_LANGUAGES, ['eng']),
@@ -703,20 +702,14 @@ class FullLaneSetupTest(CirculationControllerTest):
 
     This class is for the tests that do need that full set of lanes.
     """
-
-    @contextmanager
-    def default_config(self):
-        """A default lane configuration that creates a full
-        range of lanes.
-        """
-        with temp_config() as config:
-            config[Configuration.POLICIES] = {
-                Configuration.LANGUAGE_POLICY : {
-                    Configuration.LARGE_COLLECTION_LANGUAGES : 'eng',
-                    Configuration.SMALL_COLLECTION_LANGUAGES : 'spa,chi',
-                }
-            }
-            yield config
+    def library_setup(self, library):
+        super(FullLaneSetupTest, self).library_setup(library)
+        for k, v in [
+                (Configuration.LARGE_COLLECTION_LANGUAGES, ['eng']),
+                (Configuration.SMALL_COLLECTION_LANGUAGES, ['spa', 'chi']),
+                (Configuration.TINY_COLLECTION_LANGUAGES, [])
+        ]:
+            ConfigurationSetting.for_library(k, library).value = json.dumps(v)
     
     def test_load_lane(self):
         with self.request_context_with_library("/"):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -665,10 +665,9 @@ class TestBaseController(CirculationControllerTest):
         # Before we make the change, a request to the library's new name
         # will fail.
         assert new_name not in self.manager.auth.library_authenticators
-        with self.default_config():
-            with self.app.test_request_context("/"):
-                problem = self.controller.library_for_request(new_name)
-                eq_(LIBRARY_NOT_FOUND, problem)
+        with self.app.test_request_context("/"):
+            problem = self.controller.library_for_request(new_name)
+            eq_(LIBRARY_NOT_FOUND, problem)
 
 
         # Make the change.
@@ -686,13 +685,12 @@ class TestBaseController(CirculationControllerTest):
         
         # But the first time we make a request that calls the library
         # by its new name, those settings are reloaded.
-        with self.default_config():
-            with self.app.test_request_context("/"):
-                value = self.controller.library_for_request(new_name)
-                eq_(self._default_library, value)
+        with self.app.test_request_context("/"):
+            value = self.controller.library_for_request(new_name)
+            eq_(self._default_library, value)
                 
-                # An assertion that would have failed before works now.
-                assert new_name in self.manager.auth.library_authenticators
+            # An assertion that would have failed before works now.
+            assert new_name in self.manager.auth.library_authenticators
 
 
 class FullLaneSetupTest(CirculationControllerTest):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2365,8 +2365,7 @@ class TestDeviceManagementProtocolController(ControllerTest):
         # Set up the Adobe configuration for this library and
         # reload the CirculationManager configuration.
         self.manager.setup_adobe_vendor_id(self.library)
-        with self.default_config() as config:
-            self.manager.load_settings()
+        self.manager.load_settings()
 
         # Now the controller is enabled and we can use it in this
         # test.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -39,6 +39,7 @@ from scripts import (
     CacheRepresentationPerLane,
     CacheFacetListsPerLane,
     InstanceInitializationScript,
+    LanguageListScript,
     LoanReaperScript,
 )
 
@@ -309,3 +310,19 @@ class TestLoanReaperScript(DatabaseTest):
         # expiration date and were created relatively recently.
         eq_(2, len(current_patron.loans))
         eq_(2, len(current_patron.holds))
+
+
+class TestLanguageListScript(DatabaseTest):
+
+    def test_languages(self):
+        """Test the method that gives this script the bulk of its output."""
+        english = self._work(language='eng', with_open_access_download=True)
+        tagalog = self._work(language="tgl", with_license_pool=True)
+        [pool] = tagalog.license_pools
+        self._add_generic_delivery_mechanism(pool)
+        script = LanguageListScript(self._db)
+        output = list(script.languages(self._default_library))
+
+        # English is ignored because all its works are open-access.
+        # Tagalog shows up with the correct estimate.
+        eq_(["tgl 1 (Tagalog)", output])

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -6,6 +6,7 @@ from nose.tools import (
 import contextlib
 import datetime
 import flask
+import json
 
 from api.adobe_vendor_id import (
     AdobeVendorIDModel,
@@ -98,89 +99,81 @@ class TestLaneScript(DatabaseTest):
         base_url_setting = ConfigurationSetting.sitewide(
             self._db, Configuration.BASE_URL_KEY)
         base_url_setting.value = u'http://test-circulation-manager/'
-
-    @contextlib.contextmanager
-    def temp_config(self):
-        """Create a temporary configuration with the bare-bones policies
-        and integrations necessary to start up a script.
-        """
-        with temp_config() as config:
-            config[Configuration.POLICIES] = {
-                Configuration.LANGUAGE_POLICY : {
-                    Configuration.LARGE_COLLECTION_LANGUAGES : 'eng',
-                    Configuration.SMALL_COLLECTION_LANGUAGES : 'fre',
-                }
-            }
-            yield config
+        for k, v in [
+                (Configuration.LARGE_COLLECTION_LANGUAGES, []),
+                (Configuration.SMALL_COLLECTION_LANGUAGES, []),
+                (Configuration.TINY_COLLECTION_LANGUAGES, ['eng', 'fre'])
+        ]:
+            ConfigurationSetting.for_library(
+                k, self._default_library).value = json.dumps(v)
 
 
 class TestRepresentationPerLane(TestLaneScript):
    
     def test_language_filter(self):
-        with self.temp_config() as config:
-            script = CacheRepresentationPerLane(
-                self._db, ["--language=fre", "--language=English", "--language=none", "--min-depth=0"],
-                testing=True
-            )
-            eq_(['fre', 'eng'], script.languages)
+        script = CacheRepresentationPerLane(
+            self._db, ["--language=fre", "--language=English", "--language=none", "--min-depth=0"],
+            testing=True
+        )
+        eq_(['fre', 'eng'], script.languages)
 
-            english_lane = Lane(self._db, self._default_library, self._str, languages=['eng'])
-            eq_(True, script.should_process_lane(english_lane))
+        english_lane = Lane(self._db, self._default_library, self._str, languages=['eng'])
+        eq_(True, script.should_process_lane(english_lane))
 
-            no_english_lane = Lane(self._db, self._default_library, self._str, exclude_languages=['eng'])
-            eq_(True, script.should_process_lane(no_english_lane))
+        no_english_lane = Lane(self._db, self._default_library, self._str, exclude_languages=['eng'])
+        eq_(True, script.should_process_lane(no_english_lane))
 
-            no_english_or_french_lane = Lane(
-                self._db, self._default_library, self._str, exclude_languages=['eng', 'fre']
-            )
-            eq_(False, script.should_process_lane(no_english_or_french_lane))
+        no_english_or_french_lane = Lane(
+            self._db, self._default_library, self._str, exclude_languages=['eng', 'fre']
+        )
+        eq_(False, script.should_process_lane(no_english_or_french_lane))
             
     def test_max_and_min_depth(self):
-        with self.temp_config() as config:
-            script = CacheRepresentationPerLane(
-                self._db, ["--max-depth=0", "--min-depth=0"],
-                testing=True
-            )
-            eq_(0, script.max_depth)
+        script = CacheRepresentationPerLane(
+            self._db, ["--max-depth=0", "--min-depth=0"],
+            testing=True
+        )
+        eq_(0, script.max_depth)
 
-            child = Lane(self._db, self._default_library, "sublane")
-            parent = Lane(self._db, self._default_library, "parent", sublanes=[child])
-            eq_(True, script.should_process_lane(parent))
-            eq_(False, script.should_process_lane(child))
-
-            script = CacheRepresentationPerLane(
-                self._db, ["--min-depth=1"], testing=True
-            )
-            eq_(1, script.min_depth)
-            eq_(False, script.should_process_lane(parent))
-            eq_(True, script.should_process_lane(child))
+        child = Lane(self._db, self._default_library, "sublane")
+        parent = Lane(self._db, self._default_library, "parent", sublanes=[child])
+        eq_(True, script.should_process_lane(parent))
+        eq_(False, script.should_process_lane(child))
 
 
+    def test_min_depth(self):
+        script = CacheRepresentationPerLane(
+            self._db, ["--min-depth=1"], testing=True
+        )
+        eq_(1, script.min_depth)
+        eq_(False, script.should_process_lane(parent))
+        eq_(True, script.should_process_lane(child))
+
+            
 class TestCacheFacetListsPerLane(TestLaneScript):
 
     def test_arguments(self):
-        with self.temp_config() as config:
-            script = CacheFacetListsPerLane(
-                self._db, ["--order=title", "--order=added"],
-                testing=True
-            )
-            eq_(['title', 'added'], script.orders)
-            script = CacheFacetListsPerLane(
-                self._db, ["--availability=all", "--availability=always"],
-                testing=True
-            )
-            eq_(['all', 'always'], script.availabilities)
+        script = CacheFacetListsPerLane(
+            self._db, ["--order=title", "--order=added"],
+            testing=True
+        )
+        eq_(['title', 'added'], script.orders)
+        script = CacheFacetListsPerLane(
+            self._db, ["--availability=all", "--availability=always"],
+            testing=True
+        )
+        eq_(['all', 'always'], script.availabilities)
 
-            script = CacheFacetListsPerLane(
-                self._db, ["--collection=main", "--collection=full"],
-                testing=True
-            )
-            eq_(['main', 'full'], script.collections)
+        script = CacheFacetListsPerLane(
+            self._db, ["--collection=main", "--collection=full"],
+            testing=True
+        )
+        eq_(['main', 'full'], script.collections)
 
-            script = CacheFacetListsPerLane(
-                self._db, ['--pages=1'], testing=True
-            )
-            eq_(1, script.pages)
+        script = CacheFacetListsPerLane(
+            self._db, ['--pages=1'], testing=True
+        )
+        eq_(1, script.pages)
 
     def test_process_lane(self):
         with self.temp_config() as config:
@@ -325,4 +318,4 @@ class TestLanguageListScript(DatabaseTest):
 
         # English is ignored because all its works are open-access.
         # Tagalog shows up with the correct estimate.
-        eq_(["tgl 1 (Tagalog)", output])
+        eq_(["tgl 1 (Tagalog)"], output)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -140,8 +140,6 @@ class TestRepresentationPerLane(TestLaneScript):
         eq_(True, script.should_process_lane(parent))
         eq_(False, script.should_process_lane(child))
 
-
-    def test_min_depth(self):
         script = CacheRepresentationPerLane(
             self._db, ["--min-depth=1"], testing=True
         )
@@ -176,20 +174,19 @@ class TestCacheFacetListsPerLane(TestLaneScript):
         eq_(1, script.pages)
 
     def test_process_lane(self):
-        with self.temp_config() as config:
-            lane = Lane(self._db, self._default_library, self._str)
+        lane = Lane(self._db, self._default_library, self._str)
 
-            script = CacheFacetListsPerLane(
-                self._db, ["--availability=all", "--availability=always",
-                           "--collection=main", "--collection=full",
-                           "--order=title", "--pages=1"],
-                testing=True
-            )
-            with script.app.test_request_context("/"):
-                flask.request.library = self._default_library
-                cached_feeds = script.process_lane(lane)
-                # 2 availabilities * 2 collections * 1 order * 1 page = 4 feeds
-                eq_(4, len(cached_feeds))
+        script = CacheFacetListsPerLane(
+            self._db, ["--availability=all", "--availability=always",
+                       "--collection=main", "--collection=full",
+                       "--order=title", "--pages=1"],
+            testing=True
+        )
+        with script.app.test_request_context("/"):
+            flask.request.library = self._default_library
+            cached_feeds = script.process_lane(lane)
+            # 2 availabilities * 2 collections * 1 order * 1 page = 4 feeds
+            eq_(4, len(cached_feeds))
 
 
 class TestInstanceInitializationScript(DatabaseTest):


### PR DESCRIPTION
This branch moves into the database the most basic lane configuration: which languages in a library's should get the multi-lane "large collection" treatment, which should get the "small collection" treatment which distinguishes only between fiction and nonfiction, and which are 'tiny collections' that should be contained within a single lane.

Unlike other configuration settings, these values are set automatically the first time they're needed. I use the `estimated_holdings_by_language` method to get the raw data, and a new method that uses semi-arbitrary cutoffs for "large", "small", and "tiny".

Right now, this is serious overkill. The first time this value is needed, there will almost certainly be no titles in the collection, so the default (English gets a "large" collection and no other languages are presumed to exist) will always apply to start with. However in the future we can add a button to the admin interface that lets you reset the language settings based on the current collection, or shows you what they _would_ be at the moment and lets you change them yourself.

If you give an invalid value to one of these configuration settings, it redoes the estimate. This ensures that there's always a valid value and we can always create a set of lanes that make sense. I'm not really happy about this, but I figure it's a good backstop for whatever editor we put into place in the admin interface.