### PR TITLE
Fixed error when collection in CirculationManager.api_for_collection is not bound to session

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -221,7 +221,7 @@ class CirculationAPI(object):
                     )
                     self.initialization_exceptions[collection.id] = e
                 if api:
-                    self.api_for_collection[collection] = api
+                    self.api_for_collection[collection.id] = api
                     self.collection_ids_for_sync.append(collection.id)
 
     @property
@@ -246,7 +246,7 @@ class CirculationAPI(object):
 
     def api_for_license_pool(self, licensepool):
         """Find the API to use for the given license pool."""
-        return self.api_for_collection.get(licensepool.collection)
+        return self.api_for_collection.get(licensepool.collection.id)
 
     def can_revoke_hold(self, licensepool, hold):
         """Some circulation providers allow you to cancel a hold

--- a/api/services.py
+++ b/api/services.py
@@ -4,7 +4,11 @@ import logging
 from nose.tools import set_trace
 from sqlalchemy.orm.session import Session
 
-from core.model import ConfigurationSetting
+from core.model import (
+    Collection,
+    ConfigurationSetting,
+    get_one,
+)
 from core.scripts import (
     Script,
     IdentifierInputScript,
@@ -87,7 +91,8 @@ class ServiceStatus(object):
             self.log.error(error)
             status[service] = error
             return status
-        for collection, api in self.circulation.api_for_collection.items():
+        for collection_id, api in self.circulation.api_for_collection.items():
+            collection = get_one(self._db, Collection, id=collection_id)
             data_source_name = collection.data_source.name
             service = "%s patron account (%s)" % (
                 collection.name, collection.data_source.name

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -178,7 +178,7 @@ class TestBibliothecaAPI(BibliothecaAPITest):
             self.collection.protocol : MockBibliothecaAPI
         })
 
-        api = circulation.api_for_collection[self.collection]
+        api = circulation.api_for_collection[self.collection.id]
         api.queue_response(200, content=self.sample_data("checkouts.xml"))
         circulation.sync_bookshelf(patron, "dummy pin")
 

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -626,7 +626,7 @@ class TestCirculationAPI(DatabaseTest):
             self._db, self._default_library, api_map={
             ExternalIntegration.BIBLIOTHECA : MockBibliothecaAPI
         })
-        mock_bibliotheca = circulation.api_for_collection[self.collection]
+        mock_bibliotheca = circulation.api_for_collection[self.collection.id]
 
         data = sample_data("checkouts.xml", "threem")
         mock_bibliotheca.queue_response(200, content=data)

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -47,7 +47,7 @@ class OverdriveAPITest(DatabaseTest):
         self.circulation = CirculationAPI(
             self._db, library, api_map={ExternalIntegration.OVERDRIVE:MockOverdriveAPI}
         )
-        self.api = self.circulation.api_for_collection[self.collection]
+        self.api = self.circulation.api_for_collection[self.collection.id]
         
     @classmethod
     def sample_data(self, filename):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -222,7 +222,7 @@ class TestServiceStatusMonitor(DatabaseTest):
             assert value.startswith('SUCCESS')
 
         # The mock Overdrive API had all its methods called.
-        api = status.circulation.api_for_collection[overdrive_collection]
+        api = status.circulation.api_for_collection[overdrive_collection.id]
         eq_(True, api.borrowed)
         eq_(True, api.fulfilled)
         eq_(True, api.revoked)
@@ -253,7 +253,7 @@ class TestServiceStatusMonitor(DatabaseTest):
         assert 'FAILURE: Doomed to fail!' in response.values()
 
         # But at least we got through the borrow and fulfill steps.
-        api = status.circulation.api_for_collection[overdrive_collection]
+        api = status.circulation.api_for_collection[overdrive_collection.id]
         eq_(True, api.borrowed)
         eq_(True, api.fulfilled)
         eq_(False, api.revoked)


### PR DESCRIPTION
This branch fixes the error
```
  File "/Users/amyslagle/dev/circulation/api/circulation.py", line 295, in borrow
    api.SET_DELIVERY_MECHANISM_AT == BaseCirculationAPI.BORROW_STEP)
AttributeError: 'NoneType' object has no attribute 'SET_DELIVERY_MECHANISM_AT'
```

I got this error when I was setting up a new circ manager, and trying to look at api_for_collection gave me ```*** DetachedInstanceError: Instance <Collection at 0x10bc20390> is not bound to a Session; attribute refresh operation cannot proceed```. Storing the collection id instead of the Collection seems to work.