### PR TITLE
Allow family name auth to parse "First Last"

### DIFF
--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -171,7 +171,10 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         """Does `supposed_family_name` match `actual_name`?"""
         if actual_name is None or supposed_family_name is None:
             return False
-        actual_family_name = actual_name.split(',')[0]
+        if acutal_name.find(',') != -1:
+            actual_family_name = actual_name.split(',')[0]
+        else:
+            actual_family_name = actual_name.split(' ')[1]
         if actual_family_name.upper() == supposed_family_name.upper():
             return True
         return False

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -171,7 +171,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         """Does `supposed_family_name` match `actual_name`?"""
         if actual_name is None or supposed_family_name is None:
             return False
-        if acutal_name.find(',') != -1:
+        if actual_name.find(',') != -1:
             actual_family_name = actual_name.split(',')[0]
         else:
             actual_family_name = actual_name.split(' ')[1]

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -175,7 +175,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
             actual_family_name = actual_name.split(',')[0]
         else:
             actual_name_split = actual_name.split(' ')
-            actual_family_name = actual_name_split[len(actual_name_split)-1]
+            actual_family_name = actual_name_split[-1]
         if actual_family_name.upper() == supposed_family_name.upper():
             return True
         return False

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -174,7 +174,8 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         if actual_name.find(',') != -1:
             actual_family_name = actual_name.split(',')[0]
         else:
-            actual_family_name = actual_name.split(' ')[1]
+            actual_name_split = actual_name.split(' ')
+            actual_family_name = actual_name_split[len(actual_name_split)-1]
         if actual_family_name.upper() == supposed_family_name.upper():
             return True
         return False

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -428,6 +428,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         eq_(False, m("cher", "chert"))
         eq_(True, m("cherryh, c.j.", "cherryh"))
         eq_(True, m("c.j. cherryh", "cherryh"))
+        eq_(True, m("caroline janice cherryh", "cherryh"))
 
     def test_misconfigured_authentication_mode(self):
         assert_raises_regexp(

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -427,6 +427,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         eq_(False, m("chert", "cher"))
         eq_(False, m("cher", "chert"))
         eq_(True, m("cherryh, c.j.", "cherryh"))
+        eq_(True, m("c.j. cherryh", "cherryh"))
 
     def test_misconfigured_authentication_mode(self):
         assert_raises_regexp(


### PR DESCRIPTION
Patron names won't always be stored as "Lastname, Firstname" so we need to account for the major alternative, "Firstname Lastname".