### PR TITLE
Library logo 2

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -684,6 +684,12 @@ class LibraryAuthenticator(object):
             Configuration.WEBSITE_URL, library).value
         if library_uri:
             links['alternate'] = dict(type="text/html", href=library_uri)
+
+        # Add the library's logo, if it has one.
+        logo = ConfigurationSetting.for_library(
+            Configuration.LOGO, library).value
+        if logo:
+            links["logo"] = dict(type="image/png", href=logo)
                 
         library_name = self.library_name or unicode(_("Library"))
         doc = OPDSAuthenticationDocument.fill_in(
@@ -695,8 +701,8 @@ class LibraryAuthenticator(object):
         description = ConfigurationSetting.for_library(
             Configuration.COLOR_SCHEME, library).value
         if description:
-            doc['color_scheme'] = description        
-        
+            doc['color_scheme'] = description
+
         # Add the description of the library as the OPDS feed's
         # service_description.
         description = ConfigurationSetting.for_library(

--- a/api/config.py
+++ b/api/config.py
@@ -129,6 +129,7 @@ class Configuration(CoreConfiguration):
             "label": _("Logo image"),
             "type": "image",
             "optional": True,
+            "description": _("The image must be in GIF, PNG, or JPG format, approximately square, no larger than 135x135 pixels, and look good on a white background."),
         },
         {
             "key": MAX_OUTSTANDING_FINES,

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1345,6 +1345,7 @@ class TestSettingsController(AdminControllerTest):
     def test_libraries_post_create(self):
         class TestFileUpload(StringIO):
             headers = { "Content-Type": "image/png" }
+        image_data = '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x01\x03\x00\x00\x00%\xdbV\xca\x00\x00\x00\x06PLTE\xffM\x00\x01\x01\x01\x8e\x1e\xe5\x1b\x00\x00\x00\x01tRNS\xcc\xd24V\xfd\x00\x00\x00\nIDATx\x9cc`\x00\x00\x00\x02\x00\x01H\xaf\xa4q\x00\x00\x00\x00IEND\xaeB`\x82'
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
@@ -1359,7 +1360,7 @@ class TestSettingsController(AdminControllerTest):
                  ''),
             ])
             flask.request.files = MultiDict([
-                (Configuration.LOGO, TestFileUpload("image data")),
+                (Configuration.LOGO, TestFileUpload(image_data)),
             ])
             response = self.manager.admin_settings_controller.libraries()
             eq_(response.status_code, 201)
@@ -1377,7 +1378,7 @@ class TestSettingsController(AdminControllerTest):
             ConfigurationSetting.for_library(
                 Configuration.ENABLED_FACETS_KEY_PREFIX + FacetConstants.ORDER_FACET_GROUP_NAME,
                 library).value)
-        eq_("data:image/png;base64,%s" % base64.b64encode("image data"),
+        eq_("data:image/png;base64,%s" % base64.b64encode(image_data),
             ConfigurationSetting.for_library(Configuration.LOGO, library).value)
 
     def test_libraries_post_edit(self):

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -943,6 +943,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             CirculationManagerAnnotator.ABOUT: "http://about",
             CirculationManagerAnnotator.LICENSE: "http://license/",
             CirculationManagerAnnotator.REGISTER: "custom-registration-hook://library/",
+            Configuration.LOGO: "image data",
         }
 
         for rel, value in link_config.iteritems():
@@ -1002,6 +1003,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             eq_("http://copyright", links['copyright']['href'])
             eq_("http://about", links['about']['href'])
             eq_("http://license/", links['license']['href'])
+            eq_("image data", links['logo']['href'])
 
             # Most of the links have type='text/html'
             eq_("text/html", links['about']['type'])
@@ -1011,6 +1013,9 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             register = links['register']
             eq_({'href': 'custom-registration-hook://library/'},
                 links['register'])
+
+            # The logo link has type "image/png".
+            eq_("image/png", links["logo"]["type"])
 
             # We have three help links.
             uri, web, email = sorted(links['help'], key=lambda x: x['href'])


### PR DESCRIPTION
This is a follow up to #588. It checks the media type of the uploaded logo and resizes the logo if it's too large. It also adds the logo to the authentication for OPDS document.

This fixes #566.