### PR TITLE
If there's no Overdrive or OneClick configuration, don't create one.

### DIFF
--- a/migration/20170224-2-copy-collection-configuration-into-database.py
+++ b/migration/20170224-2-copy-collection-configuration-into-database.py
@@ -37,6 +37,7 @@ def convert_overdrive(_db, library):
     config = Configuration.integration('Overdrive')
     if not config:
         print u"No Overdrive configuration, not creating a Collection for it."
+        return
     print u"Creating Collection object for Overdrive collection."
     username = config.get('client_key')
     password = config.get('client_secret')
@@ -100,6 +101,7 @@ def convert_one_click(_db, library):
     config = Configuration.integration('OneClick')
     if not config:
         print u"No OneClick configuration, not creating a Collection for it."
+        return
     print u"Creating Collection object for OneClick collection."
     basic_token = config.get('basic_token')
     library_id = config.get('library_id')


### PR DESCRIPTION
This was causing the Overdrive error I saw after a test Open Ebooks migration. An Overdrive collection was created even though the migration script said it wasn't going to do that.