### PR TITLE
Run migrations without configuration file

### DIFF
--- a/migration/20170713-13-move-authentication-configuration-to-external-integrations.py
+++ b/migration/20170713-13-move-authentication-configuration-to-external-integrations.py
@@ -104,8 +104,12 @@ def convert_clever(_db, integration, provider):
         integration.setting(OAuthAuthenticationProvider.TOKEN_EXPIRATION_DAYS
         ).value = expiration_days
     
+configuration = Configuration.load()
+if not configuration:
+    # No need to import configuration if there isn't any.
+    sys.exit()
+
 try:
-    Configuration.load()
     _db = production_session()
     integrations = []
     auth_conf = Configuration.policy('authentication')


### PR DESCRIPTION
This fixes a hiccup when creating and running migrations in the Docker container without a configuration file. It depends on the merge in NYPL-Simplified/server_core#575.