### PR TITLE
Warn on missing series tag

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -407,7 +407,7 @@ class CirculationManagerAnnotator(Annotator):
     def add_series_link(self, work, feed, entry):
         series_tag = OPDSFeed.schema_('Series')
         series_entry = entry.find(series_tag)
-        if not series_entry:
+        if series_entry is None:
             # There is no <series> tag, and thus nothing to annotate.
             # This probably indicates an out-of-date OPDS entry.
             if isinstance(work, Work):

--- a/api/opds.py
+++ b/api/opds.py
@@ -75,9 +75,11 @@ class CirculationManagerAnnotator(Annotator):
                  test_mode=False,
                  top_level_title="All Books"
     ):
-        self.log = logging.getLogger(
-            "Circulation Manager Annotator for %s" % lane.name
-        )
+        if lane:
+            logger_name = "Circulation Manager Annotator for %s" % lane.name
+        else:
+            logger_name = "Circulation Manager Annotator"
+        self.log = logging.getLogger(logger_name)
         self.circulation = circulation
         self.lane = lane
         self.library = library

--- a/api/opds.py
+++ b/api/opds.py
@@ -1,5 +1,6 @@
 import urllib
 import copy
+import logging
 from nose.tools import set_trace
 from flask import url_for
 from lxml import etree
@@ -74,6 +75,9 @@ class CirculationManagerAnnotator(Annotator):
                  test_mode=False,
                  top_level_title="All Books"
     ):
+        self.log = logging.getLogger(
+            "Circulation Manager Annotator for %s" % lane.name
+        )
         self.circulation = circulation
         self.lane = lane
         self.library = library
@@ -401,22 +405,37 @@ class CirculationManagerAnnotator(Annotator):
     def add_series_link(self, work, feed, entry):
         series_tag = OPDSFeed.schema_('Series')
         series_entry = entry.find(series_tag)
-
+        if not series_entry:
+            # There is no <series> tag, and thus nothing to annotate.
+            # This probably indicates an out-of-date OPDS entry.
+            if isinstance(work, Work):
+                work_id = work.id
+                title = work.title
+            else:
+                work_id = work.works_id
+                work_title = work.sort_title
+            self.log.error(
+                'add_series_link() called on work %s ("%s"), which has no <schema:Series> tag in its OPDS entry.',
+                work_id, work_title
+            )
+            return
+        
         series_name = work.series
         languages, audiences = self.language_and_audience_key_from_work(work)
+        href = self.url_for(
+            'series',
+            series_name=series_name,
+            languages=languages,
+            audiences=audiences,
+            library_short_name=self.library.short_name,
+            _external=True,
+        )
         feed.add_link_to_entry(
             series_entry,
             rel='series',
             type=OPDSFeed.ACQUISITION_FEED_TYPE,
             title=series_name,
-            href=self.url_for(
-                'series',
-                series_name=series_name,
-                languages=languages,
-                audiences=audiences,
-                library_short_name=self.library.short_name,
-                _external=True,
-            )
+            href=href
         )
 
     def annotate_feed(self, feed, lane):

--- a/api/opds.py
+++ b/api/opds.py
@@ -412,7 +412,7 @@ class CirculationManagerAnnotator(Annotator):
             # This probably indicates an out-of-date OPDS entry.
             if isinstance(work, Work):
                 work_id = work.id
-                title = work.title
+                work_title = work.title
             else:
                 work_id = work.works_id
                 work_title = work.sort_title

--- a/migration/20170713-15-move-library-configuration-to-configurationsettings.py
+++ b/migration/20170713-15-move-library-configuration-to-configurationsettings.py
@@ -80,15 +80,14 @@ try:
         for k, v in default.items():
             library.default_facet_setting(k).value = v
             
-    # Copy external type regular expression into each collection for each
-    # library.
+    # Copy external type regular expression into each authentication
+    # mechanism for each library.
     key = 'external_type_regular_expression'
     value = Configuration.policy(key)
     if value:
         for library in libraries:
-            for collection in library.collections:
-                integration = collection.external_integration
-                if not integration:
+            for integration in library.integrations:
+                if integration.goal != ExternalIntegration.PATRON_AUTH_GOAL:
                     continue
                 ConfigurationSetting.for_library_and_externalintegration(
                     _db, key, library, integration).value = value

--- a/migration/20170714-add-collection-id-to-licensepools.py
+++ b/migration/20170714-add-collection-id-to-licensepools.py
@@ -44,16 +44,17 @@ try:
     threem_qu = base_query.filter(LicensePool.data_source_id.in_(old_sources))
 
     # Associate these LicensePools with the Bibliotheca Collection.
-    bibliotheca_collection = collections_by_data_source[bibliotheca]
-    result = threem_qu.update(
-        {LicensePool.collection_id : bibliotheca_collection.id},
-        synchronize_session='fetch'
-    )
+    bibliotheca_collection = collections_by_data_source.get(bibliotheca)
+    if bibliotheca_collection:
+        result = threem_qu.update(
+            {LicensePool.collection_id : bibliotheca_collection.id},
+            synchronize_session='fetch'
+        )
 
-    # If something changed, log it.
-    threem_count = fast_query_count(threem_qu)
-    if threem_count:
-        log_change(threem_count, bibliotheca_collection)
+        # If something changed, log it.
+        threem_count = fast_query_count(threem_qu)
+        if threem_count:
+            log_change(threem_count, bibliotheca_collection)
 
     remaining = fast_query_count(base_query)
     if remaining > 0:


### PR DESCRIPTION
This branch fixes a crash during OPDS entry annotation that I don't think will happen on a real site. If a Work has a series but its OPDS entry doesn't have a <schema:Series> tag, `add_series_link()` will crash when it can't find that tag.

This should only happen if the OPDS entry hasn't been rewritten for a very long time (like the ones on Open Ebooks QA) so I think this is a good enough fix.