### PR TITLE
Don't create integrations after saying you won't.

### DIFF
--- a/migration/20170224-2-copy-collection-configuration-into-database.py
+++ b/migration/20170224-2-copy-collection-configuration-into-database.py
@@ -28,6 +28,7 @@ def copy_library_registry_information(_db, library):
     config = Configuration.integration("Adobe Vendor ID")
     if not config:
         print u"No Adobe Vendor ID configuration, not setting short name or secret."
+        return
     library.short_name = config.get("library_short_name")
     library.library_registry_short_name = config.get("library_short_name")
     library.library_registry_shared_secret = config.get("authdata_secret")
@@ -37,6 +38,7 @@ def convert_overdrive(_db, library):
     config = Configuration.integration('Overdrive')
     if not config:
         print u"No Overdrive configuration, not creating a Collection for it."
+        return
     print u"Creating Collection object for Overdrive collection."
     username = config.get('client_key')
     password = config.get('client_secret')
@@ -100,6 +102,7 @@ def convert_one_click(_db, library):
     config = Configuration.integration('OneClick')
     if not config:
         print u"No OneClick configuration, not creating a Collection for it."
+        return
     print u"Creating Collection object for OneClick collection."
     basic_token = config.get('basic_token')
     library_id = config.get('library_id')


### PR DESCRIPTION
This branch adds some more return statements to code run in the migration to 1.1.23, so that we don't create empty ExternalIntegrations for integration a library doesn't use.

I wrote very similar (but not identical) code yesterday; I'm not sure what happened.

https://github.com/NYPL-Simplified/circulation/pull/591/files