### PR TITLE
Fix auth migration; Submodule update.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ git:
   submodules: false
 
 before_install:
+  # Access the submodule via https instead of default SSH
   - git config submodule.core.url https://github.com/NYPL-Simplified/server_core.git
   - git submodule update --init --recursive
 

--- a/migration/20170713-13-move-authentication-configuration-to-external-integrations.py
+++ b/migration/20170713-13-move-authentication-configuration-to-external-integrations.py
@@ -113,6 +113,8 @@ try:
     _db = production_session()
     integrations = []
     auth_conf = Configuration.policy('authentication')
+    if not auth_conf:
+        sys.exit()
 
     bearer_token_signing_secret = auth_conf.get('bearer_token_signing_secret')
     secret_setting = ConfigurationSetting.sitewide(


### PR DESCRIPTION
Strong feelings of déjà vu here, but alas. This keeps the migrations running when a config file isn't available or authentication isn't configured.