### PR TITLE
Added admin controller for registering libraries with a discovery service.

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1935,8 +1935,8 @@ class SettingsController(CirculationManagerController):
             if not register_url:
                 return REMOTE_INTEGRATION_FAILED.detailed(_("The discovery service did not provide a register link."))
 
-            auth_document_url = self.url_for("acquisition_groups", library_short_name=library.short_name)
-            do_post(register_url, dict(url=auth_document_url), allowed_response_codes=["2xx"])
+            library_url = self.url_for("acquisition_groups", library_short_name=library.short_name)
+            do_post(register_url, dict(url=library_url), allowed_response_codes=["2xx"])
 
         return Response(unicode(_("Success")), 200)
 

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1924,7 +1924,6 @@ class SettingsController(CirculationManagerController):
             if not library:
                 return NO_SUCH_LIBRARY
 
-            auth_document_url = self.url_for("acquisition_groups", library_short_name=library.short_name)
             response = do_get(integration.url, allowed_response_codes=["2xx", "3xx"])
             feed = feedparser.parse(response.content)
             links = feed.get("feed", {}).get("links", [])
@@ -1935,6 +1934,8 @@ class SettingsController(CirculationManagerController):
                     break
             if not register_url:
                 return REMOTE_INTEGRATION_FAILED.detailed(_("The discovery service did not provide a register link."))
+
+            auth_document_url = self.url_for("acquisition_groups", library_short_name=library.short_name)
             do_post(register_url, dict(url=auth_document_url), allowed_response_codes=["2xx"])
 
         return Response(unicode(_("Success")), 200)

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.38"
+    "simplified-circulation-web": "0.0.39"
   }
 }

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -174,7 +174,7 @@ NO_SUCH_LIBRARY = pd(
     "http://librarysimplified.org/terms/problem/no-such-library",
     status_code=400,
     title=_("No such library"),
-    detail=_("One of the libraries you attempted to add the collection to does not exist."),
+    detail=_("A library in your request does not exist."),
 )
 
 INCOMPLETE_CONFIGURATION = pd(

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -422,6 +422,18 @@ def sitewide_settings():
         return data
     return flask.jsonify(**data)
 
+@app.route("/admin/library_registrations", methods=['POST'])
+@returns_problem_detail
+@requires_admin
+@requires_csrf_token
+def library_registrations():
+    data = app.manager.admin_settings_controller.library_registrations()
+    if isinstance(data, ProblemDetail):
+        return data
+    if isinstance(data, Response):
+        return data
+    return flask.jsonify(**data)
+
 @app.route('/admin/sign_in_again')
 def admin_sign_in_again():
     """Allows an  admin with expired credentials to sign back in


### PR DESCRIPTION
This is for https://github.com/NYPL-Simplified/circulation/issues/577.

It doesn't do a great job of showing the results yet - it will tell you if there was an error, but I think eventually the circ manager should keep track of registration status for all libraries and registries and return that info in response to a GET. 