### PR TITLE
Use the .ils_name instead of the literal string 'default'

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -55,7 +55,8 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         { "key": BaseOverdriveAPI.WEBSITE_ID, "label": _("Website ID") },
         { "key": ExternalIntegration.USERNAME, "label": _("Client Key") },
         { "key": ExternalIntegration.PASSWORD, "label": _("Client Secret") },
-        { "key": BaseOverdriveAPI.ILS_NAME, "label": _("ILS Name") },
+        { "key": BaseOverdriveAPI.ILS_NAME, "label": _("ILS Name"),
+          "default": "default" },
     ] + BaseCirculationAPI.SETTINGS
 
     # An Overdrive Advantage collection inherits everything except the library id

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -55,6 +55,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         { "key": BaseOverdriveAPI.WEBSITE_ID, "label": _("Website ID") },
         { "key": ExternalIntegration.USERNAME, "label": _("Client Key") },
         { "key": ExternalIntegration.PASSWORD, "label": _("Client Secret") },
+        { "key": BaseOverdriveAPI.ILS_NAME, "label": _("ILS Name") },
     ] + BaseCirculationAPI.SETTINGS
 
     # An Overdrive Advantage collection inherits everything except the library id
@@ -152,7 +153,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
             grant_type="password",
             username=patron.authorization_identifier,
             scope="websiteid:%s authorizationname:%s" % (
-                self.website_id, "default")
+                self.website_id, self.ils_name)
         )
         if pin:
             # A PIN was provided.

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1656,6 +1656,7 @@ class TestSettingsController(AdminControllerTest):
                 ("username", "username"),
                 ("password", "password"),
                 ("website_id", "1234"),
+                ("ils_name", "the_ils"),
                 ("default_loan_period", "14"),
                 ("default_reservation_period", "3"),
             ])
@@ -1733,6 +1734,7 @@ class TestSettingsController(AdminControllerTest):
                 ("username", "user2"),
                 ("password", "password"),
                 ("website_id", "1234"),
+                ("ils_name", "the_ils"),
                 ("libraries", json.dumps([{"short_name": "L1"}])),
                 ("default_loan_period", "14"),
                 ("default_reservation_period", "3"),
@@ -1768,6 +1770,7 @@ class TestSettingsController(AdminControllerTest):
                 ("username", "user2"),
                 ("password", "password"),
                 ("website_id", "1234"),
+                ("ils_name", "the_ils"),
                 ("default_loan_period", "14"),
                 ("default_reservation_period", "3"),
                 ("libraries", json.dumps([])),

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -489,14 +489,17 @@ class TestOverdriveAPI(OverdriveAPITest):
         url, payload, headers, kwargs = with_pin
         eq_("https://oauth-patron.overdrive.com/patrontoken", url)
         eq_("barcode", payload['username'])
-        eq_("websiteid:d authorizationname:default", payload['scope'])
+        expect_scope = "websiteid:%s authorizationname:%s" % (
+            self.api.website_id, self.api.ils_name
+        )
+        eq_(expect_scope, payload['scope'])
         eq_("a pin", payload['password'])
         assert not 'password_required' in payload
 
         url, payload, headers, kwargs = without_pin
         eq_("https://oauth-patron.overdrive.com/patrontoken", url)
         eq_("barcode", payload['username'])
-        eq_("websiteid:d authorizationname:default", payload['scope'])
+        eq_(expect_scope, payload['scope'])
         eq_("false", payload['password_required'])
         eq_("[ignore]", payload['password'])
         


### PR DESCRIPTION
This branch pulls the Overdrive ILS name from the `ils_name` configuration setting instead of assuming it's always the literal string 'default'.

This fixes https://github.com/NYPL-Simplified/circulation/issues/610