### PR TITLE
Run docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 
 addons:
   postgresql: "9.3"
@@ -8,6 +8,7 @@ addons:
 
 services:
   - postgresql
+  - docker
 
 language: python
 
@@ -39,6 +40,8 @@ before_script:
   - psql -c 'grant all privileges on database simplified_circulation_test to simplified_test;' -U postgres
 
 env:
- - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_circulation_test"
+  - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_circulation_test"
 
-script: ./verbose-test
+script:
+  - ./verbose-test
+  - ./docker-test

--- a/docker-test
+++ b/docker-test
@@ -28,7 +28,7 @@ if ! [[ -z ${TRAVIS_TAG} ]] || [[ ${TRAVIS_BRANCH} == "run-docker-builds" ]]; th
     --name circ --rm nypl/circ-deploy;
 
   # Run the tests in the container.
-  docker exec circ /bin/bash -c "source env/bin/activate && ./verbose-test && cd core && ./test";
+  docker exec circ /bin/bash -c "source env/bin/activate && ./verbose-test && cd core && ./test -v";
 
   # Create a library so the app will start.
   docker exec -u postgres pg psql -U simplified -d docker_prod \

--- a/docker-test
+++ b/docker-test
@@ -2,7 +2,7 @@
 
 set -ev
 
-if ! [[ -z ${TRAVIS_TAG} ]] || [[ ${TRAVIS_BRANCH} == "run-docker-builds" ]]; then
+if ! [[ -z ${TRAVIS_TAG} ]]; then
   # Create a container with test and production postgres databases.
   docker pull postgres:9.5;
   docker run -d --name pg postgres:9.5;
@@ -19,7 +19,7 @@ if ! [[ -z ${TRAVIS_TAG} ]] || [[ ${TRAVIS_BRANCH} == "run-docker-builds" ]]; th
 
   # Create a base and deployment container with this tag.
   git clone "https://github.com/NYPL-Simplified/circulation-docker" && cd "circulation-docker";
-  docker build --build-arg version=${TRAVIS_BRANCH} -t nypl/circ-base base/;
+  docker build --build-arg version=${TRAVIS_TAG} -t nypl/circ-base base/;
   docker build -t nypl/circ-deploy deploy/;
   docker run -d -p 80:80 \
     -e SIMPLIFIED_DB_TASK='init' \

--- a/docker-test
+++ b/docker-test
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -ev
+
+if ! [[ -z ${TRAVIS_TAG} ]] || [[ ${TRAVIS_BRANCH} == "run-docker-builds" ]]; then
+  # Create a container with test and production postgres databases.
+  docker pull postgres:9.5;
+  docker run -d --name pg postgres:9.5;
+
+  # Sleep to let PostgreSQL start up.
+  sleep 10;
+
+  # Create production and test databases.
+  docker exec -u postgres pg psql -c "create user simplified with password 'test';";
+  docker exec -u postgres pg psql -c "create database docker_prod;";
+  docker exec -u postgres pg psql -c "create database docker_test;";
+  docker exec -u postgres pg psql -c "grant all privileges on database docker_prod to simplified;";
+  docker exec -u postgres pg psql -c "grant all privileges on database docker_test to simplified;";
+
+  # Create a base and deployment container with this tag.
+  git clone "https://github.com/NYPL-Simplified/circulation-docker" && cd "circulation-docker";
+  docker build --build-arg version=${TRAVIS_BRANCH} -t nypl/circ-base base/;
+  docker build -t nypl/circ-deploy deploy/;
+  docker run -d -p 80:80 \
+    -e SIMPLIFIED_DB_TASK='init' \
+    -e SIMPLIFIED_TEST_DATABASE='postgres://simplified:test@172.17.0.2:5432/docker_test' \
+    -e SIMPLIFIED_PRODUCTION_DATABASE='postgres://simplified:test@172.17.0.2:5432/docker_prod' \
+    --name circ --rm nypl/circ-deploy;
+
+  # Run the tests in the container.
+  docker exec circ /bin/bash -c "source env/bin/activate && ./verbose-test && cd core && ./test";
+
+  # Create a library so the app will start.
+  docker exec -u postgres pg psql -U simplified -d docker_prod \
+      -c "insert into libraries(name, short_name, uuid, is_default) values ('default', 'default', '1234', 't');";
+
+  # Check to make sure the deployed app is running.
+  healthcheck=$(curl --write-out "%{http_code}" --silent --output /dev/null http://localhost/healthcheck.html);
+  if ! [[ ${healthcheck} == '200' ]]; then exit 1; fi
+
+  feed_type=$(curl --write-out "%{content_type}" --silent --output /dev/null http://localhost/groups);
+  if ! [[ ${feed_type} == 'application/atom+xml;profile=opds-catalog;kind=acquisition' ]]; then\
+    exit 1;
+  fi
+fi
+
+exit 0;

--- a/scripts.py
+++ b/scripts.py
@@ -76,7 +76,10 @@ from core.external_list import CustomListFromCSV
 from core.external_search import ExternalSearchIndex
 from core.util import LanguageCodes
 
-from api.config import Configuration
+from api.config import (
+    CannotLoadConfiguration,
+    Configuration,
+)
 from api.adobe_vendor_id import (
     AdobeVendorIDModel,
     AuthdataUtility,
@@ -758,7 +761,11 @@ class InstanceInitializationScript(Script):
     def do_run(self, ignore_search=False):
         # Creates a "-current" alias on the Elasticsearch client.
         if not ignore_search:
-            search_client = ExternalSearchIndex(self._db)
+            try:
+                search_client = ExternalSearchIndex(self._db)
+            except CannotLoadConfiguration as e:
+                # Elasticsearch isn't configured, so do nothing.
+                pass
 
         # Set a timestamp that represents the new database's version.
         db_init_script = DatabaseMigrationInitializationScript(_db=self._db)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -12,7 +12,7 @@ from . import (
     sample_data,
 )
 
-from core.scripts import RunCoverageProviderScript
+from core.scripts import RunCollectionCoverageProviderScript
 from core.testing import MockRequestsResponse
 
 from core.config import (
@@ -657,16 +657,21 @@ class TestMetadataWranglerCollectionReaper(MetadataWranglerCollectionManagerTest
 class TestContentServerBibliographicCoverageProvider(DatabaseTest):
 
     def test_script_instantiation(self):
-        """Test that RunCoverageProviderScript can instantiate
+        """Test that RunCollectionCoverageProviderScript can instantiate
         the coverage provider.
         """
-        script = RunCoverageProviderScript(
-            ContentServerBibliographicCoverageProvider,
-            self._default_collection, lookup_client=object(),
-            cmd_args=[]
+        # Create a Collection to be found.
+        collection = self._collection(
+            name="OA Content", data_source_name=DataSource.OA_CONTENT_SERVER
         )
-        assert isinstance(script.provider, 
+
+        script = RunCollectionCoverageProviderScript(
+            ContentServerBibliographicCoverageProvider,
+            _db=self._db, lookup_client=object()
+        )
+        assert isinstance(script.providers[0],
                           ContentServerBibliographicCoverageProvider)
+        eq_(collection, script.providers[0].collection)
 
     def test_finalize_license_pool(self):
 


### PR DESCRIPTION
This branch adds a run of the tests in a docker container environment. Some small errors came up, corrected here and in NYPL-Simplified/server_core#591.

As I mention there, I'm a little worried that this will raise strange, annoying-to-diagnose errors just before (or after) we've launched something. I'm hoping that the use of release candidate tags will avoid this by causing the tests before anything is on production. I don't want to add the length of this test sequence to development pushes and PRs, so I think this is the next best option.

Fixes #612.