### PR TITLE
Backwards compatible drm migration

### DIFF
--- a/migration/20170713-19-move-third-party-config-to-external-integrations.py
+++ b/migration/20170713-19-move-third-party-config-to-external-integrations.py
@@ -99,7 +99,7 @@ try:
             log_import(integration)
 
         # Import short client token configuration.
-        integration = EI(protocol=EI.SHORT_CLIENT_TOKEN, goal=EI.DRM_GOAL)
+        integration = EI(protocol=u'Short Client Token', goal=EI.DRM_GOAL)
         _db.add(integration)
         integration.set_setting(
             AuthdataUtility.VENDOR_ID_KEY, vendor_id


### PR DESCRIPTION
This change will keep the migrations from breaking between 2.0.0 and the bugfixes in impending 2.0.1.