### PR TITLE
Collection monitor takes redundant database connection

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -326,8 +326,8 @@ class AxisCollectionReaper(IdentifierSweepMonitor):
     SERVICE_NAME = "Axis Collection Reaper"
     INTERVAL_SECONDS = 3600*12
     
-    def __init__(self, collection, api_class=Axis360API):
-        super(AxisCollectionReaper, self).__init__(collection)
+    def __init__(self, _db, collection, api_class=Axis360API):
+        super(AxisCollectionReaper, self).__init__(_db, collection)
         if isinstance(api_class, Axis360API):
             # Use a preexisting Axis360API instance rather than
             # creating a new one.

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -776,9 +776,8 @@ class OneClickCirculationMonitor(CollectionMonitor):
     INTERVAL_SECONDS = 1200
     DEFAULT_BATCH_SIZE = 50
     
-    def __init__(self, collection, batch_size=None, api_class=OneClickAPI,
+    def __init__(self, _db, collection, batch_size=None, api_class=OneClickAPI,
                  api_class_kwargs={}):
-        _db = Session.object_session(collection)
         super(OneClickCirculationMonitor, self).__init__(_db, collection)
         self.batch_size = batch_size or self.DEFAULT_BATCH_SIZE
 

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -919,8 +919,7 @@ class OverdriveCollectionReaper(IdentifierSweepMonitor):
     SERVICE_NAME = "Overdrive Collection Reaper"
     INTERVAL_SECONDS = 3600*4
     
-    def __init__(self, collection, api_class=OverdriveAPI):
-        _db = Session.object_session(collection)
+    def __init__(self, _db, collection, api_class=OverdriveAPI):
         super(OverdriveCollectionReaper, self).__init__(_db, collection)
         self.api = api_class(collection)
 

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -274,7 +274,7 @@ class TestCirculationMonitor(Axis360Test):
         eq_(9, licensepool.licenses_owned)
 
 
-class TestReaper(DatabaseTest):
+class TestReaper(Axis360Test):
 
     def test_instantiate(self):
         # Validate the standard CollectionMonitor interface.

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -33,6 +33,7 @@ from core.opds_import import(
 )
 
 from api.axis import (
+    AxisCollectionReaper,
     Axis360CirculationMonitor,
     Axis360API,
     AvailabilityResponseParser,
@@ -272,6 +273,16 @@ class TestCirculationMonitor(Axis360Test):
         # Now we have information based on the CirculationData.
         eq_(9, licensepool.licenses_owned)
 
+
+class TestReaper(DatabaseTest):
+
+    def test_instantiate(self):
+        # Validate the standard CollectionMonitor interface.
+        monitor = AxisCollectionReaper(
+            self._db, self.collection,
+            api_class=MockAxis360API
+        )
+        
 
 class TestResponseParser(object):
 

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -433,7 +433,7 @@ class TestCirculationMonitor(OneClickAPITest):
 
     def test_process_availability(self):
         monitor = OneClickCirculationMonitor(
-            self.collection, api_class=MockOneClickAPI, 
+            self._db, self.collection, api_class=MockOneClickAPI, 
             api_class_kwargs=dict(base_path=self.base_path)
         )
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -11,6 +11,7 @@ from datetime import (
 )
 from api.overdrive import (
     MockOverdriveAPI,
+    OverdriveCollectionReaper,
 )
 
 from api.circulation import (
@@ -696,3 +697,13 @@ class TestSyncBookshelf(OverdriveAPITest):
         loans, holds = self.circulation.sync_bookshelf(patron, "dummy pin")
         eq_(5, len(patron.holds))
         assert overdrive_hold in patron.holds
+
+
+class TestReaper(OverdriveAPITest):
+
+    def test_instantiate(self):
+        # Validate the standard CollectionMonitor interface.
+        monitor = OverdriveCollectionReaper(
+            self._db, self.collection,
+            api_class=MockOverdriveAPI
+        )


### PR DESCRIPTION
This branch makes sure that certain `CollectionMonitor`s take a database connection in their constructor. Even though it's redundant, the `CollectionMonitor` class takes a database connection as well as a `Collection`, for the sake of preserving a single constructor signature between `Monitor` and `CollectionMonitor`.

I looked into removing the database connection from the argument, but that single constructor signature is really important. In particular, some subclasses use`IdentifierSweepMonitor` as a `CollectionMonitor` and some use it as a regular `Monitor.