### PR TITLE
API constructor takes database connection

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -333,7 +333,7 @@ class AxisCollectionReaper(IdentifierSweepMonitor):
             # creating a new one.
             self.api = api_class
         else:
-            self.api = api_class(collection)
+            self.api = api_class(_db, collection)
 
     def process_batch(self, identifiers):
         self.api.update_licensepools_for_identifiers(identifiers)

--- a/api/axis.py
+++ b/api/axis.py
@@ -256,7 +256,7 @@ class Axis360CirculationMonitor(CollectionMonitor):
             # creating a new one.
             self.api = api_class
         else:
-            self.api = api_class(collection)
+            self.api = api_class(_db, collection)
         if not metadata_client:
             metadata_client = MetadataWranglerOPDSLookup.from_config(
                 _db, collection=collection

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -634,7 +634,7 @@ class BibliothecaCirculationSweep(IdentifierSweepMonitor):
         if isinstance(api_class, BibliothecaAPI):
             self.api = api_class
         else:
-            self.api = api_class(collection)
+            self.api = api_class(_db, collection)
         self.analytics = Analytics(_db)
     
     def process_batch(self, identifiers):

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -722,7 +722,7 @@ class BibliothecaEventMonitor(CollectionMonitor):
     
     def __init__(self, _db, collection, api_class=BibliothecaAPI):
         super(BibliothecaEventMonitor, self).__init__(_db, collection)
-        self.api = api_class(collection)
+        self.api = api_class(_db, collection)
         self.bibliographic_coverage_provider = BibliothecaBibliographicCoverageProvider(
             collection, self.api
         )

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -213,7 +213,7 @@ class CirculationAPI(object):
             if collection.protocol in api_map:
                 api = None
                 try:
-                    api = api_map[collection.protocol](collection)
+                    api = api_map[collection.protocol](_db, collection)
                 except CannotLoadConfiguration, e:
                     self.log.error(
                         "Error loading configuration for %s: %s",

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -782,7 +782,7 @@ class OneClickCirculationMonitor(CollectionMonitor):
         super(OneClickCirculationMonitor, self).__init__(_db, collection)
         self.batch_size = batch_size or self.DEFAULT_BATCH_SIZE
 
-        self.api = api_class(self.collection, **api_class_kwargs)
+        self.api = api_class(_db, self.collection, **api_class_kwargs)
         self.bibliographic_coverage_provider = (
             OneClickBibliographicCoverageProvider(
                 collection=self.collection, api_class=self.api,

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -92,8 +92,8 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
     # displayed to a patron, so it doesn't matter much.
     DEFAULT_ERROR_URL = "http://librarysimplified.org/"
 
-    def __init__(self, collection):
-        super(OverdriveAPI, self).__init__(collection)
+    def __init__(self, _db, collection):
+        super(OverdriveAPI, self).__init__(_db, collection)
         self.overdrive_bibliographic_coverage_provider = (
             OverdriveBibliographicCoverageProvider(
                 collection, api_class=self

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -847,7 +847,7 @@ class OverdriveCirculationMonitor(CollectionMonitor):
     def __init__(self, _db, collection, api_class=OverdriveAPI):
         """Constructor."""
         super(OverdriveCirculationMonitor, self).__init__(_db, collection)
-        self.api = api_class(collection)
+        self.api = api_class(_db, collection)
         self.maximum_consecutive_unchanged_books = (
             self.MAXIMUM_CONSECUTIVE_UNCHANGED_BOOKS
         )
@@ -921,7 +921,7 @@ class OverdriveCollectionReaper(IdentifierSweepMonitor):
     
     def __init__(self, _db, collection, api_class=OverdriveAPI):
         super(OverdriveCollectionReaper, self).__init__(_db, collection)
-        self.api = api_class(collection)
+        self.api = api_class(_db, collection)
 
     def process_item(self, identifier):
         self.api.update_licensepool(identifier.identifier)
@@ -944,7 +944,7 @@ class OverdriveFormatSweep(IdentifierSweepMonitor):
 
     def __init__(self, collection, api_class=OverdriveAPI):
         _db = Session.object_session(collection)
-        api = api_class(collection)
+        api = api_class(_db, collection)
         super(OverdriveFormatSweep, self).__init__(_db, collection)
 
     def process_identifier(self, identifier):

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -69,7 +69,7 @@ class Axis360Test(DatabaseTest):
     def setup(self):
         super(Axis360Test,self).setup()
         self.collection = MockAxis360API.mock_collection(self._db)
-        self.api = MockAxis360API(self.collection)
+        self.api = MockAxis360API(self._db, self.collection)
 
     @classmethod
     def sample_data(self, filename):

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -56,7 +56,7 @@ class BibliothecaAPITest(DatabaseTest):
     def setup(self):
         super(BibliothecaAPITest,self).setup()
         self.collection = MockBibliothecaAPI.mock_collection(self._db)
-        self.api = MockBibliothecaAPI(self.collection)
+        self.api = MockBibliothecaAPI(self._db, self.collection)
 
     @classmethod
     def sample_data(self, filename):

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -648,7 +648,7 @@ class TestConfigurationFailures(DatabaseTest):
 
     class MisconfiguredAPI(object):
 
-        def __init__(self, collection):
+        def __init__(self, _db, collection):
             raise CannotLoadConfiguration("doomed!")
 
     def test_configuration_exception_is_stored(self):

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -61,7 +61,9 @@ class OneClickAPITest(DatabaseTest):
 
         self.base_path = os.path.split(__file__)[0]
         self.collection = MockOneClickAPI.mock_collection(self._db)
-        self.api = MockOneClickAPI(self.collection, base_path=self.base_path)
+        self.api = MockOneClickAPI(
+            self._db, self.collection, base_path=self.base_path
+        )
 
         self.default_patron = self._patron(external_identifier="oneclick_testuser")
         self.default_patron.authorization_identifier="13057226"


### PR DESCRIPTION
This branch updates the circulation manager to pass in the database connection whenever it creates an API object, for the reasons outlined in https://github.com/NYPL-Simplified/server_core/pull/605.