### PR TITLE
Change the OneClick import scripts to run CollectionMonitorScript

### DIFF
--- a/bin/oneclick_library_delta
+++ b/bin/oneclick_library_delta
@@ -1,16 +1,11 @@
 #!/usr/bin/env python
-"""Add new books, change metadata, remove license pools for OneClick library catalog."""
+"""Make sure a OneClick collection is up to date."""
 import os
 import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
-from core.scripts import OneClickDeltaScript
 
-from api.config import Configuration
-Configuration.load()
-library_id = Configuration.integration(Configuration.ONECLICK_INTEGRATION).get("library_id", None)
-
-print "Applying catalog delta of library #%s" % library_id
-OneClickDeltaScript().run()
-
+from core.scripts import RunCollectionMonitorScript
+from core.oneclick import OneClickDeltaMonitor
+RunCollectionMonitorScript(OneClickDeltaMonitor).run()

--- a/bin/oneclick_library_import
+++ b/bin/oneclick_library_import
@@ -1,22 +1,13 @@
 #!/usr/bin/env python
-"""Update the circulation manager server with new books from the
+"""Update a OneClick collection with new books from the
 OneClick content server.
-
-If you want to test with sample OneClick data on a non-test database, 
-run like so:
-python bin/oneclick_library_import --mock
 """
 import os
 import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
-from core.scripts import OneClickImportScript
 
-from api.config import Configuration
-Configuration.load()
-library_id = Configuration.integration(Configuration.ONECLICK_INTEGRATION).get("library_id", None)
-
-print "Importing catalog of library #%s" % library_id
-OneClickImportScript().run()
-
+from core.scripts import RunCollectionMonitorScript
+from core.oneclick import OneClickImportMonitor
+RunCollectionMonitorScript(OneClickImportMonitor).run()


### PR DESCRIPTION
This branch changes the OneClick sync scripts to use `CollectionMonitorScript` instead of the custom scripts which were removed in https://github.com/NYPL-Simplified/server_core/pull/606.