### PR TITLE
Fix session problem

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -45,9 +45,9 @@ logging.getLogger().info("Application debug mode==%r" % debug)
 app.config['DEBUG'] = debug
 app.debug = debug
 
-def run():
+def run(url=None):
     base_url = ConfigurationSetting.sitewide(_db, Configuration.BASE_URL_KEY)
-    base_url = base_url.value or u'http://localhost:6500/'
+    base_url = url or base_url.value or u'http://localhost:6500/'
     scheme, netloc, path, parameters, query, fragment = urlparse.urlparse(base_url)
     if ':' in netloc:
         host, port = netloc.split(':')

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -126,6 +126,7 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
         patron_id = patron.authorization_identifier
         path = "circulation/patron/%s" % patron_id
         response = self.request(path)
+        collection = self.collection
         return PatronCirculationParser(self.collection).process_all(response.content)
 
     TEMPLATE = "<%(request_type)s><ItemId>%(item_id)s</ItemId><PatronId>%(patron_id)s</PatronId></%(request_type)s>"
@@ -663,7 +664,7 @@ class BibliothecaCirculationSweep(IdentifierSweepMonitor):
                 # identifier?--but it shouldn't be a big deal to
                 # create one.
                 pool, ignore = LicensePool.for_foreign_id(
-                    self._db, self.data_source, identifier.type,
+                    self._db, self.collection.data_source, identifier.type,
                     identifier.identifier, collection=collection
                 )
 

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -53,9 +53,13 @@ class CirculationInfo(object):
         self.identifier_type = identifier_type
         self.identifier = identifier
 
+    def collection(self, _db):
+        """Find the Collection to which this object belongs."""
+        return get_one(_db, Collection, id=self.collection_id)
+    
     def license_pool(self, _db):
         """Find the LicensePool model object corresponding to this object."""
-        collection = get_one(_db, Collection, id=self.collection_id)
+        collection = self.collection(_db)
         pool, is_new = LicensePool.for_foreign_id(
             _db, self.data_source_name, self.identifier_type, self.identifier,
             collection=collection

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -48,18 +48,17 @@ class CirculationInfo(object):
             with the LicensePool.
         :param identifier: The string identifying the LicensePool.
         """
-        self.collection = collection
+        self.collection_id = collection.id
         self.data_source_name = data_source_name
         self.identifier_type = identifier_type
         self.identifier = identifier
 
-    @property
-    def license_pool(self):
+    def license_pool(self, _db):
         """Find the LicensePool model object corresponding to this object."""
-        _db = Session.object_session(self.collection)
+        collection = get_one(_db, Collection, id=self.collection_id)
         pool, is_new = LicensePool.for_foreign_id(
             _db, self.data_source_name, self.identifier_type, self.identifier,
-            collection=self.collection
+            collection=collection
         )
         return pool
         
@@ -767,7 +766,7 @@ class CirculationAPI(object):
         for loan in remote_loans:
             # This is a remote loan. Find or create the corresponding
             # local loan.
-            pool = loan.license_pool
+            pool = loan.license_pool(self._db)
             start = loan.start_date or now
             end = loan.end_date
             local_loan, new = pool.loan_to(patron, start, end)
@@ -782,7 +781,7 @@ class CirculationAPI(object):
         for hold in remote_holds:
             # This is a remote hold. Find or create the corresponding
             # local hold.
-            pool = hold.license_pool
+            pool = hold.license_pool(self._db)
             start = hold.start_date or now
             end = hold.end_date
             position = hold.hold_position

--- a/api/controller.py
+++ b/api/controller.py
@@ -708,7 +708,6 @@ class LoanController(CirculationManagerController):
         header = self.authorization_header()
         credential = self.manager.auth.get_credential_from_header(header)
         problem_doc = None
-
         try:
             loan, hold, is_new = self.circulation.borrow(
                 patron, credential, pool, mechanism

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -460,10 +460,8 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
             holds = {}
 
         for checkout in loans.get('checkouts', []):
-            loan_info = self.process_checkout_data(checkout)
-            if loan_info:
-                loan_info.collection = self.collection
-                yield loan_info
+            loan_info = self.process_checkout_data(checkout, self.collection)
+            yield loan_info
 
         for hold in holds.get('holds', []):
             overdrive_identifier = hold['reserveId'].lower()
@@ -488,7 +486,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
             )
 
     @classmethod
-    def process_checkout_data(cls, checkout):
+    def process_checkout_data(cls, checkout, collection):
         """Convert one checkout from Overdrive's list of checkouts
         into a LoanInfo object.
 
@@ -530,7 +528,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         # not count overdrive-read), put it into fulfillment_info and
         # let the caller make the decision whether or not to show it.
         return LoanInfo(
-            None,
+            collection,
             DataSource.OVERDRIVE,
             Identifier.OVERDRIVE_ID,
             overdrive_identifier,

--- a/app.py
+++ b/app.py
@@ -1,4 +1,9 @@
 from api import app
+import sys
 
+url = None
+if len(sys.argv) > 1:
+    url = sys.argv[1]
+    
 if __name__ == "__main__":
-    app.run()
+    app.run(url)

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -293,9 +293,12 @@ class TestResponseParser(object):
     def setup(self):
         # We don't need an actual Collection object to test this
         # class, but we do need to test that whatever object we
-        # _claim_ is a Collection will be put into the right spot of
-        # HoldInfo and LoanInfo objects.
-        self._default_collection = object()
+        # _claim_ is a Collection will have its id put into the 
+        # right spot of HoldInfo and LoanInfo objects.
+        class MockCollection(object):
+            pass
+        self._default_collection = MockCollection()
+        self._default_collection.id = object()
     
 class TestRaiseExceptionOnError(TestResponseParser):
 
@@ -331,7 +334,7 @@ class TestCheckoutResponseParser(TestResponseParser):
         parser = CheckoutResponseParser(self._default_collection)
         parsed = parser.process_all(data)
         assert isinstance(parsed, LoanInfo)
-        eq_(self._default_collection, parsed.collection)
+        eq_(self._default_collection.id, parsed.collection.id)
         eq_(DataSource.AXIS_360, parsed.data_source_name)
         eq_(Identifier.AXIS_360_ID, parsed.identifier_type)
         eq_(datetime.datetime(2015, 8, 11, 18, 57, 42), 
@@ -362,7 +365,7 @@ class TestHoldResponseParser(TestResponseParser):
 
         # The HoldInfo is given the Collection object we passed into
         # the HoldResponseParser.
-        eq_(self._default_collection, parsed.collection)
+        eq_(self._default_collection.id, parsed.collection.id)
         
     def test_parse_already_on_hold(self):
         data = self.sample_data("already_on_hold.xml")
@@ -388,18 +391,18 @@ class TestAvailabilityResponseParser(TestResponseParser):
         parser = AvailabilityResponseParser(self._default_collection)
         activity = list(parser.process_all(data))
         hold, loan, reserved = sorted(activity, key=lambda x: x.identifier)
-        eq_(self._default_collection, hold.collection)
+        eq_(self._default_collection.id, hold.collection.id)
         eq_(Identifier.AXIS_360_ID, hold.identifier_type)
         eq_("0012533119", hold.identifier)
         eq_(1, hold.hold_position)
         eq_(None, hold.end_date)
 
-        eq_(self._default_collection, loan.collection)
+        eq_(self._default_collection.id, loan.collection.id)
         eq_("0015176429", loan.identifier)
         eq_("http://fulfillment/", loan.fulfillment_info.content_link)
         eq_(datetime.datetime(2015, 8, 12, 17, 40, 27), loan.end_date)
 
-        eq_(self._default_collection, reserved.collection)
+        eq_(self._default_collection.id, reserved.collection.id)
         eq_("1111111111", reserved.identifier)
         eq_(datetime.datetime(2015, 1, 1, 13, 11, 11), reserved.end_date)
         eq_(0, reserved.hold_position)
@@ -409,7 +412,7 @@ class TestAvailabilityResponseParser(TestResponseParser):
         parser = AvailabilityResponseParser(self._default_collection)
         [loan] = list(parser.process_all(data))
 
-        eq_(self._default_collection, loan.collection)
+        eq_(self._default_collection.id, loan.collection.id)
         eq_("0015176429", loan.identifier)
         eq_(None, loan.fulfillment_info)
         eq_(datetime.datetime(2015, 8, 12, 17, 40, 27), loan.end_date)

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -252,7 +252,7 @@ class TestPatronCirculationParser(BibliothecaAPITest):
 
     def test_parse(self):
         data = self.sample_data("checkouts.xml")
-        collection = object()
+        collection = self.collection
         loans_and_holds = PatronCirculationParser(collection).process_all(data)
         loans = [x for x in loans_and_holds if isinstance(x, LoanInfo)]
         holds = [x for x in loans_and_holds if isinstance(x, HoldInfo)]
@@ -269,7 +269,7 @@ class TestPatronCirculationParser(BibliothecaAPITest):
         [h1, h2] = sorted(holds, key=lambda x: x.identifier)
 
         # This is the book on reserve.
-        eq_(collection, h1.collection)
+        eq_(collection.id, h1.collection_id)
         eq_(DataSource.BIBLIOTHECA, h1.data_source_name)
         eq_("9wd8", h1.identifier)
         expect_hold_start = datetime.datetime(2015, 5, 25, 17, 5, 34)
@@ -280,7 +280,7 @@ class TestPatronCirculationParser(BibliothecaAPITest):
 
         # This is the book on hold.
         eq_("d4o8r9", h2.identifier)
-        eq_(collection, h2.collection)
+        eq_(collection.id, h2.collection_id)
         eq_(DataSource.BIBLIOTHECA, h2.data_source_name)
         expect_hold_start = datetime.datetime(2015, 3, 24, 15, 6, 56)
         expect_hold_end = datetime.datetime(2015, 3, 24, 15, 7, 51)

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -541,22 +541,22 @@ class TestExtractData(OverdriveAPITest):
 
         # The book already fulfilled on Kindle doesn't get turned into
         # LoanInfo.
-        eq_(None, MockOverdriveAPI.process_checkout_data(on_kindle))
+        eq_(None, MockOverdriveAPI.process_checkout_data(on_kindle, self.collection))
 
         # The book not yet fulfilled does show up as a LoanInfo.
-        loan_info = MockOverdriveAPI.process_checkout_data(not_on_kindle)
+        loan_info = MockOverdriveAPI.process_checkout_data(not_on_kindle, self.collection)
         eq_("2fadd2ac-a8ec-4938-a369-4c3260e8922b", loan_info.identifier)
 
         data, format_locked_in = self.sample_json("checkout_response_locked_in_format.json")
 
         # A book that's on loan with a format locked in shows up.
-        loan_info = MockOverdriveAPI.process_checkout_data(format_locked_in)
+        loan_info = MockOverdriveAPI.process_checkout_data(format_locked_in, self.collection)
         assert loan_info != None
 
         data, no_format_locked_in = self.sample_json("checkout_response_no_format_locked_in.json")
 
         # A book that's on loan with no format locked in also shows up.
-        loan_info = MockOverdriveAPI.process_checkout_data(no_format_locked_in)
+        loan_info = MockOverdriveAPI.process_checkout_data(no_format_locked_in, self.collection)
         assert loan_info != None
 
         # TODO: In the future both of these tests should return a


### PR DESCRIPTION
This branch fixes a problem where a non-scoped database session was used to get a LicensePool before creating a loan or hold. This conflicted with the scoped database session used to get the Patron whose loan or hold it was.

Amy wrote the code, I'm just making a clean PR for review.