### PR TITLE
Lookup cache before finding adobe identifier

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -773,11 +773,18 @@ class CirculationManagerAnnotator(Annotator):
         # tags that explain how the patron can get an Adobe ID, and
         # reuse them across <entry> tags. This saves a little time,
         # makes tests more reliable, and stops us from providing a
-        # different authdata value for every <entry> tag.
+        # different Short Client Token for every <entry> tag.
         if isinstance(patron_identifier, Patron):
-            patron_identifier = self._adobe_patron_identifier(patron_identifier)
-        cached = self._adobe_id_tags.get(patron_identifier)
+            cache_key = patron_identifier.id
+        else:
+            cache_key = patron_identifier
+        cached = self._adobe_id_tags.get(cache_key)
         if cached is None:
+            if isinstance(patron_identifier, Patron):
+                # Find the patron's identifier for Adobe ID purposes.
+                patron_identifier = self._adobe_patron_identifier(
+                    patron_identifier
+                )
             cached = []
             authdata = AuthdataUtility.from_config(self.library)
             if authdata:
@@ -807,7 +814,7 @@ class CirculationManagerAnnotator(Annotator):
                 drm_licensor.append(device_list_link)
                 cached = [drm_licensor]
 
-            self._adobe_id_tags[patron_identifier] = cached
+            self._adobe_id_tags[cache_key] = cached
         else:
             cached = copy.deepcopy(cached)
         return cached

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -2389,7 +2389,6 @@ class TestSettingsController(AdminControllerTest):
             assert AcquisitionFeed.NONGROUPED_MAX_AGE_POLICY in keys
             assert Configuration.SECRET_KEY in keys
 
-        set_trace()
         ConfigurationSetting.sitewide(self._db, AcquisitionFeed.GROUPED_MAX_AGE_POLICY).value = 0
         ConfigurationSetting.sitewide(self._db, Configuration.SECRET_KEY).value = "secret"
 


### PR DESCRIPTION
We have a cache that helps us avoid regenerating a Short Client Token for the same patron over and over again within a single request, but there's an unavoidable database access just before the cache lookup, because the cache is keyed on the patron's identifier for Adobe ID purposes. This branch changes the code to use the patron's database ID (which we already have) as the key, eliminating the database access on a cache hit.

When a patron loads the loans feed, this eliminates N-1 database hits, where N is the number of books they have on loan that use Adobe DRM.

This branch also collapses the two database queries that look up a patron by either username or authorization identifier. When a patron authenticates with a username, this eliminates a database query on every request that requires authorization.