### PR TITLE
When the remote mentions a loan we already have loaded from the database, modify it in place rather than load it again.

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -771,9 +771,22 @@ class CirculationAPI(object):
             # This is a remote loan. Find or create the corresponding
             # local loan.
             pool = loan.license_pool(self._db)
-            start = loan.start_date or now
+            start = loan.start_date
             end = loan.end_date
-            local_loan, new = pool.loan_to(patron, start, end)
+            key = (loan.identifier_type, loan.identifier)
+            if key in local_loans_by_identifier:
+                # We already have the Loan object, we don't need to look
+                # it up again.
+                local_loan = local_loans_by_identifier[key]
+
+                # But maybe the remote's opinions as to the loan's
+                # start or end date have changed.
+                if start:
+                    local_loan.start = start
+                if end:
+                    local_loan.end = end
+            else:
+                local_loan, new = pool.loan_to(patron, start, end)
             active_loans.append(local_loan)
 
             # Check the local loan off the list we're keeping so we
@@ -786,15 +799,24 @@ class CirculationAPI(object):
             # This is a remote hold. Find or create the corresponding
             # local hold.
             pool = hold.license_pool(self._db)
-            start = hold.start_date or now
+            start = hold.start_date
             end = hold.end_date
             position = hold.hold_position
-            local_hold, new = pool.on_hold_to(patron, start, end, position)
+            key = (hold.identifier_type, hold.identifier)
+            if key in local_holds_by_identifier:
+                # We already have the Hold object, we don't need to look
+                # it up again.
+                local_hold = local_holds_by_identifier[key]
+
+                # But maybe the remote's opinions as to the hold's
+                # start or end date have changed.
+                local_hold.update(start, end, position)
+            else:
+                local_hold, new = pool.on_hold_to(patron, start, end, position)
             active_holds.append(local_hold)
 
             # Check the local hold off the list we're keeping so that
             # we don't delete it later.
-            key = (hold.identifier_type, hold.identifier)
             if key in local_holds_by_identifier:
                 del local_holds_by_identifier[key]
 


### PR DESCRIPTION
Part of https://github.com/NYPL-Simplified/circulation/issues/638 turned out to be a lot easier than I thought, so I implemented the fix. When a patron loads their loans feed, this saves one database request per loan or hold.

While I'm at it, I handled the (unusual) case where the source of truth modifies the term of a loan during the loan.