### PR TITLE
Update licenses owned and licenses available

### DIFF
--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -342,10 +342,14 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
         licenses_available = 999
         if not availability:
             licenses_available = 0
-
-        circulation_data = CirculationData(data_source=DataSource.ONECLICK, 
+        licenses_owned = licenses_available
+        
+        circulation_data = CirculationData(
+            data_source=DataSource.ONECLICK, 
             primary_identifier=license_pool.identifier, 
-            licenses_available=licenses_available)
+            licenses_owned=licenses_owned,
+            licenses_available=licenses_available
+        )
 
         license_pool, circulation_changed = circulation_data.apply(
             self._db,

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -406,8 +406,8 @@ class TestOneClickAPI(OneClickAPITest):
         # We have never checked the circulation information for this
         # LicensePool. Put some random junk in the pool to verify
         # that it gets changed.
-        pool.licenses_owned = 10
-        pool.licenses_available = 5
+        pool.licenses_owned = 5
+        pool.licenses_available = 3
         pool.patrons_in_hold_queue = 3
         eq_(None, pool.last_checked)
 
@@ -421,14 +421,15 @@ class TestOneClickAPI(OneClickAPITest):
 
         # The availability information has been updated, as has the
         # date the availability information was last checked.
-        eq_(10, pool.licenses_owned)
+        eq_(0, pool.licenses_owned)
         eq_(0, pool.licenses_available)
         eq_(3, pool.patrons_in_hold_queue)
         assert pool.last_checked is not None
 
         self.api.update_licensepool_for_identifier(isbn, True)
+        eq_(999, pool.licenses_owned)
         eq_(999, pool.licenses_available)
-
+        eq_(3, pool.patrons_in_hold_queue)
 
 
 class TestCirculationMonitor(OneClickAPITest):


### PR DESCRIPTION
This branch fixes a bug that stopped OneClick books from being available. `licenses_available` was being updated but `licenses_owned` was always staying at zero.

Maybe we should also put some stuff in core that freaks out if `licenses_available` is set to a value higher than `licenses_owned`, but this fixes the problem for OneClick.