### PR TITLE
Oneclick fixes

### DIFF
--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -843,6 +843,8 @@ class OneClickCirculationMonitor(CollectionMonitor):
     DEFAULT_START_TIME = datetime.datetime(1970, 1, 1)
     INTERVAL_SECONDS = 1200
     DEFAULT_BATCH_SIZE = 50
+
+    PROTOCOL = ExternalIntegration.ONE_CLICK
     
     def __init__(self, _db, collection, batch_size=None, api_class=OneClickAPI,
                  api_class_kwargs={}):

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -290,7 +290,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
 
         resp_dict = self.circulate_item(patron_id=patron_oneclick_id, item_id=item_oneclick_id, hold=True, return_item=True)
 
-        if resp_dict == {}:
+        if resp_dict.get('message') == 'success':
             self.log.debug("Patron %s/%s released hold %s.", patron.authorization_identifier, 
                 patron_oneclick_id, item_oneclick_id)
             return True

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -102,7 +102,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
 
         resp_dict = self.circulate_item(patron_id=patron_oneclick_id, item_id=item_oneclick_id, return_item=True)
 
-        if resp_dict == {}:
+        if resp_dict.get('message') == 'success':
             self.log.debug("Patron %s/%s returned item %s.", patron.authorization_identifier, 
                 patron_oneclick_id, item_oneclick_id)
             return True
@@ -185,7 +185,6 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
         message = None
         try:
             response = self.request(url=url, method=method)
-
             if response.text:
                 resp_obj = response.json()
 
@@ -788,6 +787,8 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
                 elif message == "Checkout item already exists":
                     # we tried to borrow something the patron already has
                     raise AlreadyCheckedOut(action + ": " + message)
+                elif message == "Title is not available for checkout":
+                    raise NoAvailableCopies(message)
                 else:
                     raise CannotLoan(action + ": " + message)
 
@@ -797,16 +798,19 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
                     raise NotCheckedOut(action + ": " + message)
                 else:
                     raise CannotReturn(action + ": " + message)
-
+                
             if response.status_code == 404:
                 raise NotFoundOnRemote(action + ": " + message)
 
             if response.status_code == 400:
                 raise InvalidInputException(action + ": " + message)
-
+            
         elif message:
-            # http code was OK, but info wasn't sucessfully read from db
-            if message.startswith("eXtensible Framework was unable to locate the resource for RB.API.OneClick.UserPatron.Get"):
+            if message == 'success':
+                # There is no additional information to be had.
+                return
+            elif message.startswith("eXtensible Framework was unable to locate the resource for RB.API.OneClick.UserPatron.Get"):
+                # http code was OK, but info wasn't sucessfully read from db
                 raise PatronNotFoundOnRemote(action + ": " + message)
             else:
                 self.log.warning("%s not retrieved: %s ", action, message)

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -788,6 +788,10 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
                     # we tried to borrow something the patron already has
                     raise AlreadyCheckedOut(action + ": " + message)
                 elif message == "Title is not available for checkout":
+                    # This will put the book on hold, and if it ever
+                    # shows up again it'll be checked out
+                    # automatically. If it doesn't show up again...
+                    # best not to think about that.
                     raise NoAvailableCopies(message)
                 else:
                     raise CannotLoan(action + ": " + message)

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -21,6 +21,7 @@ from core.model import (
     DataSource,
     DeliveryMechanism,
     Edition,
+    ExternalIntegration,
     Identifier,
     LicensePool,
     Patron,
@@ -558,6 +559,7 @@ class TestCirculationMonitor(OneClickAPITest):
             self._db, self.collection, api_class=MockOneClickAPI, 
             api_class_kwargs=dict(base_path=self.base_path)
         )
+        eq_(ExternalIntegration.ONE_CLICK, monitor.protocol)
 
         # Create a LicensePool that needs updating.
         edition_ebook, pool_ebook = self._edition(

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -148,7 +148,7 @@ class TestOneClickAPI(OneClickAPITest):
         datastr, datadict = self.api.get_data("response_checkout_unavailable.json")
         self.api.queue_response(status_code=409, content=datastr)
         assert_raises_regexp(
-            CannotLoan, "checkout:", 
+            NoAvailableCopies, "Title is not available for checkout", 
             self.api.circulate_item, patron.oneclick_id, edition.primary_identifier.identifier
         )
         request_url, request_args, request_kwargs = self.api.requests[-1]
@@ -219,7 +219,7 @@ class TestOneClickAPI(OneClickAPITest):
         datastr, datadict = self.api.get_data("response_patron_internal_id_found.json")
         self.api.queue_response(status_code=200, content=datastr)
         # queue checkin success
-        self.api.queue_response(status_code=200, content="")
+        self.api.queue_response(status_code=200, content='{"message": "success"}')
 
         success = self.api.checkin(patron, None, pool)
         eq_(True, success)
@@ -473,7 +473,7 @@ class TestOneClickAPI(OneClickAPITest):
         datastr, datadict = self.api.get_data("response_patron_internal_id_found.json")
         self.api.queue_response(status_code=200, content=datastr)
         # queue release success
-        self.api.queue_response(status_code=200, content="")
+        self.api.queue_response(status_code=200, content='{"message": "success"}')
 
         success = self.api.release_hold(patron, None, pool)
         eq_(True, success)


### PR DESCRIPTION
This branch fixes the OneClick branch to bring it into sync with how the API actually works.

* When there are no available copies of a book, we raise NoAvailableCopies instead of CannotLoan. This puts the book on hold automatically. Previously the "no available copies" case was not handled specially.
* When revoking a loan or hold, the API returns `{"message": "success"}`. The code assumes it returns no entity-body, which may have been true earlier.

It might be the case that we should never put a OneClick book on hold, but if things turn out that way, it's an easy change to make.