### PR TITLE
More accurately depict what we know about the current state of a OneClick collection.

### DIFF
--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -338,13 +338,16 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
             analytics=Analytics(self._db),
         )
 
-        # licenses_available can be 0 or 999, depending on whether the book is 
-        # lendable or not.   
-        licenses_available = 999
+        # We don't know exactly how many licenses are available, but
+        # we know that it's either zero (book is not lendable) or greater
+        # than zero (book is lendable)
+        licenses_available = 1
         if not availability:
             licenses_available = 0
-        licenses_owned = licenses_available
 
+        # Because the book showed up in availability, we know we own
+        # at least one license to it.
+        licenses_owned = 1
 
         # If possible, create a FormatData object representing
         # how the book is available.

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -505,8 +505,8 @@ class TestOneClickAPI(OneClickAPITest):
         )
         eq_(True, is_new)
         eq_(True, circulation_changed)
-        eq_(999, pool.licenses_owned)
-        eq_(999, pool.licenses_available)
+        eq_(1, pool.licenses_owned)
+        eq_(1, pool.licenses_available)
         [lpdm] = pool.delivery_mechanisms
         eq_(Representation.EPUB_MEDIA_TYPE, lpdm.delivery_mechanism.content_type)
         eq_(DeliveryMechanism.ADOBE_DRM, lpdm.delivery_mechanism.drm_scheme)
@@ -536,7 +536,10 @@ class TestOneClickAPI(OneClickAPITest):
 
         # The availability information has been updated, as has the
         # date the availability information was last checked.
-        eq_(0, pool.licenses_owned)
+        #
+        # We still own a license, but it's no longer available for
+        # checkout.
+        eq_(1, pool.licenses_owned)
         eq_(0, pool.licenses_available)
         eq_(3, pool.patrons_in_hold_queue)
         assert pool.last_checked is not None
@@ -547,8 +550,8 @@ class TestOneClickAPI(OneClickAPITest):
         eq_(None, lpdm.delivery_mechanism.drm_scheme)
 
         self.api.update_licensepool_for_identifier(isbn, True, 'ebook')
-        eq_(999, pool.licenses_owned)
-        eq_(999, pool.licenses_available)
+        eq_(1, pool.licenses_owned)
+        eq_(1, pool.licenses_available)
         eq_(3, pool.patrons_in_hold_queue)
 
 


### PR DESCRIPTION
This branch changes how we represent OneClick licenses. The old code made it look like a OneClick collection worked on an unlimited-usage model, when it actually works on a simultaneous-use model (it's just that we can't see how many uses are left at any given time).

* If a book is available, licenses_available is set to 1 instead of 999. Using 999 makes it look like an unlimited usage model (like we have with Open Ebooks). Using 1 makes it look like a boolean status, which, as far as we can tell, it is.
* If a book is not available, its licenses_available becomes 0 but its licenses_owned stays at 1. licenses_owned only becomes 0 when the delta scripts discovers the book has been removed from the collection altogether. Treating "not available" as "not in the collection anymore" also reflects the incorrect assumption that we're under an unlimited-usage model.
