### PR TITLE
Add more SIP2 patron statuses that don't remove borrowing privileges

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -74,6 +74,21 @@ class PatronData(object):
     UNKNOWN_BLOCK = 'unknown'
     CARD_REPORTED_LOST = 'card reported lost'
     EXCESSIVE_FINES = 'excessive fines'
+    EXCESSIVE_FEES = 'excessive fees'
+    NO_BORROWING_PRIVILEGES = 'no borrowing privileges'
+    TOO_MANY_LOANS = 'too many active loans'
+    TOO_MANY_RENEWALS = 'too many renewals'
+    TOO_MANY_OVERDUE = 'too many items overdue'
+    TOO_MANY_LOST = 'too many items lost'
+
+    # Patron is being billed for too many items (as opposed to
+    # excessive fines, which means patron's fines have exceeded a
+    # certain amount).
+    TOO_MANY_ITEMS_BILLED = 'too many items billed'
+
+    # Patron was asked to return an item so someone else could borrow it,
+    # but didn't return the item.
+    RECALL_OVERDUE = 'recall overdue'
     
     def __init__(self,
                  permanent_id=None,

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -218,6 +218,20 @@ class SIPClient(Constants):
         RECALL_OVERDUE,
         TOO_MANY_ITEMS_BILLED
     ]
+
+    # Some, but not all, of these fields, imply that a patron has lost
+    # borrowing privileges.
+    PATRON_STATUS_FIELDS_THAT_DENY_BORROWING_PRIVILEGES = [
+        CHARGE_PRIVILEGES_DENIED,
+        CARD_REPORTED_LOST,
+        TOO_MANY_ITEMS_CHARGED,
+        TOO_MANY_ITEMS_OVERDUE,
+        TOO_MANY_LOST,
+        EXCESSIVE_FINES,
+        EXCESSIVE_FEES,
+        RECALL_OVERDUE,
+        TOO_MANY_ITEMS_BILLED
+    ]
     
     def __init__(self, target_server, target_port, login_user_id=None,
                  login_password=None, location_code=None, separator=None,

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -114,7 +114,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         eq_("Booth Expired Test", patrondata.personal_name)
         eq_(0, patrondata.fines)
         eq_(datetime(2008, 9, 7), patrondata.authorization_expires)
-        eq_(PatronData.UNKNOWN_BLOCK, patrondata.block_reason)
+        eq_(PatronData.NO_BORROWING_PRIVILEGES, patrondata.block_reason)
 
         # A patron with excessive fines
         client.queue_response(self.evergreen_excessive_fines)
@@ -125,12 +125,15 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         eq_(100, patrondata.fines)
         eq_(datetime(2019, 10, 04), patrondata.authorization_expires)
 
-        # We happen know that this patron can't borrow books due to
-        # excessive fines, but that information doesn't make it into
-        # block_reason, because Evergreen doesn't also provide the
+        # We happen to know that this patron can't borrow books due to
+        # excessive fines, but that information doesn't show up as a 
+        # block, because Evergreen doesn't also provide the
         # fine limit. This isn't a big deal -- we'll pick it up later
         # when we apply the site policy.
-        eq_(PatronData.UNKNOWN_BLOCK, patrondata.block_reason)
+        #
+        # This patron also has "Recall privileges denied" set, but
+        # that's not a reason to block them.
+        eq_(PatronData.NO_VALUE, patrondata.block_reason)
 
         # "Hold privileges denied" is not a block because you can
         # still borrow books.


### PR DESCRIPTION
This branch adds detailed block statuses corresponding to the reasons why SIP2 might report a patron has no borrowing privileges. This will help people debug weird SIP2 setups.

This branch also makes it so that two more patron statuses ("no recall privileges" and "no renew privileges") don't restrict a patron's borrowing privileges. Previously only "no hold privileges" was treated this way.