### PR TITLE
Make registration work in a real test

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1909,7 +1909,10 @@ class SettingsController(CirculationManagerController):
             # OPDS Authentication document.
             self._db.commit()
 
-            library_url = self.url_for("index", library_short_name=library.short_name)
+            library_url = self.url_for(
+                "authentication_document", 
+                library_short_name=library.short_name
+            )
             response = do_post(
                 register_url, dict(url=library_url), 
                 allowed_response_codes=["2xx"], timeout=60

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1050,9 +1050,10 @@ class SettingsController(CirculationManagerController):
         if short_name:
             library.short_name = short_name
 
+        NO_VALUE = object()
         for setting in Configuration.LIBRARY_SETTINGS:
             # Start off by assuming the value is not set.
-            value = ""
+            value = NO_VALUE
             if setting.get("type") == "list":
                 if setting.get('options'):
                     # Restrict to the values in 'options'.
@@ -1089,7 +1090,8 @@ class SettingsController(CirculationManagerController):
                     value = "data:image/png;base64,%s" % b64
             else:
                 value = flask.request.form.get(setting['key'], None)
-            ConfigurationSetting.for_library(setting['key'], library).value = value
+            if value != NO_VALUE:
+                ConfigurationSetting.for_library(setting['key'], library).value = value
 
         if is_new:
             return Response(unicode(_("Success")), 201)

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1051,6 +1051,8 @@ class SettingsController(CirculationManagerController):
             library.short_name = short_name
 
         for setting in Configuration.LIBRARY_SETTINGS:
+            # Start off by assuming the value is not set.
+            value = ""
             if setting.get("type") == "list":
                 if setting.get('options'):
                     # Restrict to the values in 'options'.
@@ -1908,7 +1910,10 @@ class SettingsController(CirculationManagerController):
             self._db.commit()
 
             library_url = self.url_for("index", library_short_name=library.short_name)
-            response = do_post(register_url, dict(url=library_url), allowed_response_codes=["2xx"])
+            response = do_post(
+                register_url, dict(url=library_url), 
+                allowed_response_codes=["2xx"], timeout=60
+            )
             catalog = json.loads(response.content)
 
             # Since we generated a public key, the catalog should have the short name

--- a/api/app.py
+++ b/api/app.py
@@ -68,6 +68,6 @@ def run(url=None):
         socket.setdefaulttimeout(None)
 
     logging.info("Starting app on %s:%s", host, port)
-    app.run(debug=debug, host=host, port=port)
+    app.run(debug=debug, host=host, port=port, threaded=True)
 
 

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -668,6 +668,15 @@ class LibraryAuthenticator(object):
         token = decoded['token']
         return (provider_name, token)
 
+    def authentication_document_url(self, library):
+        """Return the URL of the authentication document for the
+        given library.
+        """
+        return url_for(
+            "authentication_document", library_short_name=library.short_name,
+            _external=True
+        )
+
     def create_authentication_document(self):
         """Create the Authentication For OPDS document to be used when
         a request comes in with no authentication.
@@ -710,10 +719,7 @@ class LibraryAuthenticator(object):
             links.append(dict(rel="logo", type="image/png", href=logo))
                 
         library_name = self.library_name or unicode(_("Library"))
-        auth_doc_url = url_for(
-            "authentication_document", library_short_name=library.short_name,
-            _external=True
-        )
+        auth_doc_url = self.authentication_document_url(library)
         doc = AuthenticationForOPDSDocument(
             id=auth_doc_url, title=library_name,
             authentication_flows=list(self.providers),
@@ -754,8 +760,13 @@ class LibraryAuthenticator(object):
     def create_authentication_headers(self):
         """Create the HTTP headers to return with the OPDS
         authentication document."""
+        library = Library.by_id(self._db, self.library_id)
         headers = Headers()
         headers.add('Content-Type', AuthenticationForOPDSDocument.MEDIA_TYPE)
+        headers.add('Link', "<%s>; rel=%s" % (
+            self.authentication_document_url(library),
+            AuthenticationForOPDSDocument.LINK_RELATION
+        ))
         # if requested from a web client, don't include WWW-Authenticate header,
         # which forces the default browser authentication prompt
         if self.basic_auth_provider and not flask.request.headers.get("X-Requested-With") == "XMLHttpRequest":

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -3,6 +3,7 @@ from config import (
     Configuration,
     CannotLoadConfiguration,
 )
+from core.opds import OPDSFeed
 from core.model import (
     get_one,
     get_one_or_create,
@@ -698,6 +699,14 @@ class LibraryAuthenticator(object):
                 # assume anything about other URL schemes.
                 link['type'] = "text/html"
             links.append(link)
+
+        # Add a rel="start" link pointing to the root OPDS feed.
+        index_url = url_for("index", _external=True,
+                            library_short_name=library.short_name)
+        links.append(
+            dict(rel="start", href=index_url, 
+                 type=OPDSFeed.ACQUISITION_FEED_TYPE)
+        )
                 
         # Add a rel="help" link for every type of URL scheme that
         # leads to library-specific help.

--- a/api/opds.py
+++ b/api/opds.py
@@ -443,7 +443,12 @@ class CirculationManagerAnnotator(Annotator):
 
     def annotate_feed(self, feed, lane):
         if self.patron:
+            # A patron is authenticated.
             self.add_patron(feed)
+        else:
+            # No patron is authenticated. Show them how to
+            # authenticate.
+            self.add_authentication_document_link(feed)
         
         # Add a 'search' link.
         lane_name, languages = self._lane_name_and_languages(lane)
@@ -842,6 +847,20 @@ class CirculationManagerAnnotator(Annotator):
 
         patron_tag = OPDSFeed.makeelement("{%s}patron" % OPDSFeed.SIMPLIFIED_NS, patron_details)
         feed_obj.feed.append(patron_tag)
+
+    def add_authentication_document_link(self, feed_obj):
+        """Create a <link> tag that points to the circulation
+        manager's Authentication for OPDS document
+        for the current library.
+        """
+        feed_obj.add_link_to_feed(
+            feed_obj.feed,
+            rel='http://opds-spec.org/auth/document',
+            href=self.url_for(
+                'authentication_document', 
+                library_short_name=self.library.short_name, _external=True
+            )
+        )
 
 
 class CirculationManagerLoanAndHoldAnnotator(CirculationManagerAnnotator):

--- a/api/routes.py
+++ b/api/routes.py
@@ -190,9 +190,7 @@ def index():
 @has_library
 @returns_problem_detail
 def authentication_document():
-    return app.manager.index_controller.authentication_document(
-        app.manager._db
-    )
+    return app.manager.index_controller.authentication_document()
 
 @library_dir_route('/groups', defaults=dict(lane_name=None, languages=None))
 @library_dir_route('/groups/<languages>', defaults=dict(lane_name=None))

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1406,6 +1406,9 @@ class TestSettingsController(AdminControllerTest):
         ConfigurationSetting.for_library(
             Configuration.ENABLED_FACETS_KEY_PREFIX + FacetConstants.ORDER_FACET_GROUP_NAME, library
         ).value = json.dumps([FacetConstants.ORDER_TITLE, FacetConstants.ORDER_RANDOM])
+        ConfigurationSetting.for_library(
+            Configuration.LOGO, library
+        ).value = "A tiny image"
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
@@ -1442,6 +1445,10 @@ class TestSettingsController(AdminControllerTest):
                 Configuration.ENABLED_FACETS_KEY_PREFIX + FacetConstants.ORDER_FACET_GROUP_NAME,
                 library).value)
 
+        # A library-wide setting that was not updated has been left alone.
+        eq_("A tiny image", 
+            ConfigurationSetting.for_library(Configuration.LOGO, library).value
+        )
         
     def test_collections_get_with_no_collections(self):
         # Delete any existing collections created by the test setup.

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1445,7 +1445,7 @@ class TestSettingsController(AdminControllerTest):
                 Configuration.ENABLED_FACETS_KEY_PREFIX + FacetConstants.ORDER_FACET_GROUP_NAME,
                 library).value)
 
-        # A library-wide setting that was not updated has been left alone.
+        # The library-wide logo was not updated and has been left alone.
         eq_("A tiny image", 
             ConfigurationSetting.for_library(Configuration.LOGO, library).value
         )

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -977,6 +977,11 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         base_url.value = u'http://circulation-manager/'
        
         with self.app.test_request_context("/"):
+            url = authenticator.authentication_document_url(library)
+            assert url.endswith(
+                "/%s/authentication_document" % library.short_name
+            )
+
             doc = json.loads(authenticator.create_authentication_document())
             # The main thing we need to test is that the
             # sub-documents are assembled properly and placed in the
@@ -990,11 +995,11 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             expect_oauth = oauth.authentication_flow_document(self._db)
             eq_(expect_oauth, oauth_doc)
 
-            # We also need to test that the library's name and UUID
+            # We also need to test that the library's name and ID
             # were placed in the document.
             eq_("A Fabulous Library", doc['title'])
             eq_("Just the best.", doc['service_description'])
-            eq_(url_for("authentication_document", library_short_name=self._default_library.short_name, _external=True), doc['id'])
+            eq_(url, doc['id'])
 
             # The color scheme is correctly reported.
             eq_("plaid", doc['color_scheme'])

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1056,6 +1056,15 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             eq_(AuthenticationForOPDSDocument.MEDIA_TYPE, headers['Content-Type'])
             eq_(basic.authentication_header, headers['WWW-Authenticate'])
 
+            # The response contains a Link header pointing to the authentication
+            # document
+            expect = "<%s>; rel=%s" % (
+                authenticator.authentication_document_url(self._default_library),
+                AuthenticationForOPDSDocument.LINK_RELATION
+            )
+            eq_(expect, headers['Link'])
+
+
             # If the authenticator does not include a basic auth provider,
             # no WWW-Authenticate header is provided.
             authenticator = LibraryAuthenticator(

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -19,6 +19,7 @@ import urlparse
 import flask
 from flask import url_for
 
+from core.opds import OPDSFeed
 from core.model import (
     CirculationEvent,
     ConfigurationSetting,
@@ -1001,7 +1002,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             # We also need to test that the links got pulled in
             # from the configuration.
             (about, alternate, copyright, help_uri, help_web, help_email,
-             license, logo, privacy_policy, register, terms_of_service) = sorted(
+             license, logo, privacy_policy, register, start, terms_of_service) = sorted(
                  doc['links'], key=lambda x: (x['rel'], x['href'])
              )
             eq_("http://terms", terms_of_service['href'])
@@ -1010,8 +1011,16 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             eq_("http://about", about['href'])
             eq_("http://license/", license['href'])
             eq_("image data", logo['href'])
+            expect_start = url_for(
+                "index", library_short_name=self._default_library.short_name, 
+                _external=True
+            )
+            eq_(expect_start, start['href'])
 
-            # Most of the links have type='text/html'
+            # The start link points to an OPDS feed.
+            eq_(OPDSFeed.ACQUISITION_FEED_TYPE, start['type'])
+
+            # Most of the other links have type='text/html'
             eq_("text/html", about['type'])
 
             # The registration link doesn't have a type, because it

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -601,7 +601,8 @@ class TestSyncBookshelf(OverdriveAPITest):
             data_source_name=DataSource.OVERDRIVE,
             with_license_pool=True, collection=self.collection
         )
-        overdrive_loan, new = overdrive_edition.license_pools[0].loan_to(patron)
+        [pool] = overdrive_edition.license_pools
+        overdrive_loan, new = pool.loan_to(patron)
         yesterday = datetime.utcnow() - timedelta(days=1)
         overdrive_loan.start = yesterday
 
@@ -617,7 +618,8 @@ class TestSyncBookshelf(OverdriveAPITest):
         patron = self._patron()
         gutenberg, new = self._edition(data_source_name=DataSource.GUTENBERG,
                                        with_license_pool=True)
-        gutenberg_loan, new = gutenberg.license_pools[0].loan_to(patron)
+        [pool] = gutenberg.license_pools
+        gutenberg_loan, new = pool.loan_to(patron)
         loans_data, json_loans = self.sample_json("shelf_with_some_checked_out_books.json")
         holds_data, json_holds = self.sample_json("no_holds.json")     
    
@@ -661,9 +663,8 @@ class TestSyncBookshelf(OverdriveAPITest):
             with_license_pool=True,
             collection=self.collection
         )
-        overdrive_hold, new = overdrive_edition.license_pools[0].on_hold_to(
-            patron
-        )
+        [pool] = overdrive_edition.license_pools
+        overdrive_hold, new = pool.on_hold_to(patron)
 
 
         self.api.queue_response(200, content=loans_data)
@@ -689,7 +690,8 @@ class TestSyncBookshelf(OverdriveAPITest):
             with_license_pool=True,
             collection=self._collection()
         )
-        overdrive_hold, new = overdrive.license_pools[0].on_hold_to(patron)
+        [pool] = overdrive.license_pools
+        overdrive_hold, new = pool.on_hold_to(patron)
    
         self.api.queue_response(200, content=loans_data)
         self.api.queue_response(200, content=holds_data)


### PR DESCRIPTION
This branch makes the changes necessary to make a circulation manager able to register itself with the library registry in a real test.

The `Link` header is not used by the library registry, but I'll start picking it up in my follow-up branch that verifies the two-way connection between the Authentication For OPDS document and the OPDS document at the other end of its `start` link.