### PR TITLE
Fix Monitors to run properly when invoked as scripts

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -325,6 +325,7 @@ class AxisCollectionReaper(IdentifierSweepMonitor):
     """
     SERVICE_NAME = "Axis Collection Reaper"
     INTERVAL_SECONDS = 3600*12
+    PROTOCOL = ExternalIntegration.AXIS_360
     
     def __init__(self, _db, collection, api_class=Axis360API):
         super(AxisCollectionReaper, self).__init__(_db, collection)

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -626,8 +626,9 @@ class BibliothecaCirculationSweep(IdentifierSweepMonitor):
     """
     SERVICE_NAME = "Bibliotheca Circulation Sweep"
     DEFAULT_BATCH_SIZE = 25
+    PROTOCOL = ExternalIntegration.BIBLIOTHECA
 
-    def __init__(self, collection, api_class=BibliothecaAPI, **kwargs):
+    def __init__(self, _db, collection, api_class=BibliothecaAPI, **kwargs):
         _db = Session.object_session(collection)
         super(BibliothecaCirculationSweep, self).__init__(
             _db, collection, **kwargs
@@ -737,13 +738,18 @@ class BibliothecaEventMonitor(CollectionMonitor):
 
     SERVICE_NAME = "Bibliotheca Event Monitor"
     DEFAULT_START_TIME = datetime.timedelta(365*3)
-    
-    def __init__(self, _db, collection, api_class=BibliothecaAPI):
+    PROTOCOL = ExternalIntegration.BIBLIOTHECA
+
+    def __init__(self, _db, collection, api_class=BibliothecaAPI, cli_date=None):
         super(BibliothecaEventMonitor, self).__init__(_db, collection)
         self.api = api_class(_db, collection)
         self.bibliographic_coverage_provider = BibliothecaBibliographicCoverageProvider(
             collection, self.api
         )
+        if cli_date:
+            self.default_start_time = self.create_default_start_time(
+                _db,  cli_date
+            )
 
     def create_default_start_time(self, _db, cli_date):
         """Sets the default start time if it's passed as an argument.
@@ -755,7 +761,10 @@ class BibliothecaEventMonitor(CollectionMonitor):
 
         if cli_date:
             try:
-                date = cli_date[0]
+                if isinstance(cli_date, basestring):
+                    date = cli_date
+                else:
+                    date = cli_date[0]
                 return datetime.datetime.strptime(date, "%Y-%m-%d")
             except ValueError as e:
                 # Date argument wasn't in the proper format.

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -118,7 +118,7 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
     def update_availability(self, licensepool):
         """Update the availability information for a single LicensePool."""
         monitor = BibliothecaCirculationSweep(
-            licensepool.collection, api_class=self
+            self._db, licensepool.collection, api_class=self
         )
         return monitor.process_batch([licensepool.identifier])
 

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -656,6 +656,9 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
 
         metadata = OverdriveRepresentationExtractor.book_info_to_metadata(
             info, include_bibliographic=False, include_formats=True)
+        if not metadata:
+            # No work to be done.
+            return
         circulation_data = metadata.circulation
 
         # The identifier in the CirculationData needs to match the
@@ -943,14 +946,15 @@ class OverdriveFormatSweep(IdentifierSweepMonitor):
     DEFAULT_BATCH_SIZE = 25
     PROTOCOL = ExternalIntegration.OVERDRIVE
 
-    def __init__(self, collection, api_class=OverdriveAPI):
-        _db = Session.object_session(collection)
-        api = api_class(_db, collection)
+    def __init__(self, _db, collection, api_class=OverdriveAPI):
         super(OverdriveFormatSweep, self).__init__(_db, collection)
+        self.api = api_class(_db, collection)
 
-    def process_identifier(self, identifier):
-        pool = identifier.licensed_through
-        self.api.update_formats(pool)
+    def process_item(self, identifier):
+        pools = identifier.licensed_through
+        for pool in pools:
+            self.api.update_formats(pool)
+
         
 class OverdriveAdvantageAccountListScript(Script):
 

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -917,6 +917,7 @@ class OverdriveCollectionReaper(IdentifierSweepMonitor):
     """
     SERVICE_NAME = "Overdrive Collection Reaper"
     INTERVAL_SECONDS = 3600*4
+    PROTOCOL = ExternalIntegration.OVERDRIVE
     
     def __init__(self, _db, collection, api_class=OverdriveAPI):
         super(OverdriveCollectionReaper, self).__init__(_db, collection)
@@ -940,6 +941,7 @@ class OverdriveFormatSweep(IdentifierSweepMonitor):
     """
     SERVICE_NAME = "Overdrive Format Sweep"
     DEFAULT_BATCH_SIZE = 25
+    PROTOCOL = ExternalIntegration.OVERDRIVE
 
     def __init__(self, collection, api_class=OverdriveAPI):
         _db = Session.object_session(collection)

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -248,7 +248,7 @@ class TestBibliothecaCirculationSweep(BibliothecaAPITest):
         # Update availability using that data.
         self.api.queue_response(200, content=data)
         monitor = BibliothecaCirculationSweep(
-            self.collection, api_class=self.api
+            self._db, self.collection, api_class=self.api
         )
         monitor.process_batch([identifier])
         

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -618,13 +618,29 @@ class TestBibliothecaEventMonitor(BibliothecaAPITest):
         )
         expected = datetime.datetime.utcnow() - monitor.DEFAULT_START_TIME
 
-        # Returns a date long in the past if the monitor has never
-        # been run before.
+        # When the monitor has never been run before, the default
+        # start time is a date long in the past.
+        assert abs((expected-monitor.default_start_time).total_seconds()) <= 1
         default_start_time = monitor.create_default_start_time(self._db, [])
         assert abs((expected-default_start_time).total_seconds()) <= 1
 
-        # After Bibliotheca has been initialized, it returns None if no
-        # arguments are passed
+        # It's possible to override this by instantiating
+        # BibliothecaEventMonitor with a specific date.
+        monitor = BibliothecaEventMonitor(
+            self._db, self.collection, api_class=MockBibliothecaAPI,
+            cli_date="2011-01-01"
+        )
+        expected = datetime.datetime(year=2011, month=1, day=1)
+        eq_(expected, monitor.default_start_time)
+        for cli_date in ('2011-01-01', ['2011-01-01']):
+            default_start_time = monitor.create_default_start_time(
+                self._db, cli_date
+            )
+            eq_(expected, default_start_time)
+
+        # After Bibliotheca has been initialized,
+        # create_default_start_time returns None, rather than a date
+        # far in the bast, if no cli_date is passed in.
         Timestamp.stamp(self._db, monitor.service_name, self.collection)
         eq_(None, monitor.create_default_start_time(self._db, []))
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -12,6 +12,7 @@ from datetime import (
 from api.overdrive import (
     MockOverdriveAPI,
     OverdriveCollectionReaper,
+    OverdriveFormatSweep,
 )
 
 from api.circulation import (
@@ -701,6 +702,22 @@ class TestSyncBookshelf(OverdriveAPITest):
         loans, holds = self.circulation.sync_bookshelf(patron, "dummy pin")
         eq_(5, len(patron.holds))
         assert overdrive_hold in patron.holds
+
+class TestOverdriveFormatSweep(OverdriveAPITest):
+
+    def test_process_item(self):
+        # Validate the standard CollectionMonitor interface.
+        monitor = OverdriveFormatSweep(
+            self._db, self.collection,
+            api_class=MockOverdriveAPI
+        )
+
+        # We're not testing that the work actually gets done (that's
+        # tested in test_update_formats), only that the monitor
+        # implements the expected process_item API without crashing.
+        monitor.api.queue_response(404)
+        edition, pool = self._edition(with_license_pool=True)
+        monitor.process_item(pool.identifier)
 
 
 class TestReaper(OverdriveAPITest):


### PR DESCRIPTION
This branch makes a number of changes to Monitors that are invoked as scripts. The main one is adding a PROTOCOL constant to a number of Monitors. Without this constant, running a Monitor as a script will run it against every collection, whether or not it uses the right protocol. I don't believe this is a fatal error, but it adds frightening error messages to the logs.

This branch also fixes two fatal errors. First, the `cli_date` command-line argument was removed from the `BibliothecaEventMonitor`, but the script still gathered it and sent it in. I added what I think is appropriate handling for that argument, and tested a code branch that passes `cli_date` into the `BibliothecaEventMonitor` constructor, so that a test will fail if it's even removed again.

Second, the `OverdriveFormatSweep` was never ported to the new Monitor system, and had a number of API incompatibilities which I fixed and added tests for.