### PR TITLE
Use superclass annotator

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -255,6 +255,9 @@ class CirculationManagerAnnotator(Annotator):
         return url
 
     def annotate_work_entry(self, work, active_license_pool, edition, identifier, feed, entry):
+        Annotator.annotate_work_entry(
+            work, active_license_pool, edition, identifier, feed, entry
+        )
         active_loan = self.active_loans_by_work.get(work)
         active_hold = self.active_holds_by_work.get(work)
         active_fulfillment = self.active_fulfillments_by_work.get(work)


### PR DESCRIPTION
This branch brings circulation up to date with https://github.com/NYPL-Simplified/server_core/pull/634. Previously `Annotation.annotate_work_entry` was a no-op so it didn't matter that the subclass didn't call it, but now it matters.