### PR TITLE
Fix several errors exposed by using an Authenticator instead of a LibraryAuthenticator as the OAuthController's .auth

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -370,13 +370,13 @@ class Authenticator(object):
     def __init__(self, _db, analytics=None):
         self.library_authenticators = {}
 
-        self.populate_authenticators()
+        self.populate_authenticators(_db, analytics)
 
     @property
     def current_library_short_name(self):
         return flask.request.library.short_name
 
-    def populate_authenticators(self):
+    def populate_authenticators(self, _db, analytics):
         for library in _db.query(Library):
             self.library_authenticators[library.short_name] = LibraryAuthenticator.from_config(_db, library, analytics)
 

--- a/migration/20170713-13-move-authentication-configuration-to-external-integrations.py
+++ b/migration/20170713-13-move-authentication-configuration-to-external-integrations.py
@@ -103,7 +103,7 @@ def convert_clever(_db, integration, provider):
     if expiration_days:
         integration.setting(OAuthAuthenticationProvider.TOKEN_EXPIRATION_DAYS
         ).value = expiration_days
-    
+
 Configuration.load()
 if not Configuration.instance:
     # No need to import configuration if there isn't any.

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -389,7 +389,7 @@ class MockAuthenticator(Authenticator):
         self.current_library_name = current_library.short_name
         self.library_authenticators = authenticators
 
-    def populate_authenticators(self):
+    def populate_authenticators(self, *args, **kwargs):
         """Do nothing -- authenticators were set in the constructor."""
 
     @property
@@ -1989,9 +1989,10 @@ class TestOAuthController(AuthenticatorTest):
             oauth_providers=[self.oauth1, self.oauth2],
             bearer_token_signing_secret="a secret"
         )
-        self._db.commit()
+
         self.auth = MockAuthenticator(
-            self._default_library, { 
+            self._default_library, 
+            { 
                 self._default_library.short_name : self.library_auth
             }
         )


### PR DESCRIPTION
In real usage, `OAuthController.auth` is an `Authenticator` object and the methods called on it (e.g. `create_bearer_token` are supposed to be delegated corresponding `LibraryAuthenticator` object. Three of these methods were defined on `LibraryAuthenticator` but the delegate methods on `Authenticator` were not implemented. Tests didn't catch this because our test code populated `OAuthController.auth` with a `LibraryAuthenticator` object, not an `Authenticator`.

This branch adds the missing delegate methods. It introduces a `MockAuthenticator` which makes it easy to test `Authenticator` code outside of a request context, and changes the `OAuthController` tests to use that instead of a `LibraryAuthenticator`. This will catch any future errors of this type.