### PR TITLE
Adobe vendor id controller takes scoped session

### DIFF
--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -35,11 +35,11 @@ class AdobeVendorIDController(object):
     """Flask controllers that implement the Account Service and
     Authorization Service portions of the Adobe Vendor ID protocol.
     """
-    def __init__(self, library, vendor_id, node_value, authenticator):
+    def __init__(self, _db, library, vendor_id, node_value, authenticator):
         self.library = library
-        self._db = Session.object_session(library)
+        self._db = _db
         self.request_handler = AdobeVendorIDRequestHandler(vendor_id)
-        self.model = AdobeVendorIDModel(library, authenticator, node_value)
+        self.model = AdobeVendorIDModel(_db, library, authenticator, node_value)
 
     def create_authdata_handler(self, patron):
         """Create an authdata token for the given patron.
@@ -332,10 +332,10 @@ class AdobeVendorIDModel(object):
     AUTHDATA_TOKEN_TYPE = "Authdata for Adobe Vendor ID"
     VENDOR_ID_UUID_TOKEN_TYPE = "Vendor ID UUID"
 
-    def __init__(self, library, authenticator, node_value,
+    def __init__(self, _db, library, authenticator, node_value,
                  temporary_token_duration=None):
         self.library = library
-        self._db = Session.object_session(library)
+        self._db = _db
         self.authenticator = authenticator
         self.temporary_token_duration = (
             temporary_token_duration or datetime.timedelta(minutes=10))

--- a/api/controller.py
+++ b/api/controller.py
@@ -331,6 +331,7 @@ class CirculationManager(object):
                         "Multiple libraries define an Adobe Vendor ID integration. This is not supported and the last library seen will take precedence."
                     )
                 self.adobe_vendor_id = AdobeVendorIDController(
+                    _db,
                     library,
                     vendor_id,
                     node_value,


### PR DESCRIPTION
This branch fixes a dreaded "object is already attached to session" error by stopping AdobeVendorIDController from storing a database session associated with a specific object (a Library). Instead, the scoped database session must be passed in as a separate argument.

`AdobeVendorIDController` currently has no test coverage, so I added a small test of one of its methods with also tests the new constructor.