### PR TITLE
setup_adobe_vendor_id needs to be given a scoped session or the objects it creates will be given a bad session.

### DIFF
--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -36,8 +36,8 @@ class AdobeVendorIDController(object):
     Authorization Service portions of the Adobe Vendor ID protocol.
     """
     def __init__(self, _db, library, vendor_id, node_value, authenticator):
-        self.library = library
         self._db = _db
+        self.library = library
         self.request_handler = AdobeVendorIDRequestHandler(vendor_id)
         self.model = AdobeVendorIDModel(_db, library, authenticator, node_value)
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -198,7 +198,7 @@ class CirculationManager(object):
             self.circulation_apis[library.id] = self.setup_circulation(
                 library, self.analytics
             )
-            authdata = self.setup_adobe_vendor_id(library)
+            authdata = self.setup_adobe_vendor_id(self._db, library)
             if authdata and not self.adobe_device_management:
                 # There's at least one library on this system that
                 # wants Vendor IDs. This means we need to advertise support
@@ -303,18 +303,16 @@ class CirculationManager(object):
         """
         self.oauth_controller = OAuthController(self.auth)        
         
-    def setup_adobe_vendor_id(self, library):
+    def setup_adobe_vendor_id(self, _db, library):
         """If this Library has an Adobe Vendor ID integration,
         configure the controller for it.
 
         :return: An Authdata object for `library`, if one could be created.
         """
-        _db = Session.object_session(library)
         adobe = ExternalIntegration.lookup(
             _db, ExternalIntegration.ADOBE_VENDOR_ID,
             ExternalIntegration.DRM_GOAL, library=library
         )
-
         warning = (
             'Adobe Vendor ID controller is disabled due to missing or'
             ' incomplete configuration. This is probably nothing to'

--- a/migration/20170713-13-move-authentication-configuration-to-external-integrations.py
+++ b/migration/20170713-13-move-authentication-configuration-to-external-integrations.py
@@ -109,8 +109,8 @@ if not Configuration.instance:
     # No need to import configuration if there isn't any.
     sys.exit()
 
+_db = production_session()
 try:
-    _db = production_session()
     integrations = []
     auth_conf = Configuration.policy('authentication')
     if not auth_conf:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -387,7 +387,7 @@ class TestCirculationManager(CirculationControllerTest):
 
         # Then try to set up the Adobe Vendor ID configuration for
         # that library.
-        self.manager.setup_adobe_vendor_id(self.library)
+        self.manager.setup_adobe_vendor_id(self._db, self.library)
 
         # The exception caused when we tried to load the incomplete
         # configuration was stored here.
@@ -2408,7 +2408,7 @@ class TestDeviceManagementProtocolController(ControllerTest):
 
         # Set up the Adobe configuration for this library and
         # reload the CirculationManager configuration.
-        self.manager.setup_adobe_vendor_id(self.library)
+        self.manager.setup_adobe_vendor_id(self._db, self.library)
         self.manager.load_settings()
 
         # Now the controller is enabled and we can use it in this


### PR DESCRIPTION
My previous branch didn't go far enough. The database session passed into the AdobeVendorIDController was not the scoped session. I had to go up a level to make sure the scoped session was available to pass in in the first place.