### PR TITLE
Fixed CORS decorator to handle config in the db.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -208,6 +208,9 @@ class CirculationManager(object):
             Configuration.policy('lending', {})
         )
 
+        self.patron_web_client_url = ConfigurationSetting.sitewide(
+            self._db, Configuration.PATRON_WEB_CLIENT_URL).value
+
         self.setup_configuration_dependent_controllers()
         self.authentication_for_opds_documents = {}
     


### PR DESCRIPTION
The CORS headers to support the patron web client stopped working when we moved the configuration into the database.

It's no longer possible to look up a ConfigurationSetting when the routes are created, so I couldn't use the cross_origin decorator from flask_cors and had to write my own based on it. 

As a bonus, this means you can edit the patron web client url in the admin interface and changes will take effect without restarting the app.

Unfortunately I don't think there's any way to have an automated test for this.