### PR TITLE
Fix NoveListAPI

### DIFF
--- a/api/novelist.py
+++ b/api/novelist.py
@@ -195,12 +195,12 @@ class NoveListAPI(object):
         scrubbed_url = unicode(self.scrubbed_url(params))
 
         representation = self.cached_representation(scrubbed_url)
-        if representation:
+        if not representation:
             self.log.info("No cached NoveList request available.")
 
             url = self.build_query_url(params)
             self.log.debug("NoveList lookup: %s",  url)
-            representation, from_cache = Representation.cacheable_post(
+            representation, from_cache = Representation.post(
                 self._db, unicode(url), '', max_age=self.MAX_REPRESENTATION_AGE,
                 response_reviewer=self.review_response
             )

--- a/api/novelist.py
+++ b/api/novelist.py
@@ -57,7 +57,7 @@ class NoveListAPI(object):
     # the Representation object needs a unique URL to return the proper data
     # from the database.
     QUERY_ENDPOINT = (
-        "http://novselect.ebscohost.com/Data/ContentByQuery?"
+        "https://novselect.ebscohost.com/Data/ContentByQuery?"
         "ISBN=%(ISBN)s&ClientIdentifier=%(ClientIdentifier)s&version=%(version)s"
     )
     AUTH_PARAMS = "&profile=%(profile)s&password=%(password)s"

--- a/api/novelist.py
+++ b/api/novelist.py
@@ -204,7 +204,7 @@ class NoveListAPI(object):
         if not representation or not representation.is_fresher_than(max_age):
             self.log.info("No cached NoveList request available.")
 
-            url = self._build_query(params)
+            url = self.build_query_url(params)
             self.log.debug("NoveList lookup: %s",  url)
             representation, from_cache = Representation.cacheable_post(
                 self._db, unicode(url), '', max_age=max_age,
@@ -231,7 +231,7 @@ class NoveListAPI(object):
     @classmethod
     def scrubbed_url(cls, params):
         """Removes authentication details from cached Representation.url"""
-        cls._build_query(params, include_auth=False)
+        return cls.build_query_url(params, include_auth=False)
 
     @classmethod
     def _scrub_subtitle(cls, subtitle):
@@ -243,14 +243,16 @@ class NoveListAPI(object):
         return subtitle
 
     @classmethod
-    def _build_query(cls, params, include_auth=True):
+    def build_query_url(cls, params, include_auth=True):
         """Builds a unique and url-encoded query endpoint"""
         url = cls.QUERY_ENDPOINT
         if include_auth:
             url += cls.AUTH_PARAMS
+
+        urlencoded_params = dict()
         for name, value in params.items():
-            params[name] = urllib.quote(value)
-        return url % params
+            urlencoded_params[name] = urllib.quote(value)
+        return url % urlencoded_params
 
     def lookup_info_to_metadata(self, lookup_representation):
         """Transforms a NoveList JSON representation into a Metadata object"""

--- a/api/novelist.py
+++ b/api/novelist.py
@@ -201,7 +201,7 @@ class NoveListAPI(object):
         representation = get_one(
             self._db, Representation, 'interchangeable', url=scrubbed_url
         )
-        if not representation or not representation.is_fresher_than(max_age):
+        if not (representation and representation.is_fresher_than(max_age)):
             self.log.info("No cached NoveList request available.")
 
             url = self.build_query_url(params)

--- a/tests/test_novelist.py
+++ b/tests/test_novelist.py
@@ -195,6 +195,38 @@ class TestNoveListAPI(DatabaseTest):
         result = self.novelist.lookup_info_to_metadata(empty_response)
         eq_(None, result)
 
+    def test_build_query_url(self):
+        params = dict(
+            ClientIdentifier='C I',
+            ISBN='456',
+            version='2.2',
+            profile='username',
+            password='secret'
+        )
+
+        # Authentication information is included in the URL by default
+        full_result = self.novelist.build_query_url(params)
+        auth_details = '&profile=username&password=secret'
+        eq_(True, full_result.endswith(auth_details))
+        assert 'profile=username' in full_result
+        assert 'password=secret' in full_result
+
+        # With a scrub, no authentication information is included.
+        scrubbed_result = self.novelist.build_query_url(params, include_auth=False)
+        eq_(False, scrubbed_result.endswith(auth_details))
+        assert 'profile=username' not in scrubbed_result
+        assert 'password=secret' not in scrubbed_result
+
+        # Other details are urlencoded and available in both versions.
+        for url in (scrubbed_result, full_result):
+            assert 'ClientIdentifier=C%20I' in url
+            assert 'ISBN=456' in url
+            assert 'version=2.2' in url
+
+        # The method to create a scrubbed url returns the same result
+        # as the NoveListAPI.build_query_url
+        eq_(scrubbed_result, self.novelist.scrubbed_url(params))
+
     def test_scrub_subtitle(self):
         """Unnecessary title segments are removed from subtitles"""
 


### PR DESCRIPTION
Some embarrassing bugfixes for NoveListAPI -- this version actually sends the authentication details, helpfully enough.

Because I don't want to hold the authentication details in the database, I try to find a cached version of the recommendations outside of `Representation.get` and scrub the authentication details out of the URL. I also cut the max cache age down to one week.

Fixes #682.