### PR TITLE
If BASE_URL_KEY has no value, set it the first time an admin authenticates.

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -181,6 +181,18 @@ class AdminController(object):
         # when the user closes the browser.
         flask.session.permanent = True
 
+        # If this is the first time an admin has been authenticated,
+        # make sure there is a value set for the sitewide BASE_URL_KEY
+        # setting. If it's not set, set it to the hostname of the
+        # current request. This assumes the first authenticated admin
+        # is accessing the admin interface through the hostname they
+        # want to be used for the site itself.
+        base_url = ConfigurationSetting.sitewide(
+            self._db, Configuration.BASE_URL_KEY
+        )
+        if not base_url.value:
+            base_url.value = urlparse.urljoin(flask.request.url, '/')
+
         return admin
 
     def check_csrf_token(self):


### PR DESCRIPTION
Currently when BASE_URL_KEY is not set, generated URLs use the URL the site was configured with when `app.py` was run. This may not be the outward-facing URL people use to access the site, and in some cases it may be `localhost`, a hostname not accessible to the public. 

This branch makes sure that BASE_URL_KEY is set the first time an admin authenticates with the admin interface. If it's not set at this point, it gets set to the hostname that admin used to access the admin interface. If it is set, authenticating through a different hostname won't change anything. The BASE_URL_KEY can still be changed through the admin interface, of course.