### PR TITLE
Reduce the risk of race conditions in CirculationManager.load_settings

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -173,29 +173,24 @@ class CirculationManager(object):
         self.analytics = Analytics(self._db)
         self.auth = Authenticator(self._db, self.analytics)
 
-        self.__external_search = None
-        self.external_search_initialization_exception = None
+        self.setup_external_search()
         
         # Track the Lane configuration for each library by mapping its
         # short name to the top-level lane.
-        self.top_level_lanes = {}
-
+        new_top_level_lanes = {}
         # Create a CirculationAPI for each library.
-        self.circulation_apis = {}
+        new_circulation_apis = {}
         
-        self.adobe_vendor_id = None
-        self.adobe_device_management = None
-        self.short_client_token_initialization_exceptions = dict()
         for library in self._db.query(Library):
             lanes = make_lanes(self._db, library, self.lane_descriptions)
             
-            self.top_level_lanes[library.id] = (
+            new_top_level_lanes[library.id] = (
                 self.create_top_level_lane(
                     self._db, library, lanes
                 )
             )
 
-            self.circulation_apis[library.id] = self.setup_circulation(
+            new_circulation_apis[library.id] = self.setup_circulation(
                 library, self.analytics
             )
             authdata = self.setup_adobe_vendor_id(self._db, library)
@@ -204,6 +199,8 @@ class CirculationManager(object):
                 # wants Vendor IDs. This means we need to advertise support
                 # for the Device Management Protocol.
                 self.adobe_device_management = DeviceManagementProtocolController(self)
+        self.top_level_lanes = new_top_level_lanes
+        self.circulation_apis = new_circulation_apis
         self.lending_policy = load_lending_policy(
             Configuration.policy('lending', {})
         )
@@ -222,14 +219,18 @@ class CirculationManager(object):
         affects searches, not the rest of the circulation manager.
         """
         if not self.__external_search:
-            try:
-                self.__external_search = self.setup_search()
-                self.external_search_initialization_exception = None
-            except CannotLoadConfiguration, e:
-                self.log.error(
-                    "Exception loading search configuration: %s", e
-                )
-                self.external_search_initialization_exception = e
+            self.setup_external_search()
+        return self.__external_search
+
+    def setup_external_search(self):
+        try:
+            self.__external_search = self.setup_search()
+            self.external_search_initialization_exception = None
+        except CannotLoadConfiguration, e:
+            self.log.error(
+                "Exception loading search configuration: %s", e
+            )
+            self.external_search_initialization_exception = e
         return self.__external_search
 
     def create_top_level_lane(self, _db, library, lanelist):
@@ -312,6 +313,7 @@ class CirculationManager(object):
 
         :return: An Authdata object for `library`, if one could be created.
         """
+        short_client_token_initialization_exceptions = dict()
         adobe = ExternalIntegration.lookup(
             _db, ExternalIntegration.ADOBE_VENDOR_ID,
             ExternalIntegration.DRM_GOAL, library=library
@@ -355,11 +357,12 @@ class CirculationManager(object):
             try:
                 authdata = AuthdataUtility.from_config(library, _db)
             except CannotLoadConfiguration, e:
-                self.short_client_token_initialization_exceptions[library.id] = e
+                short_client_token_initialization_exceptions[library.id] = e
                 self.log.error(
                     "Short Client Token configuration for %s is present but not working. This may be cause for concern. Original error: %s",
                     library.name, e
                 )
+        self.short_client_token_initialization_exceptions = short_client_token_initialization_exceptions
         return authdata
 
     def annotator(self, lane, *args, **kwargs):

--- a/api/controller.py
+++ b/api/controller.py
@@ -181,6 +181,7 @@ class CirculationManager(object):
         # Create a CirculationAPI for each library.
         new_circulation_apis = {}
         
+        new_adobe_device_management = None
         for library in self._db.query(Library):
             lanes = make_lanes(self._db, library, self.lane_descriptions)
             
@@ -194,13 +195,12 @@ class CirculationManager(object):
                 library, self.analytics
             )
             authdata = self.setup_adobe_vendor_id(self._db, library)
-            if authdata:
+            if authdata and not new_adobe_device_management:
                 # There's at least one library on this system that
                 # wants Vendor IDs. This means we need to advertise support
                 # for the Device Management Protocol.
-                self.adobe_device_management = DeviceManagementProtocolController(self)
-            else:
-                self.adobe_device_management = None
+                new_adobe_device_management = DeviceManagementProtocolController(self)
+        self.adobe_device_management = new_adobe_device_management
         self.top_level_lanes = new_top_level_lanes
         self.circulation_apis = new_circulation_apis
         self.lending_policy = load_lending_policy(

--- a/api/controller.py
+++ b/api/controller.py
@@ -194,11 +194,13 @@ class CirculationManager(object):
                 library, self.analytics
             )
             authdata = self.setup_adobe_vendor_id(self._db, library)
-            if authdata and not self.adobe_device_management:
+            if authdata:
                 # There's at least one library on this system that
                 # wants Vendor IDs. This means we need to advertise support
                 # for the Device Management Protocol.
                 self.adobe_device_management = DeviceManagementProtocolController(self)
+            else:
+                self.adobe_device_management = None
         self.top_level_lanes = new_top_level_lanes
         self.circulation_apis = new_circulation_apis
         self.lending_policy = load_lending_policy(

--- a/api/controller.py
+++ b/api/controller.py
@@ -230,6 +230,7 @@ class CirculationManager(object):
             self.log.error(
                 "Exception loading search configuration: %s", e
             )
+            self.__external_search = None
             self.external_search_initialization_exception = e
         return self.__external_search
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -363,11 +363,9 @@ class TestCirculationManager(CirculationControllerTest):
                 raise CannotLoadConfiguration("doomed!")
 
         circulation = BadSearch(self._db, lanes=None, testing=True)
-        eq_(None, circulation.external_search_initialization_exception)
-        search = circulation.external_search
 
         # We didn't get a search object.
-        eq_(None, search)
+        eq_(None, circulation.external_search)
 
         # The reason why is stored here.
         ex = circulation.external_search_initialization_exception


### PR DESCRIPTION
load_settings() had a lot of code that put the CirculationManager into an invalid state and then fixed it. Fixing it sometimes took several seconds, and in those intervening seconds incoming requests would fail. This branch tries to make sure CirculationManager is always in a valid (if not self-consistent) state by calculating the new values first and then assigning them to CirculationManager instance variables.

The only thing that still gets cleared out is `authentication_for_opds_documents`, which was generated on demand to begin with. It's not a problem if an A4OPDS document gets generated twice, since it'll get the same document each time.