### PR TITLE
Make sure the current library (inevitably the default) is set when running AdobeAuth/SignIn.

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -382,7 +382,8 @@ def adobe_vendor_id_get_token():
         )
     return app.manager.adobe_vendor_id.create_authdata_handler(flask.request.patron)
 
-@app.route('/AdobeAuth/SignIn', methods=['POST'])
+@library_route('/AdobeAuth/SignIn', methods=['POST'])
+@has_library
 @returns_problem_detail
 def adobe_vendor_id_signin():
     return app.manager.adobe_vendor_id.signin_handler()


### PR DESCRIPTION
Although the AdobeAuth controllers act independently of any library, sometimes it's useful to have `flask.request.library` set to the default library. `/AdobeAuth/authdata` has `@has_library` set, because its fallback mechanism is to try to authenticate a user against the default library.

This branch brings the same behavior to `/AdobeAuth/SignIn`. Its fallback behavior is to treat a username and password as an attempt to authenticate a user against the default library. This is not expected to work, but right now `SignIn` on an invalid Short Client Token will cause a crash (when the authentication code doesn't work) rather than trying the authentication code, failing, and returning a normal error.