### PR TITLE
Script to add library information to Adobe Vendor ID configuration

### DIFF
--- a/bin/short_client_token_library_configuration
+++ b/bin/short_client_token_library_configuration
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""Set the short name and secret for a library that sends Short Client
+Tokens to this circulation manager's Adobe Vendor ID implementation.
+"""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from api.adobe_vendor_id import ShortClientTokenLibraryConfigurationScript
+
+ShortClientTokenLibraryConfigurationScript().run()


### PR DESCRIPTION
This script gives a simple interface to editing the complex 'other_libraries' configuration on the default library's Adobe Vendor ID configuration. This replaces the previously complicated process of adding libraries to the system through the JSON config.

I'll write tests if you like, but I hope it's not necessary to run this too many times, and it's never run automatically so if it breaks we'll find out the next time we need it.