### PR TITLE
Fixed missing service error when editing an existing admin auth service.

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1405,7 +1405,7 @@ class SettingsController(CirculationManagerController):
         is_new = False
         auth_service = ExternalIntegration.admin_authentication(self._db)
         if auth_service:
-            if id and id != auth_service.id:
+            if id and int(id) != auth_service.id:
                 return MISSING_SERVICE
             if protocol != auth_service.protocol:
                 return CANNOT_CHANGE_PROTOCOL

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.42"
+    "simplified-circulation-web": "0.0.43"
   }
 }

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1895,7 +1895,7 @@ class TestSettingsController(AdminControllerTest):
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
-                ("id", auth_service.id),
+                ("id", str(auth_service.id)),
             ])
             response = self.manager.admin_settings_controller.admin_auth_services()
             eq_(response, CANNOT_CHANGE_PROTOCOL)


### PR DESCRIPTION
This also pulls in https://github.com/NYPL-Simplified/circulation-web/pull/114