### PR TITLE
Track library registration status in a ConfigurationSetting.

### DIFF
--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.43"
+    "simplified-circulation-web": "0.0.44"
   }
 }

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -410,7 +410,7 @@ def sitewide_settings():
         return data
     return flask.jsonify(**data)
 
-@app.route("/admin/library_registrations", methods=['POST'])
+@app.route("/admin/library_registrations", methods=['GET', 'POST'])
 @returns_problem_detail
 @requires_admin
 @requires_csrf_token

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -3197,6 +3197,43 @@ class TestSettingsController(AdminControllerTest):
         eq_(ExternalIntegration.OPDS_REGISTRATION, discovery_service.protocol)
         eq_("new registry url", discovery_service.url)
 
+    def test_library_registrations_get(self):
+        discovery_service, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=ExternalIntegration.OPDS_REGISTRATION,
+            goal=ExternalIntegration.DISCOVERY_GOAL,
+        )
+        succeeded, ignore = create(
+            self._db, Library, name="Library 1", short_name="L1",
+        )
+        ConfigurationSetting.for_library_and_externalintegration(
+            self._db, "library-registration-status", succeeded, discovery_service,
+            ).value = "success"
+        failed, ignore = create(
+            self._db, Library, name="Library 2", short_name="L2",
+        )
+        ConfigurationSetting.for_library_and_externalintegration(
+            self._db, "library-registration-status", failed, discovery_service,
+            ).value = "failure"
+        unregistered, ignore = create(
+            self._db, Library, name="Library 3", short_name="L3",
+        )
+        discovery_service.libraries = [succeeded, failed, unregistered]
+
+        with self.app.test_request_context("/", method="GET"):
+            response = self.manager.admin_settings_controller.library_registrations()
+
+            serviceInfo = response.get("library_registrations")
+            eq_(1, len(serviceInfo))
+            eq_(discovery_service.id, serviceInfo[0].get("id"))
+
+            libraryInfo = serviceInfo[0].get("libraries")
+            expected = [
+                dict(short_name=succeeded.short_name, status="success"),
+                dict(short_name=failed.short_name, status="failure"),
+            ]
+            eq_(expected, libraryInfo)
+
     def test_library_registrations_post_errors(self):
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
@@ -3234,6 +3271,8 @@ class TestSettingsController(AdminControllerTest):
             eq_(REMOTE_INTEGRATION_FAILED.uri, response.uri)
             eq_("The discovery service did not return OPDS.", response.detail)
             eq_([discovery_service.url], self.requests)
+            eq_("failure", ConfigurationSetting.for_library_and_externalintegration(
+                    self._db, "library-registration-status", library, discovery_service).value)
 
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
@@ -3248,6 +3287,8 @@ class TestSettingsController(AdminControllerTest):
             eq_(REMOTE_INTEGRATION_FAILED.uri, response.uri)
             eq_("The discovery service did not provide a register link.", response.detail)
             eq_([discovery_service.url], self.requests[1:])
+            eq_("failure", ConfigurationSetting.for_library_and_externalintegration(
+                    self._db, "library-registration-status", library, discovery_service).value)
 
     def test_library_registrations_post_success(self):
         discovery_service, ignore = create(
@@ -3282,6 +3323,10 @@ class TestSettingsController(AdminControllerTest):
             eq_(None, ConfigurationSetting.for_library_and_externalintegration(
                     self._db, ExternalIntegration.PASSWORD, library, discovery_service).value)
 
+            # The registration status was recorded.
+            eq_("success", ConfigurationSetting.for_library_and_externalintegration(
+                    self._db, "library-registration-status", library, discovery_service).value)
+
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
                 ("integration_id", discovery_service.id),
@@ -3313,6 +3358,10 @@ class TestSettingsController(AdminControllerTest):
                     self._db, ExternalIntegration.USERNAME, library, discovery_service).value)
             eq_("secret", ConfigurationSetting.for_library_and_externalintegration(
                     self._db, ExternalIntegration.PASSWORD, library, discovery_service).value)
+
+            # The registration status is the same.
+            eq_("success", ConfigurationSetting.for_library_and_externalintegration(
+                    self._db, "library-registration-status", library, discovery_service).value)
 
     def test_sitewide_registration_post_errors(self):
         def assert_remote_integration_error(response, message=None):


### PR DESCRIPTION
This branch uses a ConfigurationSetting to track library registration status, and adds an endpoint for retrieving it to show in the admin interface, for #702. I'm not sure this is the best place for it.