### PR TITLE
Use debuggable response handling when integrating with other systems

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -2006,7 +2006,6 @@ class SettingsController(CirculationManagerController):
 
             return dict(library_registrations=services)
 
->>>>>>> master
         if flask.request.method == "POST":
 
             integration_id = flask.request.form.get("integration_id")

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -2052,7 +2052,7 @@ class SettingsController(CirculationManagerController):
             shared_secret = catalog.get("metadata", {}).get("shared_secret")
 
             if short_name and shared_secret:
-                shared_secret = self._descrypt_shared_secret(encryptor, shared_secret)
+                shared_secret = self._decrypt_shared_secret(encryptor, shared_secret)
                 if isinstance(shared_secret, ProblemDetail):
                     return shared_secret
 
@@ -2070,6 +2070,11 @@ class SettingsController(CirculationManagerController):
         return Response(unicode(_("Success")), 200)
 
     def _decrypt_shared_secret(self, encryptor, shared_secret):
+        """Attempt to decrypt an encrypted shared secret.
+
+        :return: The decrypted shared secret, or a ProblemDetail if
+        it could not be decrypted.
+        """
         try:
             shared_secret = encryptor.decrypt(base64.b64decode(shared_secret))
         except ValueError, e:

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -198,6 +198,13 @@ MISSING_PGCRYPTO_EXTENSION = pd(
     detail=_("You tried to store a password for an individual admin, but the database does not have the pgcrypto extension installed."),
 )
 
+SHARED_SECRET_DECRYPTION_ERROR = pd(
+    "http://librarysimplified.org/terms/problem/decryption-error",
+    status_code=502,
+    title=_("Decryption error"),
+    detail=_("Failed to decrypt a shared secret retrieved from another computer.")
+)
+
 MISSING_SERVICE = pd(
     "http://librarysimplified.org/terms/problem/missing-service",
     status_code=404,


### PR DESCRIPTION
This branch changes the SettingsController so that requests to integrate with the metadata wrangler and library registry use the debuggable response handling introduced here: https://github.com/NYPL-Simplified/server_core/pull/665

This makes the error messages ugly, but it's a lot easier to diagnose integration problems.

This branch also returns a ProblemDetail instead of raising an exception when the CM is unable to decrypt the shared secret (which is the actual problem I'm having, for whatever reason).