### PR TITLE
Added setting to control static file cache time for the admin interface.

### DIFF
--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -464,10 +464,16 @@ def admin_base(**kwargs):
 @returns_problem_detail
 def admin_js():
     directory = os.path.join(os.path.abspath(os.path.dirname(__file__)), "node_modules", "simplified-circulation-web", "dist")
-    return flask.send_from_directory(directory, "circulation-web.js")
+    cache_timeout = ConfigurationSetting.sitewide(
+        _db, Configuration.STATIC_FILE_CACHE_TIME
+    ).int_value
+    return flask.send_from_directory(directory, "circulation-web.js", cache_timeout=cache_timeout)
 
 @app.route('/admin/static/circulation-web.css')
 @returns_problem_detail
 def admin_css():
     directory = os.path.join(os.path.abspath(os.path.dirname(__file__)), "node_modules", "simplified-circulation-web", "dist")
-    return flask.send_from_directory(directory, "circulation-web.css")
+    cache_timeout = ConfigurationSetting.sitewide(
+        _db, Configuration.STATIC_FILE_CACHE_TIME
+    ).int_value
+    return flask.send_from_directory(directory, "circulation-web.css", cache_timeout=cache_timeout)

--- a/api/config.py
+++ b/api/config.py
@@ -28,6 +28,9 @@ class Configuration(CoreConfiguration):
     # The name of the sitewide secret used to sign cookies for admin login.
     SECRET_KEY = u"secret_key"
 
+    # The name of the setting that controls how long static files are cached.
+    STATIC_FILE_CACHE_TIME = u"static_file_cache_time"
+
     # A short description of the library, used in its Authentication
     # for OPDS document.
     LIBRARY_DESCRIPTION = 'library_description'
@@ -106,6 +109,10 @@ class Configuration(CoreConfiguration):
         {
             "key": PATRON_WEB_CLIENT_URL,
             "label": _("URL of the web catalog for patrons"),
+        },
+        {
+            "key": STATIC_FILE_CACHE_TIME,
+            "label": _("Cache time for static JS and CSS files for the admin interface"),
         },
     ]
 


### PR DESCRIPTION
This change makes it easier to work on the admin interface. I've been setting cache timeouts to 0 in the two static file routes and not committing it, but it's nicer to have it be a setting. Probably no one except me will use this setting, but if anyone else works on the admin interface it will be useful.