### PR TITLE
Consistently update a patron's external_type no matter how we ended up updating the rest of their data.

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -990,9 +990,7 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
         """
         remote_patron_info = self.remote_patron_lookup(patron)
         if isinstance(remote_patron_info, PatronData):
-            remote_patron_info.apply(patron)
-        if self.external_type_regular_expression:
-            self.update_patron_external_type(patron)
+            self.apply_patrondata(remote_patron_info, patron)
 
     def update_patron_external_type(self, patron):
         """Make sure the patron's external type reflects
@@ -1355,7 +1353,7 @@ class BasicAuthenticationProvider(AuthenticationProvider):
         if patron:
             # We found them! Make sure their data is up to date
             # with whatever we just got from remote.
-            patrondata.apply(patron)
+            self.apply_patrondata(patrondata, patron)
             return patron
         
         # We didn't find them. Now the question is: _why_ didn't the
@@ -1397,8 +1395,17 @@ class BasicAuthenticationProvider(AuthenticationProvider):
         # the patron's identifiers changed. Either way, we need to
         # update the Patron record with the account information we
         # just got from the source of truth.
-        patrondata.apply(patron)
+        self.apply_patrondata(patrondata, patron)
         return patron
+
+    def apply_patrondata(self, patrondata, patron):
+        """Apply a PatronData object to the given patron and make sure
+        any fields that need to be updated as a result of new data
+        are updated.
+        """
+        patrondata.apply(patron)
+        if self.external_type_regular_expression:
+            self.update_patron_external_type(patron)
 
     def get_credential_from_header(self, header):
         """Extract a password credential from a WWW-Authenticate header

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1709,6 +1709,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
         )
 
         provider = self.mock_basic(patrondata=patrondata)
+        provider.external_type_regular_expression = re.compile("^(.)")
         patron2 = provider.authenticate(self._db, self.credentials)
 
         # We were able to match our local patron to the patron held by the
@@ -1719,6 +1720,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
         # new identifiers.
         eq_(new_identifier, patron.authorization_identifier)
         eq_(new_username, patron.username)
+        eq_(patron.authorization_identifier[0], patron.external_type)
 
     def test_authentication_updates_outdated_patron_on_username_match(self):
         # This patron has no permanent ID. Their library card number has


### PR DESCRIPTION
This branch fixes a bug where a patron's external_type was not updated if we updated the rest of their data in the course of an `authenticate` call, as opposed to an `update_patron_metadata` call. It defines a method to call `PatronData.apply` and then refresh the patron's external_type, and uses it whenever `PatronData.apply` was used previously.

This is a hotfix for Open Ebooks which I'll deploy tomorrow morning once approved.