### PR TITLE
Return a problem detail instead of raising an exception when the client provides an invalid bearer token.

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -598,9 +598,12 @@ class LibraryAuthenticator(object):
 
             # The patron wants to use an
             # OAuthAuthenticationProvider. Figure out which one.
-            provider_name, provider_token = self.decode_bearer_token_from_header(
-                header
-            )
+            try:
+                provider_name, provider_token = self.decode_bearer_token_from_header(
+                    header
+                )
+            except jwt.exceptions.InvalidTokenError, e:
+                return INVALID_OAUTH_BEARER_TOKEN
             provider = self.oauth_provider_lookup(provider_name)
             if isinstance(provider, ProblemDetail):
                 # There was a problem turning the provider name into

--- a/api/base_controller.py
+++ b/api/base_controller.py
@@ -44,6 +44,10 @@ class BaseCirculationManagerController(object):
             return REMOTE_INTEGRATION_FAILED.detailed(
                 _("Error in authentication service")
             )
+        if patron is None:
+            # Credentials were provided but they turned out not
+            # to identify anyone in particular.
+            return self.authenticate()
         if isinstance(patron, ProblemDetail):
             flask.request.patron = None
             return patron

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -205,6 +205,13 @@ UNKNOWN_OAUTH_PROVIDER = pd(
     detail=_("The specified OAuth provider name isn't one of the known providers."),
 )
 
+INVALID_OAUTH_BEARER_TOKEN = pd(
+    "http://librarysimplified.org/terms/problem/credentials-invalid",
+    status_code=400,
+    title=_("Invalid OAuth bearer token."),
+    detail=_("The provided OAuth bearer token couldn't be verified."),
+)
+
 UNSUPPORTED_AUTHENTICATION_MECHANISM = pd(
     "http://librarysimplified.org/terms/problem/unsupported-authentication-mechanism",
     status_code=400,

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1837,7 +1837,7 @@ class TestOAuthAuthenticationProvider(AuthenticatorTest):
         data_source = provider.token_data_source(self._db)
 
         # Until we call create_token, this won't work.
-        eq_(None, provider.authenticated_patron(self._db, "some other token"))
+        eq_(None, provider.authenticated_patron(self._db, "some token"))
 
         token, is_new = provider.create_token(self._db, patron, "some token")
         eq_(True, is_new)
@@ -2075,3 +2075,12 @@ class TestOAuthController(AuthenticatorTest):
         eq_(None, fragments.get('access_token'))
         error = json.loads(fragments.get('error')[0])
         eq_(UNKNOWN_OAUTH_PROVIDER.uri, error.get('type'))
+
+    def test_oauth_authentication_invalid_token(self):
+        """If an invalid bearer token is provided, an appropriate problem
+        detail is returned.
+        """
+        problem = self.library_auth.authenticated_patron(
+            self._db, "Bearer - this is a bad token"
+        )
+        eq_(INVALID_OAUTH_BEARER_TOKEN, problem)


### PR DESCRIPTION
This fixes a problem we're seeing on the Open Ebooks circulation manager.