### PR TITLE
CSRF token consistency and other admin interface fixes

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -203,8 +203,6 @@ class AdminController(object):
     def check_csrf_token(self):
         """Verifies that the CSRF token in the form data or X-CSRF-Token header
         matches the one in the session cookie.
-        TODO: Change all requests to use the X-CSRF-Token header instead of form
-        data.
         """
         cookie_token = self.get_csrf_token()
         header_token = flask.request.headers.get("X-CSRF-Token")

--- a/api/admin/opds.py
+++ b/api/admin/opds.py
@@ -19,16 +19,11 @@ class AdminAnnotator(CirculationManagerAnnotator):
 
         super(AdminAnnotator, self).annotate_work_entry(work, active_license_pool, edition, identifier, feed, entry)
 
-        if isinstance(work, BaseMaterializedWork):
-            data_source_name = work.name
-        else:
-            data_source_name = active_license_pool.data_source.name
-
         feed.add_link_to_entry(
             entry,
             rel="http://librarysimplified.org/terms/rel/refresh",
             href=self.url_for(
-                "refresh", data_source=data_source_name,
+                "refresh",
                 identifier_type=identifier.type,
                 identifier=identifier.identifier, _external=True)
         )
@@ -38,7 +33,7 @@ class AdminAnnotator(CirculationManagerAnnotator):
                 entry,
                 rel="http://librarysimplified.org/terms/rel/restore",
                 href=self.url_for(
-                    "unsuppress", data_source=data_source_name,
+                    "unsuppress",
                     identifier_type=identifier.type,
                     identifier=identifier.identifier, _external=True)
             )
@@ -47,7 +42,7 @@ class AdminAnnotator(CirculationManagerAnnotator):
                 entry,
                 rel="http://librarysimplified.org/terms/rel/hide",
                 href=self.url_for(
-                    "suppress", data_source=data_source_name,
+                    "suppress",
                     identifier_type=identifier.type,
                     identifier=identifier.identifier, _external=True)
             )
@@ -56,7 +51,7 @@ class AdminAnnotator(CirculationManagerAnnotator):
             entry,
             rel="edit",
             href=self.url_for(
-                "edit", data_source=data_source_name,
+                "edit",
                 identifier_type=identifier.type,
                 identifier=identifier.identifier, _external=True)
         )

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.45"
+    "simplified-circulation-web": "0.0.46"
   }
 }


### PR DESCRIPTION
This branch changes the admin interface to only accept CSRF tokens in an "X-CSRF-Token" header - form data no longer works. This change is *not* backwards-compatible with the old version of the front-end code, so everyone will have to re-run npm install when updating or the admin interface will no longer work.

In addition, I found a couple other problems with the admin interface while testing this and fixed them here.