### PR TITLE
Changed the admin interface to go to edit page after creating a new config item.

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1215,9 +1215,9 @@ class SettingsController(CirculationManagerController):
                     ))
 
         if is_new:
-            return Response(unicode(_("Success")), 201)
+            return Response(unicode(library.uuid), 201)
         else:
-            return Response(unicode(_("Success")), 200)
+            return Response(unicode(library.uuid), 200)
 
     def _get_integration_protocols(self, provider_apis, protocol_name_attr="__module__"):
         protocols = []
@@ -1487,9 +1487,9 @@ class SettingsController(CirculationManagerController):
                 library.collections.remove(collection)
 
         if is_new:
-            return Response(unicode(_("Success")), 201)
+            return Response(unicode(collection.id), 201)
         else:
-            return Response(unicode(_("Success")), 200)
+            return Response(unicode(collection.id), 200)
 
     def admin_auth_services(self):
         provider_apis = [GoogleOAuthAdminAuthenticationProvider]
@@ -1536,9 +1536,9 @@ class SettingsController(CirculationManagerController):
             return result
 
         if is_new:
-            return Response(unicode(_("Success")), 201)
+            return Response(unicode(auth_service.protocol), 201)
         else:
-            return Response(unicode(_("Success")), 200)
+            return Response(unicode(auth_service.protocol), 200)
 
     def individual_admins(self):
         if flask.request.method == 'GET':
@@ -1566,9 +1566,9 @@ class SettingsController(CirculationManagerController):
             return MISSING_PGCRYPTO_EXTENSION
 
         if is_new:
-            return Response(unicode(_("Success")), 201)
+            return Response(unicode(admin.email), 201)
         else:
-            return Response(unicode(_("Success")), 200)
+            return Response(unicode(admin.email), 200)
 
     def patron_auth_services(self):
         provider_apis = [SimpleAuthenticationProvider,
@@ -1653,9 +1653,9 @@ class SettingsController(CirculationManagerController):
                     return INVALID_EXTERNAL_TYPE_REGULAR_EXPRESSION
 
         if is_new:
-            return Response(unicode(_("Success")), 201)
+            return Response(unicode(auth_service.id), 201)
         else:
-            return Response(unicode(_("Success")), 200)
+            return Response(unicode(auth_service.id), 200)
 
     def sitewide_settings(self):
         if flask.request.method == 'GET':
@@ -1680,7 +1680,7 @@ class SettingsController(CirculationManagerController):
 
         setting = ConfigurationSetting.sitewide(self._db, key)
         setting.value = value
-        return Response(unicode(_("Success")), 200)
+        return Response(unicode(setting.key), 200)
 
     def metadata_services(
             self, do_get=HTTP.debuggable_get, do_post=HTTP.debuggable_post, 
@@ -1747,9 +1747,9 @@ class SettingsController(CirculationManagerController):
                 return problem_detail
 
         if is_new:
-            return Response(unicode(_("Success")), 201)
+            return Response(unicode(service.id), 201)
         else:
-            return Response(unicode(_("Success")), 200)
+            return Response(unicode(service.id), 200)
 
     def sitewide_registration(self, integration, do_get=HTTP.debuggable_get,
                               do_post=HTTP.debuggable_post, key=None
@@ -1890,9 +1890,9 @@ class SettingsController(CirculationManagerController):
             return result
 
         if is_new:
-            return Response(unicode(_("Success")), 201)
+            return Response(unicode(service.id), 201)
         else:
-            return Response(unicode(_("Success")), 200)
+            return Response(unicode(service.id), 200)
 
     def cdn_services(self):
         protocols = [
@@ -1950,9 +1950,9 @@ class SettingsController(CirculationManagerController):
             return result
 
         if is_new:
-            return Response(unicode(_("Success")), 201)
+            return Response(unicode(service.id), 201)
         else:
-            return Response(unicode(_("Success")), 200)
+            return Response(unicode(service.id), 200)
 
 
     def search_services(self):
@@ -2007,9 +2007,9 @@ class SettingsController(CirculationManagerController):
             return result
 
         if is_new:
-            return Response(unicode(_("Success")), 201)
+            return Response(unicode(service.id), 201)
         else:
-            return Response(unicode(_("Success")), 200)
+            return Response(unicode(service.id), 200)
 
     def discovery_services(self):
         protocols = [
@@ -2076,9 +2076,9 @@ class SettingsController(CirculationManagerController):
             return result
 
         if is_new:
-            return Response(unicode(_("Success")), 201)
+            return Response(unicode(service.id), 201)
         else:
-            return Response(unicode(_("Success")), 200)
+            return Response(unicode(service.id), 200)
 
     def library_registrations(self, do_get=HTTP.debuggable_get, 
                               do_post=HTTP.debuggable_post, key=None):

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.46"
+    "simplified-circulation-web": "0.0.47"
   }
 }

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1564,6 +1564,7 @@ class TestSettingsController(AdminControllerTest):
 
         library = get_one(self._db, Library, short_name="nypl")
 
+        eq_(library.uuid, response.response[0])
         eq_(library.name, "The New York Public Library")
         eq_(library.short_name, "nypl")
         eq_("5", ConfigurationSetting.for_library(Configuration.FEATURED_LANE_SIZE, library).value)
@@ -1618,6 +1619,7 @@ class TestSettingsController(AdminControllerTest):
 
         library = get_one(self._db, Library)
 
+        eq_(library.uuid, response.response[0])
         eq_(library.name, "The New York Public Library")
         eq_(library.short_name, "nypl")
 
@@ -1862,6 +1864,7 @@ class TestSettingsController(AdminControllerTest):
 
         # The collection was created and configured properly.
         collection = get_one(self._db, Collection, name="New Collection")
+        eq_(collection.id, int(response.response[0]))
         eq_("New Collection", collection.name)
         eq_("acctid", collection.external_account_id)
         eq_("username", collection.external_integration.username)
@@ -1899,6 +1902,7 @@ class TestSettingsController(AdminControllerTest):
 
         # The collection was created and configured properly.
         child = get_one(self._db, Collection, name="Child Collection")
+        eq_(child.id, int(response.response[0]))
         eq_("Child Collection", child.name)
         eq_("child-acctid", child.external_account_id)
 
@@ -1939,6 +1943,8 @@ class TestSettingsController(AdminControllerTest):
             response = self.manager.admin_settings_controller.collections()
             eq_(response.status_code, 200)
 
+        eq_(collection.id, int(response.response[0]))
+
         # The collection has been changed.
         eq_("user2", collection.external_integration.username)
 
@@ -1975,6 +1981,8 @@ class TestSettingsController(AdminControllerTest):
             response = self.manager.admin_settings_controller.collections()
             eq_(response.status_code, 200)
 
+        eq_(collection.id, int(response.response[0]))
+
         # The collection is the same.
         eq_("user2", collection.external_integration.username)
         eq_(ExternalIntegration.OVERDRIVE, collection.protocol)
@@ -1998,6 +2006,8 @@ class TestSettingsController(AdminControllerTest):
             ])
             response = self.manager.admin_settings_controller.collections()
             eq_(response.status_code, 200)
+
+        eq_(collection.id, int(response.response[0]))
 
         # The collection now has a parent.
         eq_(parent, collection.parent)
@@ -2091,6 +2101,7 @@ class TestSettingsController(AdminControllerTest):
 
         # The auth service was created and configured properly.
         auth_service = ExternalIntegration.admin_authentication(self._db)
+        eq_(auth_service.protocol, response.response[0])
         eq_("oauth", auth_service.name)
         eq_("url", auth_service.url)
         eq_("username", auth_service.username)
@@ -2124,6 +2135,7 @@ class TestSettingsController(AdminControllerTest):
             response = self.manager.admin_settings_controller.admin_auth_services()
             eq_(response.status_code, 200)
 
+        eq_(auth_service.protocol, response.response[0])
         eq_("oauth", auth_service.name)
         eq_("url2", auth_service.url)
         eq_("user2", auth_service.username)
@@ -2163,6 +2175,7 @@ class TestSettingsController(AdminControllerTest):
 
         # The admin was created.
         admin_match = Admin.authenticate(self._db, "admin@nypl.org", "pass")
+        eq_(admin_match.email, response.response[0])
         assert admin_match
         assert admin_match.has_password("pass")
 
@@ -2180,6 +2193,8 @@ class TestSettingsController(AdminControllerTest):
             ])
             response = self.manager.admin_settings_controller.individual_admins()
             eq_(response.status_code, 200)
+
+        eq_(admin.email, response.response[0])
 
         # The password was changed.
         old_password_match = Admin.authenticate(self._db, "admin@nypl.org", "password")
@@ -2505,6 +2520,7 @@ class TestSettingsController(AdminControllerTest):
             eq_(response.status_code, 201)
 
         auth_service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.PATRON_AUTH_GOAL)
+        eq_(auth_service.id, int(response.response[0]))
         eq_(SimpleAuthenticationProvider.__module__, auth_service.protocol)
         eq_("user", auth_service.setting(BasicAuthenticationProvider.TEST_IDENTIFIER).value)
         eq_("pass", auth_service.setting(BasicAuthenticationProvider.TEST_PASSWORD).value)
@@ -2527,6 +2543,7 @@ class TestSettingsController(AdminControllerTest):
                                goal=ExternalIntegration.PATRON_AUTH_GOAL,
                                protocol=MilleniumPatronAPI.__module__)
         assert auth_service2 != auth_service
+        eq_(auth_service2.id, int(response.response[0]))
         eq_("url", auth_service2.url)
         eq_("user", auth_service2.setting(BasicAuthenticationProvider.TEST_IDENTIFIER).value)
         eq_("pass", auth_service2.setting(BasicAuthenticationProvider.TEST_PASSWORD).value)
@@ -2566,6 +2583,7 @@ class TestSettingsController(AdminControllerTest):
             response = self.manager.admin_settings_controller.patron_auth_services()
             eq_(response.status_code, 200)
 
+        eq_(auth_service.id, int(response.response[0]))
         eq_(SimpleAuthenticationProvider.__module__, auth_service.protocol)
         eq_("user", auth_service.setting(BasicAuthenticationProvider.TEST_IDENTIFIER).value)
         eq_("pass", auth_service.setting(BasicAuthenticationProvider.TEST_PASSWORD).value)
@@ -2628,6 +2646,7 @@ class TestSettingsController(AdminControllerTest):
 
         # The setting was created.
         setting = ConfigurationSetting.sitewide(self._db, AcquisitionFeed.GROUPED_MAX_AGE_POLICY)
+        eq_(setting.key, response.response[0])
         eq_("10", setting.value)
 
     def test_sitewide_settings_post_edit(self):
@@ -2643,6 +2662,7 @@ class TestSettingsController(AdminControllerTest):
             eq_(response.status_code, 200)
 
         # The setting was changed.
+        eq_(setting.key, response.response[0])
         eq_("20", setting.value)
 
     def test_metadata_services_get_with_no_services(self):
@@ -2775,6 +2795,7 @@ class TestSettingsController(AdminControllerTest):
             eq_(response.status_code, 201)
 
         service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.METADATA_GOAL)
+        eq_(service.id, int(response.response[0]))
         eq_(ExternalIntegration.NOVELIST, service.protocol)
         eq_("user", service.username)
         eq_("pass", service.password)
@@ -2808,6 +2829,7 @@ class TestSettingsController(AdminControllerTest):
             response = self.manager.admin_settings_controller.metadata_services()
             eq_(response.status_code, 200)
 
+        eq_(novelist_service.id, int(response.response[0]))
         eq_(ExternalIntegration.NOVELIST, novelist_service.protocol)
         eq_("user", novelist_service.username)
         eq_("pass", novelist_service.password)
@@ -2979,6 +3001,7 @@ class TestSettingsController(AdminControllerTest):
             eq_(response.status_code, 201)
 
         service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.ANALYTICS_GOAL)
+        eq_(service.id, int(response.response[0]))
         eq_(GoogleAnalyticsProvider.__module__, service.protocol)
         eq_("url", service.url)
         eq_([library], service.libraries)
@@ -3011,6 +3034,7 @@ class TestSettingsController(AdminControllerTest):
             response = self.manager.admin_settings_controller.analytics_services()
             eq_(response.status_code, 200)
 
+        eq_(ga_service.id, int(response.response[0]))
         eq_(GoogleAnalyticsProvider.__module__, ga_service.protocol)
         eq_("url", ga_service.url)
         eq_([l2], ga_service.libraries)
@@ -3103,6 +3127,7 @@ class TestSettingsController(AdminControllerTest):
             eq_(response.status_code, 201)
 
         service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.CDN_GOAL)
+        eq_(service.id, int(response.response[0]))
         eq_(ExternalIntegration.CDN, service.protocol)
         eq_("cdn url", service.url)
         eq_("mirrored domain", service.setting(Configuration.CDN_MIRRORED_DOMAIN_KEY).value)
@@ -3126,6 +3151,7 @@ class TestSettingsController(AdminControllerTest):
             response = self.manager.admin_settings_controller.cdn_services()
             eq_(response.status_code, 200)
 
+        eq_(cdn_service.id, int(response.response[0]))
         eq_(ExternalIntegration.CDN, cdn_service.protocol)
         eq_("new cdn url", cdn_service.url)
         eq_("new mirrored domain", cdn_service.setting(Configuration.CDN_MIRRORED_DOMAIN_KEY).value)
@@ -3230,6 +3256,7 @@ class TestSettingsController(AdminControllerTest):
             eq_(response.status_code, 201)
 
         service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.SEARCH_GOAL)
+        eq_(service.id, int(response.response[0]))
         eq_(ExternalIntegration.ELASTICSEARCH, service.protocol)
         eq_("search url", service.url)
         eq_("works-index", service.setting(ExternalSearchIndex.WORKS_INDEX_KEY).value)
@@ -3253,6 +3280,7 @@ class TestSettingsController(AdminControllerTest):
             response = self.manager.admin_settings_controller.search_services()
             eq_(response.status_code, 200)
 
+        eq_(search_service.id, int(response.response[0]))
         eq_(ExternalIntegration.ELASTICSEARCH, search_service.protocol)
         eq_("new search url", search_service.url)
         eq_("new-works-index", search_service.setting(ExternalSearchIndex.WORKS_INDEX_KEY).value)
@@ -3342,6 +3370,7 @@ class TestSettingsController(AdminControllerTest):
             eq_(response.status_code, 201)
 
         service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.DISCOVERY_GOAL)
+        eq_(service.id, int(response.response[0]))
         eq_(ExternalIntegration.OPDS_REGISTRATION, service.protocol)
         eq_("registry url", service.url)
 
@@ -3362,6 +3391,7 @@ class TestSettingsController(AdminControllerTest):
             response = self.manager.admin_settings_controller.discovery_services()
             eq_(response.status_code, 200)
 
+        eq_(discovery_service.id, int(response.response[0]))
         eq_(ExternalIntegration.OPDS_REGISTRATION, discovery_service.protocol)
         eq_("new registry url", discovery_service.url)
 


### PR DESCRIPTION
See https://github.com/NYPL-Simplified/circulation-web/pull/118, this is the server-side part.

Editing or creating a config item now returns whatever the admin interface uses as the unique identifier for that item in urls.