### PR TITLE
Bring the axis-raw-bibliographic script up to date with collections.

### DIFF
--- a/bin/informational/axis-raw-bibliographic
+++ b/bin/informational/axis-raw-bibliographic
@@ -8,17 +8,24 @@ bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 
+from core.model import (
+    Collection,
+    ExternalIntegration,
+)
 from core.scripts import IdentifierInputScript
 from api.axis import Axis360API
 
 class Axis360RawBibliographicScript(IdentifierInputScript):
     def run(self):
-        api = Axis360API(self._db)
-        args = self.parse_command_line(self._db)
-        for identifier in args.identifiers:
-            response = api.availability(title_ids=[identifier.identifier])
-            xml = minidom.parseString(response.content)
-            print xml.toprettyxml()
-            print
+        for collection in Collection.by_protocol(
+                self._db, ExternalIntegration.AXIS_360
+        ):
+            api = Axis360API(self._db, collection)
+            args = self.parse_command_line(self._db)
+            for identifier in args.identifiers:
+                response = api.availability(title_ids=[identifier.identifier])
+                xml = minidom.parseString(response.content)
+                print xml.toprettyxml()
+                print
 
 Axis360RawBibliographicScript().run()


### PR DESCRIPTION
This branch updates the untested axis-raw-bibliographic script to use the 2.0 system, where creating an API object requires having access to a Collection. For simplicity's sake, we look up the given identifiers in every appropriate collection on a site.