### PR TITLE
Set default API URLs for the collection integrations that have them.

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -66,7 +66,7 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI):
         { "key": ExternalIntegration.USERNAME, "label": _("Username") },
         { "key": ExternalIntegration.PASSWORD, "label": _("Password") },
         { "key": Collection.EXTERNAL_ACCOUNT_ID_KEY, "label": _("Library ID") },
-        { "key": ExternalIntegration.URL, "label": _("Server") },
+        { "key": ExternalIntegration.URL, "label": _("Server"), "default": BaseAxis360API.PRODUCTION_BASE_URL },
     ] + BaseCirculationAPI.SETTINGS
 
     SET_DELIVERY_MECHANISM_AT = BaseCirculationAPI.BORROW_STEP

--- a/api/enki.py
+++ b/api/enki.py
@@ -83,13 +83,14 @@ from core.testing import DatabaseTest
 
 class EnkiAPI(BaseCirculationAPI):
 
+    PRODUCTION_BASE_URL = "http://enkilibrary.org/API/"
+
     DESCRIPTION = _("Integrate an Enki collection.")
     SETTINGS = [
         { "key": Collection.EXTERNAL_ACCOUNT_ID_KEY, "label": _("Library ID") },
-        { "key": ExternalIntegration.URL, "label": _("URL") },
+        { "key": ExternalIntegration.URL, "label": _("URL"), "default": PRODUCTION_BASE_URL },
     ] + BaseCirculationAPI.SETTINGS
 
-    PRODUCTION_BASE_URL = "http://enkilibrary.org/API/"
     availability_endpoint = "ListAPI"
     item_endpoint = "ItemAPI"
     user_endpoint = "UserAPI"

--- a/api/enki.py
+++ b/api/enki.py
@@ -83,7 +83,7 @@ from core.testing import DatabaseTest
 
 class EnkiAPI(BaseCirculationAPI):
 
-    PRODUCTION_BASE_URL = "http://enkilibrary.org/API/"
+    PRODUCTION_BASE_URL = "https://enkilibrary.org/API/"
 
     DESCRIPTION = _("Integrate an Enki collection.")
     SETTINGS = [

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -61,7 +61,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
     SETTINGS = [
         { "key": ExternalIntegration.PASSWORD, "label": _("Basic Token") },
         { "key": Collection.EXTERNAL_ACCOUNT_ID_KEY, "label": _("Library ID") },
-        { "key": ExternalIntegration.URL, "label": _("URL") },
+        { "key": ExternalIntegration.URL, "label": _("URL"), "default": BaseOneClickAPI.PRODUCTION_BASE_URL },
     ] + BaseCirculationAPI.SETTINGS
     
     EXPIRATION_DATE_FORMAT = '%Y-%m-%d'


### PR DESCRIPTION
This branch eliminates the need to remember the standard API endpoints for Axis 360, ENKI, and RBDigital when configuring collections.