### PR TITLE
The Axis 360 API client does not use the metadata wrangler at all, so don't create one when it might not be available.

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -249,7 +249,7 @@ class Axis360CirculationMonitor(CollectionMonitor):
     DEFAULT_START_TIME = datetime(1970, 1, 1)
     FIVE_MINUTES = timedelta(minutes=5)
 
-    def __init__(self, _db, collection, api_class=Axis360API, metadata_client=None):
+    def __init__(self, _db, collection, api_class=Axis360API):
         super(Axis360CirculationMonitor, self).__init__(_db, collection)
         if isinstance(api_class, Axis360API):
             # Use a preexisting Axis360API instance rather than
@@ -257,13 +257,8 @@ class Axis360CirculationMonitor(CollectionMonitor):
             self.api = api_class
         else:
             self.api = api_class(_db, collection)
-        if not metadata_client:
-            metadata_client = MetadataWranglerOPDSLookup.from_config(
-                _db, collection=collection
-            )
 
         self.batch_size = self.DEFAULT_BATCH_SIZE
-        self.metadata_client = metadata_client
         self.bibliographic_coverage_provider = (
             Axis360BibliographicCoverageProvider(collection, api_class=self.api)
         )

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -28,10 +28,6 @@ from core.metadata_layer import (
     SubjectData,
 )
 
-from core.opds_import import(
-    MockMetadataWranglerOPDSLookup
-)
-
 from api.axis import (
     AxisCollectionReaper,
     Axis360CirculationMonitor,
@@ -190,7 +186,6 @@ class TestCirculationMonitor(Axis360Test):
 
         monitor = Axis360CirculationMonitor(
             self._db, self.collection, api_class=MockAxis360API,
-            metadata_client=MockMetadataWranglerOPDSLookup('url')
         )
         edition, license_pool = monitor.process_book(
             self.BIBLIOGRAPHIC_DATA, self.AVAILABILITY_DATA)
@@ -264,7 +259,6 @@ class TestCirculationMonitor(Axis360Test):
         metadata = Metadata(DataSource.AXIS_360, primary_identifier=identifier)
         monitor = Axis360CirculationMonitor(
             self._db, self.collection, api_class=MockAxis360API,
-            metadata_client=MockMetadataWranglerOPDSLookup('url')
         )
         edition, licensepool = monitor.process_book(
             metadata, self.AVAILABILITY_DATA


### PR DESCRIPTION
I believe the Axis 360 API _used_ to use the metadata wrangler to look up author display names from sort names, but then Axis 360 started sending the display names, so we don't need it anymore.

Removing this code allows you to set up an Axis 360 collection without having a working metadata wrangler integration.