### PR TITLE
Dont crash on unconnectable patron authentication providers

### DIFF
--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -22,7 +22,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
     FIELD_SEPARATOR = "field separator"
     
     SETTINGS = [
-        { "key": ExternalIntegration.URL, "label": _("URL") },
+        { "key": ExternalIntegration.URL, "label": _("Server") },
         { "key": PORT, "label": _("Port") },
         { "key": ExternalIntegration.USERNAME, "label": _("Login User ID"), "optional": True },
         { "key": ExternalIntegration.PASSWORD, "label": _("Login Password"), "optional": True },

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -295,7 +295,14 @@ class SIPClient(Constants):
         """Create a socket connection to a SIP server."""
         with self.socket_lock:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.connect((self.target_server, self.target_port))
+            try:
+                sock.connect((self.target_server, self.target_port))
+            except TypeError:
+                raise IOError(
+                    "Could not connect to %s:%s" % (
+                        self.target_server, self.target_port
+                    )
+                )
 
             # Since this is a new socket connection, reset the message count
             # and, potentially, logged_in.

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -631,6 +631,23 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             "Loaded module api.lanes but could not find a class called AuthenticationProvider inside.",
             auth.register_provider, integration
         )        
+
+    def test_register_provider_fails_but_does_not_explode_on_remote_integration_error(self):
+        library = self._default_library
+        # We're going to instantiate the SIP2 client but since we're not
+        # specifying a server or a port, it will raise an IOError immediately,
+        # which will become a RemoteIntegrationException, which will become
+        # a CannotLoadConfiguration.
+        integration = self._external_integration(
+            "api.sip", ExternalIntegration.PATRON_AUTH_GOAL
+        )
+        library.integrations.append(integration)
+        auth = LibraryAuthenticator(_db=self._db, library=library)
+        assert_raises_regexp(
+            CannotLoadConfiguration,
+            "Could not instantiate .* authentication provider for library .*, possibly due to a network connection problem.",
+            auth.register_provider, integration
+        )
         
     def test_register_provider_basic_auth(self):
         firstbook = self._external_integration(


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/circulation/issues/568 by turning an authentication provider's `RemoteIntegrationException` (which is treated as fatal) into a `CannotLoadConfiguration` (which merely results in an authentication provider not being registered).