### PR TITLE
Stop retrieving ACSM links when patron just wants to see their loans

### DIFF
--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -561,96 +561,56 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
 
         # by now we can assume response is either empty or a list
         for item in resp_obj:
-            # go through patron's checkouts and generate LoanInfo objects, 
-            # with FulfillmentInfo objects included
-            media_type = item.get('mediaType', 'eBook')
-            isbn = item.get('isbn', None)
-            can_renew = item.get('canRenew', None)
-            title = item.get('title', None)
-            authors = item.get('authors', None)
-            # refers to checkout expiration date, not the downloadUrl's
-            expires = item.get('expiration', None)
-            if expires:
-                expires = datetime.datetime.strptime(expires, self.EXPIRATION_DATE_FORMAT).date()
-
-            identifier, made_new = Identifier.for_foreign_id(self._db, 
-                    foreign_identifier_type=Identifier.RB_DIGITAL_ID, 
-                    foreign_id=isbn, autocreate=False)
-
-            # Note: if OneClick knows about a patron's checked-out item that wasn't
-            # checked out through us, we ignore it
-            if not identifier:
-                continue
-
-            # Get a list of files associated with this loan.
-            files = item.get('files', [])
-
-            # TODO: This only works for ebooks, where there is a single file
-            # in the manifest. For audiobooks, we need to convert the entire
-            # manifest to an application/audiobook+json file.
-            for file in files:
-                filename = file.get('filename', None)
-                # assume fileFormat is same for all files associated with this checkout
-                # and use the last one mentioned.  Ex: "fileFormat": "EPUB".
-                # note: audio books don't list fileFormat field, just the filename, and the mediaType.
-                file_format = file.get('fileFormat', None)
-                if file_format == 'EPUB':
-                    file_format = Representation.EPUB_MEDIA_TYPE
-                else:
-                    # TODO: RBdigital audiobook manifests will be
-                    # converted to this standard manifest format.
-                    file_format = Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE
-
-                # Note: download urls expire 15 minutes after being handed out
-                # in the checkouts call
-                download_url = file.get('downloadUrl', None)
-                # is included in the downloadUrl, actually
-                acs_resource_id = file.get('acsResourceId', None)
-
-            # The document at the other end of download_url is a manifest.
-            # For audio books, the manifest includes a list of parts.
-            # For ebooks, the manifest includes a single link to an ACSM
-            # file.
-            #
-            # We can't do anything about audiobook manifests right
-            # now, but we can turn an ebook manifest into a
-            # FulfillmentInfo.
-
-            # We need to use self._make_request instead of self.request
-            # because it's a different server that will reject the credentials
-            # we use for the API.
-            access_document = self._make_request(download_url, 'GET', {})
-            data = json.loads(access_document.content)
-            content_link = data['url']
-            content_type = data['type']
-            if content_type == 'application/vnd.adobe':
-                # The manifest spells the media type wrong. Fix it.
-                content_type = DeliveryMechanism.ADOBE_DRM
-            fulfillment_info = FulfillmentInfo(
-                self.collection,
-                DataSource.RB_DIGITAL,
-                Identifier.RB_DIGITAL_ID, 
-                identifier, 
-                content_link = content_link, 
-                content_type = content_type, 
-                content = None, 
-                content_expires = None
-            )
-
-            loan = LoanInfo(
-                self.collection,
-                DataSource.RB_DIGITAL,
-                Identifier.RB_DIGITAL_ID,
-                isbn,
-                start_date=None,
-                end_date=expires,
-                fulfillment_info=fulfillment_info,
-            )
-
-            loans.append(loan)
-
+            loan_info = self._make_loan_info(item)
+            if loan_info:
+                loans.append(loan_info)
         return loans
 
+    def _make_loan_info(self, item, fulfill=False):
+        """Convert one of the items returned by a request to /checkouts into a
+        LoanInfo with an RBFulfillmentInfo.
+        """
+
+        media_type = item.get('mediaType', 'eBook')
+        isbn = item.get('isbn', None)
+        can_renew = item.get('canRenew', None)
+        title = item.get('title', None)
+        authors = item.get('authors', None)
+
+        # 'expiration' here refers to the expiration date of the loan, not
+        # of the fulfillment URL.
+        expires = item.get('expiration', None)
+        if expires:
+            expires = datetime.datetime.strptime(
+                expires, self.EXPIRATION_DATE_FORMAT
+            ).date()
+
+        identifier, made_new = Identifier.for_foreign_id(
+            self._db, foreign_identifier_type=Identifier.RB_DIGITAL_ID, 
+            foreign_id=isbn, autocreate=False
+        )
+        if not identifier:
+            # We have never heard of this book, which means the patron
+            # didn't borrow it through us.
+            return None
+
+        fulfillment_info = RBFulfillmentInfo(
+            self.collection,
+            DataSource.RB_DIGITAL,
+            Identifier.RB_DIGITAL_ID, 
+            identifier, 
+            item,
+        )
+
+        return LoanInfo(
+            self.collection,
+            DataSource.RB_DIGITAL,
+            Identifier.RB_DIGITAL_ID,
+            isbn,
+            start_date=None,
+            end_date=expires,
+            fulfillment_info=fulfillment_info,
+        )
 
     def get_patron_holds(self, patron_id):
         """
@@ -839,10 +799,129 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
         pass
 
 
+class RBFulfillmentInfo(object):
+    """An RBdigital-specific FulfillmentInfo implementation.
+
+    We use these instead of real FulfillmentInfo objects because
+    generating a FulfillmentInfo object may require an extra HTTP request,
+    and there's often no need to make that request.
+    """
+
+    def __init__(self, collection, data_source, identifier,
+                 raw_data):
+        self.collection = collection
+        self.data_source = data_source
+        self._identifier = identifier
+        self.identifier_type = identifier.type
+        self.identifier = identifier.identifier
+        self.raw_data = raw_data
+
+        self._fetched = False
+        self._content_link = None
+        self._content_type = None
+        self._content = None
+        self._content_expires = None
+        
+    @property
+    def content_link(self):
+        self.fetch()
+        return self._content_link
+
+    @property
+    def content_type(self):
+        self.fetch()
+        return self._content_type
+
+    @property
+    def content(self):
+        self.fetch()
+        return self._content
+
+    @property
+    def content_expires(self):
+        self.fetch()
+        return self._content_expires
+
+    def fetch(self):
+        if self._fetched:
+            return
+
+        # Get a list of files associated with this loan.
+        files = self.raw_data.get('files', [])
+
+        # Determine if we're fulfilling an ebook or an audiobook.
+        ebook_download_url = None
+        representation_format = None
+        if files:
+            # If we have an ebook, there should only be one file in
+            # the list. If we have an audiobook, the first file should
+            # be representative of the whole.
+            file = files[0]
+            file_format = file.get('fileFormat', None)
+            if file_format == 'EPUB':
+                file_format = Representation.EPUB_MEDIA_TYPE
+            else:
+                # Audio books don't list a fileFormat at all. TODO:
+                # they do list a mediaType, which could be useful.
+                file_format = Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE
+            self._content_type = file_format
+            ebook_download_url = file.get('downloadUrl', None)
+            
+        if self._content_type == Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE:
+            # We have an audiobook.
+            self._content = self.process_audiobook_manifest(self.raw_data)
+        else:
+            # We have some other kind of file. Follow the download
+            # link, which will return a JSON-based access document
+            # pointing to the 'real' download link.
+            #
+            # We don't send our normal RBdigital credentials with this
+            # request because it's going to a different, publicly
+            # accessible server.
+            access_document = cls._make_request(download_url, 'GET', {})
+            self._content_type, self._content_link, self._content_expires = self.process_access_document(
+                access_document
+            )
+        self._fetched = True
+
+    @classmethod
+    def process_audiobook_manifest(self, rb_data):
+        """Convert RBdigital's proprietary manifest format
+        into a standard Audiobook Manifest document.
+       
+        TODO: This currently just returns the original manifest.
+        """
+        return json.dumps(rb_data)
+
+    @classmethod
+    def process_access_document(self, document):
+        """Process the intermediary document RBdigital serves that tells
+        you how to actually download a file.
+        """
+        data = json.loads(access_document.content)
+        content_link = data.get('url')
+        content_type = data.get('type')
+        if content_type == 'application/vnd.adobe':
+            # The manifest spells the media type wrong. Fix it.
+            content_type = DeliveryMechanism.ADOBE_DRM
+
+        # Now that we've found the download URL, the client has 15
+        # minutes to use it. Set it to expire in 14 minutes to be
+        # conservative.
+        expires = datetime.datetime.utcnow() + datetime.timedelta(minutes=14)
+        return content_link, content_type, expires
+
+    @classmethod
+    def _make_request(self, url, method, headers, data=None, params=None, **kwargs):
+        """Actually make an HTTP request."""
+        return HTTP.request_with_timeout(
+            method, url, headers=headers, data=data,
+            params=params, **kwargs
+        )
+
 
 class MockOneClickAPI(BaseMockOneClickAPI, OneClickAPI):
     pass
-
 
 
 class OneClickCirculationMonitor(CollectionMonitor):

--- a/tests/files/oneclick/response_patron_checkouts_with_audiobook.json
+++ b/tests/files/oneclick/response_patron_checkouts_with_audiobook.json
@@ -1,0 +1,225 @@
+[
+  {
+    "minutes": 878.50,
+    "downloadUrl": "https://download/full-book.zip",
+    "encryptionKey": "",
+    "files": [
+      {
+        "id": 358456,
+        "display": "Introduction",
+        "filename": "53923_001_IN.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 1.15,
+        "size": 417200
+      },
+      {
+        "id": 358457,
+        "display": "Introduction",
+        "filename": "53923_002_IN.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 6.13,
+        "size": 2207192
+      },
+      {
+        "id": 358458,
+        "display": "Prologue",
+        "filename": "53923_003_PR.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 9.45,
+        "size": 3406856
+      },
+      {
+        "id": 358459,
+        "display": "Chapter 1",
+        "filename": "53923_004_C001.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 40.55,
+        "size": 14598032
+      },
+      {
+        "id": 358460,
+        "display": "Chapter 1",
+        "filename": "53923_005_C001.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 39.15,
+        "size": 14098856
+      },
+      {
+        "id": 358461,
+        "display": "Chapter 2",
+        "filename": "53923_006_C002.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 49.02,
+        "size": 17650544
+      },
+      {
+        "id": 358462,
+        "display": "Chapter 2",
+        "filename": "53923_007_C002.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 49.78,
+        "size": 17923568
+      },
+      {
+        "id": 358463,
+        "display": "Chapter 3",
+        "filename": "53923_008_C003.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 56.03,
+        "size": 20172776
+      },
+      {
+        "id": 358464,
+        "display": "Chapter 3",
+        "filename": "53923_009_C003.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 56.42,
+        "size": 20314472
+      },
+      {
+        "id": 358465,
+        "display": "Chapter 4",
+        "filename": "53923_010_C004.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 58.60,
+        "size": 21100496
+      },
+      {
+        "id": 358466,
+        "display": "Chapter 4",
+        "filename": "53923_011_C004.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 59.15,
+        "size": 21297056
+      },
+      {
+        "id": 358467,
+        "display": "Chapter 5",
+        "filename": "53923_012_C005.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 48.98,
+        "size": 17638016
+      },
+      {
+        "id": 358468,
+        "display": "Chapter 5",
+        "filename": "53923_013_C005.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 49.02,
+        "size": 17647304
+      },
+      {
+        "id": 358469,
+        "display": "Chapter 6",
+        "filename": "53923_014_C006.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 52.08,
+        "size": 18753440
+      },
+      {
+        "id": 358470,
+        "display": "Chapter 6",
+        "filename": "53923_015_C006.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 51.40,
+        "size": 18505688
+      },
+      {
+        "id": 358471,
+        "display": "Chapter 7",
+        "filename": "53923_016_C007.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 55.88,
+        "size": 20119424
+      },
+      {
+        "id": 358472,
+        "display": "Chapter 7",
+        "filename": "53923_017_C007.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 56.50,
+        "size": 20343416
+      },
+      {
+        "id": 358473,
+        "display": "Chapter 8",
+        "filename": "53923_018_C008.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 39.98,
+        "size": 14393264
+      },
+      {
+        "id": 358474,
+        "display": "Chapter 9",
+        "filename": "53923_019_C009.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 30.63,
+        "size": 11027552
+      },
+      {
+        "id": 359380,
+        "display": "Chapter 10",
+        "filename": "53923_020_C010.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 32.70,
+        "size": 11774696
+      },
+      {
+        "id": 359381,
+        "display": "",
+        "filename": "53923_021_IV.mp3",
+        "downloadUrl": "https://download-chapter/",
+        "minutes": 35.90,
+        "size": 12924680
+      }
+    ],
+    "size": 316314528,
+    "bookmarks": [],
+    "hasBookmark": false,
+    "dateAdded": "2011-03-28",
+    "description": "Award-winning, New York Times best-selling novelist Sharyn McCrumb crafts absorbing, lyrical tales featuring the rich culture and lore of Appalachia. In the compelling...",
+    "hasDrm": false,
+    "narrators": "Barbara Rosenblat",
+    "images": [
+      {
+        "name": "xx-small",
+        "url": "https://d2cv0ie6dlin9h.cloudfront.net/53923/53923_image_32x50.jpg"
+      },
+      {
+        "name": "x-small",
+        "url": "https://d2cv0ie6dlin9h.cloudfront.net/53923/53923_image_37x56.jpg"
+      },
+      {
+        "name": "small",
+        "url": "https://d2cv0ie6dlin9h.cloudfront.net/53923/53923_image_71x108.jpg"
+      },
+      {
+        "name": "medium",
+        "url": "https://d2cv0ie6dlin9h.cloudfront.net/53923/53923_image_95x140.jpg"
+      },
+      {
+        "name": "large",
+        "url": "https://d2cv0ie6dlin9h.cloudfront.net/53923/53923_image_128x192.jpg"
+      },
+      {
+        "name": "x-large",
+        "url": "https://d2cv0ie6dlin9h.cloudfront.net/53923/53923_image_148x230.jpg"
+      },
+      {
+        "name": "xx-large",
+        "url": "https://d2cv0ie6dlin9h.cloudfront.net/53923/53923_image_512x512_iTunes.png"
+      }
+    ],
+    "titleId": 0,
+    "isbn": "9781449871789",
+    "title": "The Ballad of Frankie Silver",
+    "publisher": "Recorded Books, Inc.",
+    "expiration": "2017-11-15",
+    "canRenew": true,
+    "authors": "Sharyn McCrumb",
+    "transactionId": 101,
+    "mediaType": "eAudio",
+    "patronId": 111,
+    "libraryId": 222
+  }
+]

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -524,7 +524,7 @@ class TestOneClickAPI(OneClickAPITest):
         # a (improperly formatted) audiobook manifest for the loan.
         eq_(Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE, 
             found_fulfillment.content_type)
-        eq_(assert "downloadUrl" in found_fulfillment.content)
+        assert "downloadUrl" in found_fulfillment.content
 
 
     def test_patron_activity(self):

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -456,6 +456,15 @@ class TestOneClickAPI(OneClickAPITest):
         eq_(download_url, found_fulfillment.content_link)
         eq_(u'application/epub+zip', found_fulfillment.content_type)
         eq_(None, found_fulfillment.content)
+        
+        # The fulfillment link expires in about 14 minutes -- rather
+        # than testing this exactly we estimate it.
+        expires = found_fulfillment.content_expires
+        now = datetime.datetime.utcnow()
+        thirteen_minutes = now + datetime.timedelta(minutes=13)
+        fifteen_minutes = now + datetime.timedelta(minutes=15)
+        assert expires > thirteen_minutes
+        assert expires < fifteen_minutes
 
         # Here's another pool that the patron doesn't have checked out.
         edition2, pool2  = self._edition(


### PR DESCRIPTION
This branch refactors a lot of code (but changes relatively little) to improve the performance of the RBdigital API by removing unnecessary requests.

When you call `get_patron_checkouts()` you get information about each loan. If the loan is for an ebook, you get a small JSON structure including a single download link that points to what I'm calling an "access document". The access document is a small JSON document that points to a time-limited URL that gives you an ACSM file.

If the loan is for an audiobook, you get a much larger JSON data structure that includes links to an access document for each chapter. (This data structure could be converted into a standard Audiobook Manifest, but this branch just serves the JSON data structure as-is with the Audiobook Manifest media type, as preparation for what will happen in the future.)

The problem this branch is solving is that calling `get_patron_checkouts()` triggers an HTTP request to the access document for every single ebook you have on loan. If you have N RBdigital ebooks on loan, this means N unnecessary requests when you just want to look at your loans, and N-1 unnecessary requests when you want to download an EPUB.

These requests are happening while the LoanInfo is being built, in the name of making sure every one of them has an accurate FulfillmentInfo. I fix the problem by using the new `RBFulfillmentInfo` class instead of `FulfillmentINfo`, which keeps the information necessary to actually fulfill a loan safe until it's requested. If that happens, RBFulfillmentInfo will make the HTTP request to find the ACSM link (for an ebook) or spit out a fake Audiobook Manifest (for an audio book).

`RBFulfillmentInfo` could be tested separately but I have only added tests to verify that fewer HTTP requests are being made and to test the new functionality I've introduced:

* Audiobook data from RBdigital is now served as though it were an Audiobook Manifest.
* Links in access documents expire after 15 minutes; this information has been moved from a comment to the `content_expires` field of `RBFulfillmentInfo`.