### PR TITLE
Added migration script for RBdigital users with active loans.

### DIFF
--- a/migration/20171026-set-rbdigital-identifier-for-patrons-with-active-loans.sql
+++ b/migration/20171026-set-rbdigital-identifier-for-patrons-with-active-loans.sql
@@ -1,0 +1,20 @@
+-- Set patron's authorization identifier as their RBdigital identifier
+insert into credentials(data_source_id, patron_id, type, credential) select
+ datasources.id,
+ patrons.id,
+ 'Identifier Sent To Remote Service',
+ patrons.authorization_identifier
+from patrons join datasources on datasources.name='RBdigital'
+
+-- If they don't already have a credential
+where patrons.id not in (
+ select patron_id from credentials join datasources on credentials.data_source_id=datasources.id and datasources.name='RBdigital' where type='Identifier Sent To Remote Service'
+) and (
+ -- And they have an active RBdigital loan or hold.
+ patrons.id in (
+  select patron_id from loans join licensepools on loans.license_pool_id=licensepools.id join datasources on licensepools.data_source_id=datasources.id and datasources.name='RBdigital'
+ ) or patrons.id in (
+ select patron_id from holds join licensepools on holds.license_pool_id=licensepools.id join datasources on licensepools.data_source_id=datasources.id and datasources.name='RBdigital'
+ )
+)
+;


### PR DESCRIPTION
This branch adds a migration script that sets a patron's RBdigital identifier to their authorization identifier if they have active RBdigital loans or holds. This ensures that the circulation manager will continue to identify the patron to RBdigital using their authorization identifier, and they won't lose their loans.

There is no one using RBdigital books in production yet, but I figure this is a good safety measure because I don't know when all the pre-production circ managers will upgrade their systems.

It's also good practice for when we do this same thing to Axis and Bibliotheca.