### PR TITLE
Serve a bearer token so that the client can download the book, instead of downloading the book and passing it along

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -487,7 +487,7 @@ class CirculationManagerController(BaseCirculationManagerController):
         license_pool = get_one(self._db, LicensePool, id=license_pool_id)
         if not license_pool:
             return INVALID_INPUT.detailed(
-                _("License Pool #%d does not exist.") % license_pool_id
+                _("License Pool #%s does not exist.") % license_pool_id
             )
         return license_pool
 


### PR DESCRIPTION
This branch changes the way OPDS For Distributors collections are fulfilled. Instead of downloading the EPUB file ourselves and sending it to the client, we send the client the bearer token we use to make  requests to the OPDS For Distributors site. This allows the client to make requests on the library's behalf, for a short period of time.

In addition to changing the unit tests I've tested this on a Biblioboard collection and I was able to get all the way to a bearer token document with the correct URL in place.