### PR TITLE
Handle an ILS that leaves the CQ field blank when a patron's authorization identifier is not recognized.

### DIFF
--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -132,6 +132,11 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         SIPClient.patron_information() to an abstract,
         authenticator-independent PatronData object.
         """
+        if info.get('valid_patron', 'N') == 'N':
+            # The patron could not be identified as a patron of this
+            # library. Don't return any data.
+            return None
+
         if info.get('valid_patron_password') == 'N':
             # The patron did not authenticate correctly. Don't
             # return any data.


### PR DESCRIPTION
Without this code, a SIP2 server that doesn't set the CQ field when it doesn't recognize a barcode will allow anyone to "authenticate" with the circulation manager using a made-up barcode. It's not as bad as it seems, because the new 'patron' will start out in a blocked state and have no privileges to do anything.