### PR TITLE
Make loan duration a per-library per-collection setting and make sure it's always corectly described.

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -69,6 +69,10 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI):
         { "key": ExternalIntegration.URL, "label": _("Server"), "default": BaseAxis360API.PRODUCTION_BASE_URL },
     ] + BaseCirculationAPI.SETTINGS
 
+    LIBRARY_SETTINGS = BaseCirculationAPI.LIBRARY_SETTINGS + [
+        BaseCirculationAPI.DEFAULT_LOAN_DURATION_SETTING
+    ]
+
     SET_DELIVERY_MECHANISM_AT = BaseCirculationAPI.BORROW_STEP
 
     SERVICE_NAME = "Axis 360"

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -62,6 +62,10 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
         { "key": Collection.EXTERNAL_ACCOUNT_ID_KEY, "label": _("Library ID") },
     ] + BaseCirculationAPI.SETTINGS
 
+    LIBRARY_SETTINGS = BaseCirculationAPI.LIBRARY_SETTINGS + [
+        BaseCirculationAPI.DEFAULT_LOAN_DURATION_SETTING
+    ]
+
     MAX_AGE = datetime.timedelta(days=730).seconds
     CAN_REVOKE_HOLD_WHEN_RESERVED = False
     SET_DELIVERY_MECHANISM_AT = None

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -872,7 +872,7 @@ class BaseCirculationAPI(object):
         "key" : Collection.EBOOK_LOAN_DURATION_KEY, 
         "label": _("Ebook Loan Duration (in Days)"),
         "default": Collection.STANDARD_DEFAULT_LOAN_PERIOD,
-        "description": _("When a patron uses SimplyE to borrow an audio book from this collection, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with the distributor.")
+        "description": _("When a patron uses SimplyE to borrow an ebook from this collection, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with the distributor.")
     }
 
     # Add to LIBRARY_SETTINGS if your circulation API is for a
@@ -882,7 +882,7 @@ class BaseCirculationAPI(object):
         "key" : Collection.AUDIOBOOK_LOAN_DURATION_KEY,
         "label": _("Audiobook Loan Duration (in Days)"),
         "default": Collection.STANDARD_DEFAULT_LOAN_PERIOD,
-        "description": _("When a patron uses SimplyE to borrow an audio book from this collection, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with the distributor.")
+        "description": _("When a patron uses SimplyE to borrow an audiobook from this collection, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with the distributor.")
     }
 
     # Add to LIBRARY_SETTINGS if your circulation API is for a

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -865,13 +865,46 @@ class CirculationAPI(object):
 class BaseCirculationAPI(object):
     """Encapsulates logic common to all circulation APIs."""
 
-    DEFAULT_LOAN_PERIOD = "default_loan_period"
-    DEFAULT_RESERVATION_PERIOD = "default_reservation_period"
+    # Add to LIBRARY_SETTINGS if your circulation API is for a
+    # distributor which includes ebooks and allows clients to specify
+    # their own loan lengths.
+    EBOOK_LOAN_DURATION_SETTING = {
+        "key" : Collection.EBOOK_LOAN_DURATION_KEY, 
+        "label": _("Ebook Loan Duration (in Days)"),
+        "default": Collection.STANDARD_DEFAULT_LOAN_PERIOD,
+        "description": _("When a patron uses SimplyE to borrow an audio book from this collection, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with the distributor.")
+    }
 
-    SETTINGS = [
-        { "key": DEFAULT_LOAN_PERIOD, "label": _("Default Loan Period (in Days)"), "optional": True, "type": "number" },
-        { "key": DEFAULT_RESERVATION_PERIOD, "label": _("Default Reservation Period (in Days)"), "optional": True, "type": "number" },
-    ]
+    # Add to LIBRARY_SETTINGS if your circulation API is for a
+    # distributor which includes audiobooks and allows clients to
+    # specify their own loan lengths.
+    AUDIOBOOK_LOAN_DURATION_SETTING = { 
+        "key" : Collection.AUDIOBOOK_LOAN_DURATION_KEY,
+        "label": _("Audiobook Loan Duration (in Days)"),
+        "default": Collection.STANDARD_DEFAULT_LOAN_PERIOD,
+        "description": _("When a patron uses SimplyE to borrow an audio book from this collection, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with the distributor.")
+    }
+
+    # Add to LIBRARY_SETTINGS if your circulation API is for a
+    # distributor with a default loan period negotiated out-of-band,
+    # such that the circulation manager cannot _specify_ the length of
+    # a loan.
+    DEFAULT_LOAN_DURATION_SETTING = { 
+        "key": Collection.EBOOK_LOAN_DURATION_KEY, 
+        "label": _("Default Loan Period (in Days)"),
+        "optional": True, 
+        "type": "number",
+        "default": Collection.STANDARD_DEFAULT_LOAN_PERIOD,
+        "description": _("Until it hears otherwise from the distributor, this server will assume that any given loan for this library from this collection will last this number of days. This number is usually a negotiated value between the library and the distributor. This only affects estimates&mdash;it cannot affect the actual length of loans.")
+    }
+
+    # These collection-specific settings should be inherited by all
+    # distributors.
+    SETTINGS = []
+
+    # These library- and collection-specific settings should be
+    # inherited by all distributors.
+    LIBRARY_SETTINGS = []
 
     BORROW_STEP = 'borrow'
     FULFILL_STEP = 'fulfill'

--- a/api/config.py
+++ b/api/config.py
@@ -125,7 +125,7 @@ class Configuration(CoreConfiguration):
         {
             "key": DEFAULT_NOTIFICATION_EMAIL_ADDRESS,
             "label": _("Default email address to use when notifying patrons of changes."),
-            "description": _("This should be an address that the library controls, but it is currently not used for anything. Holds cannot be placed on Overdrive, Bibliotheca, or Axis 360 books unless this address is specified.")
+            "description": _("This should be an address that the library controls, but no emails will (currently) be sent to this address. If this address is not specified, no holds can be placed on Overdrive, Bibliotheca, or Axis 360 titles, and no RBdigital titles can be put on loan.")
         },
         {
             "key": COLOR_SCHEME,

--- a/api/odl.py
+++ b/api/odl.py
@@ -156,7 +156,6 @@ class ODLWithConsolidatedCopiesAPI(BaseCirculationAPI):
         self.username = collection.external_integration.username
         self.password = collection.external_integration.password
         self.consolidated_loan_url = collection.external_integration.setting(self.CONSOLIDATED_LOAN_URL_KEY).value
-        self.default_loan_period = collection.external_integration.setting(Collection.EBOOK_LOAN_DURATION_KEY).int_value or Collection.STANDARD_DEFAULT_LOAN_PERIOD
 
     def internal_format(self, delivery_mechanism):
         """Each consolidated copy is only available in one format, so we don't need
@@ -202,7 +201,12 @@ class ODLWithConsolidatedCopiesAPI(BaseCirculationAPI):
         else:
             id = loan.license_pool.identifier.identifier
             checkout_id = str(uuid.uuid1())
-            expires = datetime.datetime.utcnow() + datetime.timedelta(days=self.default_loan_period)
+            default_loan_period = self.collection(_db).default_loan_period(
+                loan.patron.library
+            )
+            expires = datetime.datetime.utcnow() + datetime.timedelta(
+                days=default_loan_period
+            )
             # The patron UUID is generated randomly on each loan, so the distributor
             # doesn't know when multiple loans come from the same patron.
             patron_id = str(uuid.uuid1())

--- a/api/odl.py
+++ b/api/odl.py
@@ -156,7 +156,7 @@ class ODLWithConsolidatedCopiesAPI(BaseCirculationAPI):
         self.username = collection.external_integration.username
         self.password = collection.external_integration.password
         self.consolidated_loan_url = collection.external_integration.setting(self.CONSOLIDATED_LOAN_URL_KEY).value
-        self.default_loan_period = collection.external_integration.setting(BaseCirculationAPI.EBOOK_LOAN_DURATION).int_value or Collection.STANDARD_DEFAULT_LOAN_PERIOD
+        self.default_loan_period = collection.external_integration.setting(Collection.EBOOK_LOAN_DURATION_KEY).int_value or Collection.STANDARD_DEFAULT_LOAN_PERIOD
 
     def internal_format(self, delivery_mechanism):
         """Each consolidated copy is only available in one format, so we don't need

--- a/api/odl.py
+++ b/api/odl.py
@@ -105,15 +105,8 @@ class ODLWithConsolidatedCopiesAPI(BaseCirculationAPI):
         }
     ]
 
-    my_ebook_loan_duration_setting = dict(
-        BaseCirculationAPI.EBOOK_LOAN_DURATION_SETTING
-    )
-    my_ebook_loan_duration_setting.update(
-        description = _("When a patron uses SimplyE to borrow an ebook from this ODL server, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with the distributor.")
-    )
-
     LIBRARY_SETTINGS = BaseCirculationAPI.LIBRARY_SETTINGS + [
-        my_ebook_loan_duration_setting
+        BaseCirculationAPI.EBOOK_LOAN_DURATION_SETTING
     ]
 
     SET_DELIVERY_MECHANISM_AT = BaseCirculationAPI.FULFILL_STEP

--- a/api/odl.py
+++ b/api/odl.py
@@ -100,15 +100,20 @@ class ODLWithConsolidatedCopiesAPI(BaseCirculationAPI):
             "label": _("Library's API password"),
         },
         {
-            "key": BaseCirculationAPI.DEFAULT_LOAN_PERIOD,
-            "label": _("Default Loan Period (in Days, Maximum 59)"),
-            "default": 21,
-            "type": "number",
-        },
-        {
             "key": Collection.DATA_SOURCE_NAME_SETTING,
             "label": _("Data source name"),
         }
+    ]
+
+    my_ebook_loan_duration_setting = dict(
+        BaseCirculationAPI.EBOOK_LOAN_DURATION_SETTING
+    )
+    my_ebook_loan_duration_setting.update(
+        description = _("When a patron uses SimplyE to borrow an ebook from this ODL server, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with the distributor.")
+    )
+
+    LIBRARY_SETTINGS = BaseCirculationAPI.LIBRARY_SETTINGS + [
+        my_ebook_loan_duration_setting
     ]
 
     SET_DELIVERY_MECHANISM_AT = BaseCirculationAPI.FULFILL_STEP
@@ -158,7 +163,7 @@ class ODLWithConsolidatedCopiesAPI(BaseCirculationAPI):
         self.username = collection.external_integration.username
         self.password = collection.external_integration.password
         self.consolidated_loan_url = collection.external_integration.setting(self.CONSOLIDATED_LOAN_URL_KEY).value
-        self.default_loan_period = collection.external_integration.setting(BaseCirculationAPI.DEFAULT_LOAN_PERIOD).int_value or 21
+        self.default_loan_period = collection.external_integration.setting(BaseCirculationAPI.EBOOK_LOAN_DURATION).int_value or Collection.STANDARD_DEFAULT_LOAN_PERIOD
 
     def internal_format(self, delivery_mechanism):
         """Each consolidated copy is only available in one format, so we don't need

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -966,10 +966,10 @@ class MockOneClickAPI(BaseMockOneClickAPI, OneClickAPI):
     def mock_collection(cls, _db):
         collection = BaseMockOneClickAPI.mock_collection(_db)
         collection.external_integration.set_setting(
-            cls.AUDIOBOOK_LOAN_DURATION, 1
+            Collection.AUDIOBOOK_LOAN_DURATION_KEY, 1
         )
         collection.external_integration.set_setting(
-            cls.EBOOK_LOAN_DURATION, 2
+            Collection.EBOOK_LOAN_DURATION_KEY, 2
         )
         return collection
 

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -71,23 +71,28 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
         { "key": ExternalIntegration.URL, "label": _("URL"), "default": BaseOneClickAPI.PRODUCTION_BASE_URL },
     ] + BASE_SETTINGS
     
-    AUDIOBOOK_LOAN_DURATION = 'audio_loan_duration'
-    EBOOK_LOAN_DURATION = 'ebook_loan_duration'
-
-    LIBRARY_SETTINGS = [
-        { "key" : AUDIOBOOK_LOAN_DURATION, 
-          "label": _("Audiobook Loan Duration (in Days)"),
-        "description": _("When a patron uses SimplyE to borrow an RBdigital audio book, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with RBdigital.")
-        },
-        { "key" : EBOOK_LOAN_DURATION, 
-          "label": _("Ebook Loan Duration (in Days)"),
-        "description": _("When a patron uses SimplyE to borrow an RBdigital ebook, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with RBdigital.")
-        },
-    ]
-
     # The loan duration must be specified when connecting a library to an
     # RBdigital account, but if it's not specified, try one week.
     DEFAULT_LOAN_DURATION = 7
+
+    my_audiobook_setting = dict(
+        BaseCirculationAPI.AUDIOBOOK_LOAN_DURATION_SETTING
+    )
+    my_audiobook_setting.update(
+        description = _("When a patron uses SimplyE to borrow an RBdigital audio book, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with RBdigital."),
+        default=DEFAULT_LOAN_DURATION,
+    )
+    my_ebook_setting = dict(
+        BaseCirculationAPI.EBOOK_LOAN_DURATION_SETTING
+    )
+    my_ebook_setting.update(
+        description = _("When a patron uses SimplyE to borrow an RBdigital ebook, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with RBdigital."),
+        default=DEFAULT_LOAN_DURATION,
+    )
+    LIBRARY_SETTINGS = BaseCirculationAPI.LIBRARY_SETTINGS + [
+        my_audiobook_setting, 
+        my_ebook_setting
+    ]
 
     EXPIRATION_DATE_FORMAT = '%Y-%m-%d'
 
@@ -103,11 +108,11 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
 
         integration = self.collection.external_integration
         self.audiobook_duration_days = (
-            integration.setting(self.AUDIOBOOK_LOAN_DURATION).int_value 
+            integration.setting(Collection.AUDIOBOOK_LOAN_DURATION_KEY).int_value 
             or self.DEFAULT_LOAN_DURATION
         )
         self.ebook_duration_days = (
-            integration.setting(self.EBOOK_LOAN_DURATION).int_value 
+            integration.setting(Collection.EBOOK_LOAN_DURATION_KEY).int_value 
             or self.DEFAULT_LOAN_DURATION
         )
         

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -80,17 +80,11 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
     my_audiobook_setting = dict(
         BaseCirculationAPI.AUDIOBOOK_LOAN_DURATION_SETTING
     )
-    my_audiobook_setting.update(
-        description = _("When a patron uses SimplyE to borrow an RBdigital audio book, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with RBdigital."),
-        default=DEFAULT_LOAN_DURATION,
-    )
+    my_audiobook_setting.update(default=DEFAULT_LOAN_DURATION)
     my_ebook_setting = dict(
         BaseCirculationAPI.EBOOK_LOAN_DURATION_SETTING
     )
-    my_ebook_setting.update(
-        description = _("When a patron uses SimplyE to borrow an RBdigital ebook, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with RBdigital."),
-        default=DEFAULT_LOAN_DURATION,
-    )
+    my_ebook_setting.update(default=DEFAULT_LOAN_DURATION)
     LIBRARY_SETTINGS = BaseCirculationAPI.LIBRARY_SETTINGS + [
         my_audiobook_setting, 
         my_ebook_setting

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -60,6 +60,10 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
           "default": "default" },
     ] + BaseCirculationAPI.SETTINGS
 
+    LIBRARY_SETTINGS = BaseCirculationAPI.LIBRARY_SETTINGS + [
+        BaseCirculationAPI.DEFAULT_LOAN_DURATION_SETTING
+    ]
+
     # An Overdrive Advantage collection inherits everything except the library id
     # from its parent.
     CHILD_SETTINGS = [

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1869,7 +1869,7 @@ class TestSettingsController(AdminControllerTest):
                 ("password", "password"),
                 ("website_id", "1234"),
                 ("ils_name", "the_ils"),
-                ("default_loan_period", "14"),
+                ("ebook_loan_duration", "14"),
                 ("default_reservation_period", "3"),
             ])
             response = self.manager.admin_settings_controller.collections()
@@ -1893,8 +1893,8 @@ class TestSettingsController(AdminControllerTest):
         eq_("website_id", setting.key)
         eq_("1234", setting.value)
 
-        setting = collection.external_integration.setting("default_loan_period")
-        eq_("default_loan_period", setting.key)
+        setting = collection.external_integration.setting("ebook_loan_duration")
+        eq_("ebook_loan_duration", setting.key)
         eq_("14", setting.value)
 
         setting = collection.external_integration.setting("default_reservation_period")

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1950,7 +1950,7 @@ class TestSettingsController(AdminControllerTest):
                 ("website_id", "1234"),
                 ("ils_name", "the_ils"),
                 ("libraries", json.dumps([{"short_name": "L1"}])),
-                ("default_loan_period", "14"),
+                ("ebook_loan_duration", "14"),
                 ("default_reservation_period", "3"),
             ])
             response = self.manager.admin_settings_controller.collections()
@@ -1969,8 +1969,8 @@ class TestSettingsController(AdminControllerTest):
         eq_("website_id", setting.key)
         eq_("1234", setting.value)
 
-        setting = collection.external_integration.setting("default_loan_period")
-        eq_("default_loan_period", setting.key)
+        setting = collection.external_integration.setting("ebook_loan_duration")
+        eq_("ebook_loan_duration", setting.key)
         eq_("14", setting.value)
 
         setting = collection.external_integration.setting("default_reservation_period")
@@ -1987,7 +1987,7 @@ class TestSettingsController(AdminControllerTest):
                 ("password", "password"),
                 ("website_id", "1234"),
                 ("ils_name", "the_ils"),
-                ("default_loan_period", "14"),
+                ("ebook_loan_duration", "14"),
                 ("default_reservation_period", "3"),
                 ("libraries", json.dumps([])),
             ])

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1869,7 +1869,6 @@ class TestSettingsController(AdminControllerTest):
                 ("password", "password"),
                 ("website_id", "1234"),
                 ("ils_name", "the_ils"),
-                ("default_reservation_period", "3"),
             ])
             response = self.manager.admin_settings_controller.collections()
             eq_(response.status_code, 201)
@@ -1891,10 +1890,6 @@ class TestSettingsController(AdminControllerTest):
         setting = collection.external_integration.setting("website_id")
         eq_("website_id", setting.key)
         eq_("1234", setting.value)
-
-        setting = collection.external_integration.setting("default_reservation_period")
-        eq_("default_reservation_period", setting.key)
-        eq_("3", setting.value)
 
         # This collection will be a child of the first collection.
         with self.app.test_request_context("/", method="POST"):
@@ -1972,7 +1967,6 @@ class TestSettingsController(AdminControllerTest):
                 ("password", "password"),
                 ("website_id", "1234"),
                 ("ils_name", "the_ils"),
-                ("default_reservation_period", "3"),
                 ("libraries", json.dumps([])),
             ])
             response = self.manager.admin_settings_controller.collections()

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1869,7 +1869,6 @@ class TestSettingsController(AdminControllerTest):
                 ("password", "password"),
                 ("website_id", "1234"),
                 ("ils_name", "the_ils"),
-                ("ebook_loan_duration", "14"),
                 ("default_reservation_period", "3"),
             ])
             response = self.manager.admin_settings_controller.collections()
@@ -1892,10 +1891,6 @@ class TestSettingsController(AdminControllerTest):
         setting = collection.external_integration.setting("website_id")
         eq_("website_id", setting.key)
         eq_("1234", setting.value)
-
-        setting = collection.external_integration.setting("ebook_loan_duration")
-        eq_("ebook_loan_duration", setting.key)
-        eq_("14", setting.value)
 
         setting = collection.external_integration.setting("default_reservation_period")
         eq_("default_reservation_period", setting.key)
@@ -1949,9 +1944,7 @@ class TestSettingsController(AdminControllerTest):
                 ("password", "password"),
                 ("website_id", "1234"),
                 ("ils_name", "the_ils"),
-                ("libraries", json.dumps([{"short_name": "L1"}])),
-                ("ebook_loan_duration", "14"),
-                ("default_reservation_period", "3"),
+                ("libraries", json.dumps([{"short_name": "L1", "ebook_loan_duration": "14"}])),
             ])
             response = self.manager.admin_settings_controller.collections()
             eq_(response.status_code, 200)
@@ -1969,14 +1962,6 @@ class TestSettingsController(AdminControllerTest):
         eq_("website_id", setting.key)
         eq_("1234", setting.value)
 
-        setting = collection.external_integration.setting("ebook_loan_duration")
-        eq_("ebook_loan_duration", setting.key)
-        eq_("14", setting.value)
-
-        setting = collection.external_integration.setting("default_reservation_period")
-        eq_("default_reservation_period", setting.key)
-        eq_("3", setting.value)
-
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
                 ("id", collection.id),
@@ -1987,7 +1972,6 @@ class TestSettingsController(AdminControllerTest):
                 ("password", "password"),
                 ("website_id", "1234"),
                 ("ils_name", "the_ils"),
-                ("ebook_loan_duration", "14"),
                 ("default_reservation_period", "3"),
                 ("libraries", json.dumps([])),
             ])

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -11,13 +11,14 @@ from nose.tools import (
 import os
 from StringIO import StringIO
 
-from core.config import (
+from api.config import (
     Configuration, 
     temp_config,
 )
 
 from core.model import (
     get_one_or_create,
+    ConfigurationSetting,
     Contributor,
     Credential,
     DataSource,
@@ -73,6 +74,7 @@ class OneClickAPITest(DatabaseTest):
         self.default_patron = self._patron(external_identifier="oneclick_testuser")
         self.default_patron.authorization_identifier="13057226"
 
+
 class TestOneClickAPI(OneClickAPITest):
 
     def test_loan_duration(self):
@@ -114,6 +116,16 @@ class TestOneClickAPI(OneClickAPITest):
         eq_(Credential.IDENTIFIER_FROM_REMOTE_SERVICE, credential.type)
         eq_(external_id, credential.credential)
         eq_(None, credential.expires)
+
+    def _set_notification_address(self, library):
+        """Set the default notification address for the given library.
+
+        This is necessary to create RBdigital user accounts for its
+        patrons.
+        """
+        ConfigurationSetting.for_library(
+            Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, library
+        ).value = 'genericemail@library.org'
 
     def test_patron_remote_identifier_new_patron(self):
 
@@ -168,6 +180,31 @@ class TestOneClickAPI(OneClickAPITest):
         self._assert_patron_has_remote_identifier_credential(
             patron, "i know you"
         )
+
+    def test_patron_remote_email_address(self):
+
+        patron = self.default_patron
+
+        # Without a setting for DEFAULT_NOTIFICATION_EMAIL_ADDRESS, we
+        # can't calculate the email address to send RBdigital for a
+        # patron.
+        assert_raises_regexp(
+            RemotePatronCreationFailedException,
+            "Cannot create remote account for patron because library's default notification address is not set.",
+            self.api.remote_email_address, patron
+        )
+
+        self._set_notification_address(patron.library)
+        address = self.api.remote_email_address(patron)
+
+        # A credential was created to use when talking to RBdigital
+        # about this patron.
+        [credential] = patron.credentials
+
+        # The credential and default notification email address were
+        # used to construct the patron's
+        eq_("genericemail+rbdigital-%s@library.org" % credential.credential,
+            address)
 
     def test_patron_remote_identifier_lookup(self):
 
@@ -400,6 +437,7 @@ class TestOneClickAPI(OneClickAPITest):
         on the RBdigital side.
         """
         patron = self.default_patron
+        self._set_notification_address(patron.library)
 
         # If the patron already has an account, a
         # RemotePatronCreationFailedException is raised.
@@ -433,7 +471,7 @@ class TestOneClickAPI(OneClickAPITest):
         eq_(self.api.library_id, form_data['libraryId'])
         eq_(remote, form_data['libraryCardNumber'])
         eq_("username_" + remote, form_data['userName'])
-        eq_("patron_%s@librarysimplified.org" % remote, form_data['email'])
+        eq_("genericemail+rbdigital-%s@library.org" % remote, form_data['email'])
         eq_("Patron", form_data['firstName'])
         eq_("Reader", form_data['lastName'])
 


### PR DESCRIPTION
This branch makes sure that all of our CollectionAPI subclasses (except the ones that offer unlimited-length loans) have one (ebooks) or two (ebooks+audiobooks) settings relating to loan durations.

For Overdrive, Axis, and Bibliotheca, these settings are informative only. They reflect the _default_ or _assumed average_ lengths of loans but the circulation manager has no power over the lengths of loans created through these services.

For ODL and RBdigital, these settings are active. When a loan is created, the duration of the loan is taken from this setting.

All this code existed before, but ODL and RBdigital were handled inconsistently, the settings were per-collection instead of per-library per-collection, and the descriptions of the settings didn't make it clear when these settings were informative and when they were active.