### PR TITLE
Overdrive "ils_name" setting is per library

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -56,11 +56,13 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         { "key": BaseOverdriveAPI.WEBSITE_ID, "label": _("Website ID") },
         { "key": ExternalIntegration.USERNAME, "label": _("Client Key") },
         { "key": ExternalIntegration.PASSWORD, "label": _("Client Secret") },
-        { "key": BaseOverdriveAPI.ILS_NAME, "label": _("ILS Name"),
-          "default": "default" },
     ] + BaseCirculationAPI.SETTINGS
 
     LIBRARY_SETTINGS = BaseCirculationAPI.LIBRARY_SETTINGS + [
+        { "key": BaseOverdriveAPI.ILS_NAME_KEY, "label": _("ILS Name"),
+          "default": BaseOverdriveAPI.ILS_NAME_DEFAULT,
+          "description": _("When multiple libraries share an Overdrive account, Overdrive uses a setting called 'ILS Name' to determine which ILS to check when validating a given patron."),
+        },
         BaseCirculationAPI.DEFAULT_LOAN_DURATION_SETTING
     ]
 
@@ -159,7 +161,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
             grant_type="password",
             username=patron.authorization_identifier,
             scope="websiteid:%s authorizationname:%s" % (
-                self.website_id, self.ils_name)
+                self.website_id, self.ils_name(patron.library))
         )
         if pin:
             # A PIN was provided.

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -492,7 +492,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         eq_("https://oauth-patron.overdrive.com/patrontoken", url)
         eq_("barcode", payload['username'])
         expect_scope = "websiteid:%s authorizationname:%s" % (
-            self.api.website_id, self.api.ils_name
+            self.api.website_id, self.api.ils_name(patron.library)
         )
         eq_(expect_scope, payload['scope'])
         eq_("a pin", payload['password'])


### PR DESCRIPTION
The circulation branch to match https://github.com/NYPL-Simplified/server_core/pull/708.

Each library can have a different ILS name, so pass in the patron's library when looking up the ILS name for purposes of access token negotiation.