### PR TITLE
Remove lane identifier

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -20,8 +20,6 @@ class Configuration(CoreConfiguration):
 
     DEFAULT_OPDS_FORMAT = "simple_opds_entry"
 
-    ROOT_LANE_POLICY = "root_lane"
-
     # The name of the sitewide url that points to the patron web catalog.
     PATRON_WEB_CLIENT_URL = u"Patron Web Client"
 
@@ -125,7 +123,7 @@ class Configuration(CoreConfiguration):
         {
             "key": DEFAULT_NOTIFICATION_EMAIL_ADDRESS,
             "label": _("Default email address to use when notifying patrons of changes."),
-            "description": _("This should be an address that the library controls, but it is currently not used for anything. Holds cannot be placed on Overdrive, Bibliotheca, or Axis 360 books unless this address is specified.")
+            "description": _("This should be an address that the library controls, but no emails will (currently) be sent to this address. If this address is not specified, no holds can be placed on Overdrive, Bibliotheca, or Axis 360 titles, and no RBdigital titles can be put on loan.")
         },
         {
             "key": COLOR_SCHEME,
@@ -224,10 +222,6 @@ class Configuration(CoreConfiguration):
     @classmethod
     def lending_policy(cls):
         return cls.policy(cls.LENDING_POLICY)
-
-    @classmethod
-    def root_lane_policy(cls):
-        return cls.policy(cls.ROOT_LANE_POLICY)
 
     @classmethod
     def _collection_languages(cls, library, key):

--- a/api/controller.py
+++ b/api/controller.py
@@ -498,8 +498,7 @@ class IndexController(CirculationManagerController):
     def __call__(self):
         # The simple case: the app is equally open to all clients.
         library_short_name = flask.request.library.short_name
-        policy = Configuration.root_lane_policy()
-        if not policy:
+        if not self.has_root_lanes():
             return redirect(self.cdn_url_for('acquisition_groups', library_short_name=library_short_name))
 
         # The more complex case. We must authorize the patron, check
@@ -516,6 +515,14 @@ class IndexController(CirculationManagerController):
             }
         )
 
+    def has_root_lanes(self):
+        root_lanes = self._db.query(Lane).filter(
+            Lane.library==flask.request.library
+        ).filter(
+            Lane.root_for_patron_type!=None
+        )
+        return root_lanes.count() > 0
+
     def authenticated_patron_root_lane(self):
         patron = self.authenticated_patron_from_request()
         if isinstance(patron, ProblemDetail):
@@ -523,12 +530,15 @@ class IndexController(CirculationManagerController):
         if isinstance(patron, Response):
             return patron
 
-        policy = Configuration.root_lane_policy()
-        lane_identifier = policy.get(patron.external_type)
-        if lane_identifier is None:
+        lanes = self._db.query(Lane).filter(
+            Lane.library==flask.request.library
+        ).filter(
+            Lane.root_for_patron_type.any(patron.external_type)
+        )
+        if lanes.count() < 1:
             return None
         else:
-            return self.load_lane(lane_identifier)
+            return lanes.one()
 
     def appropriate_index_for_patron_type(self):
         library_short_name = flask.request.library.short_name

--- a/api/controller.py
+++ b/api/controller.py
@@ -409,11 +409,13 @@ class CirculationManagerController(BaseCirculationManagerController):
         if lane_identifier is None:
             return top_level_lane
 
-        lane = get_one(self._db, Lane, identifier=lane_identifier, library_id=library_id)
+        lane = get_one(self._db, Lane, id=lane_identifier, library_id=library_id)
 
         if not lane:
             return NO_SUCH_LANE.detailed(
-                _("No such lane: %(lane_identifier)s", lane_identifier=lane_identifier)
+                _("Lane %(lane_identifier)s does not exist or is not associated with library %(library_id)s", 
+                  lane_identifier=lane_identifier, library_id=library_id
+                )
             )
         return lane
 
@@ -547,7 +549,7 @@ class IndexController(CirculationManagerController):
             self.cdn_url_for(
                 'acquisition_groups', 
                 library_short_name=library_short_name,
-                lane_identifier=root_lane.identifier,
+                lane_identifier=root_lane.id,
             )
         )
 

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -435,9 +435,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
                          identifier=ya_fiction_identifier + " " + genres.Steampunk.name,
                          priority=ya_fiction_priority, **ya_common_args))
     ya_fiction_priority += 1
-    # TODO:
-    # Paranormal -- what is it exactly?
-
 
     ya_nonfiction_identifier = "%s Young Adult Nonfiction" % language_identifier
     ya_nonfiction, ignore = create(
@@ -750,7 +747,11 @@ def create_lane_for_tiny_collections(_db, library, languages, priority=0):
     return priority
 
 
-class WorkBasedLane(WorkList):
+class DynamicLane(WorkList):
+    """A WorkList that's used to from an OPDS lane, but isn't a Lane
+    in the database."""
+
+class WorkBasedLane(DynamicLane):
     """A query-based lane connected on a particular Work"""
 
     DISPLAY_NAME = None
@@ -915,7 +916,7 @@ class RecommendationLane(WorkBasedLane):
         return super(RecommendationLane, self).apply_filters(
             _db, qu, work_model, facets, pagination, featured=featured)
 
-class SeriesLane(WorkList):
+class SeriesLane(DynamicLane):
     """A lane of Works in a particular series"""
 
     ROUTE = 'series'
@@ -972,7 +973,7 @@ class SeriesLane(WorkList):
             _db, qu, work_model, facets, pagination, featured)
 
 
-class ContributorLane(WorkList):
+class ContributorLane(DynamicLane):
     """A lane of Works written by a particular contributor"""
 
     ROUTE = 'contributor'

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -676,7 +676,6 @@ def create_lane_for_small_collection(_db, library, languages, priority=0):
 
     adult_fiction, ignore = create(
         _db, Lane, library=library,
-        identifier=language_identifier + " Adult Fiction",
         display_name="Fiction",
         fiction=True,
         audiences=ADULT,
@@ -687,7 +686,6 @@ def create_lane_for_small_collection(_db, library, languages, priority=0):
 
     adult_nonfiction, ignore = create(
         _db, Lane, library=library,
-        identifier=language_identifier + " Adult Nonfiction",
         display_name="Nonfiction",
         fiction=False,
         audiences=ADULT,
@@ -698,7 +696,6 @@ def create_lane_for_small_collection(_db, library, languages, priority=0):
 
     ya_children, ignore = create(
         _db, Lane, library=library,
-        identifier=language_identifier + " Children & Young Adult",
         display_name="Children & Young Adult",
         fiction=None,
         audiences=YA_CHILDREN,
@@ -709,7 +706,6 @@ def create_lane_for_small_collection(_db, library, languages, priority=0):
 
     lane, ignore = create(
         _db, Lane, library=library,
-        identifier=language_identifier,
         display_name=language_identifier,
         sublanes=[adult_fiction, adult_nonfiction, ya_children],
         priority=priority,
@@ -732,7 +728,6 @@ def create_lane_for_tiny_collections(_db, library, languages, priority=0):
         name = LanguageCodes.name_for_languageset(language_set)
         language_lane, ignore = create(
             _db, Lane, library=library,
-            identifier=name,
             display_name=name,
             genres=[],
             fiction=None,
@@ -744,7 +739,6 @@ def create_lane_for_tiny_collections(_db, library, languages, priority=0):
 
     lane, ignore = create(
         _db, Lane, library=library, 
-        identifier="Other Languages",
         display_name="Other Languages", 
         sublanes=language_lanes,
         genres=[],

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -128,7 +128,7 @@ def create_default_lanes(_db, library):
         _db, library, tiny, priority=priority
     )
 
-def lane_from_genres(_db, library, genres, identifier=None, display_name=None,
+def lane_from_genres(_db, library, genres, display_name=None,
                      exclude_genres=None, priority=0, audiences=None, **extra_args):
     """Turn genre info into a Lane object."""
 
@@ -150,7 +150,7 @@ def lane_from_genres(_db, library, genres, identifier=None, display_name=None,
             sublane_priority = 0
             for subgenre in genre.get("subgenres", []):
                 sublanes.append(lane_from_genres(
-                        _db, library, [subgenre], identifier=identifier + " " + subgenre,
+                        _db, library, [subgenre], 
                         priority=sublane_priority, **extra_args))
                 sublane_priority += 1
 
@@ -165,8 +165,6 @@ def lane_from_genres(_db, library, genres, identifier=None, display_name=None,
                       else genre
                       for genre in exclude_genres or []]
 
-    if not identifier and len(genres) == 1:
-        identifier = genres[0]
     fiction = None
     visible = True
     if len(genres) == 1:
@@ -186,13 +184,10 @@ def lane_from_genres(_db, library, genres, identifier=None, display_name=None,
                 visible = instructions.get("visible")
 
     if not display_name:
-        if len(genres) == 1:
-            display_name = genres[0]
-        else:
-            display_name = identifier
+        display_name = ", ".join(sorted(genres))
 
     lane, ignore = create(_db, Lane, library_id=library.id,
-                          identifier=identifier, display_name=display_name,
+                          display_name=display_name,
                           fiction=fiction, audiences=audiences,
                           sublanes=sublanes, priority=priority,
                           **extra_args)
@@ -256,7 +251,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
     if include_best_sellers:
         best_sellers, ignore = create(
             _db, Lane, library=library,
-            identifier = "%s Best Sellers" % language_identifier,
             display_name="Best Sellers",
             priority=priority,
             languages=languages
@@ -275,7 +269,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
     if include_best_sellers:
         adult_fiction_best_sellers, ignore = create(
             _db, Lane, library=library,
-            identifier = "%s Adult Fiction Best Sellers" % language_identifier,
             display_name="Best Sellers",
             fiction=True,
             priority=adult_fiction_priority,
@@ -292,7 +285,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
             genre_name = genre.get("name")
         genre_lane = lane_from_genres(
             _db, library, [genre],
-            identifier="%s Adult Fiction %s" % (language_identifier, genre_name),
             priority=adult_fiction_priority,
             **adult_common_args)
         adult_fiction_priority += 1
@@ -300,7 +292,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     adult_fiction, ignore = create(
         _db, Lane, library=library,
-        identifier="%s Adult Fiction" % language_identifier,
         display_name="Fiction",
         genres=[],
         sublanes=adult_fiction_sublanes,
@@ -316,7 +307,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
     if include_best_sellers:
         adult_nonfiction_best_sellers, ignore = create(
             _db, Lane, library=library,
-            identifier = "%s Adult Nonfiction Best Sellers" % language_identifier,
             display_name="Best Sellers",
             fiction=False,
             priority=adult_nonfiction_priority,
@@ -336,7 +326,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
                 genre_name = genre.get("name")
             genre_lane = lane_from_genres(
                 _db, library, [genre],
-                identifier="%s Adult Nonfiction %s" % (language_identifier, genre_name),
                 priority=adult_nonfiction_priority,
                 **adult_common_args)
             adult_nonfiction_priority += 1
@@ -344,7 +333,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     adult_nonfiction, ignore = create(
         _db, Lane, library=library,
-        identifier="%s Adult Nonfiction" % language_identifier,
         display_name="Nonfiction",
         genres=[],
         sublanes=adult_nonfiction_sublanes,
@@ -360,10 +348,8 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
         languages=languages,
     )
 
-    ya_fiction_identifier = "%s Young Adult Fiction" % language_identifier
     ya_fiction, ignore = create(
         _db, Lane, library=library,
-        identifier=ya_fiction_identifier,
         display_name="Young Adult Fiction",
         genres=[], fiction=True,
         sublanes=[],
@@ -377,7 +363,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
     if include_best_sellers:
         ya_fiction_best_sellers, ignore = create(
             _db, Lane, library=library,
-            identifier = "%s Best Sellers" % ya_fiction_identifier,
             display_name="Best Sellers",
             fiction=True,
             priority=ya_fiction_priority,
@@ -389,57 +374,46 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     ya_fiction.sublanes.append(
         lane_from_genres(_db, library, [genres.Dystopian_SF],
-                         identifier=ya_fiction_identifier + " " + genres.Dystopian_SF.name,
                          priority=ya_fiction_priority, **ya_common_args))
     ya_fiction_priority += 1
     ya_fiction.sublanes.append(
         lane_from_genres(_db, library, [genres.Fantasy],
-                         identifier=ya_fiction_identifier + " " + genres.Fantasy.name,
                          priority=ya_fiction_priority, **ya_common_args))
     ya_fiction_priority += 1
     ya_fiction.sublanes.append(
         lane_from_genres(_db, library, [genres.Comics_Graphic_Novels],
-                         identifier=ya_fiction_identifier + " " + genres.Comics_Graphic_Novels.name,
                          priority=ya_fiction_priority, **ya_common_args))
     ya_fiction_priority += 1
     ya_fiction.sublanes.append(
         lane_from_genres(_db, library, [genres.Literary_Fiction],
-                         identifier=ya_fiction_identifier + " " + genres.Literary_Fiction.name,
                          display_name="Contemporary Fiction",
                          priority=ya_fiction_priority, **ya_common_args))
     ya_fiction_priority += 1
     ya_fiction.sublanes.append(
         lane_from_genres(_db, library, [genres.LGBTQ_Fiction],
-                         identifier=ya_fiction_identifier + " " + genres.LGBTQ_Fiction.name,
                          priority=ya_fiction_priority, **ya_common_args))
     ya_fiction_priority += 1
     ya_fiction.sublanes.append(
         lane_from_genres(_db, library, [genres.Suspense_Thriller, genres.Mystery],
-                         identifier=ya_fiction_identifier + " Mystery & Thriller",
                          display_name="Mystery & Thriller",
                          priority=ya_fiction_priority, **ya_common_args))
     ya_fiction_priority += 1
     ya_fiction.sublanes.append(
         lane_from_genres(_db, library, [genres.Romance],
-                         identifier=ya_fiction_identifier + " " + genres.Romance.name,
                          priority=ya_fiction_priority, **ya_common_args))
     ya_fiction_priority += 1
     ya_fiction.sublanes.append(
         lane_from_genres(_db, library, [genres.Science_Fiction],
                          exclude_genres=[genres.Dystopian_SF, genres.Steampunk],
-                         identifier=ya_fiction_identifier + " " + genres.Science_Fiction.name,
                          priority=ya_fiction_priority, **ya_common_args))
     ya_fiction_priority += 1
     ya_fiction.sublanes.append(
         lane_from_genres(_db, library, [genres.Steampunk],
-                         identifier=ya_fiction_identifier + " " + genres.Steampunk.name,
                          priority=ya_fiction_priority, **ya_common_args))
     ya_fiction_priority += 1
 
-    ya_nonfiction_identifier = "%s Young Adult Nonfiction" % language_identifier
     ya_nonfiction, ignore = create(
         _db, Lane, library=library,
-        identifier=ya_nonfiction_identifier,
         display_name="Young Adult Nonfiction",
         genres=[], fiction=False,
         sublanes=[],
@@ -453,7 +427,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
     if include_best_sellers:
         ya_nonfiction_best_sellers, ignore = create(
             _db, Lane, library=library,
-            identifier = "%s Best Sellers" % ya_nonfiction_identifier,
             display_name="Best Sellers",
             fiction=False,
             priority=ya_nonfiction_priority,
@@ -465,24 +438,20 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     ya_nonfiction.sublanes.append(
         lane_from_genres(_db, library, [genres.Biography_Memoir],
-                         identifier=ya_nonfiction_identifier + " " + genres.Biography_Memoir.name,
                          display_name="Biography",
                          priority=ya_nonfiction_priority, **ya_common_args))
     ya_nonfiction_priority += 1
     ya_nonfiction.sublanes.append(
         lane_from_genres(_db, library, [genres.History, genres.Social_Sciences],
-                         identifier=ya_nonfiction_identifier + " History & Sociology",
                          display_name="History & Sociology",
                          priority=ya_nonfiction_priority, **ya_common_args))
     ya_nonfiction_priority += 1
     ya_nonfiction.sublanes.append(
         lane_from_genres(_db, library, [genres.Life_Strategies],
-                         identifier=ya_nonfiction_identifier + " " + genres.Life_Strategies.name,
                          priority=ya_nonfiction_priority, **ya_common_args))
     ya_nonfiction_priority += 1
     ya_nonfiction.sublanes.append(
         lane_from_genres(_db, library, [genres.Religion_Spirituality],
-                         identifier=ya_nonfiction_identifier + " " + genres.Religion_Spirituality.name,
                          priority=ya_nonfiction_priority, **ya_common_args))
     ya_nonfiction_priority += 1
 
@@ -492,11 +461,8 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
         languages=languages,
     )
 
-    children_identifier = "%s Children and Middle Grade" % language_identifier
-
     children, ignore = create(
         _db, Lane, library=library,
-        identifier=children_identifier,
         display_name="Children and Middle Grade",
         genres=[], fiction=None,
         sublanes=[],
@@ -510,7 +476,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
     if include_best_sellers:
         children_best_sellers, ignore = create(
             _db, Lane, library=library,
-            identifier = "%s Best Sellers" % children_identifier,
             display_name="Best Sellers",
             priority=children_priority,
             **children_common_args
@@ -521,7 +486,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     picture_books, ignore = create(
         _db, Lane, library=library,
-        identifier=children_identifier + " Picture Books",
         display_name="Picture Books",
         target_age=(0,4), genres=[], fiction=None,
         priority=children_priority,
@@ -532,7 +496,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     easy_readers, ignore = create(
         _db, Lane, library=library,
-        identifier=children_identifier + " Easy Readers",
         display_name="Easy Readers",
         target_age=(5,8), genres=[], fiction=None,
         priority=children_priority,
@@ -543,7 +506,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     chapter_books, ignore = create(
         _db, Lane, library=library,
-        identifier=children_identifier + " Chapter Books",
         display_name="Chapter Books",
         target_age=(9,12), genres=[], fiction=None,
         priority=children_priority,
@@ -554,7 +516,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     children_poetry, ignore = create(
         _db, Lane, library=library,
-        identifier=children_identifier + " Poetry",
         display_name="Poetry Books",
         priority=children_priority,
         **children_common_args
@@ -565,7 +526,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     children_folklore, ignore = create(
         _db, Lane, library=library,
-        identifier=children_identifier + " Folklore",
         display_name="Folklore",
         priority=children_priority,
         **children_common_args
@@ -576,7 +536,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     children_fantasy, ignore = create(
         _db, Lane, library=library,
-        identifier=children_identifier + " Fantasy",
         display_name="Fantasy",
         fiction=True,
         priority=children_priority,
@@ -588,7 +547,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     children_sf, ignore = create(
         _db, Lane, library=library,
-        identifier=children_identifier + " SF",
         display_name="Science Fiction",
         fiction=True,
         priority=children_priority,
@@ -600,7 +558,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     realistic_fiction, ignore = create(
         _db, Lane, library=library,
-        identifier=children_identifier + " Realistic Fiction",
         display_name="Realistic Fiction",
         fiction=True,
         priority=children_priority,
@@ -612,7 +569,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     children_graphic_novels, ignore = create(
         _db, Lane, library=library,
-        identifier=children_identifier + " Graphic Novels",
         display_name="Comics & Graphic Novels",
         priority=children_priority,
         **children_common_args
@@ -623,7 +579,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     children_biography, ignore = create(
         _db, Lane, library=library,
-        identifier=children_identifier + " Biography",
         display_name="Biography",
         priority=children_priority,
         **children_common_args
@@ -634,7 +589,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     children_historical_fiction, ignore = create(
         _db, Lane, library=library,
-        identifier=children_identifier + " Historical Fiction",
         display_name="Historical Fiction",
         priority=children_priority,
         **children_common_args
@@ -645,7 +599,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     informational, ignore = create(
         _db, Lane, library=library,
-        identifier=children_identifier + " Informational Books",
         display_name="Informational Books",
         fiction=False, genres=[],
         priority=children_priority,

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -86,6 +86,19 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
         )
         self.eaudio_expiration_default = self.ebook_expiration_default
 
+    def remote_email_address(self, patron):
+        """The fake email address to send to RBdigital when
+        signing up this patron.
+        """
+        default = self.default_notification_email_address(patron, None)
+        if not default:
+            raise RemotePatronCreationFailedException(
+                _("Cannot create remote account for patron because library's default notification address is not set.")
+            )
+        patron_identifier = patron.identifier_to_remote_service(
+            DataSource.RB_DIGITAL
+        )
+        return default.replace('@', '+rbdigital-%s@' % patron_identifier, 1)
 
     def checkin(self, patron, pin, licensepool):
         """
@@ -468,7 +481,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
         # Generate meaningless values for account fields that are not
         # relevant to our usage of the API.
         post_args['userName'] = 'username_' + patron_identifier
-        post_args['email'] = 'patron_' + patron_identifier + '@librarysimplified.org'
+        post_args['email'] = self.remote_email_address(patron)
         post_args['firstName'] = 'Patron'
         post_args['lastName'] = 'Reader'
 

--- a/api/opds.py
+++ b/api/opds.py
@@ -37,11 +37,7 @@ from core.lane import (
     Lane,
     WorkList,
 )
-from api.lanes import (
-    WorkBasedLane,
-    ContributorLane,
-    SeriesLane,
-)
+from api.lanes import DynamicLane
 from core.app_server import cdn_url_for
 
 from adobe_vendor_id import AuthdataUtility
@@ -245,9 +241,7 @@ class CirculationManagerAnnotator(Annotator):
             url = self.groups_url(lane)
         elif lane and (
             isinstance(lane, Lane)
-            or isinstance(lane, WorkBasedLane)
-            or isinstance(lane, ContributorLane)
-            or isinstance(lane, SeriesLane)
+            or isinstance(lane, DynamicLane)
             ):
             url = self.feed_url(lane)
         else:

--- a/api/opds.py
+++ b/api/opds.py
@@ -137,7 +137,7 @@ class CirculationManagerAnnotator(Annotator):
 
     def _lane_identifier(self, lane):
         if isinstance(lane, Lane):
-            return lane.identifier
+            return lane.id
         return None
 
     def facet_url(self, facets):

--- a/scripts.py
+++ b/scripts.py
@@ -425,7 +425,7 @@ class CacheRepresentationPerLane(LaneSweeperScript):
         annotator = self.app.manager.annotator(lane)
         a = time.time()
         self.log.info(
-            "Generating feed(s) for %s", lane.identifier
+            "Generating feed(s) for %s/%s", lane.id, lane.display_name
         )
         cached_feeds = list(self.do_generate(lane))
         b = time.time()

--- a/scripts.py
+++ b/scripts.py
@@ -383,9 +383,6 @@ class CacheRepresentationPerLane(LaneSweeperScript):
         return parsed
     
     def should_process_lane(self, lane):
-        if lane.identifier is None:
-            return False
-            
         if not isinstance(lane, Lane):
             return False
 

--- a/scripts.py
+++ b/scripts.py
@@ -425,14 +425,14 @@ class CacheRepresentationPerLane(LaneSweeperScript):
         annotator = self.app.manager.annotator(lane)
         a = time.time()
         self.log.info(
-            "Generating feed(s) for %s/%s", lane.id, lane.display_name
+            "Generating feed(s) for %s", lane.full_identifier
         )
         cached_feeds = list(self.do_generate(lane))
         b = time.time()
         total_size = sum(len(x.content) for x in cached_feeds if x)
         self.log.info(
             "Generated %d feed(s) for %s. Took %.2fsec to make %d bytes.",
-            len(cached_feeds), lane.identifier, (b-a), total_size
+            len(cached_feeds), lane.full_identifier, (b-a), total_size
         )
         return cached_feeds
         

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -756,8 +756,9 @@ class TestIndexController(CirculationControllerTest):
         with temp_config() as config:
             # Patrons of external type '1' get sent to the Adult
             # Fiction lane.
+            root_lane = self.library.lanes[0]
             config[Configuration.POLICIES] = {
-                Configuration.ROOT_LANE_POLICY : { "1": "English Adult Fiction"},
+                Configuration.ROOT_LANE_POLICY : { "1": root_lane.id},
             }
             with self.request_context_with_library(
                 "/", headers=dict(Authorization=self.invalid_auth)):
@@ -768,7 +769,7 @@ class TestIndexController(CirculationControllerTest):
                 "/", headers=dict(Authorization=self.valid_auth)):
                 response = self.manager.index_controller()
                 eq_(302, response.status_code)
-                eq_("http://cdn/default/groups/English%20Adult%20Fiction", response.headers['location'])
+                eq_("http://cdn/default/groups/%s" % root_lane.id, response.headers['location'])
 
             # Now those patrons get sent to the top-level lane.
             config['policies'][Configuration.ROOT_LANE_POLICY] = { "1": None }
@@ -2395,7 +2396,7 @@ class TestFeedController(CirculationControllerTest):
 
             # The query also works in a different searchable lane.
             english = self._lane("English", languages=["eng"])
-            response = self.manager.opds_feeds.search(english.identifier)
+            response = self.manager.opds_feeds.search(english.id)
             feed = feedparser.parse(response.data)
             entries = feed['entries']
             eq_(1, len(entries))

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -96,7 +96,6 @@ from api.adobe_vendor_id import (
     DeviceManagementProtocolController,
 )
 from api.odl import MockODLWithConsolidatedCopiesAPI
-from api.lanes import make_lanes_default
 import base64
 import feedparser
 from core.opds import (

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -118,18 +118,13 @@ class TestRepresentationPerLane(TestLaneScript):
         )
         eq_(['fre', 'eng'], script.languages)
 
-        english_lane, ignore = create(self._db, Lane, library=self._default_library,
-                                      identifier=self._str, languages=['eng'])
+        english_lane = self._lane(languages=['eng'])
         eq_(True, script.should_process_lane(english_lane))
 
-        no_english_lane, ignore = create(self._db, Lane, library=self._default_library,
-                                         identifier=self._str, languages=['spa','fre'])
+        no_english_lane = self._lane(languages=['spa','fre'])
         eq_(True, script.should_process_lane(no_english_lane))
 
-        no_english_or_french_lane, ignore = create(
-            self._db, Lane, library=self._default_library,
-            identifier=self._str, languages=['spa']
-        )
+        no_english_or_french_lane = self._lane(languages=['spa'])
         eq_(False, script.should_process_lane(no_english_or_french_lane))
             
     def test_max_and_min_depth(self):
@@ -139,8 +134,9 @@ class TestRepresentationPerLane(TestLaneScript):
         )
         eq_(0, script.max_depth)
 
-        child, ignore = create(self._db, Lane, library=self._default_library, identifier="sublane")
-        parent, ignore = create(self._db, Lane, library=self._default_library, identifier="parent", sublanes=[child])
+        child = self._lane(display_name="sublane")
+        parent = self._lane(display_name="parent")
+        parent.sublanes=[child]
         eq_(True, script.should_process_lane(parent))
         eq_(False, script.should_process_lane(child))
 
@@ -186,7 +182,7 @@ class TestCacheFacetListsPerLane(TestLaneScript):
         )
         with script.app.test_request_context("/"):
             flask.request.library = self._default_library
-            lane, ignore = create(self._db, Lane, library=self._default_library, identifier=self._str)
+            lane, ignore = self._lane()
             cached_feeds = script.process_lane(lane)
             # 2 availabilities * 2 collections * 1 order * 1 page = 4 feeds
             eq_(4, len(cached_feeds))

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -182,7 +182,7 @@ class TestCacheFacetListsPerLane(TestLaneScript):
         )
         with script.app.test_request_context("/"):
             flask.request.library = self._default_library
-            lane, ignore = self._lane()
+            lane = self._lane()
             cached_feeds = script.process_lane(lane)
             # 2 availabilities * 2 collections * 1 order * 1 page = 4 feeds
             eq_(4, len(cached_feeds))


### PR DESCRIPTION
This branch takes care of the fallout from https://github.com/NYPL-Simplified/server_core/pull/713 by changing everything that used to use `Lane.identifier` to use either `Lane.id` (the database ID) or `Lane.full_identifier` (for logging).