### PR TITLE
Immediately remove the 'reap' coverage records for relicensed works, …

### DIFF
--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -268,7 +268,7 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
         )
         cr = self._coverage_record(
             pool.identifier, self.provider.data_source,
-            operation=self.provider.OPERATION
+            operation=self.provider.OPERATION, collection=self.collection
         )
 
         # We have a coverage record already, so this book doesn't show
@@ -298,7 +298,8 @@ class TestMetadataWranglerCoverageProvider(DatabaseTest):
         cr = self._coverage_record(
             pool.identifier, self.provider.data_source, 
             operation=self.provider.operation,
-            status=CoverageRecord.TRANSIENT_FAILURE
+            status=CoverageRecord.TRANSIENT_FAILURE,
+            collection=self.collection
         )
         
         # Ordinarily, a transient failure does not count as coverage.
@@ -550,9 +551,7 @@ class TestMetadataWranglerCollectionSync(MetadataWranglerCollectionManagerTest):
         eq_(2, len(items))
 
         # The REAP coverage record for the repurchased book has been
-        # deleted, and committing will remove it from the database.
-        assert relicensed_coverage_record in relicensed.identifier.coverage_records
-        self._db.commit()
+        # deleted and removed from the database.
         assert relicensed_coverage_record not in relicensed.identifier.coverage_records
 
     def test_process_batch(self):
@@ -701,7 +700,7 @@ class TestMetadataUploadCoverageProvider(DatabaseTest):
         
         cr = self._coverage_record(
             pool.identifier, self.provider.data_source,
-            operation=self.provider.OPERATION
+            operation=self.provider.OPERATION, collection=self.collection
         )
 
         # With a successful or persistent failure CoverageRecord, it still doesn't show up.


### PR DESCRIPTION
…instead of adding all the relicensed works in with a union() call.

This branch removes the union() call for finding works that were reaped from a collection, but then relicensed. Instead, the 'reap' CoverageRecords are immediately removed and the database session committed. This was going to happen soon enough anyway, and doing it immediately lets us avoid treating relicensed works specially.

The use of union() was making `items_that_need_coverage` treat _all_ relicensed works as needing coverage, even ones that already had coverage records. These works were showing up over and over again, and being processed over and over again, blocking other titles from being published.