### PR TITLE
BaseCirculationAPI.fulfill takes the internal format, not the DeliveryMechanism.

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -81,6 +81,9 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
         (Representation.PDF_MEDIA_TYPE, adobe_drm): 'PDF',
         (Representation.MP3_MEDIA_TYPE, findaway_drm) : 'MP3'
     }
+    internal_format_to_delivery_mechanism = dict(
+        [v,k] for k, v in delivery_mechanism_to_internal_format.items()
+    )
 
     def get_events_between(self, start, end, cache_result=False):
         """Return event objects for events between the given times."""
@@ -186,8 +189,11 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
         )
         return loan
 
-    def fulfill(self, patron, password, pool, delivery_mechanism):
-        if delivery_mechanism.drm_scheme == DeliveryMechanism.FINDAWAY_DRM:
+    def fulfill(self, patron, password, pool, internal_delivery):
+        media_type, drm_scheme = self.internal_format_to_delivery_mechanism.get(
+            internal_delivery, internal_delivery
+        )
+        if drm_scheme == DeliveryMechanism.FINDAWAY_DRM:
             fulfill_method = self.get_audio_fulfillment_file
             # The provided media type is application/json, which
             # is too vague for us.

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -247,24 +247,13 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         edition, pool = self._edition(
             data_source_name=DataSource.BIBLIOTHECA, with_license_pool=True
         )
-        audio = pool.set_delivery_mechanism(
-            Representation.MP3_MEDIA_TYPE,
-            DeliveryMechanism.FINDAWAY_DRM,
-            rights_uri=None
-        ).delivery_mechanism
-
-        epub = pool.set_delivery_mechanism(
-            Representation.EPUB_MEDIA_TYPE,
-            DeliveryMechanism.ADOBE_DRM,
-            rights_uri=None
-        ).delivery_mechanism
 
         # Let's fulfill the EPUB first.
         self.api.queue_response(
             200, headers={"Content-Type": "presumably/an-acsm"},
             content="this is an ACSM"
         )
-        fulfillment = self.api.fulfill(patron, 'password', pool, epub)
+        fulfillment = self.api.fulfill(patron, 'password', pool, 'ePub')
         assert isinstance(fulfillment, FulfillmentInfo)
         eq_("this is an ACSM", fulfillment.content)
         eq_(pool.identifier.identifier, fulfillment.identifier)
@@ -279,7 +268,7 @@ class TestBibliothecaAPI(BibliothecaAPITest):
             200, headers={"Content-Type": "application/json"},
             content="this is a Findaway license"
         )
-        fulfillment = self.api.fulfill(patron, 'password', pool, audio)
+        fulfillment = self.api.fulfill(patron, 'password', pool, 'MP3')
         assert isinstance(fulfillment, FulfillmentInfo)
         eq_("this is a Findaway license", fulfillment.content)
 


### PR DESCRIPTION
This branch fixes an error in the BibliothecaAPI which assumed that `fulfill` took a DeliveryMechanism object. The tests passed because they were written to pass in DeliveryMechanism objects, but CirculationAPI actually converts the DeliveryMechanism into an internal format (a string) and passes that in.