### PR TITLE
Real short client token configuration script

### DIFF
--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -723,7 +723,6 @@ class AuthdataUtility(object):
         secret = ConfigurationSetting.for_library_and_externalintegration(
             _db, ExternalIntegration.PASSWORD, library, integration
         ).value
-        set_trace()
 
         other_libraries = None
         adobe_integration = ExternalIntegration.lookup(
@@ -1038,7 +1037,6 @@ class VendorIDLibraryConfigurationScript(Script):
             _db, ExternalIntegration.ADOBE_VENDOR_ID,
             ExternalIntegration.DRM_GOAL, library=default_library
         )
-
         if not adobe_integration:
             output.write(
                 "Could not find an Adobe Vendor ID integration for default library %s.\n" %

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -1126,7 +1126,7 @@ class ShortClientTokenLibraryConfigurationScript(Script):
 
         self.set_secret(
             _db, args.website_url, args.vendor_id, args.short_name,
-            args.secret
+            args.secret, output
         )
         _db.commit()
 

--- a/bin/configuration/short_client_token_library_configuration
+++ b/bin/configuration/short_client_token_library_configuration
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""Set the short name and secret used by this library
+to sign Short Client Tokens.
+"""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+from api.adobe_vendor_id import ShortClientTokenLibraryConfigurationScript
+
+ShortClientTokenLibraryConfigurationScript().run()

--- a/bin/configuration/vendor_id_library_configuration
+++ b/bin/configuration/vendor_id_library_configuration
@@ -5,7 +5,7 @@ Tokens to this circulation manager's Adobe Vendor ID implementation.
 import os
 import sys
 bin_dir = os.path.split(__file__)[0]
-package_dir = os.path.join(bin_dir, "..")
+package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 from api.adobe_vendor_id import VendorIDLibraryConfigurationScript
 

--- a/bin/vendor_id_library_configuration
+++ b/bin/vendor_id_library_configuration
@@ -7,6 +7,6 @@ import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
-from api.adobe_vendor_id import ShortClientTokenLibraryConfigurationScript
+from api.adobe_vendor_id import VendorIDLibraryConfigurationScript
 
-ShortClientTokenLibraryConfigurationScript().run()
+VendorIDLibraryConfigurationScript().run()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,4 +1,5 @@
 from nose.tools import (
+    assert_raises_regexp,
     set_trace,
     eq_,
 )
@@ -7,10 +8,12 @@ import contextlib
 import datetime
 import flask
 import json
+from StringIO import StringIO
 
 from api.adobe_vendor_id import (
     AdobeVendorIDModel,
     AuthdataUtility,
+    ShortClientTokenLibraryConfigurationScript,
 )
 
 from api.config import (
@@ -329,3 +332,67 @@ class TestLanguageListScript(DatabaseTest):
         # English is ignored because all its works are open-access.
         # Tagalog shows up with the correct estimate.
         eq_(["tgl 1 (Tagalog)"], output)
+
+
+class TestShortClientTokenLibraryConfigurationScript(DatabaseTest):
+
+    def setup(self):
+        super(TestShortClientTokenLibraryConfigurationScript, self).setup()
+        self._default_library.setting(
+            Configuration.WEBSITE_URL
+        ).value = "http://foo/"
+        self.script = ShortClientTokenLibraryConfigurationScript(self._db)
+
+    def test_identify_library_by_url(self):
+        assert_raises_regexp(
+            Exception,
+            "Could not locate library with URL http://bar/. Available URLs: http://foo/",
+            self.script.set_secret,
+            self._db, "http://bar/", "vendorid", "libraryname", "secret", None
+        )
+
+    def test_set_secret(self):
+        eq_([], self._default_library.integrations)
+
+        output = StringIO()
+        self.script.set_secret(
+            self._db, "http://foo/", "vendorid", "libraryname", "secret", 
+            output
+        )
+        eq_(
+            u'Current Short Client Token configuration for http://foo/:\n Vendor ID: vendorid\n Library name: libraryname\n Shared secret: secret\n',
+            output.getvalue()
+        )
+        [integration] = self._default_library.integrations
+        eq_(
+            [('password', 'secret'), ('username', 'libraryname'),
+             ('vendor_id', 'vendorid')],
+            sorted((x.key, x.value) for x in integration.settings)
+        )
+
+        # We can modify an existing configuration.
+        output = StringIO()
+        self.script.set_secret(
+            self._db, "http://foo/", "newid", "newname", "newsecret", 
+            output
+        )
+        expect = u'Current Short Client Token configuration for http://foo/:\n Vendor ID: newid\n Library name: newname\n Shared secret: newsecret\n'
+        eq_(expect, output.getvalue())
+        expect_settings = [
+            ('password', 'newsecret'), ('username', 'newname'),
+             ('vendor_id', 'newid')
+        ]
+        eq_(expect_settings,
+            sorted((x.key, x.value) for x in integration.settings)
+        )
+
+        # We can also just check on the existing configuration without
+        # changing anything.
+        output = StringIO()
+        self.script.set_secret(
+            self._db, "http://foo/", None, None, None, output
+        )
+        eq_(expect, output.getvalue())
+        eq_(expect_settings,
+            sorted((x.key, x.value) for x in integration.settings)
+        )


### PR DESCRIPTION
We have a script called `short_client_token_library_configuration` but it's intended for use by NYPL for registering the short client token configurations for _other_ libraries. This branch renames that script and provides a new `short_client_token_library_configuration` script that's intended for use by a library that's just getting things set up. NYPL runs the old script and the other library runs the new script with similar values, and we're all set up. This will keep us going until SimplyE starts using the library registry.