### PR TITLE
Add script to list Collection metadata identifiers

### DIFF
--- a/bin/informational/list_collection_metadata_identifiers
+++ b/bin/informational/list_collection_metadata_identifiers
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+from nose.tools import set_trace
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from core.scripts import ListCollectionMetadataIdentifiersScript
+
+ListCollectionMetadataIdentifiersScript().run() 

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,4 +43,4 @@ newrelic
 # for author name manipulations
 nameparser
 fuzzywuzzy
-
+python-Levenshtein


### PR DESCRIPTION
This adds the script created in NYPL-Simplified/server_core#737, and adds a dependency to remove a long-standing warning from the fuzzywuzzy package.