### PR TITLE
Added an option for the simple authentication provider to have additional test identifiers.

### DIFF
--- a/api/simple_authentication.py
+++ b/api/simple_authentication.py
@@ -24,16 +24,34 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
         This is useful for testing a circulation manager before connecting
         it to an ILS.""")
 
+    ADDITIONAL_TEST_IDENTIFIERS = 'additional_test_identifiers'
+
+    SETTINGS = BasicAuthenticationProvider.SETTINGS + [
+        { "key": ADDITIONAL_TEST_IDENTIFIERS,
+          "label": _("Additional test identifiers"),
+          "type": "list",
+          "optional": True,
+          "description": _("Identifiers for additional patrons to use in testing. The identifiers will all use the same test password as the first identifier."),
+        }
+    ]
+
     def __init__(self, library, integration, analytics=None):
         super(SimpleAuthenticationProvider, self).__init__(
             library, integration, analytics
         )
-        self.test_identifier = integration.setting(self.TEST_IDENTIFIER).value
+
         self.test_password = integration.setting(self.TEST_PASSWORD).value
-        if not (self.test_identifier and self.test_password):
+        test_identifier = integration.setting(self.TEST_IDENTIFIER).value
+        if not (test_identifier and self.test_password):
             raise CannotLoadConfiguration(
                 "Test identifier and password not set."
             )
+
+        self.test_identifiers = [test_identifier, test_identifier + "_username"]
+        additional_identifiers = integration.setting(self.ADDITIONAL_TEST_IDENTIFIERS).json_value
+        if additional_identifiers:
+            for identifier in additional_identifiers:
+                self.test_identifiers += [identifier, identifier + "_username"]
         
     def remote_authenticate(self, username, password):
         "Fake 'remote' authentication."
@@ -43,11 +61,17 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
         if not self.valid_patron(username, password):
             return None
 
-        username = self.test_identifier
+        if username.endswith("_username"):
+            username = username
+            identifier = username[:-9]
+        else:
+            identifier = username
+            username = identifier + "_username"
+
         patrondata = PatronData(
-            authorization_identifier=username,
-            permanent_id=username + "_id",
-            username=username + "_username",
+            authorization_identifier=identifier,
+            permanent_id=identifier + "_id",
+            username=username,
             authorization_expires = None,
             fines = None,
         )
@@ -61,8 +85,7 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
         the given dictionary?
         """
         return password==self.test_password and (
-            username==self.test_identifier
-            or username == self.test_identifier + '_username'
+            username in self.test_identifiers
         )
 
 AuthenticationProvider = SimpleAuthenticationProvider

--- a/tests/test_simple_auth.py
+++ b/tests/test_simple_auth.py
@@ -3,6 +3,7 @@ from nose.tools import (
     assert_raises_regexp,
     set_trace,
 )
+import json
 
 from api.authenticator import PatronData
 
@@ -44,3 +45,44 @@ class TestSimpleAuth(DatabaseTest):
         # User can also authenticate by their 'username'
         user2 = provider.remote_authenticate("barcode_username", "pass")
         eq_("barcode", user2.authorization_identifier)
+
+    def test_additional_identifiers(self):
+        p = SimpleAuthenticationProvider
+        integration = self._external_integration(self._str)
+
+        assert_raises_regexp(
+            CannotLoadConfiguration,
+            "Test identifier and password not set.",
+            p, self._default_library, integration
+        )
+
+        integration.setting(p.TEST_IDENTIFIER).value = "barcode"
+        integration.setting(p.TEST_PASSWORD).value = "pass"
+        integration.setting(p.ADDITIONAL_TEST_IDENTIFIERS).value = json.dumps(["a", "b", "c"])
+        provider = p(self._default_library, integration)
+
+        eq_(None, provider.remote_authenticate("a", None))
+        eq_(None, provider.remote_authenticate(None, "pass"))
+        
+        user = provider.remote_authenticate("a", "pass")
+        assert isinstance(user, PatronData)
+        eq_("a", user.authorization_identifier)
+        eq_("a_id", user.permanent_id)
+        eq_("a_username", user.username)
+
+        user2 = provider.remote_authenticate("b", "pass")
+        assert isinstance(user, PatronData)
+        eq_("b", user2.authorization_identifier)
+        eq_("b_id", user2.permanent_id)
+        eq_("b_username", user2.username)
+
+        # Users can also authenticate by their 'username'
+        user3 = provider.remote_authenticate("a_username", "pass")
+        eq_("a", user3.authorization_identifier)
+
+        user4 = provider.remote_authenticate("b_username", "pass")
+        eq_("b", user4.authorization_identifier)
+
+        # The main user can still authenticate too.
+        user5 = provider.remote_authenticate("barcode", "pass")
+        eq_("barcode", user5.authorization_identifier)


### PR DESCRIPTION
This adds a configuration setting for the simple auth provider to allow additional test identifiers (all with the same password as the main test identifier), to facilitate testing with multiple patrons without an ILS.