### PR TITLE
Use precalculated lane size in admin interface instead of running the count every time

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -917,8 +917,7 @@ class LanesController(CirculationManagerController):
                 return [{ "id": lane.id,
                           "display_name": lane.display_name,
                           "visible": lane.visible,
-                          # TODO: getting the counts is very slow.
-                          "count": fast_query_count(lane.works(self._db).limit(None)),
+                          "count": lane.size,
                           "sublanes": lanes_for_parent(lane),
                           "custom_list_ids": [list.id for list in lane.customlists],
                           "inherit_parent_restrictions": lane.inherit_parent_restrictions,

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -895,7 +895,7 @@ class CustomListsController(CirculationManagerController):
             if membership_change:
                 # If this list was used to populate any lanes, those
                 # lanes need to have their counts updated.
-                for lane in Lane.affected_by_customlist(customlist):
+                for lane in Lane.affected_by_customlist(list):
                     lane.update_size(self._db)
 
             if is_new:

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -982,6 +982,7 @@ class LanesController(CirculationManagerController):
             for list in lane.customlists:
                 if list.id not in custom_list_ids:
                     lane.customlists.remove(list)
+            lane.update_size(self._db)
 
             if is_new:
                 return Response(unicode(lane.id), 201)

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -870,6 +870,7 @@ class CustomListsController(CirculationManagerController):
                 entries = []
 
             old_entries = list.entries
+            membership_change = False
             for entry in entries:
                 pwid = entry.get("pwid")
                 work = self._db.query(
@@ -881,12 +882,21 @@ class CustomListsController(CirculationManagerController):
                 ).one()
 
                 if work:
-                    list.add_entry(work, featured=True)
+                    entry, entry_is_new = list.add_entry(work, featured=True)
+                    if entry_is_new:
+                        membership_change = True
 
             new_pwids = [entry.get("pwid") for entry in entries]
             for entry in old_entries:
                 if entry.edition.permanent_work_id not in new_pwids:
                     list.remove_entry(entry.edition)
+                    membership_change = True
+
+            if membership_change:
+                # If this list was used to populate any lanes, those
+                # lanes need to have their counts updated.
+                for lane in Lane.affected_by_customlist(customlist):
+                    lane.update_size(self._db)
 
             if is_new:
                 return Response(unicode(list.id), 201)
@@ -900,9 +910,15 @@ class CustomListsController(CirculationManagerController):
             list = get_one(self._db, CustomList, id=list_id, data_source=data_source)
             if not list:
                 return MISSING_CUSTOM_LIST
+
+            # Build the list of affected lanes before modifying the
+            # CustomList.
+            affected_lanes = Lane.affected_by_customlist(list)
             for entry in list.entries:
                 self._db.delete(entry)
             self._db.delete(list)
+            for lane in affected_lanes:
+                lane.update_size(self._db)
             return Response(unicode(_("Deleted")), 200)
 
 

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1171,11 +1171,17 @@ class TestCustomListsController(AdminControllerTest):
         list, ignore = create(self._db, CustomList, name=self._str, data_source=data_source)
         list.library = self._default_library
 
+        # Create a Lane that depends on this CustomList for its membership.
+        lane = self._lane()
+        lane.customlists.append(list)
+        eq_(0, lane.size)
+
         w1 = self._work(with_license_pool=True)
         w2 = self._work(with_license_pool=True)
         w3 = self._work(with_license_pool=True)
         list.add_entry(w1)
         list.add_entry(w2)
+        self.add_to_materialized_view([w1, w2, w3])
 
         new_entries = [dict(pwid=work.presentation_edition.permanent_work_id) for work in [w2, w3]]
         
@@ -1194,6 +1200,9 @@ class TestCustomListsController(AdminControllerTest):
             eq_(set([w2, w3]),
                 set([entry.work for entry in list.entries]))
 
+        # The lane's estimated size has been updated.
+        eq_(2, lane.size)
+
     def test_custom_list_delete_success(self):
         data_source = DataSource.lookup(self._db, DataSource.LIBRARY_STAFF)
         list, ignore = create(self._db, CustomList, name=self._str, data_source=data_source)
@@ -1204,12 +1213,21 @@ class TestCustomListsController(AdminControllerTest):
         list.add_entry(w1)
         list.add_entry(w2)
 
+        # This lane depends heavily on lists from this data source.
+        lane = self._lane()
+        lane.list_datasource = list.data_source
+        lane.size = 100
+
         with self.request_context_with_library("/", method="DELETE"):
             response = self.manager.admin_custom_lists_controller.custom_list(list.id)
             eq_(200, response.status_code)
 
             eq_(0, self._db.query(CustomList).count())
             eq_(0, self._db.query(CustomListEntry).count())
+
+        # The lane's estimate has been updated to reflect the removal
+        # of a list from its data source.
+        eq_(0, lane.size)
 
     def test_custom_list_delete_errors(self):
         with self.request_context_with_library("/", method="DELETE"):

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1393,10 +1393,14 @@ class TestLanesController(AdminControllerTest):
             eq_(1, sibling.priority)
 
     def test_lanes_edit(self):
+
+        work = self._work(with_license_pool=True)
+
         list1, ignore = self._customlist(data_source_name=DataSource.LIBRARY_STAFF, num_entries=0)
         list1.library = self._default_library
         list2, ignore = self._customlist(data_source_name=DataSource.LIBRARY_STAFF, num_entries=0)
         list2.library = self._default_library
+        list2.add_entry(work)
 
         lane = self._lane("old name")
         lane.customlists += [list1]
@@ -1416,6 +1420,7 @@ class TestLanesController(AdminControllerTest):
             eq_("new name", lane.display_name)
             eq_([list2], lane.customlists)
             eq_(True, lane.inherit_parent_restrictions)
+            eq_(1, lane.size)
 
     def test_lane_delete_success(self):
         library = self._library()

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1401,6 +1401,7 @@ class TestLanesController(AdminControllerTest):
         list2, ignore = self._customlist(data_source_name=DataSource.LIBRARY_STAFF, num_entries=0)
         list2.library = self._default_library
         list2.add_entry(work)
+        self.add_to_materialized_view([work])
 
         lane = self._lane("old name")
         lane.customlists += [list1]

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -206,7 +206,7 @@ class TestCacheOPDSGroupFeedPerLane(TestLaneScript):
             genres=["Science Fiction"]
         )
         self.add_to_materialized_view([work], true_opds=True)
-        script = CacheOPDSGroupFeedPerLane(self._db)
+        script = CacheOPDSGroupFeedPerLane(self._db, cmd_args=[])
         script.do_run(cmd_args=[])
 
         # The Lane object was disconnected from its database session


### PR DESCRIPTION
This should dramatically improve the user-visible performance of the lane editor.

This branch also removes some script code that was moved into core by https://github.com/NYPL-Simplified/server_core/pull/744.