### PR TITLE
Convert Findaway license documents into semistandard Web Publication Manifests

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -347,8 +347,7 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
         # of the LicensePool and its Work.
         manifest.update_bibliographic_metadata(license_pool)
 
-        # Add Findaway-specific information as extra metadata. TODO:
-        # Make this more linked-data-y.
+        # Add Findaway-specific information as extra metadata.
         for findaway_extension in [
                 'accountId', 'checkoutId', 'fulfillmentId', 'licenseId',
                 'sessionKey'
@@ -357,7 +356,7 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
             output_key = 'findaway:' + findaway_extension
             manifest.metadata[output_key] = value
 
-        # Add the timeline parts. All of them are in the same format.
+        # Add the spine items. All of them are in the same format.
         # None of them will have working 'href' fields -- it's just to
         # give the client a picture of the structure of the timeline.
         audio_format = findaway_license.get('format')
@@ -395,8 +394,8 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
             if part_number is not None:
                 kwargs["findaway:part"] = part_number
 
-            manifest.add_timeline(
-                href=None, title=title, duration=duration,
+            manifest.add_spine(
+                href=None, type=None, title=title, duration=duration,
                 **kwargs
             )
             total_duration += duration

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -387,12 +387,10 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
             kwargs = {}
 
             sequence = part.get('sequence')
-            if sequence is not None:
-                kwargs["findaway:sequence"] = sequence 
+            kwargs["findaway:sequence"] = sequence 
 
             part_number = part.get('part')
-            if part_number is not None:
-                kwargs["findaway:part"] = part_number
+            kwargs["findaway:part"] = part_number
 
             manifest.add_spine(
                 href=None, type=None, title=title, duration=duration,

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1,3 +1,4 @@
+import json
 from lxml import etree
 
 from cStringIO import StringIO
@@ -40,6 +41,7 @@ from core.monitor import (
     CollectionMonitor,
     IdentifierSweepMonitor,
 )
+from core.util.web_publication_manifest import AudiobookManifest
 from core.util.xmlparser import XMLParser
 from core.util.http import (
     BadResponseException
@@ -195,23 +197,32 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
         )
         if drm_scheme == DeliveryMechanism.FINDAWAY_DRM:
             fulfill_method = self.get_audio_fulfillment_file
-            # The provided media type is application/json, which
-            # is too vague for us.
-            force_content_type = DeliveryMechanism.FINDAWAY_DRM
+            content_transformation = self.findaway_license_to_webpub_manifest
         else:
             fulfill_method = self.get_fulfillment_file
-            force_content_type = None
+            content_transformation = None
         response = fulfill_method(
             patron.authorization_identifier, pool.identifier.identifier
         )
+        content = response.content
+        content_type = None
+        if content_transformation:
+            try:
+                content_type, content = (
+                    content_transformation(pool, content)
+                )
+            except Exception, e:
+                self.log.error(
+                    "Error transforming fulfillment document: %s",
+                    response.content, exc_info=e
+                )
         return FulfillmentInfo(
             pool.collection, DataSource.BIBLIOTHECA,
             pool.identifier.type,
             pool.identifier.identifier,
             content_link=None,
-            content_type=(force_content_type
-                          or response.headers.get('Content-Type')),
-            content=response.content,
+            content_type=content_type or response.headers.get('Content-Type'),
+            content=content,
             content_expires=None,
         )
 
@@ -302,6 +313,95 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
             circ.get(LicensePool.patrons_in_hold_queue, 0),
             analytics,
         )
+
+    # This URI prefix makes it clear when we are using a term coined
+    # by Findaway in a JSON-LD document.
+    FINDAWAY_EXTENSION_CONTEXT = "http://librarysimplified.org/terms/third-parties/findaway.com/"
+
+    @classmethod
+    def findaway_license_to_webpub_manifest(
+            cls, license_pool, findaway_license
+    ):
+        """Convert a Findaway license document to a standard Web Publication
+        Manifest (audiobook flavor).
+
+        :param license_pool: A LicensePool for the title in question.
+        This will be used to fill in basic bibliographic information.
+
+        :param findaway_license: A string containing a Findaway
+           license document, or a dictionary representing such a
+           document loaded into JSON form.
+        """
+        if isinstance(findaway_license, basestring):
+            findaway_license = json.loads(findaway_license)
+
+        context_with_extension = [
+            "http://readium.org/webpub/default.jsonld",
+            {"findaway" : cls.FINDAWAY_EXTENSION_CONTEXT},
+        ]
+
+        manifest = AudiobookManifest(context=context_with_extension)
+
+        # Add basic bibliographic information (identifier, title,
+        # cover link) to the manifest based on our existing knowledge
+        # of the LicensePool and its Work.
+        manifest.update_bibliographic_metadata(license_pool)
+
+        # Add Findaway-specific information as extra metadata. TODO:
+        # Make this more linked-data-y.
+        for findaway_extension in [
+                'accountId', 'checkoutId', 'fulfillmentId', 'licenseId',
+                'sessionKey'
+        ]:
+            value = findaway_license.get(findaway_extension, None)
+            output_key = 'findaway:' + findaway_extension
+            manifest.metadata[output_key] = value
+
+        # Add the timeline parts. All of them are in the same format.
+        # None of them will have working 'href' fields -- it's just to
+        # give the client a picture of the structure of the timeline.
+        audio_format = findaway_license.get('format')
+        if audio_format == 'MP3':
+            part_media_type = Representation.MP3_MEDIA_TYPE
+        else:
+            logging.error("Unknown Findaway audio format encountered: %s",
+                          audio_format)
+
+        # TODO: The items are in an ordered list, but each one also
+        # has an explicit 'sequence'. For now we'll pass it on but
+        # assume that it is redundant and the ordered list is always
+        # correct.
+        #
+        # TODO: Each item has a 'part' which always seems to be zero.
+        # Its purpose is unknown. For now, we simply pass it on.
+        total_duration = 0
+        for part in findaway_license.get('items'):
+            title = part.get('title')
+
+            # TODO: Incoming duration appears to be measured in
+            # milliseconds. This assumption makes our example
+            # audiobook take about 7.9 hours, and no other reasonable
+            # assumption is in the right order of magnitude. But this
+            # needs to be explicitly verified.
+            duration = part.get('duration', 0) / 1000.0
+
+            kwargs = {}
+
+            sequence = part.get('sequence')
+            if sequence is not None:
+                kwargs["findaway:sequence"] = sequence 
+
+            part_number = part.get('part')
+            if part_number is not None:
+                kwargs["findaway:part"] = part_number
+
+            manifest.add_timeline(
+                href=None, title=title, duration=duration,
+                **kwargs
+            )
+            total_duration += duration
+        manifest.metadata['duration'] = total_duration
+        return DeliveryMechanism.FINDAWAY_DRM, unicode(manifest)
 
 
 class DummyBibliothecaAPIResponse(object):

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -288,7 +288,7 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         # that the manifest contains information from the 'Findaway'
         # document as well as information from the Work.
         metadata = manifest['metadata']
-        eq_('abcdef01234789abcdef0123', metadata['findaway.checkoutId'])
+        eq_('abcdef01234789abcdef0123', metadata['findaway:checkoutId'])
         eq_(work.title, metadata['title'])
 
         # Now let's see what happens to fulfillment when 'Findaway' or
@@ -345,22 +345,23 @@ class TestBibliothecaAPI(BibliothecaAPITest):
             metadata[u'findaway:sessionKey'])
 
         # Every entry in the license document's 'items' list has
-        # become an entry in the manifest's 'timeline' list.
-        timeline = manifest['timeline']
-        eq_(79, len(timeline))
+        # become a spine item in the manifest.
+        spine = manifest['spine']
+        eq_(79, len(spine))
 
-        # The duration of each timeline item has been converted to
+        # The duration of each spine item has been converted to
         # seconds.
-        first = timeline[0]
+        first = spine[0]
         eq_(16.201, first['duration'])
         eq_("Track 1", first['title'])
         eq_(1, first['findaway:sequence'])
 
-        # There is no 'href' value for the timeline items because the
-        # files must be obtained through the Findaway SDK rather than
-        # through regular HTTP requests.
-        for i in timeline:
+        # There is no 'href' or 'type' value for the spine items
+        # because the files must be obtained through the Findaway SDK
+        # rather than through regular HTTP requests.
+        for i in spine:
             eq_(None, i['href'])
+            eq_(None, i['type'])
             eq_(0, i['findaway:part'])
 
         # The total duration, in seconds, has been added to metadata.

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -5,6 +5,7 @@ from nose.tools import (
     assert_raises,
 )
 import datetime
+import json
 import os
 import pkgutil
 
@@ -34,6 +35,7 @@ from core.model import (
 from core.util.http import (
     BadResponseException,
 )
+from core.util.web_publication_manifest import AudiobookManifest
 
 from api.circulation import (
     CirculationAPI,
@@ -244,9 +246,10 @@ class TestBibliothecaAPI(BibliothecaAPITest):
 
         # This miracle book is available either as an audiobook or as
         # an EPUB.
-        edition, pool = self._edition(
+        work = self._work(
             data_source_name=DataSource.BIBLIOTHECA, with_license_pool=True
         )
+        [pool] = work.license_pools
 
         # Let's fulfill the EPUB first.
         self.api.queue_response(
@@ -264,18 +267,104 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         eq_("presumably/an-acsm", fulfillment.content_type)
 
         # Now let's try the audio version.
+        license = self.sample_data("sample_findaway_audiobook_license.json")
         self.api.queue_response(
             200, headers={"Content-Type": "application/json"},
-            content="this is a Findaway license"
+            content=license
         )
         fulfillment = self.api.fulfill(patron, 'password', pool, 'MP3')
         assert isinstance(fulfillment, FulfillmentInfo)
-        eq_("this is a Findaway license", fulfillment.content)
 
-        # The only difference here is that the media type reported by
-        # the server is _not_ passed through; it's replaced by a more
-        # specific media type
+        # Here, the media type reported by the server is not passed
+        # through; it's replaced by a more specific media type
         eq_(DeliveryMechanism.FINDAWAY_DRM, fulfillment.content_type)
+
+        # The document sent by the 'Findaway' server has been
+        # converted into a web publication manifest.
+        manifest = json.loads(fulfillment.content)
+
+        # The conversion process is tested more fully in
+        # test_findaway_license_to_webpub_manifest. This just verifies
+        # that the manifest contains information from the 'Findaway'
+        # document as well as information from the Work.
+        metadata = manifest['metadata']
+        eq_('abcdef01234789abcdef0123', metadata['findaway.checkoutId'])
+        eq_(work.title, metadata['title'])
+
+        # Now let's see what happens to fulfillment when 'Findaway' or
+        # 'Bibliotheca' sends bad information.
+        bad_media_type = "application/error+json"
+        bad_content = "This is not my beautiful license document!"
+        self.api.queue_response(
+            200, headers={"Content-Type": bad_media_type},
+            content=bad_content
+        )
+        fulfillment = self.api.fulfill(patron, 'password', pool, 'MP3')
+        assert isinstance(fulfillment, FulfillmentInfo)
+
+        # The (apparently) bad document is just passed on to the
+        # client as part of the FulfillmentInfo, in the hopes that the
+        # client will know what to do with it.
+        eq_(bad_media_type, fulfillment.content_type)
+        eq_(bad_content, fulfillment.content)
+
+    def test_findaway_license_to_webpub_manifest(self):
+        work = self._work(with_license_pool=True)
+        [pool] = work.license_pools
+        document = self.sample_data("sample_findaway_audiobook_license.json")
+        m = BibliothecaAPI.findaway_license_to_webpub_manifest
+        media_type, manifest = m(pool, document)
+        eq_(DeliveryMechanism.FINDAWAY_DRM, media_type)
+        manifest = json.loads(manifest)
+
+        # We use the default context for Web Publication Manifest
+        # files, but we also define an extension context called
+        # 'findaway', which lets us include terms coined by Findaway
+        # in a normal Web Publication Manifest document.
+        context = manifest['@context']
+        default, findaway = context
+        eq_(AudiobookManifest.DEFAULT_CONTEXT, default)
+        eq_({"findaway" : BibliothecaAPI.FINDAWAY_EXTENSION_CONTEXT},
+           findaway)
+
+        metadata = manifest['metadata']
+
+        # Information about the book has been added to metadata.
+        # (This is tested more fully in
+        # core/tests/util/test_util_web_publication_manifest.py.)
+        eq_(work.title, metadata['title'])
+        eq_(pool.identifier.urn, metadata['identifier'])
+        eq_('en', metadata['language'])
+
+        # Information about the license has been added to metadata.
+        eq_(u'abcdef01234789abcdef0123', metadata[u'findaway:checkoutId'])
+        eq_(u'1234567890987654321ababa', metadata[u'findaway:licenseId'])
+        eq_(u'3M', metadata[u'findaway:accountId'])
+        eq_(u'123456', metadata[u'findaway:fulfillmentId'])
+        eq_(u'aaaaaaaa-4444-cccc-dddd-666666666666', 
+            metadata[u'findaway:sessionKey'])
+
+        # Every entry in the license document's 'items' list has
+        # become an entry in the manifest's 'timeline' list.
+        timeline = manifest['timeline']
+        eq_(79, len(timeline))
+
+        # The duration of each timeline item has been converted to
+        # seconds.
+        first = timeline[0]
+        eq_(16.201, first['duration'])
+        eq_("Track 1", first['title'])
+        eq_(1, first['findaway:sequence'])
+
+        # There is no 'href' value for the timeline items because the
+        # files must be obtained through the Findaway SDK rather than
+        # through regular HTTP requests.
+        for i in timeline:
+            eq_(None, i['href'])
+            eq_(0, i['findaway:part'])
+
+        # The total duration, in seconds, has been added to metadata.
+        eq_(28371, int(metadata['duration']))
 
 
 class TestBibliothecaCirculationSweep(BibliothecaAPITest):


### PR DESCRIPTION
This branch relieves clients of the need to understand everything about Findaway license documents. We still serve documents with a custom media type, but the documents are basically Web Publication Manifest documents with some extensions and some missing fields. Bibliographic information (not present in the Findaway documents) is filled in from our own data.

A client can parse this document with its Web Publication Manifest parser and take note of a few extension fields, rather than needing to parse a slightly different document and then fill in missing data from its local copy of the book's bibliographic information.