### PR TITLE
Added basic support for holds in an ODL collection.

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -372,7 +372,7 @@ class ResponseParser(Axis360Parser):
         3108 : InvalidInputException, # DRM Credentials Required
         3109 : InvalidInputException, # Hold already exists or hold does not exist, depending.
         3110 : AlreadyCheckedOut,
-        3111 : CouldCheckOut,
+        3111 : CurrentlyAvailable,
         3112 : CannotFulfill,
         3113 : CannotLoan,
         (3113, "Title ID is not available for checkout") : NoAvailableCopies,

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -343,69 +343,70 @@ class CirculationAPI(object):
 
         new_loan = False
 
-        # TODO: If the book isn't available and the patron is putting it on hold,
-        # we shouldn't check the loan limit.
         loan_limit = patron.library.setting(Configuration.LOAN_LIMIT).int_value
         non_open_access_loans_with_end_date = [loan for loan in patron.loans if loan.license_pool.open_access == False and loan.end]
-        if loan_limit and len(non_open_access_loans_with_end_date) >= loan_limit:
-            raise PatronLoanLimitReached()
+        at_loan_limit = (loan_limit and len(non_open_access_loans_with_end_date) >= loan_limit)
 
-        try:
-            loan_info = api.checkout(
-                patron, pin, licensepool, internal_format
-            )
-
-            # We asked the API to create a loan and it gave us a
-            # LoanInfo object, rather than raising an exception like
-            # AlreadyCheckedOut.
-            #
-            # For record-keeping purposes we're going to treat this as
-            # a newly transacted loan, although it's possible that the
-            # API does something unusual like return LoanInfo instead
-            # of raising AlreadyCheckedOut.
-            new_loan = True
-        except AlreadyCheckedOut:
-            # This is good, but we didn't get the real loan info.
-            # Just fake it.
-            identifier = licensepool.identifier            
-            loan_info = LoanInfo(
-                licensepool.collection,
-                licensepool.data_source,
-                identifier.type,
-                identifier.identifier,
-                start_date=None,
-                end_date=now + datetime.timedelta(hours=1)
-            )
-            if existing_loan:
-                loan_info.external_identifier=existing_loan.external_identifier
-        except AlreadyOnHold:
-            # We're trying to check out a book that we already have on hold.
-            hold_info = HoldInfo(
-                licensepool.collection, licensepool.data_source,
-                licensepool.identifier.type, licensepool.identifier.identifier,
-                None, None, None
-            )
-        except NoAvailableCopies:
-            if existing_loan:
-                # The patron tried to renew a loan but there are
-                # people waiting in line for them to return the book,
-                # so renewals are not allowed.
-                raise CannotRenew(
-                    _("You cannot renew a loan if other patrons have the work on hold.")
+        # If we're at the loan limit, skip trying to check out the book and just try
+        # to place a hold. Otherwise, try to check out the book even if we think it's
+        # not available.
+        if not at_loan_limit:
+            try:
+                loan_info = api.checkout(
+                    patron, pin, licensepool, internal_format
                 )
-            else:
-                # That's fine, we'll just (try to) place a hold.
+
+                # We asked the API to create a loan and it gave us a
+                # LoanInfo object, rather than raising an exception like
+                # AlreadyCheckedOut.
                 #
+                # For record-keeping purposes we're going to treat this as
+                # a newly transacted loan, although it's possible that the
+                # API does something unusual like return LoanInfo instead
+                # of raising AlreadyCheckedOut.
+                new_loan = True
+            except AlreadyCheckedOut:
+                # This is good, but we didn't get the real loan info.
+                # Just fake it.
+                identifier = licensepool.identifier            
+                loan_info = LoanInfo(
+                    licensepool.collection,
+                    licensepool.data_source,
+                    identifier.type,
+                    identifier.identifier,
+                    start_date=None,
+                    end_date=now + datetime.timedelta(hours=1)
+                )
+                if existing_loan:
+                    loan_info.external_identifier=existing_loan.external_identifier
+            except AlreadyOnHold:
+                # We're trying to check out a book that we already have on hold.
+                hold_info = HoldInfo(
+                    licensepool.collection, licensepool.data_source,
+                    licensepool.identifier.type, licensepool.identifier.identifier,
+                    None, None, None
+                )
+            except NoAvailableCopies:
+                if existing_loan:
+                    # The patron tried to renew a loan but there are
+                    # people waiting in line for them to return the book,
+                    # so renewals are not allowed.
+                    raise CannotRenew(
+                        _("You cannot renew a loan if other patrons have the work on hold.")
+                    )
+                else:
+                    # That's fine, we'll just (try to) place a hold.
+                    #
+                    # Since the patron incorrectly believed there were
+                    # copies available, update availability information
+                    # immediately.
+                    api.update_availability(licensepool)
+            except NoLicenses, e:
                 # Since the patron incorrectly believed there were
-                # copies available, update availability information
+                # licenses available, update availability information
                 # immediately.
                 api.update_availability(licensepool)
-        except NoLicenses, e:
-            # Since the patron incorrectly believed there were
-            # licenses available, update availability information
-            # immediately.
-            api.update_availability(licensepool)
-            raise e
+                raise e
 
         if loan_info:
             # We successfuly secured a loan.  Now create it in our
@@ -456,6 +457,11 @@ class CirculationAPI(object):
                     licensepool.identifier.type, licensepool.identifier.identifier,
                     None, None, None
                 )
+            except CannotHold, e:
+                if at_loan_limit:
+                    raise PatronLoanLimitReached()
+                else:
+                    raise e
 
         # It's pretty rare that we'd go from having a loan for a book
         # to needing to put it on hold, but we do check for that case.

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -346,8 +346,8 @@ class CirculationAPI(object):
         # TODO: If the book isn't available and the patron is putting it on hold,
         # we shouldn't check the loan limit.
         loan_limit = patron.library.setting(Configuration.LOAN_LIMIT).int_value
-        non_open_access_loans = [loan for loan in patron.loans if loan.license_pool.open_access == False]
-        if loan_limit and len(non_open_access_loans) >= loan_limit:
+        non_open_access_loans_with_end_date = [loan for loan in patron.loans if loan.license_pool.open_access == False and loan.end]
+        if loan_limit and len(non_open_access_loans_with_end_date) >= loan_limit:
             raise PatronLoanLimitReached()
 
         try:

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -344,8 +344,7 @@ class CirculationAPI(object):
         new_loan = False
 
         # TODO: If the book isn't available and the patron is putting it on hold,
-        # we shouldn't check the loan limit. Or should there be one limit for loans
-        # and holds?
+        # we shouldn't check the loan limit.
         loan_limit = patron.library.setting(Configuration.LOAN_LIMIT).int_value
         non_open_access_loans = [loan for loan in patron.loans if loan.license_pool.open_access == False]
         if loan_limit and len(non_open_access_loans) >= loan_limit:

--- a/api/circulation_exceptions.py
+++ b/api/circulation_exceptions.py
@@ -161,12 +161,6 @@ class AlreadyOnHold(CannotHold):
     """
     status_code = 400
 
-class CouldCheckOut(CannotHold):
-    """The patron can't put this book on hold because they could
-    just check it out.
-    """
-    status_code = 400
-
 class NotCheckedOut(CannotReturn):
     """The patron can't return this book because they don't
     have it checked out in the first place.

--- a/api/config.py
+++ b/api/config.py
@@ -37,6 +37,15 @@ class Configuration(CoreConfiguration):
     # of fines a patron can have before losing lending privileges.
     MAX_OUTSTANDING_FINES = u"max_outstanding_fines"
 
+    # The name of the per-library settings that set the maximum amounts
+    # of books a patron can have on loan or on hold at once.
+    # (Note: depending on distributor settings, a patron may be able
+    # to exceed the limits by checking out books directly from a distributor's
+    # app. They may also get a limit exceeded error before they reach these
+    # limits if a distributor has a smaller limit.)
+    LOAN_LIMIT = u"loan_limit"
+    HOLD_LIMIT = u"hold_limit"
+
     # The name of the per-library setting that sets the default email
     # address to use when notifying patrons of changes.
     DEFAULT_NOTIFICATION_EMAIL_ADDRESS = u"default_notification_email_address"
@@ -151,6 +160,18 @@ class Configuration(CoreConfiguration):
         {
             "key": MAX_OUTSTANDING_FINES,
             "label": _("Maximum amount of fines a patron can have before losing lending privileges"),
+            "optional": True,
+        },
+        {
+            "key": LOAN_LIMIT,
+            "label": _("Maximum number of books a patron can have on loan at once."),
+            "type": "number",
+            "optional": True,
+        },
+        {
+            "key": HOLD_LIMIT,
+            "label": _("Maximum number of books a patron can have on hold at once."),
+            "type": "number",
             "optional": True,
         },
         {

--- a/api/config.py
+++ b/api/config.py
@@ -165,12 +165,14 @@ class Configuration(CoreConfiguration):
         {
             "key": LOAN_LIMIT,
             "label": _("Maximum number of books a patron can have on loan at once."),
+            "description": _("(Note: depending on distributor settings, a patron may be able to exceed the limit by checking out books directly from a distributor's app. They may also get a limit exceeded error before they reach these limits if a distributor has a smaller limit.)"),
             "type": "number",
             "optional": True,
         },
         {
             "key": HOLD_LIMIT,
             "label": _("Maximum number of books a patron can have on hold at once."),
+            "description": _("(Note: depending on distributor settings, a patron may be able to exceed the limit by checking out books directly from a distributor's app. They may also get a limit exceeded error before they reach these limits if a distributor has a smaller limit.)"),
             "type": "number",
             "optional": True,
         },

--- a/api/odl.py
+++ b/api/odl.py
@@ -485,9 +485,7 @@ class ODLWithConsolidatedCopiesAPI(BaseCirculationAPI):
             licensepool.licenses_available += 1
 
     def place_hold(self, patron, pin, licensepool, notification_email_address):
-        """Holds aren't supported yet, so attempting to place one will
-        raise an exception.
-        """
+        """Create a new hold."""
         _db = Session.object_session(patron)
 
         # Create local hold.
@@ -515,9 +513,7 @@ class ODLWithConsolidatedCopiesAPI(BaseCirculationAPI):
         )
 
     def release_hold(self, patron, pin, licensepool):
-        """Holds aren't supported yet, so attempting to release one will
-        raise an exception.
-        """
+        """Cancel a hold."""
         _db = Session.object_session(patron)
 
         hold = get_one(

--- a/api/odl.py
+++ b/api/odl.py
@@ -109,6 +109,7 @@ class ODLWithConsolidatedCopiesAPI(BaseCirculationAPI):
         {
             "key": Collection.DEFAULT_RESERVATION_PERIOD_KEY,
             "label": _("Default Reservation Period (in Days)"),
+            "description": _("The number of days a patron has to check out a book after a hold becomes available."),
             "type": "number",
             "default": Collection.STANDARD_DEFAULT_RESERVATION_PERIOD,
         },

--- a/api/odl.py
+++ b/api/odl.py
@@ -548,6 +548,12 @@ class ODLWithConsolidatedCopiesAPI(BaseCirculationAPI):
         """Create a new hold."""
         _db = Session.object_session(patron)
 
+        # Make sure pool info is updated.
+        self.update_hold_queue(licensepool)
+
+        if licensepool.licenses_available > 0:
+            raise CurrentlyAvailable()
+
         # Create local hold.
         hold, is_new = get_one_or_create(
             _db, Hold,

--- a/bin/odl_hold_reaper
+++ b/bin/odl_hold_reaper
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Check for ODL holds that have expired and delete them."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.scripts import RunCollectionMonitorScript
+from api.odl import ODLHoldReaper
+RunCollectionMonitorScript(ODLHoldReaper).run()

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -199,10 +199,10 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         eq_(datetime.datetime(2015, 3, 13, 13, 38, 19), l2.start)
         eq_(datetime.datetime(2015, 4, 3, 13, 38, 19), l2.end)
 
-        # This hold has no end date because there's no decision to be
-        # made. The patron is fourth in line.
+        # The patron is fourth in line. The end date is an estimate
+        # of when the hold will be available to check out.
         eq_(datetime.datetime(2015, 3, 24, 15, 6, 56), h1.start)
-        eq_(None, h1.end)
+        eq_(datetime.datetime(2015, 3, 24, 15, 7, 51), h1.end)
         eq_(4, h1.position)
 
         # The hold has an end date. It's time for the patron to decide

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -424,9 +424,7 @@ class TestODLWithConsolidatedCopiesAPI(DatabaseTest, BaseODLTest):
 
         self.pool.licenses_reserved = 1
 
-        # When there's no reservation period, the end date of a reserved hold is None.
         hold, ignore = self.pool.on_hold_to(self.patron, start=now, position=0)
-        eq_(None, hold.end)
 
         # Set the reservation period and loan period.
         self.collection.external_integration.set_setting(
@@ -435,7 +433,6 @@ class TestODLWithConsolidatedCopiesAPI(DatabaseTest, BaseODLTest):
         self.collection.external_integration.set_setting(
             Collection.EBOOK_LOAN_DURATION_KEY, 6
         )
-        self.api = MockODLWithConsolidatedCopiesAPI(self._db, self.collection)
 
         # A hold that's already reserved and has an end date doesn't change.
         hold.end = tomorrow
@@ -590,7 +587,6 @@ class TestODLWithConsolidatedCopiesAPI(DatabaseTest, BaseODLTest):
         self.collection.external_integration.set_setting(
             Collection.DEFAULT_RESERVATION_PERIOD_KEY, 3
         )
-        self.api = MockODLWithConsolidatedCopiesAPI(self._db, self.collection)
 
         # If there's no holds queue when we try to update the queue, it
         # will remove a reserved license and make it available instead.

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -809,6 +809,13 @@ class TestODLWithConsolidatedCopiesAPI(DatabaseTest, BaseODLTest):
             self.patron, "pin", self.pool, "notifications@librarysimplified.org",
         )
 
+    def test_place_hold_currently_available(self):
+        self.pool.licenses_owned = 1
+        assert_raises(
+            CurrentlyAvailable, self.api.place_hold,
+            self.patron, "pin", self.pool, "notifications@librarysimplified.org",
+        )
+
     def test_release_hold_success(self):
         self.pool.licenses_owned = 1
         loan, ignore = self.pool.loan_to(self._patron())

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -293,21 +293,6 @@ class TestODLWithConsolidatedCopiesAPI(DatabaseTest, BaseODLTest):
         eq_(0, self.pool.licenses_reserved)
         eq_(0, self._db.query(Hold).count())
 
-    def test_checkout_loan_limit_reached(self):
-        self.collection.external_integration.set_setting(
-            self.api.LOAN_LIMIT,
-            1
-        )
-        self.api = MockODLWithConsolidatedCopiesAPI(self._db, self.collection)
-
-        other_pool = self._licensepool(None, collection=self.collection)
-        other_pool.loan_to(self.patron)
-
-        assert_raises(
-            PatronLoanLimitReached, self.api.checkout,
-            self.patron, "pin", self.pool, Representation.EPUB_MEDIA_TYPE,
-        )
-
     def test_checkout_already_checked_out(self):
         existing_loan, ignore = self.pool.loan_to(self.patron)
         existing_loan.external_identifier = self._str
@@ -671,21 +656,6 @@ class TestODLWithConsolidatedCopiesAPI(DatabaseTest, BaseODLTest):
         eq_(tomorrow, hold.end_date)
         eq_(1, hold.hold_position)
         eq_(1, self._db.query(Hold).count())
-
-    def test_place_hold_hold_limit_reached(self):
-        self.collection.external_integration.set_setting(
-            self.api.HOLD_LIMIT,
-            1
-        )
-        self.api = MockODLWithConsolidatedCopiesAPI(self._db, self.collection)
-
-        other_pool = self._licensepool(None, collection=self.collection)
-        other_pool.on_hold_to(self.patron)
-
-        assert_raises(
-            PatronHoldLimitReached, self.api.place_hold,
-            self.patron, "pin", self.pool, "notifications@librarysimplified.org",
-        )
 
     def test_place_hold_already_on_hold(self):
         self.pool.on_hold_to(self.patron)


### PR DESCRIPTION
With ODL, a distributor doesn't manage the holds queue and the circulation manager has full control. This branch adds support for managing holds queues within a single circ manager.