### PR TITLE
Lanes only contain books

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -404,20 +404,14 @@ class CirculationManagerController(BaseCirculationManagerController):
     def load_lane(self, lane_identifier):
         """Turn user input into a Lane object."""
         library_id = flask.request.library.id
-        top_level_lane = self.manager.top_level_lanes[library_id]
-
-        def merge_lane(lane):
-            """If `lane` is a Lane, merge it with the current database
-            session. Otherwise, do nothing.
-            """
-            if isinstance(lane, Lane):
-                return self._db.merge(lane)
-            return lane
-
+        
         if lane_identifier is None:
-            return merge_lane(top_level_lane)
-
-        lane = get_one(self._db, Lane, id=lane_identifier, library_id=library_id)
+            # Return the top-level lane.
+            lane = self.manager.top_level_lanes[library_id]
+        else:
+            lane = get_one(
+                self._db, Lane, id=lane_identifier, library_id=library_id
+            )
 
         if not lane:
             return NO_SUCH_LANE.detailed(
@@ -425,7 +419,8 @@ class CirculationManagerController(BaseCirculationManagerController):
                   lane_identifier=lane_identifier, library_id=library_id
                 )
             )
-        return merge_lane(lane)
+
+        return lane
 
     def load_work(self, library, identifier_type, identifier):
         pools = self.load_licensepools(library, identifier_type, identifier)

--- a/api/controller.py
+++ b/api/controller.py
@@ -406,8 +406,16 @@ class CirculationManagerController(BaseCirculationManagerController):
         library_id = flask.request.library.id
         top_level_lane = self.manager.top_level_lanes[library_id]
 
+        def merge_lane(lane):
+            """If `lane` is a Lane, merge it with the current database
+            session. Otherwise, do nothing.
+            """
+            if isinstance(lane, Lane):
+                return self._db.merge(lane)
+            return lane
+
         if lane_identifier is None:
-            return top_level_lane
+            return merge_lane(top_level_lane)
 
         lane = get_one(self._db, Lane, id=lane_identifier, library_id=library_id)
 
@@ -417,7 +425,7 @@ class CirculationManagerController(BaseCirculationManagerController):
                   lane_identifier=lane_identifier, library_id=library_id
                 )
             )
-        return lane
+        return merge_lane(lane)
 
     def load_work(self, library, identifier_type, identifier):
         pools = self.load_licensepools(library, identifier_type, identifier)

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -52,17 +52,16 @@ def load_lanes(_db, library):
     returned.
     """
     top_level = WorkList.top_level_for_library(_db, library)
-    to_expunge = None
 
     # It's likely this WorkList will be used across sessions, so
-    # expunge any data model objects from the database.
+    # expunge any data model objects from the database session.
     if isinstance(top_level, Lane):
         to_expunge = [top_level]
     else:
         to_expunge = [x for x in top_level.children if isinstance(x, Lane)]
 
     map(_db.expunge, to_expunge)
-
+    return top_level
 
 def create_default_lanes(_db, library):
     """Reset the lanes for the given library to the default.

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -230,7 +230,7 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     common_args = dict(
         languages=languages,
-        media=Edition.BOOK_MEDIUM
+        media=[Edition.BOOK_MEDIUM]
     )
     adult_common_args = dict(common_args)
     adult_common_args['audiences'] = ADULT
@@ -611,7 +611,7 @@ def create_lane_for_small_collection(_db, library, languages, priority=0):
 
     common_args = dict(
         languages=languages,
-        media=Edition.BOOK_MEDIUM,
+        media=[Edition.BOOK_MEDIUM],
         genres=[],
     )
     language_identifier = LanguageCodes.name_for_languageset(languages)
@@ -667,6 +667,7 @@ def create_lane_for_tiny_collections(_db, library, languages, priority=0):
         languages = [languages]
 
     sublane_priority = 0
+    common_args = dict(media=[Edition.BOOK_MEDIUM])
     for language_set in languages:
         name = LanguageCodes.name_for_languageset(language_set)
         language_lane, ignore = create(
@@ -676,6 +677,7 @@ def create_lane_for_tiny_collections(_db, library, languages, priority=0):
             fiction=None,
             priority=sublane_priority,
             languages=[language_set],
+            **common_args
         )
         sublane_priority += 1
         language_lanes.append(language_lane)
@@ -688,6 +690,7 @@ def create_lane_for_tiny_collections(_db, library, languages, priority=0):
         fiction=None,
         languages=languages,
         priority=priority,
+        **common_args
     )
     priority += 1
     return priority

--- a/scripts.py
+++ b/scripts.py
@@ -327,9 +327,9 @@ class CacheRepresentationPerLane(LaneSweeperScript):
         super(CacheRepresentationPerLane, self).__init__(_db, *args, **kwargs)
         self.parse_args(cmd_args)
         from api.app import app
-        app.manager = CirculationManager(_db, testing=testing)
+        app.manager = CirculationManager(self._db, testing=testing)
         self.app = app
-        self.base_url = ConfigurationSetting.sitewide(_db, Configuration.BASE_URL_KEY).value
+        self.base_url = ConfigurationSetting.sitewide(self._db, Configuration.BASE_URL_KEY).value
         
     def parse_args(self, cmd_args=None):
         parser = self.arg_parser(self._db)

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -208,36 +208,6 @@ class TestLaneCreation(DatabaseTest):
         [other_lane] = [x for x in lanes if x.display_name == 'Other Languages']
         eq_(7, other_lane.priority)
 
-    def test_load_lanes(self):
-        # These two top-level lanes should be children of the WorkList.
-        lane1 = self._lane(display_name="Top-level Lane 1")
-        lane1.priority = 0
-        lane2 = self._lane(display_name="Top-level Lane 2")
-        lane2.priority = 1
-
-        # This lane is invisible and will be filtered out.
-        invisible_lane = self._lane(display_name="Invisible Lane")
-        invisible_lane.visible = False
-
-        # This lane has a parent and will be filtered out.
-        sublane = self._lane(display_name="Sublane")
-        lane1.sublanes.append(sublane)
-
-        # This lane belongs to a different library.
-        other_library = self._library(
-            name="Other Library", short_name="Other"
-        )
-        other_library_lane = self._lane(
-            display_name="Other Library Lane", library=other_library
-        )
-
-        # The default library gets a WorkList with the two top-level lanes as children.
-        wl = load_lanes(self._db, self._default_library)
-        eq_([lane1, lane2], wl.children)
-
-        # The other library only has one top-level lane, so we use that lane.
-        l = load_lanes(self._db, other_library)
-        eq_(other_library_lane, l)
 
 class TestWorkBasedLane(DatabaseTest):
 

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -16,6 +16,7 @@ from core.model import (
     create,
     Contribution,
     Contributor,
+    Edition,
     SessionManager,
     DataSource,
     ExternalIntegration,
@@ -60,12 +61,15 @@ class TestLaneCreation(DatabaseTest):
             # They all are restricted to English and Spanish.
             eq_(x.languages, languages)
 
+            # They only contain books.
+            eq_([Edition.BOOK_MEDIUM], x.media)
+
         eq_(
             ['Fiction', 'Nonfiction', 'Young Adult Fiction',
              'Young Adult Nonfiction', 'Children and Middle Grade'],
             [x.display_name for x in lanes]
         )
-
+        
 
         # The Adult Fiction and Adult Nonfiction lanes reproduce the
         # genre structure found in the genre definitions.
@@ -140,6 +144,8 @@ class TestLaneCreation(DatabaseTest):
         )
         for x in sublanes:
             eq_(languages, x.languages)
+            eq_([Edition.BOOK_MEDIUM], x.media)
+
         eq_(
             [set(['Adults Only', 'Adult']), 
              set(['Adults Only', 'Adult']), 
@@ -159,6 +165,7 @@ class TestLaneCreation(DatabaseTest):
 
         create_lane_for_tiny_collections(self._db, self._default_library, ['ger', 'fre', 'ita'])
         [lane] = self._db.query(Lane).filter(Lane.parent_id==None).all()
+        eq_([Edition.BOOK_MEDIUM], lane.media)
         eq_(['ger', 'fre', 'ita'], lane.languages)
         eq_("Other Languages", lane.display_name)
         eq_(
@@ -168,7 +175,8 @@ class TestLaneCreation(DatabaseTest):
         eq_([['ger'], ['fre'], ['ita']],
             [x.languages for x in lane.visible_children]
         )
-
+        for child in lane.visible_children:
+            eq_([Edition.BOOK_MEDIUM], child.media)
 
     def test_create_default_lanes(self):
         library = self._default_library


### PR DESCRIPTION
This branch changes the circulation manager to use the standard way of creating a top-level WorkList for a library (defined in https://github.com/NYPL-Simplified/server_core/pull/765).

It also changes the lanes created by default so that they only contain ebooks. (The core branch contains a migration script that puts this in place for existing lanes.)
  