### PR TITLE
Improve performance of MetadataWranglerCollectionReaper.finalize_batch

### DIFF
--- a/bin/informational/overdrive-raw-bibliographic
+++ b/bin/informational/overdrive-raw-bibliographic
@@ -7,17 +7,24 @@ bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 
+from core.model import (
+    Collection,
+    ExternalIntegration,
+)
 from core.scripts import IdentifierInputScript
 from api.overdrive import OverdriveAPI
 
 class OverdriveRawBibliographicScript(IdentifierInputScript):
     def run(self):
-        overdrive = OverdriveAPI(self._db)
         args = self.parse_command_line(self._db)
-        for identifier in args.identifiers:
-            data = overdrive.metadata_lookup(identifier)
-            print json.dumps(data, sort_keys=True, indent=4,
-                             separators=(',', ': '))
-            print
+        for collection in Collection.by_protocol(
+            self._db, ExternalIntegration.OVERDRIVE
+        ): 
+            overdrive = OverdriveAPI(self._db, collection)
+            for identifier in args.identifiers:
+                data = overdrive.metadata_lookup(identifier)
+                print json.dumps(data, sort_keys=True, indent=4,
+                                 separators=(',', ': '))
+                print
 
 OverdriveRawBibliographicScript().run()


### PR DESCRIPTION
On a large dataset, MetadataWranglerCollectionReaper.finalize_batch was consuming all available memory. I rewrote it to optimize the query without changing the behavior.

Previously, the query used the intersection of two subqueries to find all identifier IDs that had both an 'import' CoverageRecord and a 'reap' coveragerecord. Then it was looking up all the 'import' CoverageRecords for those identifiers. Both subqueries were huge and finding their intersection was apparently happening in SQLAlchemy rather than in the database.

The new query doesn't involve Identifier it at all; it selects all the 'import' records and joins CoverageRecord against an alias of itself to only find records that also have 'reap' records. Basically, it finds _pairs_ of CoverageRecords that meet a certain criteria, and then deletes one of the pair.