### PR TITLE
Add metadata needed monitor

### DIFF
--- a/api/coverage.py
+++ b/api/coverage.py
@@ -245,7 +245,7 @@ class MetadataWranglerCollectionRegistrar(BaseMetadataWranglerCoverageProvider):
 
     Once it's registered, any future updates to the available metadata
     for a given Identifier will be detected by the
-    MetadataWranglerCollectionUpdateMonitor.
+    MWCollectionUpdateMonitor.
     """
 
     SERVICE_NAME = "Metadata Wrangler Collection Registrar"

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -378,19 +378,10 @@ class MetadataUploadCoverageProvider(BaseMetadataWranglerCoverageProvider):
     SERVICE_NAME = "Metadata Upload Coverage Provider"
     OPERATION = CoverageRecord.METADATA_UPLOAD_OPERATION
     DATA_SOURCE_NAME = DataSource.INTERNAL_PROCESSING
-       
-    def items_that_need_coverage(self, identifiers=None, **kwargs):
-        """Find all identifiers lacking coverage from this CoverageProvider.
-        Only identifiers that have CoverageRecords in the 'transient
-        failure' state will be returned. Unlike with other
-        CoverageProviders, Identifiers that have no CoverageRecord at
-        all will not be processed.
-        """
-        qu = super(MetadataUploadCoverageProvider, self).items_that_need_coverage(
-            identifiers=identifiers, **kwargs
-        )
-        qu = qu.filter(CoverageRecord.id != None)
-        return qu
+
+    def __init__(self, *args, **kwargs):
+        kwargs['registered_only'] = kwargs.get('registered_only', True)
+        super(MetadataUploadCoverageProvider, self).__init__(*args, **kwargs)
 
     def process_batch(self, batch):
         """Create an OPDS feed from a batch and upload it to the metadata client."""

--- a/api/monitor.py
+++ b/api/monitor.py
@@ -66,7 +66,7 @@ class MetadataWranglerCollectionMonitor(CollectionMonitor):
         raise NotImplementedError()
 
 
-class MWUpdateMonitor(MetadataWranglerCollectionMonitor):
+class MWCollectionUpdateMonitor(MetadataWranglerCollectionMonitor):
     """Retrieves updated metadata from the Metadata Wrangler"""
 
     SERVICE_NAME = "Metadata Wrangler Collection Updates"

--- a/api/monitor.py
+++ b/api/monitor.py
@@ -14,23 +14,25 @@ from core.monitor import (
 from core.model import (
     DataSource,
     Edition,
+    Identifier,
     LicensePool,
 )
 from core.opds_import import (
     MetadataWranglerOPDSLookup,
     OPDSImporter,
+    OPDSXMLParser,
 )
 from core.util.http import RemoteIntegrationException
 
 
-class MetadataWranglerCollectionUpdateMonitor(CollectionMonitor):
-    """Retrieves updated metadata from the Metadata Wrangler"""
+class MetadataWranglerCollectionMonitor(CollectionMonitor):
 
-    SERVICE_NAME = "Metadata Wrangler Collection Updates"
-    DEFAULT_START_TIME = CollectionMonitor.NEVER
+    """Abstract base CollectionMonitor with helper methods for interactions
+    with the Metadata Wrangler.
+    """
 
     def __init__(self, _db, collection, lookup=None):
-        super(MetadataWranglerCollectionUpdateMonitor, self).__init__(
+        super(MetadataWranglerCollectionMonitor, self).__init__(
             _db, collection
         )
         self.lookup = lookup or MetadataWranglerOPDSLookup.from_config(
@@ -42,12 +44,40 @@ class MetadataWranglerCollectionUpdateMonitor(CollectionMonitor):
             metadata_client=self.lookup, map_from_collection=True,
         )
 
+    def get_response(self, url=None, **kwargs):
+        try:
+            if url:
+                response = self.lookup._get(url)
+            else:
+                response = self.endpoint(**kwargs)
+            self.lookup.check_content_type(response)
+            return response
+        except RemoteIntegrationException as e:
+            self.log.error(
+                "Error getting feed for %r: %s",
+                self.collection, e.debug_message
+            )
+            self.keep_timestamp = False
+            return None
+
+    def endpoint(self, *args, **kwargs):
+        raise NotImplementedError()
+
+
+class MWUpdateMonitor(MetadataWranglerCollectionMonitor):
+    """Retrieves updated metadata from the Metadata Wrangler"""
+
+    SERVICE_NAME = "Metadata Wrangler Collection Updates"
+    DEFAULT_START_TIME = CollectionMonitor.NEVER
+
+    def endpoint(self, timestamp):
+        return self.lookup.updates(timestamp)
+
     def run_once(self, start, cutoff):
         if not self.lookup.authenticated:
             self.keep_timestamp = False
             return
 
-        entries = list()
         queue = [None]
         seen_links = set()
 
@@ -85,7 +115,7 @@ class MetadataWranglerCollectionUpdateMonitor(CollectionMonitor):
         return new_timestamp or self.timestamp().timestamp
 
     def import_one_feed(self, timestamp, url):
-        response = self.get_response(timestamp, url=url)
+        response = self.get_response(url=url, timestamp=timestamp)
         if not response:
             return [], [], timestamp
 
@@ -113,24 +143,8 @@ class MetadataWranglerCollectionUpdateMonitor(CollectionMonitor):
         next_links = self.importer.extract_next_links(parsed)
         return next_links, editions, timestamp
 
-    def get_response(self, timestamp, url=None):
-        try:
-            if not url:
-                response = self.lookup.updates(timestamp)
-            else:
-                response = self.lookup._get(url)
-            self.lookup.check_content_type(response)
-            return response
-        except RemoteIntegrationException as e:
-            self.log.error(
-                "Error getting updates for %r: %s",
-                self.collection, e.debug_message
-            )
-            self.keep_timestamp = False
-            return None
 
-
-class MetadataWranglerAuxiliaryMetadataMonitor(CollectionMonitor):
+class MWAuxiliaryMetadataMonitor(MetadataWranglerCollectionMonitor):
 
     """Retrieves and processes requests for needed third-party metadata
     from the Metadata Wrangler.
@@ -148,21 +162,20 @@ class MetadataWranglerAuxiliaryMetadataMonitor(CollectionMonitor):
       - get the next page.
     """
 
-    SERVICE_NAME = "Metadata Wrangler Collection Updates"
+    SERVICE_NAME = "Metadata Wrangler Auxiliary Metadata Delivery"
     DEFAULT_START_TIME = CollectionMonitor.NEVER
 
-    def __init__(self, _db, collection, lookup=None):
-        super(MetadataWranglerCollectionUpdateMonitor, self).__init__(
-            _db, collection
+    def __init__(self, _db, collection, lookup=None, provider=None):
+        super(MWAuxiliaryMetadataMonitor, self).__init__(
+            _db, collection, lookup=lookup
         )
-        self.lookup = lookup or MetadataWranglerOPDSLookup.from_config(
-            self._db, collection=collection
+        self.parser = OPDSXMLParser()
+        self.provider = provider or MetadataUploadCoverageProvider(
+            collection, lookup_client=lookup
         )
-        self.importer = OPDSImporter(
-            self._db, self.collection,
-            data_source_name=DataSource.METADATA_WRANGLER,
-            metadata_client=self.lookup, map_from_collection=True,
-        )
+
+    def endpoint(self):
+        return self.lookup.metadata_needed()
 
     def run_once(self, start, cutoff):
         if not self.lookup.authenticated:

--- a/bin/metadata_wrangler_auxiliary_metadata
+++ b/bin/metadata_wrangler_auxiliary_metadata
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""Monitor metadata requests from the Metadata Wrangler remote collection."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from core.scripts import RunCollectionMonitorScript
+from api.monitor import MWAuxiliaryMetadataMonitor
+RunCollectionMonitorScript(MWAuxiliaryMetadataMonitor).run()

--- a/bin/metadata_wrangler_collection_updates
+++ b/bin/metadata_wrangler_collection_updates
@@ -6,5 +6,5 @@ bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
 from core.scripts import RunCollectionMonitorScript
-from api.monitor import MetadataWranglerCollectionUpdateMonitor
-RunCollectionMonitorScript(MetadataWranglerCollectionUpdateMonitor).run()
+from api.monitor import MWCollectionUpdateMonitor
+RunCollectionMonitorScript(MWCollectionUpdateMonitor).run()

--- a/tests/files/opds/metadata_data_needed_empty_response.opds
+++ b/tests/files/opds/metadata_data_needed_empty_response.opds
@@ -1,0 +1,7 @@
+<feed xmlns:app="http://www.w3.org/2007/app" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:drm="http://librarysimplified.org/terms/drm" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns:simplified="http://librarysimplified.org/terms/" xmlns="http://www.w3.org/2005/Atom">
+  <id>http://localhost:5500/VDNabGNtUnlhWFpsOk9ETTM%3D/metadata_needed</id>
+  <title>Overdrive Metadata Requests for example.org</title>
+  <updated>2018-01-09T22:49:54Z</updated>
+  <link href="http://localhost:5500/VDNabGNtUnlhWFpsOk9ETTM%3D/metadata_needed" rel="self"/>
+  <link href="http://another-next-link" rel="next"/>
+</feed>

--- a/tests/files/opds/metadata_data_needed_response.opds
+++ b/tests/files/opds/metadata_data_needed_response.opds
@@ -1,0 +1,72 @@
+<feed xmlns:app="http://www.w3.org/2007/app" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:drm="http://librarysimplified.org/terms/drm" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns:simplified="http://librarysimplified.org/terms/" xmlns="http://www.w3.org/2005/Atom">
+  <id>http://localhost:5500/VDNabGNtUnlhWFpsOk9ETTM%3D/metadata_needed</id>
+  <title>Overdrive Metadata Requests for example.org</title>
+  <updated>2018-01-09T22:49:54Z</updated>
+  <link href="http://localhost:5500/VDNabGNtUnlhWFpsOk9ETTM%3D/metadata_needed" rel="self"/>
+  <simplified:message>
+    <id>urn:librarysimplified.org/terms/id/Overdrive%20ID/4981c34f-d518-48ff-9659-2601b2b9bdc1</id>
+    <simplified:status_code>202</simplified:status_code>
+    <schema:description>Metadata needed.</schema:description>
+  </simplified:message>
+  <simplified:message>
+    <id>urn:isbn:9781602835740</id>
+    <simplified:status_code>202</simplified:status_code>
+    <schema:description>Metadata needed.</schema:description>
+  </simplified:message>
+  <simplified:message>
+    <id>urn:isbn:9781569478295</id>
+    <simplified:status_code>202</simplified:status_code>
+    <schema:description>Metadata needed.</schema:description>
+  </simplified:message>
+  <simplified:message>
+    <id>urn:isbn:9781471135422</id>
+    <simplified:status_code>202</simplified:status_code>
+    <schema:description>Metadata needed.</schema:description>
+  </simplified:message>
+  <simplified:message>
+    <id>urn:isbn:9781597228930</id>
+    <simplified:status_code>202</simplified:status_code>
+    <schema:description>Metadata needed.</schema:description>
+  </simplified:message>
+  <simplified:message>
+    <id>urn:isbn:9781592578474</id>
+    <simplified:status_code>202</simplified:status_code>
+    <schema:description>Metadata needed.</schema:description>
+  </simplified:message>
+  <simplified:message>
+    <id>urn:isbn:9780385495561</id>
+    <simplified:status_code>202</simplified:status_code>
+    <schema:description>Metadata needed.</schema:description>
+  </simplified:message>
+  <simplified:message>
+    <id>urn:isbn:9781470361181</id>
+    <simplified:status_code>202</simplified:status_code>
+    <schema:description>Metadata needed.</schema:description>
+  </simplified:message>
+  <simplified:message>
+    <id>urn:isbn:9785237010534</id>
+    <simplified:status_code>202</simplified:status_code>
+    <schema:description>Metadata needed.</schema:description>
+  </simplified:message>
+  <simplified:message>
+    <id>urn:isbn:9781780877952</id>
+    <simplified:status_code>202</simplified:status_code>
+    <schema:description>Metadata needed.</schema:description>
+  </simplified:message>
+  <simplified:message>
+    <id>urn:isbn:9781299056251</id>
+    <simplified:status_code>202</simplified:status_code>
+    <schema:description>Metadata needed.</schema:description>
+  </simplified:message>
+  <simplified:message>
+    <id>urn:isbn:9780843929997</id>
+    <simplified:status_code>202</simplified:status_code>
+    <schema:description>Metadata needed.</schema:description>
+  </simplified:message>
+  <simplified:message>
+    <id>urn:isbn:9789536306039</id>
+    <simplified:status_code>202</simplified:status_code>
+    <schema:description>Metadata needed.</schema:description>
+  </simplified:message>
+  <link href="http://localhost:5500/VDNabGNtUnlhWFpsOk9ETTM%3D/metadata_needed?after=25&amp;size=25" rel="next"/>
+</feed>

--- a/tests/files/opds/metadata_data_needed_response.opds
+++ b/tests/files/opds/metadata_data_needed_response.opds
@@ -18,55 +18,5 @@
     <simplified:status_code>202</simplified:status_code>
     <schema:description>Metadata needed.</schema:description>
   </simplified:message>
-  <simplified:message>
-    <id>urn:isbn:9781471135422</id>
-    <simplified:status_code>202</simplified:status_code>
-    <schema:description>Metadata needed.</schema:description>
-  </simplified:message>
-  <simplified:message>
-    <id>urn:isbn:9781597228930</id>
-    <simplified:status_code>202</simplified:status_code>
-    <schema:description>Metadata needed.</schema:description>
-  </simplified:message>
-  <simplified:message>
-    <id>urn:isbn:9781592578474</id>
-    <simplified:status_code>202</simplified:status_code>
-    <schema:description>Metadata needed.</schema:description>
-  </simplified:message>
-  <simplified:message>
-    <id>urn:isbn:9780385495561</id>
-    <simplified:status_code>202</simplified:status_code>
-    <schema:description>Metadata needed.</schema:description>
-  </simplified:message>
-  <simplified:message>
-    <id>urn:isbn:9781470361181</id>
-    <simplified:status_code>202</simplified:status_code>
-    <schema:description>Metadata needed.</schema:description>
-  </simplified:message>
-  <simplified:message>
-    <id>urn:isbn:9785237010534</id>
-    <simplified:status_code>202</simplified:status_code>
-    <schema:description>Metadata needed.</schema:description>
-  </simplified:message>
-  <simplified:message>
-    <id>urn:isbn:9781780877952</id>
-    <simplified:status_code>202</simplified:status_code>
-    <schema:description>Metadata needed.</schema:description>
-  </simplified:message>
-  <simplified:message>
-    <id>urn:isbn:9781299056251</id>
-    <simplified:status_code>202</simplified:status_code>
-    <schema:description>Metadata needed.</schema:description>
-  </simplified:message>
-  <simplified:message>
-    <id>urn:isbn:9780843929997</id>
-    <simplified:status_code>202</simplified:status_code>
-    <schema:description>Metadata needed.</schema:description>
-  </simplified:message>
-  <simplified:message>
-    <id>urn:isbn:9789536306039</id>
-    <simplified:status_code>202</simplified:status_code>
-    <schema:description>Metadata needed.</schema:description>
-  </simplified:message>
-  <link href="http://localhost:5500/VDNabGNtUnlhWFpsOk9ETTM%3D/metadata_needed?after=25&amp;size=25" rel="next"/>
+  <link href="http://next-link" rel="next"/>
 </feed>

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -25,26 +25,26 @@ from core.util.opds_writer import OPDSFeed
 
 from api.monitor import (
     MWAuxiliaryMetadataMonitor,
-    MWUpdateMonitor,
+    MWCollectionUpdateMonitor,
 )
 
 
-class InstrumentedMWUpdateMonitor(MWUpdateMonitor):
+class InstrumentedMWCollectionUpdateMonitor(MWCollectionUpdateMonitor):
     
     def __init__(self, *args, **kwargs):
-        super(InstrumentedMWUpdateMonitor, self).__init__(*args, **kwargs)
+        super(InstrumentedMWCollectionUpdateMonitor, self).__init__(*args, **kwargs)
         self.imports = []
 
     def import_one_feed(self, timestamp, url):
         self.imports.append((timestamp, url))
-        return super(InstrumentedMWUpdateMonitor,
+        return super(InstrumentedMWCollectionUpdateMonitor,
                      self).import_one_feed(timestamp, url)
 
 
-class TestMWUpdateMonitor(DatabaseTest):
+class TestMWCollectionUpdateMonitor(DatabaseTest):
 
     def setup(self):
-        super(TestMWUpdateMonitor, self).setup()
+        super(TestMWCollectionUpdateMonitor, self).setup()
         self._external_integration(
             ExternalIntegration.METADATA_WRANGLER,
             ExternalIntegration.METADATA_GOAL,
@@ -59,7 +59,7 @@ class TestMWUpdateMonitor(DatabaseTest):
             self._db, self.collection
         )
 
-        self.monitor = InstrumentedMWUpdateMonitor(
+        self.monitor = InstrumentedMWCollectionUpdateMonitor(
             self._db, self.collection, self.lookup
         )
 
@@ -229,7 +229,7 @@ class TestMWUpdateMonitor(DatabaseTest):
         # If you pass in None for the URL, it passes the timestamp into
         # updates()
         lookup = Mock()
-        monitor = MWUpdateMonitor(
+        monitor = MWCollectionUpdateMonitor(
             self._db, self.collection, lookup
         )
         timestamp = object()
@@ -241,7 +241,7 @@ class TestMWUpdateMonitor(DatabaseTest):
         # If you pass in a URL, the timestamp is ignored and
         # the URL is passed into _get().
         lookup = Mock()
-        monitor = MWUpdateMonitor(
+        monitor = MWCollectionUpdateMonitor(
             self._db, self.collection, lookup
         )
         response = monitor.get_response(timestamp=None, url='http://now used/')

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -243,3 +243,11 @@ class TestMetadataWranglerCollectionUpdateMonitor(DatabaseTest):
         eq_(200, response.status_code)
         eq_(None, lookup.last_timestamp)
         eq_(['http://now used/'], lookup.urls)
+
+
+class TestMetadataWranglerAuxiliaryMetadataMonitor(DatabaseTest):
+
+    def test_get_identifiers(self):
+        ignored = self._identifier()
+
+        pass


### PR DESCRIPTION
This branch is the other half of the metadata wrangler's new endpoint to request metadata (NYPL-Simplified/metadata_wrangler#153). It adds a monitor that will send distributor metadata to the wrangler for each collection.