### PR TITLE
Support authentication with no password

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1154,51 +1154,51 @@ class BasicAuthenticationProvider(AuthenticationProvider):
     
     # Identifiers can be presumed invalid if they don't match
     # this regular expression.
-    IDENTIFIER_REGULAR_EXPRESSION = 'identifier_regular_expression'
+    IDENTIFIER_REGULAR_EXPRESSION = u'identifier_regular_expression'
 
     # Passwords can be presumed invalid if they don't match this regular
     # expression.
-    PASSWORD_REGULAR_EXPRESSION = 'password_regular_expression'
+    PASSWORD_REGULAR_EXPRESSION = u'password_regular_expression'
 
     # The client should prefer one keyboard over another.
-    IDENTIFIER_KEYBOARD = 'identifier_keyboard'
-    PASSWORD_KEYBOARD = 'password_keyboard'
+    IDENTIFIER_KEYBOARD = u'identifier_keyboard'
+    PASSWORD_KEYBOARD = u'password_keyboard'
 
     # Constants describing different types of keyboards.
-    DEFAULT_KEYBOARD = "Default"
-    EMAIL_ADDRESS_KEYBOARD = "Email address"
-    NUMBER_PAD = "Number pad"
-    NULL_KEYBOARD = "No input"
+    DEFAULT_KEYBOARD = u"Default"
+    EMAIL_ADDRESS_KEYBOARD = u"Email address"
+    NUMBER_PAD = u"Number pad"
+    NULL_KEYBOARD = u"No input"
 
     # The identifier and password can have a maximum
     # supported length.
-    IDENTIFIER_MAXIMUM_LENGTH = "identifier_maximum_length"
-    PASSWORD_MAXIMUM_LENGTH = "password_maximum_length"
+    IDENTIFIER_MAXIMUM_LENGTH = u"identifier_maximum_length"
+    PASSWORD_MAXIMUM_LENGTH = u"password_maximum_length"
     
     # The client should use a certain string when asking for a patron's
     # "identifier" and "password"
-    IDENTIFIER_LABEL = 'identifier_label'
-    PASSWORD_LABEL = 'password_label'
-    DEFAULT_IDENTIFIER_LABEL = "Barcode"
-    DEFAULT_PASSWORD_LABEL = "PIN"
+    IDENTIFIER_LABEL = u'identifier_label'
+    PASSWORD_LABEL = u'password_label'
+    DEFAULT_IDENTIFIER_LABEL = u"Barcode"
+    DEFAULT_PASSWORD_LABEL = u"PIN"
 
     # If the identifier label is one of these strings, it will be
     # automatically localized. Otherwise, the same label will be displayed
     # to everyone.
     COMMON_IDENTIFIER_LABELS = {
-        "Barcode": _("Barcode"),
-        "Email Address": _("Email Address"),
-        "Username": _("Username"),
-        "Library Card": _("Library Card"),
-        "Card Number": _("Card Number"),
+        u"Barcode": _("Barcode"),
+        u"Email Address": _("Email Address"),
+        u"Username": _("Username"),
+        u"Library Card": _("Library Card"),
+        u"Card Number": _("Card Number"),
     }
 
     # If the password label is one of these strings, it will be
     # automatically localized. Otherwise, the same label will be
     # displayed to everyone.
     COMMON_PASSWORD_LABELS = {
-        "Password": _("Password"),
-        "PIN": _("PIN"),
+        u"Password": _("Password"),
+        u"PIN": _("PIN"),
     }
     
     # These identifier and password are supposed to be valid
@@ -1330,7 +1330,7 @@ class BasicAuthenticationProvider(AuthenticationProvider):
         """Does this BasicAuthenticationProvider expect a username
         and a password, or just a username?
         """
-        return self.password_keyboard is not self.NULL_KEYBOARD
+        return self.password_keyboard != self.NULL_KEYBOARD
 
     def testing_patron(self, _db):
         """Look up a Patron object reserved for testing purposes.

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -150,7 +150,16 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         valid, a PatronData that serves only to indicate which
         authorization identifier the patron prefers.
         """
+        if not self.collects_password:
+            # We don't even look at the password. If the patron exists, they
+            # are authenticated.
+            patrondata = self._remote_patron_lookup(username)
+            if not patrondata:
+                return False
+            return patrondata
+
         if self.auth_mode == self.PIN_AUTHENTICATION_MODE:
+            # Patrons are authenticated with a secret PIN.
             path = "%(barcode)s/%(pin)s/pintest" % dict(
                 barcode=username, pin=password
             )
@@ -161,7 +170,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
                 return PatronData(authorization_identifier=username, complete=False)
             return False
         elif self.auth_mode == self.FAMILY_NAME_AUTHENTICATION_MODE:
-
+            # Patrons are authenticated by their family name.
             patrondata = self._remote_patron_lookup(username)
             if not patrondata:
                 # The patron doesn't even exist.

--- a/api/simple_authentication.py
+++ b/api/simple_authentication.py
@@ -55,7 +55,7 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
         
     def remote_authenticate(self, username, password):
         "Fake 'remote' authentication."
-        if not username or not password:
+        if not username or (self.collects_password and not password):
             return None
 
         if not self.valid_patron(username, password):
@@ -84,8 +84,10 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
         """Is this patron associated with the given password in 
         the given dictionary?
         """
-        return password==self.test_password and (
-            username in self.test_identifiers
-        )
+        if self.collects_password:
+            password_match = (password==self.test_password)
+        else:
+            password_match = (password in (None, ''))
+        return password_match and username in self.test_identifiers
 
 AuthenticationProvider = SimpleAuthenticationProvider

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -104,10 +104,6 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
                     connect=connect
                 )
 
-            # We will only send passwords over SIP2 if the integration
-            # is set up to collect passwords.
-            self.send_password = integration.setting(
-                self.PASSWORD_KEYBOARD).value != self.NULL_KEYBOARD
         except IOError, e:
             raise RemoteIntegrationException(
                 server or 'unknown server', e.message
@@ -121,7 +117,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             number/authorization identifier.
         :param password: The patron's password/pin/access code.
         """
-        if not self.send_password:
+        if not self.collects_password:
             # Even if we were somehow given a password, we won't be
             # passing it on.
             password = None

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -103,6 +103,11 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
                     location_code=location_code, separator=field_separator,
                     connect=connect
                 )
+
+            # We will only send passwords over SIP2 if the integration
+            # is set up to collect passwords.
+            self.send_password = integration.setting(
+                self.PASSWORD_KEYBOARD).value != self.NULL_KEYBOARD
         except IOError, e:
             raise RemoteIntegrationException(
                 server or 'unknown server', e.message
@@ -116,6 +121,10 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             number/authorization identifier.
         :param password: The patron's password/pin/access code.
         """
+        if not self.send_password:
+            # Even if we were somehow given a password, we won't be
+            # passing it on.
+            password = None
         try:
             info = self.client.patron_information(username, password)
         except IOError, e:

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -48,7 +48,6 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         integration.username = "user1"
         integration.password = "pass1"
         integration.setting(p.FIELD_SEPARATOR).value = "\t"
-
         provider = p(self._default_library, integration, connect=False)
 
         # A SIPClient was initialized based on the integration values.
@@ -95,17 +94,6 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         patrondata = auth.remote_authenticate("user", "pass")
         eq_(PatronData.EXCESSIVE_FINES, patrondata.block_reason)
         
-        # Some examples taken from an Evergreen instance that doesn't
-        # use passwords.
-        client.queue_response(self.evergreen_active_user)
-        patrondata = auth.remote_authenticate("user", "pass")
-        eq_("12345", patrondata.authorization_identifier)
-        eq_("863715", patrondata.permanent_id)
-        eq_("Booth Active Test", patrondata.personal_name)
-        eq_(0, patrondata.fines)
-        eq_(datetime(2019, 10, 4), patrondata.authorization_expires)
-        eq_("Adult", patrondata.external_type)
-
         # A patron with an expired card.
         client.queue_response(self.evergreen_expired_card)
         patrondata = auth.remote_authenticate("user", "pass")
@@ -183,6 +171,30 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         patrondata = auth.remote_authenticate("user", "pass")
         eq_(None, patrondata)
 
+    def test_remote_authenticate_no_password(self):
+
+        integration = self._external_integration(self._str)
+        p = SIP2AuthenticationProvider
+        integration.setting(p.PASSWORD_KEYBOARD).value = p.NULL_KEYBOARD
+        client = MockSIPClient()
+        auth = SIP2AuthenticationProvider(
+            self._default_library, integration, client=client
+        )
+
+        # This Evergreen instance doesn't use passwords.
+        client.queue_response(self.evergreen_active_user)
+        patrondata = auth.remote_authenticate("user", None)
+        eq_("12345", patrondata.authorization_identifier)
+        eq_("863715", patrondata.permanent_id)
+        eq_("Booth Active Test", patrondata.personal_name)
+        eq_(0, patrondata.fines)
+        eq_(datetime(2019, 10, 4), patrondata.authorization_expires)
+        eq_("Adult", patrondata.external_type)
+
+        # If a password is specified, it is ignored.
+        client.queue_response(self.evergreen_active_user)
+        patrondata = auth.remote_authenticate("user", "some password")
+        eq_("12345", patrondata.authorization_identifier)
 
     def test_ioerror_during_connect_becomes_remoteintegrationexception(self):
         """If the IP of the circulation manager has not been whitelisted,

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -191,10 +191,13 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         eq_(datetime(2019, 10, 4), patrondata.authorization_expires)
         eq_("Adult", patrondata.external_type)
 
-        # If a password is specified, it is ignored.
+        # If a password is specified, it is not sent over the wire.
         client.queue_response(self.evergreen_active_user)
-        patrondata = auth.remote_authenticate("user", "some password")
+        patrondata = auth.remote_authenticate("user2", "some password")
         eq_("12345", patrondata.authorization_identifier)
+        request = client.requests[-1]
+        assert 'user2' in request
+        assert 'some password' not in request
 
     def test_ioerror_during_connect_becomes_remoteintegrationexception(self):
         """If the IP of the circulation manager has not been whitelisted,

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1505,7 +1505,18 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         eq_(True, provider.server_side_validation("foodie", "barbecue"))
         eq_(PATRON_OF_ANOTHER_LIBRARY,
             provider.server_side_validation("foo", "bar"))
-        
+
+        # If this authenticator does not look at provided passwords,
+        # then the only values that will pass validation are null
+        # and the empty string.
+        provider.password_keyboard = provider.NULL_KEYBOARD
+        eq_(False, provider.server_side_validation("food", "barbecue"))
+        eq_(False, provider.server_side_validation("food", "is good"))
+        eq_(False, provider.server_side_validation("food", " "))
+        eq_(True, provider.server_side_validation("food", None))
+        eq_(True, provider.server_side_validation("food", ""))
+        provider.password_keyboard = provider.DEFAULT_KEYBOARD
+
         # It's okay not to provide anything for server side validation.
         # The default settings will be used.
         integration.setting(b.IDENTIFIER_REGULAR_EXPRESSION).value = None

--- a/tests/test_simple_auth.py
+++ b/tests/test_simple_auth.py
@@ -46,6 +46,27 @@ class TestSimpleAuth(DatabaseTest):
         user2 = provider.remote_authenticate("barcode_username", "pass")
         eq_("barcode", user2.authorization_identifier)
 
+    def test_no_password_authentication(self):
+        """The SimpleAuthenticationProvider can be made even
+        simpler by having it authenticate solely based on username.
+        """
+        p = SimpleAuthenticationProvider
+        integration = self._external_integration(self._str)
+        integration.setting(p.TEST_IDENTIFIER).value = "barcode"
+        integration.setting(p.TEST_PASSWORD).value = "pass"
+        integration.setting(p.PASSWORD_KEYBOARD).value = p.NULL_KEYBOARD
+        provider = p(self._default_library, integration)
+
+        # If you don't provide a password, you're in.
+        user = provider.remote_authenticate("barcode", None)
+        assert isinstance(user, PatronData)
+
+        user2 =  provider.remote_authenticate("barcode", '')
+        eq_(user2.authorization_identifier, user.authorization_identifier)
+
+        # If you provide any password, you're out.
+        eq_(None, provider.remote_authenticate("barcode", "pass"))
+
     def test_additional_identifiers(self):
         p = SimpleAuthenticationProvider
         integration = self._external_integration(self._str)


### PR DESCRIPTION
This branch changes the three authentication providers that use Basic Auth (simple, SIP2 and Millenium Patron) to handle the use case where a library authenticates patrons using only a barcode, with no password.

I added a [new value](https://github.com/NYPL-Simplified/Simplified/wiki/Authentication-For-OPDS-Extensions#keyboard) for the `keyboard` extension to Authentication For OPDS, called `No input`. This signals to clients that passwords should not be gathered or provided. On the server side, it controls what CM-side validation is done on passwords (basically, they have to be empty) and how the interaction with the authentication provider goes.

When a SIP2 integration is set to not use passwords, it omits the AD field from the SIP2 message even if a password was provided.

When a Millenium Patron integration is set to not use passwords, it does a patron lookup of the patron's identifier, rather than hitting the `pintest` endpoint, and returns success if the lookup succeeds.

When a simple authenticator is set not to use passwords, it just doesn't check the incoming password. If the barcode matches, authentication is successful.