### PR TITLE
After creating a library, create some lanes for it.

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1544,6 +1544,11 @@ class SettingsController(CirculationManagerController):
                     ))
 
         if is_new:
+            # Now that the configuration settings are in place, create
+            # a default set of lanes.
+            create_default_lanes(self._db, library)
+
+        if is_new:
             return Response(unicode(library.uuid), 201)
         else:
             return Response(unicode(library.uuid), 200)

--- a/migration/20180122-make-lanes-if-none-currently.py
+++ b/migration/20180122-make-lanes-if-none-currently.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""Make sure every library has some lanes."""
+import os
+import sys
+import logging
+from nose.tools import set_trace
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from core.model import (
+    Library,
+    production_session,
+)
+from api.lanes import create_default_lanes
+
+_db = production_session()
+for library in _db.query(Library):
+    num_lanes = len(library.lanes)
+    if num_lanes:
+        logging.info(
+            "%s has %d lanes, not doing anything.",
+            library.name, num_lanes
+        )
+    else:
+        logging.warn(
+            "%s has no lanes, creating some.",
+            library.name
+        )
+        try:
+            create_default_lanes(_db, library)
+        except Exception, e:
+            logging.error(
+                "Could not create default lanes; suggest you try resetting them manually.",
+                exc_info=e
+            )

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -2001,6 +2001,7 @@ class TestSettingsController(AdminControllerTest):
                 ("name", "The New York Public Library"),
                 ("short_name", "nypl"),
                 (Configuration.WEBSITE_URL, "https://library.library/"),
+                (Configuration.TINY_COLLECTION_LANGUAGES, 'ger'),
                 (Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, "email@example.com"),
                 (Configuration.FEATURED_LANE_SIZE, "5"),
                 (Configuration.DEFAULT_FACET_KEY_PREFIX + FacetConstants.ORDER_FACET_GROUP_NAME,
@@ -2032,6 +2033,17 @@ class TestSettingsController(AdminControllerTest):
                 library).value)
         eq_("data:image/png;base64,%s" % base64.b64encode(image_data),
             ConfigurationSetting.for_library(Configuration.LOGO, library).value)
+
+        # When the library was created, default lanes were also created
+        # according to its language setup. This library has one tiny
+        # collection (not a good choice for a real library), so only
+        # two lanes were created: "Other Languages" and then "German"
+        # underneath it.
+        [other_languages, german] = library.lanes
+        eq_(None, other_languages.parent)
+        eq_(['ger', other_languages.languages)
+        eq_(other_languages, german.parent)
+        eq_(['ger'], german.languages)
 
     def test_libraries_post_edit(self):
         # A library already exists.

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -2041,7 +2041,7 @@ class TestSettingsController(AdminControllerTest):
         # underneath it.
         [other_languages, german] = library.lanes
         eq_(None, other_languages.parent)
-        eq_(['ger', other_languages.languages)
+        eq_(['ger'], other_languages.languages)
         eq_(other_languages, german.parent)
         eq_(['ger'], german.languages)
 


### PR DESCRIPTION
This branch ensures that a new library immediately has a set of lanes created for it. These are probably not the lanes the library wants in the long term but it stops a common 'where are my books?' scenario during setup.