### PR TITLE
Update SIP read message conditions to allow for a SIP server configur…

### DIFF
--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -707,9 +707,9 @@ class SIPClient(Constants):
         while not done:
             tmp = self.socket.recv(4096)
             data = data + tmp
-            if not data:
+            if not tmp:
                 raise IOError("No data read from socket.")
-            if ord(data[-1]) == 13:
+            if ord(data[-1]) == 13 or ord(data[-1]) == 10:
                 done = True
             if len(data) > max_size:
                 raise IOError("SIP2 response too large.")


### PR DESCRIPTION
…ed to send CRLF line endings and correctly handle a condition where a message has a non-CR or LF line ending.

If the original message in data has neither a CR or LF last character, it will fall through the IF conditions and repeat the loop. The second time through the loop, there is likely not to be a message in the socket. But data will still have data from the first pass, so the 'if not data' condition will fail. This results in an uncaught infinite loop. (Without adding the condition for the LF line ending, the infinite loop occurs for any SIP server sending either CRLF or LF line endings. Koha sends CRLF by default, and Evergreen allows for CRLF.)