### PR TITLE
Made it possible to associate collections with a custom list.

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1002,7 +1002,7 @@ class WorkController(CirculationManagerController):
                 else:
                     list, is_new = create(self._db, CustomList, name=name, data_source=staff_data_source, library=library)
                     list.created = datetime.now()
-                entry, was_new = list.add_entry(work)
+                entry, was_new = list.add_entry(work, featured=True)
                 if was_new:
                     for lane in Lane.affected_by_customlist(list):
                         affected_lanes.add(lane)
@@ -1072,13 +1072,17 @@ class CustomListsController(CirculationManagerController):
                                             title=entry.edition.title,
                                             authors=[author.display_name for author in entry.edition.author_contributors],
                         ))
-                custom_lists.append(dict(id=list.id, name=list.name, entries=entries))
+                collections = []
+                for collection in list.collections:
+                    collections.append(dict(id=collection.id, name=collection.name, protocol=collection.protocol))
+                custom_lists.append(dict(id=list.id, name=list.name, entries=entries, collections=collections))
             return dict(custom_lists=custom_lists)
 
         if flask.request.method == "POST":
             id = flask.request.form.get("id")
             name = flask.request.form.get("name")
             entries = flask.request.form.get("entries")
+            collections = flask.request.form.get("collections")
 
             old_list_with_name = CustomList.find(self._db, data_source, name, library)
 
@@ -1134,6 +1138,19 @@ class CustomListsController(CirculationManagerController):
                 # lanes need to have their counts updated.
                 for lane in Lane.affected_by_customlist(list):
                     lane.update_size(self._db)
+
+            if collections:
+                collections = json.loads(collections)
+            else:
+                collections = []
+            new_collections = []
+            for collection_id in collections:
+                collection = get_one(self._db, Collection, id=collection_id)
+                if not collection:
+                    self._db.rollback()
+                    return MISSING_COLLECTION
+                new_collections.append(collection)
+            list.collections = new_collections
 
             if is_new:
                 return Response(unicode(list.id), 201)

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1149,6 +1149,9 @@ class CustomListsController(CirculationManagerController):
                 if not collection:
                     self._db.rollback()
                     return MISSING_COLLECTION
+                if list.library not in collection.libraries:
+                    self._db.rollback()
+                    return COLLECTION_NOT_ASSOCIATED_WITH_LIBRARY
                 new_collections.append(collection)
             list.collections = new_collections
 

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.53"
+    "simplified-circulation-web": "0.0.54"
   }
 }

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -324,6 +324,13 @@ CUSTOM_LIST_NAME_ALREADY_IN_USE = pd(
     detail=_("The library already has a custom list with that name."),
 )
 
+COLLECTION_NOT_ASSOCIATED_WITH_LIBRARY = pd(
+    "http://librarysimplified.org/terms/problem/collection-not-associated-with-library",
+    status_code=400,
+    title=_("Collection not associated with library"),
+    detail=_("You can't add a collection to a list unless it is associated with the list's library."),
+)
+
 MISSING_LANE = pd(
     "http://librarysimplified.org/terms/problem/missing-lane",
     status_code=404,

--- a/api/controller.py
+++ b/api/controller.py
@@ -410,6 +410,8 @@ class CirculationManagerController(BaseCirculationManagerController):
             lane = self.manager.top_level_lanes[library_id]
             if isinstance(lane, Lane):
                 lane = self._db.merge(lane)
+            elif isinstance(lane, WorkList):
+                lane.children = [self._db.merge(child) for child in lane.children]
         else:
             lane = get_one(
                 self._db, Lane, id=lane_identifier, library_id=library_id

--- a/api/controller.py
+++ b/api/controller.py
@@ -408,6 +408,8 @@ class CirculationManagerController(BaseCirculationManagerController):
         if lane_identifier is None:
             # Return the top-level lane.
             lane = self.manager.top_level_lanes[library_id]
+            if isinstance(lane, Lane):
+                lane = self._db.merge(lane)
         else:
             lane = get_one(
                 self._db, Lane, id=lane_identifier, library_id=library_id

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1761,7 +1761,7 @@ class TestLanesController(AdminControllerTest):
 
     def test_hide_lane_errors(self):
         with self.request_context_with_library("/"):
-            response = self.manager.admin_lanes_controller.hide_lane(123)
+            response = self.manager.admin_lanes_controller.hide_lane(123456789)
             eq_(MISSING_LANE, response)
 
     def test_reset(self):

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1360,9 +1360,21 @@ class TestCustomListsController(AdminControllerTest):
             response = self.manager.admin_custom_lists_controller.custom_lists()
             eq_(MISSING_COLLECTION, response)
 
+    def test_custom_lists_post_collection_with_wrong_library(self):
+        # This collection is not associated with any libraries.
+        collection = self._collection()
+        with self.request_context_with_library("/", method='POST'):
+            flask.request.form = MultiDict([
+                ("name", "name"),
+                ("collections", json.dumps([collection.id])),
+            ])
+            response = self.manager.admin_custom_lists_controller.custom_lists()
+            eq_(COLLECTION_NOT_ASSOCIATED_WITH_LIBRARY, response)
+
     def test_custom_lists_create(self):
         work = self._work(with_open_access_download=True)
         collection = self._collection()
+        collection.libraries = [self._default_library]
 
         with self.request_context_with_library("/", method="POST"):
             flask.request.form = MultiDict([
@@ -1404,7 +1416,9 @@ class TestCustomListsController(AdminControllerTest):
         new_entries = [dict(pwid=work.presentation_edition.permanent_work_id) for work in [w2, w3]]
 
         c1 = self._collection()
+        c1.libraries = [self._default_library]
         c2 = self._collection()
+        c2.libraries = [self._default_library]
         list.collections = [c1]
         new_collections = [c2]
         


### PR DESCRIPTION
This uses https://github.com/NYPL-Simplified/server_core/pull/788 and https://github.com/NYPL-Simplified/circulation-web/pull/138, and changes the custom lists controller for the admin interface to handle collections.