### PR TITLE
Audiobook manifest improvements

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -350,14 +350,17 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
         # of the LicensePool and its Work.
         manifest.update_bibliographic_metadata(license_pool)
 
-        # Add Findaway-specific information as extra metadata.
+        # Add Findaway-specific DRM information as an 'encrypted' object
+        # within the metadata object.
+        encrypted = dict()
+        manifest.metadata['encrypted'] = encrypted
         for findaway_extension in [
                 'accountId', 'checkoutId', 'fulfillmentId', 'licenseId',
                 'sessionKey'
         ]:
             value = findaway_license.get(findaway_extension, None)
             output_key = 'findaway:' + findaway_extension
-            manifest.metadata[output_key] = value
+            encrypted[output_key] = value
 
         # Add the spine items. All of them are in the same format.
         # None of them will have working 'href' fields -- it's just to
@@ -368,14 +371,10 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
         else:
             logging.error("Unknown Findaway audio format encountered: %s",
                           audio_format)
+            part_media_type = None
 
-        # TODO: The items are in an ordered list, but each one also
-        # has an explicit 'sequence'. For now we'll pass it on but
-        # assume that it is redundant and the ordered list is always
-        # correct.
-        #
-        # TODO: Each item has a 'part' which always seems to be zero.
-        # Its purpose is unknown. For now, we simply pass it on.
+        part_key = 'findaway:part'
+        sequence_key = 'findaway:sequence'
         total_duration = 0
         for part in findaway_license.get('items'):
             title = part.get('title')
@@ -389,17 +388,24 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
 
             kwargs = {}
 
-            sequence = part.get('sequence')
-            kwargs["findaway:sequence"] = sequence 
+            part_number = int(part.get('part', 0))
+            kwargs[part_key] = part_number
 
-            part_number = part.get('part')
-            kwargs["findaway:part"] = part_number
+            sequence = int(part.get('sequence', 0))
+            kwargs[sequence_key] = sequence
 
             manifest.add_spine(
-                href=None, type=None, title=title, duration=duration,
-                **kwargs
+                href=None, title=title, duration=duration,
+                type=part_media_type, **kwargs
             )
             total_duration += duration
+
+        # Make sure the spine items are sorted by part (~="part" in a
+        # book) and then sequence (~="chapter" in a book).
+        def sort_key(item):
+            return (item[part_key], item[sequence_key])
+        manifest.spine.sort(key=sort_key)
+
         manifest.metadata['duration'] = total_duration
         return DeliveryMechanism.FINDAWAY_DRM, unicode(manifest)
 

--- a/api/feedbooks.py
+++ b/api/feedbooks.py
@@ -89,7 +89,7 @@ class FeedbooksOPDSImporter(OPDSImporter):
 
         self.new_css = None
         if new_css_url and self.http_get:
-            status_code, headers, content = self.http_get(new_css_url)
+            status_code, headers, content = self.http_get(new_css_url, {})
             if status_code != 200:
                 raise IOError(
                     "Replacement stylesheet URL returned %r response code." % status_code

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ cairosvg==1.0.22
 py-bcrypt
 Flask-Babel
 money
+pymarc
 
 # Ensure that we support SNI-based SSL
 ndg-httpsclient

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -8,6 +8,7 @@ import datetime
 import json
 import os
 import pkgutil
+import random
 
 from . import (
     DatabaseTest,
@@ -312,6 +313,13 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         work = self._work(with_license_pool=True)
         [pool] = work.license_pools
         document = self.sample_data("sample_findaway_audiobook_license.json")
+
+        # Randomly scramble the Findaway manifest to make sure it gets
+        # properly sorted when converted to a Webpub-like manifest.
+        document = json.loads(document)
+        document['items'].sort(key=lambda x: random.random())
+        document = json.dumps(document)
+
         m = BibliothecaAPI.findaway_license_to_webpub_manifest
         media_type, manifest = m(pool, document)
         eq_(DeliveryMechanism.FINDAWAY_DRM, media_type)
@@ -336,13 +344,15 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         eq_(pool.identifier.urn, metadata['identifier'])
         eq_('en', metadata['language'])
 
-        # Information about the license has been added to metadata.
-        eq_(u'abcdef01234789abcdef0123', metadata[u'findaway:checkoutId'])
-        eq_(u'1234567890987654321ababa', metadata[u'findaway:licenseId'])
-        eq_(u'3M', metadata[u'findaway:accountId'])
-        eq_(u'123456', metadata[u'findaway:fulfillmentId'])
+        # Information about the license has been added to an 'encryption'
+        # object within metadata.
+        encrypted = metadata['encrypted']
+        eq_(u'abcdef01234789abcdef0123', encrypted[u'findaway:checkoutId'])
+        eq_(u'1234567890987654321ababa', encrypted[u'findaway:licenseId'])
+        eq_(u'3M', encrypted[u'findaway:accountId'])
+        eq_(u'123456', encrypted[u'findaway:fulfillmentId'])
         eq_(u'aaaaaaaa-4444-cccc-dddd-666666666666', 
-            metadata[u'findaway:sessionKey'])
+            encrypted[u'findaway:sessionKey'])
 
         # Every entry in the license document's 'items' list has
         # become a spine item in the manifest.
@@ -356,12 +366,15 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         eq_("Track 1", first['title'])
         eq_(1, first['findaway:sequence'])
 
-        # There is no 'href' or 'type' value for the spine items
-        # because the files must be obtained through the Findaway SDK
-        # rather than through regular HTTP requests.
+        # There is no 'href' or value for the spine items because the
+        # files must be obtained through the Findaway SDK rather than
+        # through regular HTTP requests.
+        #
+        # Since this is a relatively small book, it only has one part,
+        # part #0.
         for i in spine:
             eq_(None, i['href'])
-            eq_(None, i['type'])
+            eq_(Representation.MP3_MEDIA_TYPE, i['type'])
             eq_(0, i['findaway:part'])
 
         # The total duration, in seconds, has been added to metadata.

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -364,18 +364,19 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         first = spine[0]
         eq_(16.201, first['duration'])
         eq_("Track 1", first['title'])
-        eq_(1, first['findaway:sequence'])
 
-        # There is no 'href' or value for the spine items because the
+        # There is no 'href' value for the spine items because the
         # files must be obtained through the Findaway SDK rather than
         # through regular HTTP requests.
         #
         # Since this is a relatively small book, it only has one part,
-        # part #0.
-        for i in spine:
-            eq_(None, i['href'])
-            eq_(Representation.MP3_MEDIA_TYPE, i['type'])
-            eq_(0, i['findaway:part'])
+        # part #0. Within that part, the items have been sorted by
+        # their sequence.
+        for i, item in enumerate(spine):
+            eq_(None, item['href'])
+            eq_(Representation.MP3_MEDIA_TYPE, item['type'])
+            eq_(0, item['findaway:part'])
+            eq_(i+1, item['findaway:sequence'])
 
         # The total duration, in seconds, has been added to metadata.
         eq_(28371, int(metadata['duration']))

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -289,7 +289,7 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         # that the manifest contains information from the 'Findaway'
         # document as well as information from the Work.
         metadata = manifest['metadata']
-        eq_('abcdef01234789abcdef0123', metadata['findaway:checkoutId'])
+        eq_('abcdef01234789abcdef0123', metadata['encrypted']['findaway:checkoutId'])
         eq_(work.title, metadata['title'])
 
         # Now let's see what happens to fulfillment when 'Findaway' or


### PR DESCRIPTION
Previously, Findaway-derived audiobook manifests looked like this:

```
{
   "spine" : [
      {
         "type" : null,
         "duration" : 16.201,
         "findaway:part" : 0,
         "href" : null,
         "title" : "Track 1",
         "findaway:sequence" : 1
      },
       ...
      {
         "href" : null,
         "findaway:sequence" : 79,
         "title" : "Track 79",
         "findaway:part" : 0,
         "duration" : 32.318,
         "type" : null
      }
   ],
   "metadata" : {
      "@type" : "http://bib.schema.org/Audiobook",
      "language" : "en",
      "title" : "2001",
      "identifier" : "http://www.gutenberg.org/ebooks/2002",
      "findaway:fulfillmentId" : "123456",
      "duration" : 28371.256,
      "authors" : [
         "2003"
      ],
      "findaway:sessionKey" : "aaaaaaaa-4444-cccc-dddd-666666666666",
      "findaway:accountId" : "3M",
      "findaway:checkoutId" : "abcdef01234789abcdef0123",
      "findaway:licenseId" : "1234567890987654321ababa"
   },
   "@context" : [
      "http://readium.org/webpub/default.jsonld",
      {
         "findaway" : "http://librarysimplified.org/terms/third-parties/findaway.com/"
      }
   ]
}
```

Now, they look like this:

```
{
   "spine" : [
      {
         "title" : "Track 1",
         "findaway:part" : 0,
         "href" : null,
         "type" : "audio/mpeg",
         "findaway:sequence" : 1,
         "duration" : 16.201
      },
       ...
      {
         "duration" : 32.318,
         "findaway:sequence" : 79,
         "href" : null,
         "title" : "Track 79",
         "findaway:part" : 0,
         "type" : "audio/mpeg"
      }
   ],
   "@context" : [
      "http://readium.org/webpub/default.jsonld",
      {
         "findaway" : "http://librarysimplified.org/terms/third-parties/findaway.com/"
      }
   ],
   "metadata" : {
      "identifier" : "http://www.gutenberg.org/ebooks/2002",
      "title" : "2001",
      "language" : "en",
      "duration" : 28371.256,
      "authors" : [
         "2003"
      ],
      "@type" : "http://bib.schema.org/Audiobook",
      "encrypted" : {
         "findaway:licenseId" : "1234567890987654321ababa",
         "findaway:checkoutId" : "abcdef01234789abcdef0123",
         "findaway:accountId" : "3M",
         "findaway:fulfillmentId" : "123456",
         "findaway:sessionKey" : "aaaaaaaa-4444-cccc-dddd-666666666666"
      }
   }
}
```

* The DRM fields are collected in a separate 'encrypted' object rather than being individual 'metadata' items.
* For the sake of maximum compatibility with `audiobook/manifest+json`, the media type of each item is included (but it doesn't matter because the client doesn't use this information).
* The spine items are sorted by `findaway:part` and then by `findaway:sequence`.