### PR TITLE
Explicitly mention the DRM scheme in the `encrypted` object

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -352,7 +352,9 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI):
 
         # Add Findaway-specific DRM information as an 'encrypted' object
         # within the metadata object.
-        encrypted = dict()
+        encrypted = dict(
+            scheme='http://librarysimplified.org/terms/drm/scheme/FAE'
+        )
         manifest.metadata['encrypted'] = encrypted
         for findaway_extension in [
                 'accountId', 'checkoutId', 'fulfillmentId', 'licenseId',

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -344,9 +344,11 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         eq_(pool.identifier.urn, metadata['identifier'])
         eq_('en', metadata['language'])
 
-        # Information about the license has been added to an 'encryption'
+        # Information about the license has been added to an 'encrypted'
         # object within metadata.
         encrypted = metadata['encrypted']
+        eq_(u'http://librarysimplified.org/terms/drm/scheme/FAE',
+            encrypted['scheme'])
         eq_(u'abcdef01234789abcdef0123', encrypted[u'findaway:checkoutId'])
         eq_(u'1234567890987654321ababa', encrypted[u'findaway:licenseId'])
         eq_(u'3M', encrypted[u'findaway:accountId'])


### PR DESCRIPTION
This branch borrows the `scheme` feature of https://github.com/readium/webpub-manifest/blob/master/extensions/epub.md#encrypted for our own custom (but superficially similar) `encrypted` blocks. This gives the client a convenient in-document place to look to see how a book is encrypted.