### PR TITLE
Added crawlable acquisition feed for a list, sorted by recently updated.

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1080,7 +1080,7 @@ class CustomListsController(CirculationManagerController):
     def _create_or_update_list(self, library, name, entries, collections, id=None):
         data_source = DataSource.lookup(self._db, DataSource.LIBRARY_STAFF)
 
-        old_list_with_name = CustomList.find(self._db, data_source, name, library)
+        old_list_with_name = CustomList.find(self._db, name, library=library)
 
         if id:
             is_new = False

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -149,6 +149,13 @@ NO_SUCH_LANE = pd(
       _("You asked for a nonexistent lane."),
 )
 
+NO_SUCH_LIST = pd(
+      "http://librarysimplified.org/terms/problem/unknown-list",
+      404,
+      _("No such list."),
+      _("You asked for a nonexistent list."),
+)
+
 FORBIDDEN_BY_POLICY = pd(
       "http://librarysimplified.org/terms/problem/forbidden-by-policy",
       403,

--- a/api/routes.py
+++ b/api/routes.py
@@ -223,6 +223,13 @@ def acquisition_groups(lane_identifier):
 def feed(lane_identifier):
     return app.manager.opds_feeds.feed(lane_identifier)
 
+@library_route('/crawlable/<list_name>')
+@has_library
+@allows_patron_web
+@returns_problem_detail
+def crawlable_feed(list_name):
+    return app.manager.opds_feeds.crawlable_feed(list_name)
+
 @library_dir_route('/search', defaults=dict(lane_identifier=None))
 @library_route('/search/<lane_identifier>')
 @has_library

--- a/api/routes.py
+++ b/api/routes.py
@@ -223,7 +223,7 @@ def acquisition_groups(lane_identifier):
 def feed(lane_identifier):
     return app.manager.opds_feeds.feed(lane_identifier)
 
-@library_route('/crawlable/<list_name>')
+@library_route('/lists/<list_name>/crawlable')
 @has_library
 @allows_patron_web
 @returns_problem_detail

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -969,7 +969,7 @@ class TestWorkController(AdminControllerTest):
             response = self.manager.admin_work_controller.custom_lists(identifier.type, identifier.identifier)
             eq_(200, response.status_code)
             eq_(1, len(work.custom_list_entries))
-            new_list = CustomList.find(self._db, staff_data_source, "new list", self._default_library)
+            new_list = CustomList.find(self._db, "new list", staff_data_source, self._default_library)
             eq_(new_list, work.custom_list_entries[0].customlist)
             eq_(True, work.custom_list_entries[0].featured)
 

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -2,6 +2,7 @@
 from collections import Counter
 from nose.tools import set_trace, eq_, assert_raises
 import json
+import datetime
 
 from . import (
     DatabaseTest,
@@ -36,6 +37,8 @@ from api.lanes import (
     _lane_configuration_from_collection_sizes,
     load_lanes,
     ContributorLane,
+    CrawlableCustomListFacets,
+    CrawlableCustomListBasedLane,
     RecommendationLane,
     RelatedBooksLane,
     SeriesLane,
@@ -677,3 +680,79 @@ class TestContributorLane(LaneTest):
             self._default_library, 'Lois Lane', audiences=list(Classifier.AUDIENCES_JUVENILE)
         )
         self.assert_works_queries(ya_lane, [children, ya])
+
+class TestCrawlableCustomListFacets(DatabaseTest):
+
+    def test_default(self):
+        facets = CrawlableCustomListFacets.default(self._default_library)
+        eq_(CrawlableCustomListFacets.COLLECTION_FULL, facets.collection)
+        eq_(CrawlableCustomListFacets.AVAILABLE_ALL, facets.availability)
+        eq_(CrawlableCustomListFacets.ORDER_LAST_UPDATE, facets.order)
+        eq_(False, facets.order_ascending)
+        enabled_facets = facets.facets_enabled_at_init
+        # There's only one enabled facets for each facet group.
+        for group in enabled_facets.itervalues():
+            eq_(1, len(group))
+
+    def test_last_update_order_facet(self):
+        facets = CrawlableCustomListFacets.default(self._default_library)
+
+        w1 = self._work(with_license_pool=True)
+        w2 = self._work(with_license_pool=True)
+        now = datetime.datetime.utcnow()
+        w1.last_update_time = now - datetime.timedelta(days=4)
+        w2.last_update_time = now - datetime.timedelta(days=3)
+        self.add_to_materialized_view([w1, w2])
+
+        from core.model import MaterializedWorkWithGenre as work_model
+        qu = self._db.query(work_model)
+        qu = facets.apply(self._db, qu)
+        # w2 is first because it was updated more recently.
+        eq_([w2.id, w1.id], [mw.works_id for mw in qu])
+
+        list, ignore = self._customlist(num_entries=0)
+        e2, ignore = list.add_entry(w2)
+        e1, ignore = list.add_entry(w1)
+        self._db.flush()
+        SessionManager.refresh_materialized_views(self._db)
+        qu = self._db.query(work_model)
+        qu = facets.apply(self._db, qu)
+        # w1 is first because it was added to the list more recently.
+        eq_([w1.id, w2.id], [mw.works_id for mw in qu])
+        
+class TestCrawlableCustomListBasedLane(DatabaseTest):
+
+    def test_initialize(self):
+        list, ignore = self._customlist()
+        lane = CrawlableCustomListBasedLane()
+        lane.initialize(self._default_library, list)
+        eq_(self._default_library.id, lane.library_id)
+        eq_([list], lane.customlists)
+        eq_(list.name, lane.display_name)
+        eq_(None, lane.audiences)
+        eq_(None, lane.languages)
+        eq_(None, lane.media)
+        eq_([], lane.children)
+
+    def test_bibliographic_filter_clause(self):
+        w1 = self._work(with_license_pool=True)
+        w2 = self._work(with_license_pool=True)
+
+        # Only w2 is in the list.
+        list, ignore = self._customlist(num_entries=0)
+        e2, ignore = list.add_entry(w2)
+        self.add_to_materialized_view([w1, w2])
+        self._db.flush()
+        SessionManager.refresh_materialized_views(self._db)
+
+        lane = CrawlableCustomListBasedLane()
+        lane.initialize(self._default_library, list)
+
+        from core.model import MaterializedWorkWithGenre as work_model
+        qu = self._db.query(work_model)
+        qu, clause = lane.bibliographic_filter_clause(self._db, qu)
+
+        qu = qu.filter(clause)
+
+        eq_([w2.id], [mw.works_id for mw in qu])
+        


### PR DESCRIPTION
This adds an endpoint for a crawlable feed for a list, and links to it from any lanes that are based on a single custom list.

Something similar could be done for collections and the top-level lane for a library, but I didn't do it here.