### PR TITLE
Upload collection from disk

### DIFF
--- a/api/feedbooks.py
+++ b/api/feedbooks.py
@@ -89,7 +89,7 @@ class FeedbooksOPDSImporter(OPDSImporter):
 
         self.new_css = None
         if new_css_url and self.http_get:
-            status_code, headers, content = self.http_get(new_css_url)
+            status_code, headers, content = self.http_get(new_css_url, {})
             if status_code != 200:
                 raise IOError(
                     "Replacement stylesheet URL returned %r response code." % status_code

--- a/bin/directory_import
+++ b/bin/directory_import
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+"""Import books into a collection from local disk storage."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import DirectoryImportScript
+DirectoryImportScript().run()

--- a/scripts.py
+++ b/scripts.py
@@ -1109,7 +1109,7 @@ class DirectoryImportScript(Script):
         :return: A 2-tuple (Collection, MirrorUploader)
         """
         collection, is_new = Collection.by_name_and_protocol(
-            self._db, collection_name, ExternalIntegration.DIRECTORY_IMPORT
+            self._db, collection_name, ExternalIntegration.MANUAL
         )
 
         if is_new:

--- a/scripts.py
+++ b/scripts.py
@@ -1199,7 +1199,8 @@ class DirectoryImportScript(Script):
         download, or None if no such book can be found.
         """
         ignore, book_media_type, book_content = self._locate_file(
-            identifier.identifier, ebook_directory, ['.epub', '.pdf'],
+            identifier.identifier, ebook_directory,
+            Representation.COMMON_EBOOK_EXTENSIONS,
             "ebook file",
         )
         if not book_content:
@@ -1242,7 +1243,7 @@ class DirectoryImportScript(Script):
        """
        cover_filename, cover_media_type, cover_content = self._locate_file(
            identifier.identifier, cover_directory, 
-           ['.jpg', '.jpeg', '.png', '.gif'], "cover image"
+           Representation.COMMON_IMAGE_EXTENSIONS, "cover image"
        )
 
        if not cover_content:

--- a/scripts.py
+++ b/scripts.py
@@ -589,7 +589,7 @@ class AdobeAccountIDResetScript(PatronInputScript):
         return parser
     
     def do_run(self, *args, **kwargs):
-        parsed = self.parse_args(self._db, *args, **kwargs)
+        parsed = self.parse_command_line(self._db, *args, **kwargs)
         patrons = parsed.patrons
         self.delete = parsed.delete
         if not self.delete:

--- a/scripts.py
+++ b/scripts.py
@@ -86,7 +86,7 @@ from core.util.opds_writer import (
 from core.external_list import CustomListFromCSV
 from core.external_search import ExternalSearchIndex
 from core.util import LanguageCodes
-from core.util.mirror import MirrorUploader
+from core.mirror import MirrorUploader
 
 from api.config import (
     CannotLoadConfiguration,

--- a/scripts.py
+++ b/scripts.py
@@ -1054,7 +1054,7 @@ class DirectoryImportScript(Script):
     def do_run(self, cmd_args=None):
         parser = self.arg_parser(self._db)
         parsed = parser.parse_args(cmd_args)
-        collection_name = parsed.data_source_name
+        collection_name = parsed.collection_name
         data_source_name = parsed.data_source_name
         metadata_file = parsed.metadata_file
         cover_directory = parsed.cover_directory

--- a/scripts.py
+++ b/scripts.py
@@ -1191,7 +1191,6 @@ class DirectoryImportScript(Script):
                 identifier
             )
 
-
     def load_circulation_data(self, identifier, data_source, ebook_directory, 
                               mirror, title):
         """Load an actual copy of a book from disk.
@@ -1200,7 +1199,7 @@ class DirectoryImportScript(Script):
         download, or None if no such book can be found.
         """
         ignore, book_media_type, book_content = self._locate_file(
-            identifier, ebook_directory, ['.epub', '.pdf'],
+            identifier.identifier, ebook_directory, ['.epub', '.pdf'],
             "ebook file",
         )
         if not book_content:
@@ -1228,8 +1227,8 @@ class DirectoryImportScript(Script):
             )
         ]
         circulation_data = CirculationData(
-            data_source.name,
-            identifier,
+            data_source=data_source.name,
+            primary_identifier=identifier,
             links=[book_link],
             formats=formats,
         )
@@ -1242,8 +1241,8 @@ class DirectoryImportScript(Script):
        if no book cover can be found.
        """
        cover_filename, cover_media_type, cover_content = self._locate_file(
-           identifier, cover_directory, ['.jpg', '.jpeg', '.png', '.gif'],
-           "cover image"
+           identifier.identifier, cover_directory, 
+           ['.jpg', '.jpeg', '.png', '.gif'], "cover image"
        )
 
        if not cover_content:
@@ -1263,11 +1262,11 @@ class DirectoryImportScript(Script):
        )
        return cover_link
 
-    def _locate_file(self, identifier, directory, extensions, file_type="file"):
+    def _locate_file(self, base_filename, directory, extensions,
+                     file_type="file"):
         """Find an acceptable file in the given directory.
 
-        :param metadata: Metadata object whose `primary_identifier` will
-        be used when looking for a file.
+        :param base_filename: A string to be used as the base of the filename.
 
         :param directory: Look for a file in this directory.
 
@@ -1281,14 +1280,13 @@ class DirectoryImportScript(Script):
         :return: A 3-tuple. (None, None, None) if no file can be
         found; otherwise (filename, media_type, contents).
         """
-        identifier = metadata.primary_identifier
         success_path = None
         media_type = None
         attempts = []
         for extension in extensions:
             if not extension.startswith('.'):
                 extension = '.' + extension
-                filename = identifier + extension
+                filename = base_filename + extension
             for ext in (extension, extension.upper):
                 path = os.path.join(directory, filename)
                 attempts.append(path)
@@ -1304,9 +1302,8 @@ class DirectoryImportScript(Script):
         # If we went through that whole loop without returning,
         # we have failed.
         logging.warn(
-            "Could not find %s for %s/%s. Looked in: %s",
-            file_type, identifier.identifier, metadata.title,
-            ", ".join(attempts)
+            "Could not find %s for %. Looked in: %s",
+            file_type, base_filename, ", ".join(attempts)
         )
         return None, None, None
 

--- a/scripts.py
+++ b/scripts.py
@@ -581,7 +581,7 @@ class AdobeAccountIDResetScript(PatronInputScript):
         return parser
     
     def do_run(self, *args, **kwargs):
-        parsed = self.parse_command_line(self._db, *args, **kwargs)
+        parsed = self.parse_args(self._db, *args, **kwargs)
         patrons = parsed.patrons
         self.delete = parsed.delete
         if not self.delete:
@@ -1001,7 +1001,7 @@ class DirectoryImportScript(Script):
 
     @classmethod
     def arg_parser(cls, _db):
-        parser = Script.arg_parser(_db)
+        parser = argparse.ArgumentParser()
         parser.add_argument(
             '--collection-name',
             help=u'Titles will be imported into a collection with this name. The collection will be created if it does not already exist.'
@@ -1025,7 +1025,9 @@ class DirectoryImportScript(Script):
         parser.add_argument(
             '--dry-run',
             help=u"Show what would be imported, but don't actually do the import.",
+            action='store_true',
         )
+        return parser
 
     def create_collection(self, data_source_name):
         name = data_source_name
@@ -1045,7 +1047,8 @@ class DirectoryImportScript(Script):
                     data_source_name, collection))
 
     def do_run(self, *args, **kwargs):
-        parsed = self.parse_command_line(self._db, *args, **kwargs)
+        parser = self.arg_parser(self._db)
+        parsed = parser.parse_args(cmd_args)
         collection_name = parsed.data_source_name
         data_source_name = parsed.data_source_name
         metadata_file = parsed.metadata_file
@@ -1205,7 +1208,7 @@ class DirectoryImportScript(Script):
         )
         return circulation_data
 
-   def load_cover_link(self, identifier, data_source, cover_directory, mirror):
+    def load_cover_link(self, identifier, data_source, cover_directory, mirror):
        """Load an actual book cover from disk.
 
        :return: A LinkData containing a cover of the book, or None
@@ -1233,7 +1236,7 @@ class DirectoryImportScript(Script):
        )
        return cover_link
 
-    def _locate_file(self, identifier directory, extensions, file_type="file"):
+    def _locate_file(self, identifier, directory, extensions, file_type="file"):
         """Find an acceptable file in the given directory.
 
         :param metadata: Metadata object whose `primary_identifier` will
@@ -1279,6 +1282,7 @@ class DirectoryImportScript(Script):
             ", ".join(attempts)
         )
         return None, None, None
+
 
 class LaneResetScript(LibraryInputScript):
     """Reset a library's lanes based on language configuration or estimates

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -536,25 +536,33 @@ class TestDirectoryImportScript(DatabaseTest):
         eq_(False, self._db.is_modified(self._default_collection))
 
     def test_load_collection_no_site_wide_mirror(self):
+        # Calling load_collection creates a new collection with
+        # the given data source.
         script = DirectoryImportScript(self._db)
         collection, mirror = script.load_collection(
             "A collection", "A data source"
         )
         eq_("A collection", collection.name)
         eq_("A data source", collection.data_source.name)
+        eq_(True, collection.data_source.offers_licenses)
 
         integration = collection.external_integration
         eq_(ExternalIntegration.LICENSE_GOAL, integration.goal)
         eq_(ExternalIntegration.DIRECTORY_IMPORT, 
             integration.protocol)
 
+        # The Collection has no mirror integration because there is no
+        # sitewide storage integration to use.
         eq_(None, collection.mirror_integration)
         eq_(None, mirror)
         
     def test_load_collection_installs_site_wide_mirror(self):
+        # We have a sitewide storage integration.
         integration = self._external_integration("my uploader")
         integration.goal = ExternalIntegration.STORAGE_GOAL
 
+        # Calling load_collection creates a Collection and installs
+        # the sitewide storage integration as its mirror integration.
         script = DirectoryImportScript(self._db)
         collection, mirror = script.load_collection(
             "A collection", "A data source"

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -45,6 +45,7 @@ from scripts import (
     CacheRepresentationPerLane,
     CacheFacetListsPerLane,
     CacheOPDSGroupFeedPerLane,
+    DirectoryImportScript,
     InstanceInitializationScript,
     LanguageListScript,
     LoanReaperScript,
@@ -422,3 +423,22 @@ class TestShortClientTokenLibraryConfigurationScript(DatabaseTest):
         eq_(expect_settings,
             sorted((x.key, x.value) for x in integration.settings)
         )
+
+
+class TestDirectoryImportScript(DatabaseTest):
+
+    def test_do_run(self):
+        class Mock(DirectoryImportScript):
+            def run_with_arguments(self, **kwargs):
+                self.ran_with = kwargs
+                
+        script = Mock(self._db)
+        script.do_run(cmd_args=[
+            "--collection-name=coll1",
+            "--data-source-name=ds1",
+            "--metadata-file=metadata",
+            "--cover-directory=covers",
+            "--ebook-directory=ebooks",
+            "--dry-run"
+        ])
+        set_trace()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -480,7 +480,7 @@ class TestDirectoryImportScript(DatabaseTest):
                 "--dry-run"
             ]
         )
-        eq_(('ds1', 'ds1', 'metadata', 'covers', 'ebooks', 'rights', True),
+        eq_(('coll1', 'ds1', 'metadata', 'covers', 'ebooks', 'rights', True),
             script.ran_with)
 
     def test_run_with_arguments(self):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -52,7 +52,7 @@ from core.model import (
 
 from core.s3 import MockS3Uploader
 
-from core.util.mirror import MirrorUploader
+from core.mirror import MirrorUploader
 
 from . import (
     DatabaseTest,

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -513,7 +513,6 @@ class TestDirectoryImportScript(DatabaseTest):
 
         # Make a change to a model object so we can track when the
         # session is committed.
-        from core.analytics import Analytics
         self._default_collection.name = 'changed'
 
         script = Mock(self._db)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -580,7 +580,7 @@ class TestDirectoryImportScript(DatabaseTest):
 
         integration = collection.external_integration
         eq_(ExternalIntegration.LICENSE_GOAL, integration.goal)
-        eq_(ExternalIntegration.DIRECTORY_IMPORT, 
+        eq_(ExternalIntegration.MANUAL, 
             integration.protocol)
 
         # The Collection has no mirror integration because there is no


### PR DESCRIPTION
This branch ports from the content server a script that creates a collection based on a local MARC file and directories full of EPUB documents and cover images.

The script was previously untested; it's now exhaustively tested. This might have been overkill, but it provides a platform for future work in making a circulation manager that can host content directly.