### PR TITLE
Set storage configuration for collection integrations

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1531,7 +1531,7 @@ class SettingsController(CirculationManagerController):
 
     METADATA_SERVICE_URI_TYPE = 'application/opds+json;profile=https://librarysimplified.org/rel/profile/metadata-service'
 
-    NO_MIRROR_INTEGRATION = "NO_MIRROR"
+    NO_MIRROR_INTEGRATION = u"NO_MIRROR"
 
     def libraries(self):
         if flask.request.method == 'GET':
@@ -1947,7 +1947,7 @@ class SettingsController(CirculationManagerController):
                 collection.external_account_id = value
             elif key == 'mirror_integration_id':
                 value = flask.request.form.get(key)
-                if value is self.NO_MIRROR_INTEGRATION:
+                if value == self.NO_MIRROR_INTEGRATION:
                     integration_id = None
                 else:
                     integration = get_one(

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1962,12 +1962,18 @@ class SettingsController(CirculationManagerController):
                 collection.external_account_id = value
             elif key == 'mirror_integration_id':
                 value = flask.request.form.get(key)
-                integration = get_one(
-                    self._db, ExternalIntegration, id=value
-                )
-                if integration.goal != ExternalIntegration.STORAGE_GOAL:
-                    return INTEGRATION_GOAL_CONFLICT
-                collection.mirror_integration_id = integration.id
+                if value is None:
+                    integration_id = None
+                else:
+                    integration = get_one(
+                        self._db, ExternalIntegration, id=value
+                    )
+                    if not integration:
+                        return MISSING_SERVICE
+                    if integration.goal != ExternalIntegration.STORAGE_GOAL:
+                        return INTEGRATION_GOAL_CONFLICT
+                    integration_id = integration.id
+                collection.mirror_integration_id = integration_id
             else:
                 result = self._set_integration_setting(collection.external_integration, setting)
                 if isinstance(result, ProblemDetail):

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1531,6 +1531,8 @@ class SettingsController(CirculationManagerController):
 
     METADATA_SERVICE_URI_TYPE = 'application/opds+json;profile=https://librarysimplified.org/rel/profile/metadata-service'
 
+    NO_MIRROR_INTEGRATION = "NO_MIRROR"
+
     def libraries(self):
         if flask.request.method == 'GET':
             libraries = []
@@ -1675,15 +1677,15 @@ class SettingsController(CirculationManagerController):
                 protocol["sitewide"] = sitewide
 
             settings = getattr(api, "SETTINGS", [])
-            protocol["settings"] = settings
+            protocol["settings"] = list(settings)
 
             child_settings = getattr(api, "CHILD_SETTINGS", None)
             if child_settings != None:
-                protocol["child_settings"] = child_settings
+                protocol["child_settings"] = list(child_settings)
 
             library_settings = getattr(api, "LIBRARY_SETTINGS", None)
             if library_settings != None:
-                protocol["library_settings"] = library_settings
+                protocol["library_settings"] = list(library_settings)
 
             protocols.append(protocol)
         return protocols
@@ -1862,7 +1864,7 @@ class SettingsController(CirculationManagerController):
                         key = setting.get("key")
                         if key not in collection["settings"]:
                             if key == 'mirror_integration_id':
-                                value = c.mirror_integration_id
+                                value = c.mirror_integration_id or self.NO_MIRROR_INTEGRATION
                             elif setting.get("type") == "list":
                                 value = c.external_integration.setting(key).json_value
                             else:
@@ -1945,7 +1947,7 @@ class SettingsController(CirculationManagerController):
                 collection.external_account_id = value
             elif key == 'mirror_integration_id':
                 value = flask.request.form.get(key)
-                if value is None:
+                if value is self.NO_MIRROR_INTEGRATION:
                     integration_id = None
                 else:
                     integration = get_one(
@@ -2007,7 +2009,7 @@ class SettingsController(CirculationManagerController):
             "type": "select",
             "options" : [
                 dict(
-                    key=None,
+                    key=self.NO_MIRROR_INTEGRATION,
                     label=_("None - Do not mirror cover images or free books")
                 )
             ]

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1954,8 +1954,10 @@ class SettingsController(CirculationManagerController):
                         self._db, ExternalIntegration, id=value
                     )
                     if not integration:
+                        self._db.rollback()
                         return MISSING_SERVICE
                     if integration.goal != ExternalIntegration.STORAGE_GOAL:
+                        self._db.rollback()
                         return INTEGRATION_GOAL_CONFLICT
                     integration_id = integration.id
                 collection.mirror_integration_id = integration_id

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.56"
+    "simplified-circulation-web": "0.0.57"
   }
 }

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -310,13 +310,6 @@ MULTIPLE_SITEWIDE_SERVICES = pd(
     detail=_("You tried to create a new sitewide service, but a sitewide service of the same type is already configured."),
 )
 
-MULTIPLE_STORAGE_SERVICES = pd(
-    "http://librarysimplified.org/terms/problem/multiple-storage-services",
-    status_code=400,
-    title=_("Multiple storage services"),
-    detail=_("You tried to create a new storage service, but a storage service is already configured."),
-)
-
 MISSING_CUSTOM_LIST = pd(
     "http://librarysimplified.org/terms/problem/missing-custom-list",
     status_code=404,

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -233,6 +233,13 @@ INTEGRATION_NAME_ALREADY_IN_USE = pd(
     detail=_("The integration name must be unique, and there's already an integration with the specified name."),
 )
 
+INTEGRATION_GOAL_CONFLICT = pd(
+    "http://librarysimplified.org/terms/problem/integration-goal-conflict",
+    status_code=409,
+    title=_("Incompatible use of integration"),
+    detail=_("You tried to use an integration in a way incompatible with the goal of that integration"),
+)
+
 MISSING_PGCRYPTO_EXTENSION = pd(
     "http://librarysimplified.org/terms/problem/missing-pgcrypto-extension",
     status_code=500,

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -2738,7 +2738,7 @@ class TestSettingsController(AdminControllerTest):
         with self.app.test_request_context("/", method="POST"):
             request = MultiDict(
                 base_request + [("mirror_integration_id",
-                                 controller.NO_MIRROR_INTEGRATION)]
+                                 str(controller.NO_MIRROR_INTEGRATION))]
             )
             flask.request.form = request
             response = controller.collections()

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -2281,8 +2281,13 @@ class TestSettingsController(AdminControllerTest):
         c2 = self._collection(
             name="Collection 2", protocol=ExternalIntegration.OVERDRIVE,
         )
+        c2_storage = self._external_integration(
+            protocol=ExternalIntegration.S3,
+            goal=ExternalIntegration.STORAGE_GOAL
+        )
         c2.external_account_id = "1234"
         c2.external_integration.password = "b"
+        c2.mirror_integration_id=c2_storage.id
 
         c3 = self._collection(
             name="Collection 3", protocol=ExternalIntegration.OVERDRIVE,
@@ -2313,12 +2318,20 @@ class TestSettingsController(AdminControllerTest):
             eq_(c2.protocol, coll2.get("protocol"))
             eq_(c3.protocol, coll3.get("protocol"))
 
-            eq_(c1.external_account_id, coll1.get("settings").get("external_account_id"))
-            eq_(c2.external_account_id, coll2.get("settings").get("external_account_id"))
-            eq_(c3.external_account_id, coll3.get("settings").get("external_account_id"))
+            settings1 = coll1.get("settings", {})
+            settings2 = coll2.get("settings", {})
+            settings3 = coll3.get("settings", {})
 
-            eq_(c1.external_integration.password, coll1.get("settings").get("password"))
-            eq_(c2.external_integration.password, coll2.get("settings").get("password"))
+            eq_(None, settings1.get("mirror_integration_id"))
+            eq_(c2_storage.id, settings2.get("mirror_integration_id"))
+            eq_(None, settings3.get("protocol"))
+
+            eq_(c1.external_account_id, settings1.get("external_account_id"))
+            eq_(c2.external_account_id, settings2.get("external_account_id"))
+            eq_(c3.external_account_id, settings3.get("external_account_id"))
+
+            eq_(c1.external_integration.password, settings1.get("password"))
+            eq_(c2.external_integration.password, settings2.get("password"))
 
             eq_(c2.id, coll3.get("parent_id"))
 


### PR DESCRIPTION
This branch adds a setting that only applies to collection-type integrations. The setting only shows up when there are one or more site-wide storage integrations configures, and it controls which (if any) of those integrations should be used as the collection's mirror integration.

We added this setting to all collections, not only OPDS import collections, because it's reasonable to want to make your own mirror of cover images from commercial sources rather than relying on the metadata wrangler.