### PR TITLE
Implement early return of DRM-free Overdrive books

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -255,6 +255,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
 
         # Get the loan for this patron to see whether or not they
         # have a delivery mechanism recorded.
+        loan = None
         loans = [l for l in patron.loans if l.license_pool == licensepool]
         if loans:
             loan = loans[0]

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -298,7 +298,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         if not internal_format:
             # Something's wrong in general, but in particular we don't know
             # which fulfillment link to ask for. Bail out.
-            return
+            return False
 
         # Ask Overdrive for a link that can be used to fulfill the book
         # (but which may also contain an early return URL).

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -289,6 +289,19 @@ class TestOverdriveAPI(OverdriveAPITest):
         # get_fulfillment_link.
         eq_([], http.requests)
 
+        # If the final attempt to hit the return URL doesn't result
+        # in a 200 status code, perform_early_return has no effect.
+        http.responses.append(
+            MockRequestsResponse(
+                302, dict(location="http://fulfill-this-book/?or=return-early")
+            )
+        )
+        http.responses.append(
+            MockRequestsResponse(401, content="Unauthorized!")
+        )
+        success = overdrive.perform_early_return(patron, pin, loan, http.do_get)
+        eq_(False, success)
+
     def test_extract_early_return_url(self):
         m = OverdriveAPI._extract_early_return_url
         eq_(None, m("http://no-early-return/"))

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -11,6 +11,7 @@ from datetime import (
 )
 from api.overdrive import (
     MockOverdriveAPI,
+    OverdriveAPI,
     OverdriveCollectionReaper,
     OverdriveFormatSweep,
 )
@@ -103,6 +104,23 @@ class TestOverdriveAPI(OverdriveAPITest):
         self.api.queue_response(404)
         eq_("notifications@example.com", 
             self.api.default_notification_email_address(patron, 'pin'))
+
+    def test_checkin(self):
+        pass
+
+    def test_perform_early_return(self):
+        # status_code 200, content "Success"
+        pass
+
+    def test_extract_early_return_url(self):
+        m = OverdriveAPI._extract_early_return_url
+
+        # This is based on a real Overdrive early return URL.
+        has_early_return = 'https://openepub-gk.cdn.overdrive.com/OpenEPUBStore1/1577-1/%7B5880F6D0-48AC-44DE-8BF1-FD1CE62E97A8%7DFzr418.epub?e=1518753718&loanExpirationDate=2018-03-01T17%3a12%3a33Z&loanEarlyReturnUrl=https%3a%2f%2fnotifications-ofs.contentreserve.com%2fEarlyReturn%2fnypl%2f037-1374147-00279%2f5480F6E1-48F3-00DE-96C1-FD3CE32D94FD-312%3fh%3dVgvxBQHdQxtsbgb43AH6%252bEmpni9LoffkPczNiUz7%252b10%253d&sourceId=nypl&h=j7nGk7qxE71X2ZcdLw%2bqa04jqEw%3d'
+        eq_('https://notifications-ofs.contentreserve.com/EarlyReturn/nypl/037-1374147-00279/5480F6E1-48F3-00DE-96C1-FD3CE32D94FD-312?h=VgvxBQHdQxtsbgb43AH6%2bEmpni9LoffkPczNiUz7%2b10%3d', m(has_early_return))
+        eq_(None, m("http://no-early-return/"))
+        eq_(None, m(""))
+        eq_(None, m(None))
 
     def test_place_hold_raises_exception_if_patron_over_hold_limit(self):
         over_hold_limit = self.error_message(


### PR DESCRIPTION
This branch fixes https://github.com/NYPL-Simplified/circulation/issues/860 by implementing Overdrive's custom API for early return of DRM-free books.

This branch adds test coverage for `OverdriveAPI.checkin`, which was previously uncovered (but also less complex than it is now).