### PR TITLE
Allow an integration class to say that only one integration of its type should be created

### DIFF
--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -226,6 +226,13 @@ INCOMPLETE_CONFIGURATION = pd(
     detail=_("The configuration is missing a required field."),
 )
 
+DUPLICATE_INTEGRATION = pd(
+    "http://librarysimplified.org/terms/problem/duplicate-integration",
+    status_code=400,
+    title=_("Duplicate integration"),
+    detail=_("A given site can only support one integration of this type.")
+)
+
 INTEGRATION_NAME_ALREADY_IN_USE = pd(
     "http://librarysimplified.org/terms/problem/integration-name-already-in-use",
     status_code=400,

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -2028,6 +2028,52 @@ class TestSettingsController(AdminControllerTest):
         response = self.responses.pop()
         return HTTP.process_debuggable_response(response)
 
+    def test_create_integration(self):
+        """Test the create_integration helper method."""
+
+        m = self.manager.admin_settings_controller.create_integration
+
+        protocol_definitions = [
+            dict(name="allow many"),
+            dict(name="allow one", cardinality=1),
+        ]
+        goal = "some goal"
+
+        # You get an error if you don't pass in a protocol.
+        eq_(
+            (NO_PROTOCOL_FOR_NEW_SERVICE, False),
+            m(protocol_definitions, None, goal)
+        )
+
+        # You get an error if you do provide a protocol but no definition
+        # for it can be found.
+        eq_(
+            (UNKNOWN_PROTOCOL, False),
+            m(protocol_definitions, "no definition", goal)
+        )
+
+        # If the protocol has multiple cardinality you can create as many
+        # integrations using that protocol as you want.
+        i1, is_new1 = m(protocol_definitions, "allow many", goal)
+        eq_(True, is_new1)
+
+        i2, is_new2 = m(protocol_definitions, "allow many", goal)
+        eq_(True, is_new2)
+
+        assert i1 != i2
+        for i in [i1, i2]:
+            eq_("allow many", i.protocol)
+            eq_(goal, i.goal)
+
+        # If the protocol has single cardinality, you can only create one
+        # integration using that protocol before you start getting errors.
+        i1, is_new1 = m(protocol_definitions, "allow one", goal)
+        eq_(True, is_new1)
+
+        i2, is_new2 = m(protocol_definitions, "allow one", goal)
+        eq_(False, is_new2)
+        eq_(DUPLICATE_INTEGRATION, i2)
+
     def test_libraries_get_with_no_libraries(self):
         # Delete any existing library created by the controller test setup.
         library = get_one(self._db, Library)


### PR DESCRIPTION
This branch addresses https://github.com/NYPL-Simplified/circulation/issues/864 by allowing the class that provides an integration to set `CARDINALITY = 1` to say that there should only ever be one integration of that type on a given site.

The motivating case is the 'Local analytics' integration, but there are probably others, so I chose the tactic of refactoring rather than adding a special case for 'Local analytics'.