### PR TITLE
Opds for distributors settings

### DIFF
--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -42,7 +42,7 @@ class OPDSForDistributorsAPI(BaseCirculationAPI):
     NAME = "OPDS for Distributors"
     DESCRIPTION = _("Import books from a distributor that requires authentication to get the OPDS feed and download books.")
 
-    SETTINGS = OPDSImporter.SETTINGS + [
+    SETTINGS = OPDSImporter.BASE_SETTINGS + [
         {
             "key": ExternalIntegration.USERNAME,
             "label": _("Library's username or access key"),


### PR DESCRIPTION
OPDS For Distributors defines its own 'username' and 'password' configuration settings which conflict with the ones recently introduced for a basic OPDS import. This branch changes OPDS For Distributors to stop reusing the conflicting settings from OPDSImporter.