### PR TITLE
Crawlable library and collection lane

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -647,9 +647,6 @@ class OPDSFeedController(CirculationManagerController):
         """Build or retrieve a crawlable acquisition feed for the
         requested collection.
         """
-        # We use a library only for purposes of creating a Facets object.
-        # The requested collection does not have to be associated with
-        # the default library.
         library = flask.request.library
         collection = get_one(self._db, Collection, name=collection_name)
         if not collection or collection not in library.collections:

--- a/api/controller.py
+++ b/api/controller.py
@@ -658,7 +658,7 @@ class OPDSFeedController(CirculationManagerController):
         url = self.cdn_url_for(
             "crawlable_collection_feed",
             library_short_name=library.short_name,
-            collection_id=collection.id
+            collection_name=collection.name
         )
         lane = CrawlableCollectionBasedLane(library, [collection])
         return self._crawlable_feed(library, title, url, lane)

--- a/api/controller.py
+++ b/api/controller.py
@@ -115,7 +115,7 @@ from lanes import (
     SeriesLane,
     CrawlableCollectionBasedLane,
     CrawlableCustomListBasedLane,
-    CrawlableCustomListFacets,
+    CrawlableFacets,
 )
 
 from adobe_vendor_id import (
@@ -683,7 +683,7 @@ class OPDSFeedController(CirculationManagerController):
 
     def _crawlable_feed(self, library, title, url, lane):
         annotator = self.manager.annotator(lane)
-        facets = CrawlableCustomListFacets.default(library)
+        facets = CrawlableFacets.default(library)
         pagination = load_pagination_from_request()
         if isinstance(pagination, ProblemDetail):
             return pagination

--- a/api/controller.py
+++ b/api/controller.py
@@ -643,25 +643,25 @@ class OPDSFeedController(CirculationManagerController):
         lane = CrawlableCollectionBasedLane(library)
         return self._crawlable_feed(library, title, url, lane)
 
-    def crawlable_collection_feed(self, collection_id):
+    def crawlable_collection_feed(self, collection_name):
         """Build or retrieve a crawlable acquisition feed for the
         requested collection.
         """
         # We use a library only for purposes of creating a Facets object.
         # The requested collection does not have to be associated with
         # the default library.
-        default_library = Library.default(self._db)
-        collection = get_one(self._db, Collection, id=collection_id)
-        if not list:
+        library = flask.request.library
+        collection = get_one(self._db, Collection, name=collection_name)
+        if not collection or collection not in library.collections:
             return NO_SUCH_COLLECTION
         title = collection.name
         url = self.cdn_url_for(
             "crawlable_collection_feed",
+            library_short_name=library.short_name,
             collection_id=collection.id
         )
-        lane = CrawlableCollectionBasedLane(default_library, [collection])
-        return self._crawlable_feed(default_library, title, url, lane)
-
+        lane = CrawlableCollectionBasedLane(library, [collection])
+        return self._crawlable_feed(library, title, url, lane)
 
     def crawlable_list_feed(self, list_name):
         """Build or retrieve a crawlable, paginated acquisition feed for the

--- a/api/controller.py
+++ b/api/controller.py
@@ -640,7 +640,7 @@ class OPDSFeedController(CirculationManagerController):
             library_short_name=library_short_name,
         )
         title = library.name
-        lane = CrawlableCollectionBasedLane(library, library.collections)
+        lane = CrawlableCollectionBasedLane(library)
         return self._crawlable_feed(library, title, url, lane)
 
     def crawlable_collection_feed(self, collection_id):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1060,6 +1060,8 @@ class CrawlableFacets(Facets):
 
 class CrawlableCollectionBasedLane(DynamicLane):
 
+    MAX_CACHE_AGE = 60 * 60 * 12 # 12 hours
+
     def __init__(self, library, collections=None):
         """Create a lane that finds all books in the given collections.
 
@@ -1102,6 +1104,8 @@ class CrawlableCollectionBasedLane(DynamicLane):
 
 class CrawlableCustomListBasedLane(DynamicLane):
     """A lane that consists of all works in a single CustomList."""
+
+    MAX_CACHE_AGE = 60 * 60 * 12 # 12 hours
 
     uses_customlists = True
 

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1031,7 +1031,8 @@ class ContributorLane(DynamicLane):
         return super(ContributorLane, self).apply_filters(
             _db, qu, facets, pagination, featured=featured)
 
-class CrawlableCustomListFacets(Facets):
+class CrawlableFacets(Facets):
+    """A special Facets class for crawlable feeds."""
     @classmethod
     def default(cls, library):
         enabled_facets = {

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1069,7 +1069,7 @@ class CrawlableCollectionBasedLane(DynamicLane):
         """
         self.library_id = library.id
         if collections:
-            identifier = " / ".join([x.name for x in collections])
+            identifier = " / ".join(sorted([x.name for x in collections]))
         else:
             identifier = library.name
             collections = library.collections

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1060,8 +1060,6 @@ class CrawlableFacets(Facets):
 
 class CrawlableCollectionBasedLane(DynamicLane):
 
-    MAX_CACHE_AGE = 60 * 60 * 12 # 12 hours
-
     def __init__(self, library, collections=None):
         """Create a lane that finds all books in the given collections.
 
@@ -1083,10 +1081,6 @@ class CrawlableCollectionBasedLane(DynamicLane):
             # further.
             self.collection_ids = [x.id for x in collections]
 
-    def get_library(self, _db):
-        """Find the Library object associated with this WorkList."""
-        return Library.by_id(_db, self.library_id)
-
     def bibliographic_filter_clause(self, _db, qu, featured=False):
         """Filter out any books that aren't in the right collections."""
         # The normal behavior of works() is to put a restriction on
@@ -1104,8 +1098,6 @@ class CrawlableCollectionBasedLane(DynamicLane):
 
 class CrawlableCustomListBasedLane(DynamicLane):
     """A lane that consists of all works in a single CustomList."""
-
-    MAX_CACHE_AGE = 60 * 60 * 12 # 12 hours
 
     uses_customlists = True
 

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1059,18 +1059,20 @@ class CrawlableCustomListFacets(Facets):
 
 class CrawlableCollectionBasedLane(DynamicLane):
 
-    def __init__(self, library, collections):
+    def __init__(self, library, collections=None):
         """Create a lane that finds all books in the given collections.
 
         :param library: The Library to use for purposes of annotating
             this Lane's OPDS feed.
-        :param collections: A list of Collections.
+        :param collections: A list of Collections. If none are specified,
+            all Collections associated with `library` will be used.
         """
         self.library_id = library.id
         if collections:
             identifier = " / ".join([x.name for x in collections])
         else:
             identifier = library.name
+            collections = library.collections
         self.initialize(library, "Crawlable feed: %s" % identifier)
         if collections:
             # initialize() set the collection IDs to all collections
@@ -1095,6 +1097,7 @@ class CrawlableCollectionBasedLane(DynamicLane):
             CrawlableCollectionBasedLane, self).bibliographic_filter_clause(
                 _db, qu, featured
             )
+
 
 class CrawlableCustomListBasedLane(DynamicLane):
     """A lane that consists of all works in a single CustomList."""

--- a/api/opds.py
+++ b/api/opds.py
@@ -477,7 +477,7 @@ class CirculationManagerAnnotator(Annotator):
 
         if lane and lane.uses_customlists and len(lane.customlists) == 1:
             crawlable_url = self.url_for(
-                "crawlable_feed", list_name=lane.customlists[0].name,
+                "crawlable_list_feed", list_name=lane.customlists[0].name,
                 library_short_name=self.library.short_name,
                 _external=True
             )

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -156,6 +156,13 @@ NO_SUCH_LIST = pd(
       _("You asked for a nonexistent list."),
 )
 
+NO_SUCH_COLLECTION = pd(
+      "http://librarysimplified.org/terms/problem/unknown-collection",
+      404,
+      _("No such collection."),
+      _("You asked for a nonexistent collection."),
+)
+
 FORBIDDEN_BY_POLICY = pd(
       "http://librarysimplified.org/terms/problem/forbidden-by-policy",
       403,

--- a/api/routes.py
+++ b/api/routes.py
@@ -238,6 +238,7 @@ def crawlable_list_feed(list_name):
     return app.manager.opds_feeds.crawlable_list_feed(list_name)
 
 @library_route('/collections/<collection_name>/crawlable')
+@has_library
 @allows_patron_web
 @returns_problem_detail
 def crawlable_collection_feed(collection_name):

--- a/api/routes.py
+++ b/api/routes.py
@@ -223,12 +223,26 @@ def acquisition_groups(lane_identifier):
 def feed(lane_identifier):
     return app.manager.opds_feeds.feed(lane_identifier)
 
+@library_route('/crawlable')
+@has_library
+@allows_patron_web
+@returns_problem_detail
+def crawlable_library_feed():
+    return app.manager.opds_feeds.crawlable_library_feed()
+
+@library_route('/collections/<collection_name>/crawlable')
+@has_library
+@allows_patron_web
+@returns_problem_detail
+def crawlable_collection_feed(collection_name):
+    return app.manager.opds_feeds.crawlable_collection_feed(collection_name)
+
 @library_route('/lists/<list_name>/crawlable')
 @has_library
 @allows_patron_web
 @returns_problem_detail
-def crawlable_feed(list_name):
-    return app.manager.opds_feeds.crawlable_feed(list_name)
+def crawlable_list_feed(list_name):
+    return app.manager.opds_feeds.crawlable_list_feed(list_name)
 
 @library_dir_route('/search', defaults=dict(lane_identifier=None))
 @library_route('/search/<lane_identifier>')

--- a/api/routes.py
+++ b/api/routes.py
@@ -230,19 +230,18 @@ def feed(lane_identifier):
 def crawlable_library_feed():
     return app.manager.opds_feeds.crawlable_library_feed()
 
-@library_route('/collections/<collection_name>/crawlable')
-@has_library
-@allows_patron_web
-@returns_problem_detail
-def crawlable_collection_feed(collection_name):
-    return app.manager.opds_feeds.crawlable_collection_feed(collection_name)
-
 @library_route('/lists/<list_name>/crawlable')
 @has_library
 @allows_patron_web
 @returns_problem_detail
 def crawlable_list_feed(list_name):
     return app.manager.opds_feeds.crawlable_list_feed(list_name)
+
+@app.route('/collections/<collection_id>/crawlable')
+@allows_patron_web
+@returns_problem_detail
+def crawlable_collection_feed(collection_id):
+    return app.manager.opds_feeds.crawlable_collection_feed(collection_id)
 
 @library_dir_route('/search', defaults=dict(lane_identifier=None))
 @library_route('/search/<lane_identifier>')

--- a/api/routes.py
+++ b/api/routes.py
@@ -237,11 +237,11 @@ def crawlable_library_feed():
 def crawlable_list_feed(list_name):
     return app.manager.opds_feeds.crawlable_list_feed(list_name)
 
-@app.route('/collections/<collection_id>/crawlable')
+@library_route('/collections/<collection_name>/crawlable')
 @allows_patron_web
 @returns_problem_detail
-def crawlable_collection_feed(collection_id):
-    return app.manager.opds_feeds.crawlable_collection_feed(collection_id)
+def crawlable_collection_feed(collection_name):
+    return app.manager.opds_feeds.crawlable_collection_feed(collection_name)
 
 @library_dir_route('/search', defaults=dict(lane_identifier=None))
 @library_route('/search/<lane_identifier>')

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -2259,7 +2259,9 @@ class TestSettingsController(AdminControllerTest):
         # collection (not a good choice for a real library), so only
         # two lanes were created: "Other Languages" and then "German"
         # underneath it.
-        [other_languages, german] = library.lanes
+        [german, other_languages] = sorted(
+            library.lanes, key=lambda x: x.display_name
+        )
         eq_(None, other_languages.parent)
         eq_(['ger'], other_languages.languages)
         eq_(other_languages, german.parent)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2482,7 +2482,7 @@ class TestFeedController(CirculationControllerTest):
         self._db.flush()
         SessionManager.refresh_materialized_views(self._db)
         with self.request_context_with_library("/?size=1"):
-            response = self.manager.opds_feeds.crawlable_feed(list.name)
+            response = self.manager.opds_feeds.crawlable_list_feed(list.name)
 
             feed = feedparser.parse(response.data)
             entries = feed['entries']
@@ -2500,7 +2500,7 @@ class TestFeedController(CirculationControllerTest):
         self._db.flush()
         SessionManager.refresh_materialized_views(self._db)
         with self.request_context_with_library("/?size=1"):
-            response = self.manager.opds_feeds.crawlable_feed(list.name)
+            response = self.manager.opds_feeds.crawlable_list_feed(list.name)
 
             feed = feedparser.parse(response.data)
             entries = feed['entries']

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2392,9 +2392,8 @@ class TestFeedController(CirculationControllerTest):
             eq_(2, counter['English'])
             eq_(1, counter['Other Languages'])
 
-    def test_crawlable_library_feed(self):
-        # set the last update times to reflect what we want to
-        # see in the list.
+    def _set_update_times(self):
+        """Set the last update times so we can create a crawlable feed."""
         now = datetime.datetime.now()
         self.english_2.last_update_time = (
             now + datetime.timedelta(hours=2)
@@ -2408,12 +2407,36 @@ class TestFeedController(CirculationControllerTest):
         self._db.commit()
         SessionManager.refresh_materialized_views(self._db)
 
+    def test_crawlable_library_feed(self):
+        self._set_update_times()
         with self.request_context_with_library("/?size=2"):
             response = self.manager.opds_feeds.crawlable_library_feed()
             feed = feedparser.parse(response.data)
             # We see the first two books sorted by update time.
             eq_([self.english_2.title, self.french_1.title],
                 [x['title'] for x in feed['entries']])
+
+    def test_crawlable_collection_feed(self):
+        self._set_update_times()
+        not_in_library = self._collection()
+        with self.request_context_with_library("/?size=2"):
+            response = self.manager.opds_feeds.crawlable_collection_feed(
+                self._default_collection.name
+            )
+            feed = feedparser.parse(response.data)
+            # We see the first two books sorted by update time.
+            eq_([self.english_2.title, self.french_1.title],
+                [x['title'] for x in feed['entries']])
+
+        # The collection must exist and it must be associated
+        # with the request library.
+        for name in ['no such collection', not_in_library.name]:
+            with self.request_context_with_library("/?size=1"):
+                response = self.manager.opds_feeds.crawlable_collection_feed(
+                    name
+                )
+                eq_(response.uri, NO_SUCH_COLLECTION.uri)
+
 
     def test_crawlable_list_feed(self):
         # Initial setup gave us two English works. Add both to a list.

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -767,16 +767,27 @@ class TestCrawlableCollectionBasedLane(DatabaseTest):
         library = self._default_library
         default_collection = self._default_collection
         other_collection = self._collection()
+        other_collection_2 = self._collection()
 
         # A lane for all the collections associated with a library.
         lane = CrawlableCollectionBasedLane(library)
+        eq_("Crawlable feed: %s" % library.name, lane.display_name)
         eq_([x.id for x in library.collections], lane.collection_ids)
 
         # A lane for a collection not actually associated with a
         # library. (A Library is still necessary to provide a point of
         # reference for classes like Facets and CachedFeed.)
-        lane = CrawlableCollectionBasedLane(library, [other_collection])
-        eq_([other_collection.id], lane.collection_ids)
+        lane = CrawlableCollectionBasedLane(
+            library, [other_collection, other_collection_2]
+        )
+        eq_(
+            "Crawlable feed: %s / %s" % (
+                sorted([other_collection.name, other_collection_2.name])
+            ),
+            lane.display_name
+        )
+        eq_(set([other_collection.id, other_collection_2.id]),
+            set(lane.collection_ids))
         eq_(library, lane.get_library(self._db))
 
     def test_bibliographic_filter_clause(self):

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -722,7 +722,7 @@ class TestCrawlableCustomListFacets(DatabaseTest):
         # w1 is first because it was added to the list more recently.
         eq_([w1.id, w2.id], [mw.works_id for mw in qu])
 
-       
+
 class TestCrawlableCustomListBasedLane(DatabaseTest):
 
     def test_initialize(self):

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -731,7 +731,7 @@ class TestCrawlableCustomListBasedLane(DatabaseTest):
         lane.initialize(self._default_library, list)
         eq_(self._default_library.id, lane.library_id)
         eq_([list], lane.customlists)
-        eq_(list.name, lane.display_name)
+        eq_("Crawlable feed: %s" % list.name, lane.display_name)
         eq_(None, lane.audiences)
         eq_(None, lane.languages)
         eq_(None, lane.media)
@@ -781,7 +781,7 @@ class TestCrawlableCollectionBasedLane(DatabaseTest):
             library, [other_collection, other_collection_2]
         )
         eq_(
-            "Crawlable feed: %s / %s" % (
+            "Crawlable feed: %s / %s" % tuple(
                 sorted([other_collection.name, other_collection_2.name])
             ),
             lane.display_name

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -39,7 +39,7 @@ from api.lanes import (
     load_lanes,
     ContributorLane,
     CrawlableCollectionBasedLane,
-    CrawlableCustomListFacets,
+    CrawlableFacets,
     CrawlableCustomListBasedLane,
     RecommendationLane,
     RelatedBooksLane,
@@ -683,13 +683,13 @@ class TestContributorLane(LaneTest):
         )
         self.assert_works_queries(ya_lane, [children, ya])
 
-class TestCrawlableCustomListFacets(DatabaseTest):
+class TestCrawlableFacets(DatabaseTest):
 
     def test_default(self):
-        facets = CrawlableCustomListFacets.default(self._default_library)
-        eq_(CrawlableCustomListFacets.COLLECTION_FULL, facets.collection)
-        eq_(CrawlableCustomListFacets.AVAILABLE_ALL, facets.availability)
-        eq_(CrawlableCustomListFacets.ORDER_LAST_UPDATE, facets.order)
+        facets = CrawlableFacets.default(self._default_library)
+        eq_(CrawlableFacets.COLLECTION_FULL, facets.collection)
+        eq_(CrawlableFacets.AVAILABLE_ALL, facets.availability)
+        eq_(CrawlableFacets.ORDER_LAST_UPDATE, facets.order)
         eq_(False, facets.order_ascending)
         enabled_facets = facets.facets_enabled_at_init
         # There's only one enabled facets for each facet group.
@@ -697,7 +697,7 @@ class TestCrawlableCustomListFacets(DatabaseTest):
             eq_(1, len(group))
 
     def test_last_update_order_facet(self):
-        facets = CrawlableCustomListFacets.default(self._default_library)
+        facets = CrawlableFacets.default(self._default_library)
 
         w1 = self._work(with_license_pool=True)
         w2 = self._work(with_license_pool=True)

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -23,6 +23,7 @@ from core.model import (
     DataSource,
     ExternalIntegration,
     Library,
+    MaterializedWorkWithGenre,
 )
 
 from api.config import (
@@ -37,6 +38,7 @@ from api.lanes import (
     _lane_configuration_from_collection_sizes,
     load_lanes,
     ContributorLane,
+    CrawlableCollectionBasedLane,
     CrawlableCustomListFacets,
     CrawlableCustomListBasedLane,
     RecommendationLane,
@@ -719,7 +721,8 @@ class TestCrawlableCustomListFacets(DatabaseTest):
         qu = facets.apply(self._db, qu)
         # w1 is first because it was added to the list more recently.
         eq_([w1.id, w2.id], [mw.works_id for mw in qu])
-        
+
+       
 class TestCrawlableCustomListBasedLane(DatabaseTest):
 
     def test_initialize(self):
@@ -756,3 +759,46 @@ class TestCrawlableCustomListBasedLane(DatabaseTest):
 
         eq_([w2.id], [mw.works_id for mw in qu])
         
+
+class TestCrawlableCollectionBasedLane(DatabaseTest):
+
+    def test_init(self):
+
+        library = self._default_library
+        default_collection = self._default_collection
+        other_collection = self._collection()
+
+        # A lane for all the collections associated with a library.
+        lane = CrawlableCollectionBasedLane(library)
+        eq_([x.id for x in library.collections], lane.collection_ids)
+
+        # A lane for a collection not actually associated with a
+        # library. (A Library is still necessary to provide a point of
+        # reference for classes like Facets and CachedFeed.)
+        lane = CrawlableCollectionBasedLane(library, [other_collection])
+        eq_([other_collection.id], lane.collection_ids)
+        eq_(library, lane.get_library(self._db))
+
+    def test_bibliographic_filter_clause(self):
+        # Normally, if collection_ids is empty it means there are no
+        # restrictions on collection. However, in this case if
+        # collections_id is empty it means no titles should be
+        # returned.
+        collection = self._default_collection
+        self._default_library.collections = []
+        lane = CrawlableCollectionBasedLane(self._default_library)
+        eq_([], lane.collection_ids)
+
+        # This is managed by having bibliographic_filter_clause return None
+        # to short-circuit a query in progress.
+        eq_((None, None), lane.bibliographic_filter_clause(object(), object()))
+
+        # If collection_ids is not empty, then
+        # bibliographic_filter_clause passed through the query it's
+        # given without changing it.
+        lane.collection_ids = [self._default_collection.id]
+        qu = self._db.query(MaterializedWorkWithGenre)
+        qu2, clause = lane.bibliographic_filter_clause(self._db, qu)
+        eq_(qu, qu2)
+        eq_(None, clause)
+

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -946,5 +946,5 @@ class TestOPDS(VendorIDTest):
         links = parsed['links'] 
 
         [crawlable_link] = [x for x in links if x['rel'].lower() == "http://opds-spec.org/crawlable".lower()]
-        assert '/crawlable_feed' in crawlable_link['href']
+        assert '/crawlable_list_feed' in crawlable_link['href']
         assert str(list1.name) in crawlable_link['href']


### PR DESCRIPTION
This branch adds controllers that let you get a crawlable feed covering an entire library, or an entire collection (within the context of one of the libraries that uses that collection).

It also renames CrawlableCustomListFacets to CrawlableFacets, since there's now more than one type of crawlable feed and they all use the same Facets subclass.

The query that builds the feed is much slower than I expected, but that can be improved later.