### PR TITLE
Simplify the ORDER BY and DISTINCT field lists for crawlable feeds

### DIFF
--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1054,8 +1054,10 @@ class CrawlableFacets(Facets):
         """Order the search results by last update time."""
         from core.model import MaterializedWorkWithGenre as work_model
         updated = func.greatest(work_model.availability_time, work_model.first_appearance, work_model.last_update_time)
+        collection_id = work_model.collection_id
         work_id = work_model.works_id
-        return [updated.desc(), work_id], [updated, work_id]
+        return ([updated.desc(), collection_id, work_id],
+                [updated, collection_id, work_id])
 
 
 class CrawlableCollectionBasedLane(DynamicLane):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1049,13 +1049,12 @@ class CrawlableFacets(Facets):
             order_ascending=cls.ORDER_DESCENDING,
         )
 
-    @classmethod
-    def order_facet_to_database_field(cls, order_facet):
-        if order_facet == cls.ORDER_LAST_UPDATE:
-            from core.model import MaterializedWorkWithGenre as work_model
-            return func.greatest(work_model.last_update_time, work_model.first_appearance)
-        else:
-            return Facets.order_facet_to_database_field(order_facet)
+    def order_by(self):
+        """Order the search results by last update time."""
+        from core.model import MaterializedWorkWithGenre as work_model
+        updated = func.greatest(work_model.availability_time, work_model.first_appearance, work_model.last_update_time)
+        work_id = work_model.works_id
+        return [updated.desc(), work_id], [updated, work_id]
 
 
 class CrawlableCollectionBasedLane(DynamicLane):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1049,7 +1049,8 @@ class CrawlableFacets(Facets):
             order_ascending=cls.ORDER_DESCENDING,
         )
 
-    def order_by(self):
+    @classmethod
+    def order_by(cls):
         """Order the search results by last update time."""
         from core.model import MaterializedWorkWithGenre as work_model
         updated = func.greatest(work_model.availability_time, work_model.first_appearance, work_model.last_update_time)

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -724,18 +724,20 @@ class TestCrawlableFacets(DatabaseTest):
 
     def test_order_by(self):
         """Crawlable feeds are always ordered by time updated and then by 
-        work id.
+        collection ID and work ID.
         """
         from core.model import MaterializedWorkWithGenre as mw
         order_by, distinct = CrawlableFacets.order_by()
 
-        updated, works_id = distinct
+        updated, collection_id, works_id = distinct
         expect_func = 'greatest(mv_works_for_lanes.availability_time, mv_works_for_lanes.first_appearance, mv_works_for_lanes.last_update_time)'
         eq_(expect_func, str(updated))
+        eq_(mw.collection_id, collection_id)
         eq_(mw.works_id, works_id)
 
-        updated_desc, works_id = order_by
+        updated_desc, collection_id, works_id = order_by
         eq_(expect_func + ' DESC', str(updated_desc))
+        eq_(mw.collection_id, collection_id)
         eq_(mw.works_id, works_id)
 
 

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -722,6 +722,22 @@ class TestCrawlableFacets(DatabaseTest):
         # w1 is first because it was added to the list more recently.
         eq_([w1.id, w2.id], [mw.works_id for mw in qu])
 
+    def test_order_by(self):
+        """Crawlable feeds are always ordered by time updated and then by 
+        work id.
+        """
+        from core.model import MaterializedWorkWithGenre as mw
+        order_by, distinct = CrawlableFacets.order_by()
+
+        updated, works_id = distinct
+        expect_func = 'greatest(mv_works_for_lanes.availability_time, mv_works_for_lanes.first_appearance, mv_works_for_lanes.last_update_time)'
+        eq_(expect_func, str(updated))
+        eq_(mw.works_id, works_id)
+
+        updated_desc, works_id = order_by
+        eq_(expect_func + ' DESC', str(updated_desc))
+        eq_(mw.works_id, works_id)
+
 
 class TestCrawlableCustomListBasedLane(DatabaseTest):
 


### PR DESCRIPTION
Crawlable feeds are ordered by update date, and then by collection ID and work ID, period. There's no need to also order them by common `Facets` fields such as author and title, and with those extra fields in the query, Postgres doesn't know to use the `mv_works_for_lanes_by_recently_updated` index when sorting search results. This made it incredibly slow to generate crawlable feeds for collections or libraries.

This branch makes `CrawlableFacets` completely override `Facets.order_by` to simplify the query into something that Postgres can match against `mv_works_for_lanes_by_recently_updated`.