### PR TITLE
Provide an example of an Odilo library base URL

### DIFF
--- a/api/odilo.py
+++ b/api/odilo.py
@@ -36,7 +36,11 @@ class OdiloAPI(BaseOdiloAPI, BaseCirculationAPI):
     NAME = ExternalIntegration.ODILO
     DESCRIPTION = _("Integrate an Odilo library collection.")
     SETTINGS = [
-                   {"key": BaseOdiloAPI.LIBRARY_API_BASE_URL, "label": _("Library API base URL")},
+                   {
+                       "key": BaseOdiloAPI.LIBRARY_API_BASE_URL,
+                       "label": _("Library API base URL"),
+                       "description": _("This might look like <code>https://[library].odilo.us/api/v2</code>."),
+                   },
                    {"key": ExternalIntegration.USERNAME, "label": _("Client Key")},
                    {"key": ExternalIntegration.PASSWORD, "label": _("Client Secret")},
                ] + BaseCirculationAPI.SETTINGS


### PR DESCRIPTION
This reduces the risk that an administrator will be unsure which URL they got from Odilo is the right one.

This branch also brings in the changes from https://github.com/NYPL-Simplified/server_core/pull/815