### PR TITLE
Treat duplicate annotations as interchangeable

### DIFF
--- a/api/annotations.py
+++ b/api/annotations.py
@@ -185,7 +185,8 @@ class AnnotationParser(object):
 
         annotation, ignore = Annotation.get_one_or_create(
             _db, patron=patron, identifier=identifier,
-            motivation=motivation, **extra_kwargs
+            motivation=motivation, on_multiple='interchangeable',
+            **extra_kwargs
         )
         annotation.target = target
         if content:


### PR DESCRIPTION
Due to a race condition it's possible for multiple identical annotations to exist in the database. This branch adds `on_multiple='interchangeable'` to the annotation parser so that if this happens we are able to update the annotation later on other than crashing.

Obviously this isn't a complete solution. I'm still trying to figure out the best way to prevent race conditions on the server side, and there's a client side component as well that is making this a lot worse than other race conditions that theoretically exist.