### PR TITLE
Set a socket timeout and add corresponding test coverage for SIPClient.

### DIFF
--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -263,6 +263,8 @@ class SIPClient(Constants):
             self.logged_in = True
             self.must_log_in = False
 
+        self.socket_lock = threading.RLock()
+
         # The only reason connect would be false is that we're running
         # a unit test and don't actually want to use a server.
         if connect:
@@ -272,7 +274,6 @@ class SIPClient(Constants):
             # We need to use an RLock here because both connect() and
             # make_request() require the lock, and make_request() will end
             # up calling connect() if there's an error.
-            self.socket_lock = threading.RLock()
             self.connect()
         
     def login(self, *args, **kwargs):
@@ -303,6 +304,7 @@ class SIPClient(Constants):
                         self.target_server, self.target_port
                     )
                 )
+            sock.settimeout(12)
 
             # Since this is a new socket connection, reset the message count
             # and, potentially, logged_in.

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -263,17 +263,17 @@ class SIPClient(Constants):
             self.logged_in = True
             self.must_log_in = False
 
+        # socket_lock controls access to the socket connection to the
+        # SIP2 server.
+        #
+        # We need to use an RLock here because both connect() and
+        # make_request() require the lock, and make_request() will end
+        # up calling connect() if there's an error.
         self.socket_lock = threading.RLock()
 
         # The only reason connect would be false is that we're running
         # a unit test and don't actually want to use a server.
         if connect:
-            # socket_lock controls access to the socket connection to the
-            # SIP2 server.
-            #
-            # We need to use an RLock here because both connect() and
-            # make_request() require the lock, and make_request() will end
-            # up calling connect() if there's an error.
             self.connect()
         
     def login(self, *args, **kwargs):

--- a/tests/sip/test_client.py
+++ b/tests/sip/test_client.py
@@ -10,7 +10,45 @@ from api.sip.client import (
     CannotReceiveMockSIPClient,
     CannotSendMockSIPClient,
     MockSIPClient,
+    SIPClient,
 )
+
+class MockSocket(object):
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.timeout = None
+        self.connected_to = None
+
+    def connect(self, server_and_port):
+        self.connected_to = server_and_port
+
+    def settimeout(self, value):
+        self.timeout = value
+
+
+class TestSIPClient(object):
+    """Test the real SIPClient class without allowing it to make
+    network connections.
+    """
+
+    def test_connect(self):
+        target_server = object()
+        sip = SIPClient(target_server, 999, connect=False)
+
+        old_socket = socket.socket
+
+        # Mock the socket.socket function.
+        socket.socket = MockSocket
+
+        # Call connect() and make sure timeout is set properly.
+        try:
+            connection = sip.connect()
+            eq_(12, connection.timeout)
+        finally:
+            # Un-mock the socket.socket function
+            socket.socket = old_socket
+
 
 class TestBasicProtocol(object):
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -895,14 +895,14 @@ class TestSyncBookshelf(OverdriveAPITest):
         loans, holds = self.circulation.sync_bookshelf(patron, "dummy pin")
         # All four loans in the sample data were created.
         eq_(4, len(holds))
-        eq_(holds, patron.holds)
+        eq_(sorted(holds), sorted(patron.holds))
 
         # Running the sync again leaves all four holds in place.
         self.api.queue_response(200, content=loans_data)
         self.api.queue_response(200, content=holds_data)
         loans, holds = self.circulation.sync_bookshelf(patron, "dummy pin")
         eq_(4, len(holds))
-        eq_(holds, patron.holds)        
+        eq_(sorted(holds), sorted(patron.holds))
 
     def test_sync_bookshelf_removes_holds_not_present_on_remote(self):
         loans_data, json_loans = self.sample_json("no_loans.json")


### PR DESCRIPTION
This branch sets the socket timeout for a SIP client to twelve seconds, a first step towards improving the behavior of the circulation manager's long-lived connections to SIP servers.

It's based on [Robert Williams's branch](https://github.com/NYPL-Simplified/circulation/pull/858). Some items in that branch will make it into a future branch, but the twelve second timeout (which was determined empirically) is enough to prevent crashes.