### PR TITLE
Fixed admin session on first request after an app restart.

### DIFF
--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -45,6 +45,13 @@ def setup_admin(_db=None):
     app.secret_key = ConfigurationSetting.sitewide_secret(
         _db, Configuration.SECRET_KEY
     )
+    # Reload the flask session in case an admin was logged in
+    # when the app restarted. The session is initially loaded
+    # from the cookie before this function runs, but it creates a
+    # null session on the first request because the secret key
+    # isn't set yet.
+    if not flask.session:
+        flask.session = app.open_session(flask.request)
 
 
 def allows_admin_auth_setup(f):

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -50,7 +50,7 @@ def setup_admin(_db=None):
     # from the cookie before this function runs, but it creates a
     # null session on the first request because the secret key
     # isn't set yet.
-    if not flask.session:
+    if not flask.session and flask.request:
         flask.session = app.open_session(flask.request)
 
 


### PR DESCRIPTION
This fixes a bug where if an admin made the first request after the circ manager started, it would give them a null session and think they were logged out. This mainly affects developers working on the admin interface, but could also happen occasionally in a real app.