### PR TITLE
Change tests to expect + in URLs instead of %20.

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2407,15 +2407,20 @@ class TestFeedController(CirculationControllerTest):
     def _set_update_times(self):
         """Set the last update times so we can create a crawlable feed."""
         now = datetime.datetime.now()
-        self.english_2.last_update_time = (
-            now + datetime.timedelta(hours=2)
-        )
-        self.french_1.last_update_time = (
-            now + datetime.timedelta(hours=1)
-        )
-        self.english_1.last_update_time = (
-            now - datetime.timedelta(hours=1)
-        )
+
+        def _set(work, time):
+            """Set all fields used when calculating a work's update date for
+            purposes of the crawlable feed.
+            """
+            work.last_update_time = time
+            for lp in work.license_pools:
+                lp.availability_time = time
+        the_far_future = now + datetime.timedelta(hours=2)
+        the_future = now + datetime.timedelta(hours=1)
+        the_past = now - datetime.timedelta(hours=1)
+        _set(self.english_2, now + datetime.timedelta(hours=2))
+        _set(self.french_1, now + datetime.timedelta(hours=1))
+        _set(self.english_1, now - datetime.timedelta(hours=1))
         self._db.commit()
         SessionManager.refresh_materialized_views(self._db)
 

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -287,7 +287,7 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         # into a LicensePoolDeliveryMechanism. The other formats were
         # ignored.
         [mechanism] = pool.delivery_mechanisms
-        eq_('https://s3.amazonaws.com/test.content.bucket/FeedBooks/URI/http%3A//www.feedbooks.com/book/677/Discourse+on+the+Method.epub',
+        eq_('https://s3.amazonaws.com/test.content.bucket/FeedBooks/URI/http%3A%2F%2Fwww.feedbooks.com%2Fbook%2F677/Discourse+on+the+Method.epub',
             mechanism.resource.representation.mirror_url
         )
         eq_(u'application/epub+zip', mechanism.delivery_mechanism.content_type)

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -287,7 +287,7 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         # into a LicensePoolDeliveryMechanism. The other formats were
         # ignored.
         [mechanism] = pool.delivery_mechanisms
-        eq_('http://s3.amazonaws.com/test.content.bucket/FeedBooks/URI/http%3A//www.feedbooks.com/book/677/Discourse%20on%20the%20Method.epub',
+        eq_('https://s3.amazonaws.com/test.content.bucket/FeedBooks/URI/http%3A//www.feedbooks.com/book/677/Discourse+on+the+Method.epub',
             mechanism.resource.representation.mirror_url
         )
         eq_(u'application/epub+zip', mechanism.delivery_mechanism.content_type)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -666,14 +666,14 @@ class TestDirectoryImportScript(DatabaseTest):
         # thumbnail.
         eq_("A book", work.title)
         assert work.cover_full_url.endswith(
-            '/test.cover.bucket/Gutenberg/Gutenberg%20ID/1003/1003.jpg'
+            '/test.cover.bucket/Gutenberg/Gutenberg+ID/1003/1003.jpg'
         )
         assert work.cover_thumbnail_url.endswith(
-            '/test.cover.bucket/scaled/300/Gutenberg/Gutenberg%20ID/1003/1003.png'
+            '/test.cover.bucket/scaled/300/Gutenberg/Gutenberg+ID/1003/1003.png'
         )
         [pool] = work.license_pools
         assert pool.open_access_download_url.endswith(
-            '/test.content.bucket/Gutenberg/Gutenberg%20ID/1003/A%20book.epub'
+            '/test.content.bucket/Gutenberg/Gutenberg+ID/1003/A+book.epub'
         )
 
         eq_(RightsStatus.CC0, 
@@ -826,7 +826,7 @@ class TestDirectoryImportScript(DatabaseTest):
         [link] = circulation.links
         eq_(Hyperlink.OPEN_ACCESS_DOWNLOAD, link.rel)
         assert link.href.endswith(
-            '/test.content.bucket/Gutenberg/Gutenberg%20ID/2345/Name%20of%20book.epub'
+            '/test.content.bucket/Gutenberg/Gutenberg+ID/2345/Name+of+book.epub'
         )
         eq_(Representation.EPUB_MEDIA_TYPE, link.media_type)
         eq_("I'm an EPUB.", link.content)
@@ -868,7 +868,7 @@ class TestDirectoryImportScript(DatabaseTest):
         link = script.load_cover_link(*args)
         eq_(Hyperlink.IMAGE, link.rel)
         assert link.href.endswith(
-            '/test.cover.bucket/Gutenberg/Gutenberg%20ID/2345/2345.jpg'
+            '/test.cover.bucket/Gutenberg/Gutenberg+ID/2345/2345.jpg'
         )
         eq_(Representation.JPEG_MEDIA_TYPE, link.media_type)
         eq_("I'm an image.", link.content)


### PR DESCRIPTION
This branch brings circulation up to date with core, and changes some tests to reflect the fact that we now use `quote_plus` when creating S3 URLs, not `quote`.