### PR TITLE
Bring the loan and hold reapers into the generic reaper system

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1645,7 +1645,8 @@ class BasicAuthenticationProvider(AuthenticationProvider):
             # be resolved over there.
             clause = or_(Patron.authorization_identifier==username,
                          Patron.username==username)
-            qu = _db.query(Patron).filter(clause).limit(1)
+            qu = _db.query(Patron).filter(clause).filter(
+                Patron.library_id==self.library_id).limit(1)
             try:
                 patron = qu.one()
             except NoResultFound:

--- a/api/monitor.py
+++ b/api/monitor.py
@@ -246,7 +246,8 @@ class LoanlikeReaperMonitor(ReaperMonitor):
 
     SOURCE_OF_TRUTH_PROTOCOLS = [
         ODLWithConsolidatedCopiesAPI.NAME,
-        SharedODLAPI.NAME
+        SharedODLAPI.NAME,
+        ExternalIntegration.OPDS_FOR_DISTRIBUTORS,
     ]
 
     @property

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -144,22 +144,13 @@ class OPDSForDistributorsAPI(BaseCirculationAPI):
 
     def checkout(self, patron, pin, licensepool, internal_format):
         now = datetime.datetime.utcnow()
-
-        # This is not open-access content, but the loans are
-        # effectively of indefinite duration. To avoid confusing this
-        # with open-access content, grant a loan of 95 years duration.
-        #
-        # By this time, the US copyright on the work will have expired
-        # and it will be open-access content -- so something needs to
-        # change between now and then anyway.
-        the_far_future = now + datetime.timedelta(days=365*95)
         return LoanInfo(
             licensepool.collection,
             licensepool.data_source.name,
             licensepool.identifier.type,
             licensepool.identifier.identifier,
             start_date=now,
-            end_date=the_far_future,
+            end_date=None,
         )
 
     def fulfill(self, patron, pin, licensepool, internal_format):

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -143,13 +143,23 @@ class OPDSForDistributorsAPI(BaseCirculationAPI):
             pass
 
     def checkout(self, patron, pin, licensepool, internal_format):
+        now = datetime.datetime.utcnow()
+
+        # This is not open-access content, but the loans are
+        # effectively of indefinite duration. To avoid confusing this
+        # with open-access content, grant a loan of 95 years duration.
+        #
+        # By this time, the US copyright on the work will have expired
+        # and it will be open-access content -- so something needs to
+        # change between now and then anyway.
+        the_far_future = now + datetime.timedelta(days=365*95)
         return LoanInfo(
             licensepool.collection,
             licensepool.data_source.name,
             licensepool.identifier.type,
             licensepool.identifier.identifier,
-            start_date=datetime.datetime.now(),
-            end_date=None,
+            start_date=now,
+            end_date=the_far_future,
         )
 
     def fulfill(self, patron, pin, licensepool, internal_format):

--- a/bin/database_reaper
+++ b/bin/database_reaper
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""Remove miscellaneous expired things (Credentials, CachedFeeds, etc.)
+from the database.
+"""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.scripts import RunReaperMonitorsScript
+RunReaperMonitorsScript().run()

--- a/bin/database_reaper
+++ b/bin/database_reaper
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Remove miscellaneous expired things (Credentials, CachedFeeds, etc.)
+"""Remove miscellaneous expired things (Credentials, CachedFeeds, Loans, etc.)
 from the database.
 """
 import os

--- a/bin/loan_reaper
+++ b/bin/loan_reaper
@@ -1,9 +1,0 @@
-#!/usr/bin/env python
-"""Remove expired loans."""
-import os
-import sys
-bin_dir = os.path.split(__file__)[0]
-package_dir = os.path.join(bin_dir, "..")
-sys.path.append(os.path.abspath(package_dir))
-from scripts import LoanReaperScript
-LoanReaperScript().run()

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1606,6 +1606,15 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         eq_(True, provider.server_side_validation("a", None))
         
     def test_local_patron_lookup(self):
+        # This patron of another library looks just like the patron
+        # we're about to create, but will never be selected.
+        other_library = self._library()
+        other_library_patron = self._patron(
+            "patron1_ext_id", library=other_library
+        )
+        other_library_patron.authorization_identifier = "patron1_auth_id"
+        other_library_patron.username = "patron1"
+
         patron1 = self._patron("patron1_ext_id")
         patron1.authorization_identifier = "patron1_auth_id"
         patron1.username = "patron1"

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -376,7 +376,11 @@ class TestLoanlikeReaperMonitor(DatabaseTest):
         """Verify that well-known source of truth protocols
         will be exempt from the reaper.
         """
-        for i in (ODLWithConsolidatedCopiesAPI.NAME, SharedODLAPI.NAME):
+        for i in (
+                ODLWithConsolidatedCopiesAPI.NAME,
+                SharedODLAPI.NAME,
+                ExternalIntegration.OPDS_FOR_DISTRIBUTORS,
+        ):
             assert i in LoanlikeReaperMonitor.SOURCE_OF_TRUTH_PROTOCOLS
 
 

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -185,7 +185,15 @@ class TestOPDSForDistributorsAPI(DatabaseTest):
         eq_(data_source.name, loan_info.data_source_name)
         eq_(Identifier.URI, loan_info.identifier_type)
         eq_(pool.identifier.identifier, loan_info.identifier)
-        eq_(None, loan_info.end_date)
+
+        # The loan's start date has been set to the current time.
+        now = datetime.datetime.utcnow()
+        assert (now - loan_info.start_date).seconds < 2
+
+        # The loan's end date is set to a date in the far future, to
+        # distinguish it from a truly indefinite open-access 'loan'.
+        the_far_future = now + datetime.timedelta(days=365*95)
+        assert (the_far_future - loan_info.end_date).seconds < 2
 
     def test_fulfill(self):
         patron = self._patron()

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -190,10 +190,8 @@ class TestOPDSForDistributorsAPI(DatabaseTest):
         now = datetime.datetime.utcnow()
         assert (now - loan_info.start_date).seconds < 2
 
-        # The loan's end date is set to a date in the far future, to
-        # distinguish it from a truly indefinite open-access 'loan'.
-        the_far_future = now + datetime.timedelta(days=365*95)
-        assert (the_far_future - loan_info.end_date).seconds < 2
+        # The loan is of indefinite duration.
+        eq_(None, loan_info.end_date)
 
     def test_fulfill(self):
         patron = self._patron()

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -862,7 +862,7 @@ class TestSyncBookshelf(OverdriveAPITest):
         loans, holds = self.circulation.sync_bookshelf(patron, "dummy pin")
 
         eq_(4, len(loans))
-        eq_(loans, patron.loans)
+        eq_(set(loans), set(patron.loans))
         assert overdrive_loan not in patron.loans
 
     def test_sync_bookshelf_ignores_loans_from_other_sources(self):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -66,7 +66,6 @@ from scripts import (
     DirectoryImportScript,
     InstanceInitializationScript,
     LanguageListScript,
-    LoanReaperScript,
 )
 
 class TestAdobeAccountIDResetScript(DatabaseTest):
@@ -262,105 +261,6 @@ class TestInstanceInitializationScript(DatabaseTest):
             secret_keys.one().value,
             ConfigurationSetting.sitewide_secret(self._db, Configuration.SECRET_KEY)
         )
-
-
-class TestLoanReaperScript(DatabaseTest):
-
-    def test_reaping(self):
-
-        # This patron stopped using the circulation manager a long time
-        # ago.
-        inactive_patron = self._patron()
-
-        # This patron is still using the circulation manager.
-        current_patron = self._patron()
-        
-        # We're going to give these patrons some loans and holds.
-        edition, open_access = self._edition(
-            with_license_pool=True, with_open_access_download=True)
-
-        not_open_access_1 = self._licensepool(edition,
-            open_access=False, data_source_name=DataSource.OVERDRIVE)
-        not_open_access_2 = self._licensepool(edition,
-            open_access=False, data_source_name=DataSource.BIBLIOTHECA)
-        not_open_access_3 = self._licensepool(edition,
-            open_access=False, data_source_name=DataSource.AXIS_360)
-        not_open_access_4 = self._licensepool(edition,
-            open_access=False, data_source_name=DataSource.ONECLICK)
-
-        now = datetime.datetime.utcnow()
-        a_long_time_ago = now - datetime.timedelta(days=1000)
-        not_very_long_ago = now - datetime.timedelta(days=60)
-        even_longer = now - datetime.timedelta(days=2000)
-        the_future = now + datetime.timedelta(days=1)
-        
-        # This loan has expired.
-        not_open_access_1.loan_to(
-            inactive_patron, start=even_longer, end=a_long_time_ago
-        )
-        
-        # This hold expired without ever becoming a loan (that we saw).
-        not_open_access_2.on_hold_to(
-            inactive_patron,
-            start=even_longer,
-            end=a_long_time_ago
-        )
-        
-        # This hold has no end date and is older than a year.
-        not_open_access_3.on_hold_to(
-            inactive_patron, start=a_long_time_ago, end=None,
-        )
-        
-        # This loan has no end date and is older than 90 days.
-        not_open_access_4.loan_to(
-            inactive_patron, start=a_long_time_ago, end=None,
-        )
-        
-        # This loan has no end date, but it's for an open-access work.
-        open_access_loan, ignore = open_access.loan_to(
-            inactive_patron, start=a_long_time_ago, end=None,
-        )
-
-        # This loan has not expired yet.
-        not_open_access_1.loan_to(
-            current_patron, start=now, end=the_future
-        )
-        
-        # This hold has not expired yet.
-        not_open_access_2.on_hold_to(
-            current_patron, start=now, end=the_future
-        )
-
-        # This loan has no end date but is pretty recent.
-        not_open_access_3.loan_to(
-            current_patron, start=not_very_long_ago, end=None
-        )
-
-        # This hold has no end date but is pretty recent.
-        not_open_access_4.on_hold_to(
-            current_patron, start=not_very_long_ago, end=None
-        )
-        
-        eq_(3, len(inactive_patron.loans))
-        eq_(2, len(inactive_patron.holds))
-
-        eq_(2, len(current_patron.loans))
-        eq_(2, len(current_patron.holds))
-
-        # Now we fire up the loan reaper.
-        script = LoanReaperScript(self._db)
-        script.do_run()
-
-        # All of the inactive patron's loans and holds have been reaped,
-        # except for the open-access loan, which will never be reaped.
-        eq_([open_access_loan], inactive_patron.loans)
-        eq_([], inactive_patron.holds)
-
-        # The active patron's loans and holds are unaffected, either
-        # because they have not expired or because they have no known
-        # expiration date and were created relatively recently.
-        eq_(2, len(current_patron.loans))
-        eq_(2, len(current_patron.holds))
 
 
 class TestLanguageListScript(DatabaseTest):


### PR DESCRIPTION
This branch removes `LoanAndHoldReaper`, replacing it with two `ReaperMonitor`s that fit into the general reaper system. The `loan_reaper` script is replaced with the `database_reaper` script.

The reapers do not affect collections where the circulation manager is the source of truth w/r/t loans and holds. Right now that means collections based on ODL or OPDS For Distributors.