### PR TITLE
Attempt to fix flask session problems

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -170,12 +170,13 @@ class AdminController(object):
             )
         return None
 
-    def authenticated_admin_from_request(self):
+    def authenticated_admin_from_request(self, email=None):
         """Returns an authenticated admin or a problem detail."""
         if not self.auth:
             return ADMIN_AUTH_NOT_CONFIGURED
 
-        email = flask.session.get("admin_email")
+        email = email or flask.session.get("admin_email")
+
         if email:
             admin = get_one(self._db, Admin, email=email)
             if admin and self.auth.active_credentials(admin):


### PR DESCRIPTION
In #891, I tried to fix the flask session after an app restart, but it my change broke the session when run from docker (and maybe anytime it was run with multiple threads, not sure). 

I don't totally understand this, but the flask session is a Werkzeug thread-local proxy object, so we can't just replace it. It seems we can, however, create another temporary session object, get the admin from it, and not save it anywhere. This is okay because if the admin is logged in they already have a cookie, and a NullSession does nothing rather than deleting the previous cookie, so the cookie will still be there for subsequent requests.

I won't be sure this works until I actually deploy it to elastic beanstalk, but I have tested it locally in docker this time.