### PR TITLE
When a library has no authentication mechanism configured, don't serve links that require authentication

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -504,6 +504,13 @@ class LibraryAuthenticator(object):
         self.assert_ready_for_oauth()
 
     @property
+    def supports_patron_authentication(self):
+        """Does this library have any way of authenticating patrons at all?"""
+        if self.basic_auth_provider or self.oauth_providers_by_name:
+            return True
+        return False
+
+    @property
     def library(self):
         return Library.by_id(self._db, self.library_id)
         

--- a/api/controller.py
+++ b/api/controller.py
@@ -381,9 +381,16 @@ class CirculationManager(object):
             library = lane.get_library(self._db)
         else:
             library = flask.request.library
+
+        # Some features are only available if a patron authentication
+        # mechanism is set up for this library.
+        authenticator = self.auth.library_authenticators.get(library.short_name)
+        auth_supported = authenticator.supports_patron_authentication
         return LibraryAnnotator(
             self.circulation_apis[library.id], lane, library,
-            top_level_title='All Books', *args, **kwargs
+            top_level_title='All Books',
+            library_supports_patron_authentication=auth_supported,
+            *args, **kwargs
         )
 
     @property

--- a/api/opds.py
+++ b/api/opds.py
@@ -338,8 +338,17 @@ class LibraryAnnotator(CirculationManagerAnnotator):
                  active_fulfillments_by_work={},
                  facet_view='feed',
                  test_mode=False,
-                 top_level_title="All Books"
+                 top_level_title="All Books",
+                 library_supports_patron_authentication = True
     ):
+        """Constructor.
+
+        :param library_supports_patron_authentication: A boolean
+          indicating whether or not this library authenticates its
+          patrons (and, thus, can distinguish between one patron and
+          another). If this is false, links that imply the library can
+          distinguish between patrons will not be included.
+        """
         super(LibraryAnnotator, self).__init__(lane, active_loans_by_work=active_loans_by_work,
                                                active_holds_by_work=active_holds_by_work,
                                                active_fulfillments_by_work=active_fulfillments_by_work,
@@ -351,6 +360,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         self.facet_view = facet_view
         self._adobe_id_tags = {}
         self._top_level_title = top_level_title
+        self.patron_auth = library_supports_patron_authentication
 
     def top_level_title(self):
         return self._top_level_title
@@ -515,18 +525,19 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             )
 
         # Add a link to get a patron's annotations for this book.
-        feed.add_link_to_entry(
-            entry,
-            rel="http://www.w3.org/ns/oa#annotationService",
-            type=AnnotationWriter.CONTENT_TYPE,
-            href=self.url_for(
-                'annotations_for_work',
-                identifier_type=identifier.type,
-                identifier=identifier.identifier,
-                library_short_name=self.library.short_name,
-                _external=True
+        if self.patron_auth:
+            feed.add_link_to_entry(
+                entry,
+                rel="http://www.w3.org/ns/oa#annotationService",
+                type=AnnotationWriter.CONTENT_TYPE,
+                href=self.url_for(
+                    'annotations_for_work',
+                    identifier_type=identifier.type,
+                    identifier=identifier.identifier,
+                    library_short_name=self.library.short_name,
+                    _external=True
+                )
             )
-        )
 
     @classmethod
     def related_books_available(cls, work, library):
@@ -625,7 +636,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             self.add_patron(feed)
         else:
             # No patron is authenticated. Show them how to
-            # authenticate.
+            # authenticate (or that authentication is not supported).
             self.add_authentication_document_link(feed)
         
         # Add a 'search' link if the lane is searchable.
@@ -643,17 +654,20 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             )
             feed.add_link_to_feed(feed.feed, **search_link)
 
-        shelf_link = dict(
-            rel="http://opds-spec.org/shelf",
-            type=OPDSFeed.ACQUISITION_FEED_TYPE,
-            href=self.url_for('active_loans', library_short_name=self.library.short_name, _external=True))
-        feed.add_link_to_feed(feed.feed, **shelf_link)
+        if self.patron_auth:
+            # Since this library authenticates patrons it can offer
+            # a bookshelf and an annotation service.
+            shelf_link = dict(
+                rel="http://opds-spec.org/shelf",
+                type=OPDSFeed.ACQUISITION_FEED_TYPE,
+                href=self.url_for('active_loans', library_short_name=self.library.short_name, _external=True))
+            feed.add_link_to_feed(feed.feed, **shelf_link)
 
-        annotations_link = dict(
-            rel="http://www.w3.org/ns/oa#annotationService",
-            type=AnnotationWriter.CONTENT_TYPE,
-            href=self.url_for('annotations', library_short_name=self.library.short_name, _external=True))
-        feed.add_link_to_feed(feed.feed, **annotations_link)
+            annotations_link = dict(
+                rel="http://www.w3.org/ns/oa#annotationService",
+                type=AnnotationWriter.CONTENT_TYPE,
+                href=self.url_for('annotations', library_short_name=self.library.short_name, _external=True))
+            feed.add_link_to_feed(feed.feed, **annotations_link)
 
         if lane and lane.uses_customlists and len(lane.customlists) == 1:
             crawlable_url = self.url_for(
@@ -714,6 +728,8 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         )
 
     def revoke_link(self, active_license_pool, active_loan, active_hold):
+        if not self.patron_auth:
+            return
         url = self.url_for(
             'revoke_loan_or_hold',
             license_pool_id=active_license_pool.id,
@@ -725,6 +741,8 @@ class LibraryAnnotator(CirculationManagerAnnotator):
 
     def borrow_link(self, identifier,
                     borrow_mechanism, fulfillment_mechanisms, active_hold=None):
+        if not self.patron_auth:
+            return
         if borrow_mechanism:
             # Following this link will both borrow the book and set
             # its delivery mechanism.
@@ -778,6 +796,8 @@ class LibraryAnnotator(CirculationManagerAnnotator):
 
         This link may include tags from the OPDS Extensions for DRM.
         """
+        if not self.patron_auth:
+            return
         if isinstance(delivery_mechanism, LicensePoolDeliveryMechanism):
             logging.warn("LicensePoolDeliveryMechanism passed into fulfill_link instead of DeliveryMechanism!")
             delivery_mechanism = delivery_mechanism.delivery_mechanism
@@ -826,7 +846,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         register a device with the DRM server that manages this loan.
         :param delivery_mechanism: A DeliveryMechanism
         """        
-        if not active_loan or not delivery_mechanism:
+        if not active_loan or not delivery_mechanism or not self.patron_auth:
             return []
         
         if delivery_mechanism.drm_scheme == DeliveryMechanism.ADOBE_DRM:
@@ -900,6 +920,8 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         return cached
         
     def add_patron(self, feed_obj):
+        if not self.patron_auth:
+            return
         patron_details = {}
         if self.patron.username:
             patron_details["{%s}username" % OPDSFeed.SIMPLIFIED_NS] = self.patron.username
@@ -914,6 +936,9 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         manager's Authentication for OPDS document
         for the current library.
         """
+        # Even if self.patron_auth is false, we include this link,
+        # because this document is the one that explains there is no
+        # patron authentication at this library.
         feed_obj.add_link_to_feed(
             feed_obj.feed,
             rel='http://opds-spec.org/auth/document',
@@ -922,6 +947,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
                 library_short_name=self.library.short_name, _external=True
             )
         )
+
 
 class SharedCollectionAnnotator(CirculationManagerAnnotator):
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -711,7 +711,30 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             library=self._default_library,
             oauth_providers=[oauth]
         )
-        
+
+    def test_supports_patron_authentication(self):
+        authenticator = LibraryAuthenticator.from_config(
+            self._db, self._default_library
+        )
+
+        # This LibraryAuthenticator does not actually support patron
+        # authentication because it has no auth providers.
+        #
+        # (This isn't necessarily a deal breaker, but most libraries
+        # do authenticate their patrons.)
+        eq_(False, authenticator.supports_patron_authentication)
+
+        # Adding a basic auth provider will make it start supporting
+        # patron authentication.
+        authenticator.basic_auth_provider = object()
+        eq_(True, authenticator.supports_patron_authentication)
+        authenticator.basic_auth_provider = None
+
+        # So will adding an OAuth provider.
+        authenticator.oauth_providers_by_name[object()] = object()
+        eq_(True, authenticator.supports_patron_authentication)        
+
+
     def test_providers(self):
         integration = self._external_integration(self._str)
         basic = MockBasicAuthenticationProvider(

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -732,7 +732,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
 
         # So will adding an OAuth provider.
         authenticator.oauth_providers_by_name[object()] = object()
-        eq_(True, authenticator.supports_patron_authentication)        
+        eq_(True, authenticator.supports_patron_authentication)
 
 
     def test_providers(self):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -418,23 +418,24 @@ class TestLibraryAnnotator(VendorIDTest):
             parsed = feedparser.parse(etree.tostring(entry))
             [entry_parsed] = parsed['entries']
             linksets.append(set([x['rel'] for x in entry_parsed['links']]))
-        
+
         with_auth, no_auth = linksets
 
         # Some links are present no matter what.
         for expect in [u'alternate', u'issues', u'related']:
             assert expect in with_auth
             assert expect in no_auth
-            
-        # Patron authentication allows for some additional links -- a
-        # link to borrow the book and a link to annotate the book.
+
+        # A library with patron authentication offers some additional
+        # links -- one to borrow the book and one to annotate the
+        # book.
         for expect in [
-                u'http://www.w3.org/ns/oa#annotationservice', 
+                u'http://www.w3.org/ns/oa#annotationservice',
                 u'http://opds-spec.org/acquisition/borrow'
         ]:
             assert expect in with_auth
             assert expect not in no_auth
-        
+
     def test_annotate_feed(self):
         lane = self._lane()
         linksets = []
@@ -455,17 +456,17 @@ class TestLibraryAnnotator(VendorIDTest):
         for rel in (
                 'self', 'search', u'http://opds-spec.org/auth/document'
         ):
-            assert link in with_auth
-            assert link in without_auth
+            assert rel in with_auth
+            assert rel in without_auth
 
         # But there's only a bookshelf link and an annotation link
         # when patron authentication is enabled.
-        for link in (
+        for rel in (
                 u'http://opds-spec.org/shelf',
                 u'http://www.w3.org/ns/oa#annotationservice'
         ):
-            assert link in with_auth
-            assert link not in without_auth
+            assert rel in with_auth
+            assert rel not in without_auth
 
 
     def get_parsed_feed(self, works, lane=None, **kwargs):


### PR DESCRIPTION
This fixes https://github.com/NYPL-Simplified/circulation/issues/892. I was originally going to create a special "null" authentication mechanism, but a library doesn't have to have an authentication mechanism at all. In fact, all libraries start out in that state. So I just made OPDS feeds work for a library in that state, by removing links that imply the library has an authentication mechanism set.

This branch adds some test coverage of bits of the OPDS annotators which were not directly tested before.