### PR TITLE
Mitigate issue where licensepools have no works attached to them

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -815,11 +815,12 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
             self._db, DataSource.OVERDRIVE, Identifier.OVERDRIVE_ID, book_id,
             collection=self.collection
         )
-        if is_new:
-            # This is the first time we've seen this book. Make sure its
-            # identifier has bibliographic coverage.
+        if is_new or not license_pool.work:
+            # Either this is the first time we've seen this book or its doesn't
+            # have an associated work. Make sure its identifier has bibliographic coverage.
             self.overdrive_bibliographic_coverage_provider.ensure_coverage(
-                license_pool.identifier
+                license_pool.identifier,
+                force=True
             )
 
         return self.update_licensepool_with_book_info(

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 from nose.tools import (
-    set_trace, eq_,
+    set_trace, eq_, ok_,
     assert_raises,
 )
 import pkgutil
@@ -567,6 +567,8 @@ class TestOverdriveAPI(OverdriveAPITest):
 
         self.api.queue_response(200, content=availability)
         self.api.queue_response(200, content=bibliographic)
+        self.api.queue_response(200, content=availability)
+        self.api.queue_response(200, content=bibliographic)
 
         # Now we're ready. When we call update_licensepool, the
         # OverdriveAPI will retrieve the availability information,
@@ -593,6 +595,19 @@ class TestOverdriveAPI(OverdriveAPITest):
             and x.data_source.name == DataSource.OVERDRIVE
         ]
         eq_(1, len(coverage))
+
+        # Call update_licensepool on an identifier that is missing a work and make
+        # sure that it provides bibliographic coverage in that case.
+        self._db.delete(pool.work)
+        self._db.commit()
+        pool, is_new = LicensePool.for_foreign_id(
+            self._db, DataSource.OVERDRIVE, Identifier.OVERDRIVE_ID, identifier.identifier,
+            collection=self.collection
+        )
+        ok_(not pool.work)
+        pool, was_new, changed = self.api.update_licensepool(identifier.identifier)
+        eq_(False, was_new)
+        eq_(True, pool.work.presentation_ready)
 
     def test_update_new_licensepool(self):
         data, raw = self.sample_json("overdrive_availability_information.json")

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -567,8 +567,6 @@ class TestOverdriveAPI(OverdriveAPITest):
 
         self.api.queue_response(200, content=availability)
         self.api.queue_response(200, content=bibliographic)
-        self.api.queue_response(200, content=availability)
-        self.api.queue_response(200, content=bibliographic)
 
         # Now we're ready. When we call update_licensepool, the
         # OverdriveAPI will retrieve the availability information,
@@ -605,6 +603,8 @@ class TestOverdriveAPI(OverdriveAPITest):
             collection=self.collection
         )
         ok_(not pool.work)
+        self.api.queue_response(200, content=availability)
+        self.api.queue_response(200, content=bibliographic)
         pool, was_new, changed = self.api.update_licensepool(identifier.identifier)
         eq_(False, was_new)
         eq_(True, pool.work.presentation_ready)


### PR DESCRIPTION
## Issue

I've been troubleshooting an issue with @leonardr where some books from Overdrive were not coming up in search results in the Circulation manager. Some sleuthing showed that many of the `licensepools` in this circulation manger were missing `works` (something like 11,870 of them). Looking at my other circulation managers, none had as large a problem, but still they all had a few `licensepools` without `works`. 

## Solution

I was not able to reproduce the problem where a license pool ended up without a work associated. Assuming its a transient problem perhaps caused by issues with the Overdrive API, this PR tries to mitigate the problem by making sure a `work` is created in `update_licensepool` if there isn't already one. 

With this patch applied when the Overdrive Reaper ran it fixed all of the `licensepools` missing `works` and all of the books became available in the circulation manger. 