### PR TITLE
Admin auth methods are no longer mutually exclusive.

### DIFF
--- a/api/admin/admin_authentication_provider.py
+++ b/api/admin/admin_authentication_provider.py
@@ -4,9 +4,9 @@ class AdminAuthenticationProvider(object):
     def __init__(self, integration):
         self.integration = integration
 
-    def auth_uri(self, redirect_url):
-        # Returns a URI that an admin can use to log in with this
-        # authentication provider.
+    def sign_in_template(self, redirect_url):
+        # Returns HTML to be rendered on the sign in page for
+        # this authentication provider.
         raise NotImplementedError()
 
     def active_credentials(self, admin):

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -156,30 +156,43 @@ class AdminController(object):
         self.cdn_url_for = self.manager.cdn_url_for
 
     @property
-    def auth(self):
+    def auth_providers(self):
+        auth_providers = []
         auth_service = ExternalIntegration.admin_authentication(self._db)
         if auth_service and auth_service.protocol == ExternalIntegration.GOOGLE_OAUTH:
-            return GoogleOAuthAdminAuthenticationProvider(
+            auth_providers.append(GoogleOAuthAdminAuthenticationProvider(
                 auth_service,
                 self.url_for('google_auth_callback'),
                 test_mode=self.manager.testing,
-            )
-        elif Admin.with_password(self._db).count() != 0:
-            return PasswordAdminAuthenticationProvider(
+            ))
+        if Admin.with_password(self._db).count() != 0:
+            auth_providers.append(PasswordAdminAuthenticationProvider(
                 auth_service,
-            )
+            ))
+        return auth_providers
+
+    def auth_provider(self, type):
+        # Return an auth provider with the given type.
+        # If no auth provider has this type, return None.
+        for provider in self.auth_providers:
+            if provider.NAME == type:
+                return provider
         return None
 
-    def authenticated_admin_from_request(self, email=None):
+    def authenticated_admin_from_request(self, email=None, type=None):
         """Returns an authenticated admin or a problem detail."""
-        if not self.auth:
+        if not self.auth_providers:
             return ADMIN_AUTH_NOT_CONFIGURED
 
         email = email or flask.session.get("admin_email")
+        type = type or flask.session.get("auth_type")
 
-        if email:
+        if email and type:
             admin = get_one(self._db, Admin, email=email)
-            if admin and self.auth.active_credentials(admin):
+            auth = self.auth_provider(type)
+            if not auth:
+                return ADMIN_AUTH_MECHANISM_NOT_CONFIGURED
+            if admin and auth.active_credentials(admin):
                 return admin
         return INVALID_ADMIN_CREDENTIALS
 
@@ -196,6 +209,7 @@ class AdminController(object):
 
         # Set up the admin's flask session.
         flask.session["admin_email"] = admin_details.get("email")
+        flask.session["auth_type"] = admin_details.get("type")
 
         # A permanent session expires after a fixed time, rather than
         # when the user closes the browser.
@@ -236,7 +250,7 @@ class AdminController(object):
 
 class ViewController(AdminController):
     def __call__(self, collection, book, path=None):
-        setting_up = (self.auth == None)
+        setting_up = (self.auth_providers == [])
         if not setting_up:
             admin = self.authenticated_admin_from_request()
             if isinstance(admin, ProblemDetail):
@@ -291,86 +305,69 @@ class SignInController(AdminController):
 </body>
 </html>"""
 
-    PASSWORD_SIGN_IN_TEMPLATE = """<!DOCTYPE HTML>
+    SIGN_IN_TEMPLATE = """<!DOCTYPE HTML>
 <html lang="en">
 <head><meta charset="utf8"></head>
-</body>
-<form action="%(password_sign_in_url)s" method="post">
-<input type="hidden" name="redirect" value="%(redirect)s"/>
-<label>Email <input type="text" name="email" /></label>
-<label>Password <input type="password" name="password" /></label>
-<button type="submit">Sign In</button>
-</form>
+<body>
+%(auth_provider_html)s
 </body>
 </html>"""
 
 
     def sign_in(self):
-        """Redirects admin if they're signed in."""
-        if not self.auth:
+        """Redirects admin if they're signed in, or shows the sign in page."""
+        if not self.auth_providers:
             return ADMIN_AUTH_NOT_CONFIGURED
 
         admin = self.authenticated_admin_from_request()
 
         if isinstance(admin, ProblemDetail):
             redirect_url = flask.request.args.get("redirect")
-            return redirect(self.auth.auth_uri(redirect_url), Response=Response)
+            auth_provider_html = [auth.sign_in_template(redirect_url) for auth in self.auth_providers]
+            auth_provider_html = "<br/><hr/>or<br/><br/>".join(auth_provider_html)
+            html = self.SIGN_IN_TEMPLATE % dict(
+                auth_provider_html=auth_provider_html
+            )
+            headers = dict()
+            headers['Content-Type'] = "text/html"
+            return Response(html, 200, headers)
         elif admin:
             return redirect(flask.request.args.get("redirect"), Response=Response)
 
     def redirect_after_google_sign_in(self):
         """Uses the Google OAuth client to determine admin details upon
         callback. Barring error, redirects to the provided redirect url.."""
-        if not self.auth:
+        if not self.auth_providers:
             return ADMIN_AUTH_NOT_CONFIGURED
 
-        if not isinstance(self.auth, GoogleOAuthAdminAuthenticationProvider):
+        auth = self.auth_provider(GoogleOAuthAdminAuthenticationProvider.NAME)
+        if not auth:
             return ADMIN_AUTH_MECHANISM_NOT_CONFIGURED
 
-        admin_details, redirect_url = self.auth.callback(flask.request.args)
+        admin_details, redirect_url = auth.callback(flask.request.args)
         if isinstance(admin_details, ProblemDetail):
             return self.error_response(admin_details)
 
-        if not self.staff_email(admin_details['email']):
+        if not auth.staff_email(self._db, admin_details['email']):
             return self.error_response(INVALID_ADMIN_CREDENTIALS)
         else:
             admin = self.authenticated_admin(admin_details)
             return redirect(redirect_url, Response=Response)
 
-
-    def staff_email(self, email):
-        """Checks the domain of an email address against the admin-authorized
-        domain"""
-        if not self.auth or not self.auth.domains:
-            return False
-
-        staff_domains = self.auth.domains
-        domain = email[email.index('@')+1:]
-        return domain.lower() in [staff_domain.lower() for staff_domain in staff_domains]
-
     def password_sign_in(self):
-        if not self.auth:
+        if not self.auth_providers:
             return ADMIN_AUTH_NOT_CONFIGURED
 
-        if not isinstance(self.auth, PasswordAdminAuthenticationProvider):
+        auth = self.auth_provider(PasswordAdminAuthenticationProvider.NAME)
+        if not auth:
             return ADMIN_AUTH_MECHANISM_NOT_CONFIGURED
 
-        if flask.request.method == 'GET':
-            html = self.PASSWORD_SIGN_IN_TEMPLATE % dict(
-                password_sign_in_url=self.url_for("password_auth"),
-                redirect=flask.request.args.get("redirect"),
-            )
-            headers = dict()
-            headers['Content-Type'] = "text/html"
-            return Response(html, 200, headers)
-
-        admin_details, redirect_url = self.auth.sign_in(self._db, flask.request.form)
+        admin_details, redirect_url = auth.sign_in(self._db, flask.request.form)
         if isinstance(admin_details, ProblemDetail):
             return self.error_response(INVALID_ADMIN_CREDENTIALS)
 
         admin = self.authenticated_admin(admin_details)
         return redirect(redirect_url, Response=Response)
-
 
     def error_response(self, problem_detail):
         """Returns a problem detail as an HTML response"""

--- a/api/admin/password_admin_authentication_provider.py
+++ b/api/admin/password_admin_authentication_provider.py
@@ -11,8 +11,19 @@ from problem_details import *
 
 class PasswordAdminAuthenticationProvider(AdminAuthenticationProvider):
 
-    def auth_uri(self, redirect):
-        return url_for('password_auth') + "?redirect=%s" % redirect
+    NAME = "Password Auth"
+
+    TEMPLATE = """
+<form action="%(password_sign_in_url)s" method="post">
+<input type="hidden" name="redirect" value="%(redirect)s"/>
+<label>Email <input type="text" name="email" /></label>
+<label>Password <input type="password" name="password" /></label>
+<button type="submit">Sign In</button>
+</form>"""
+
+    def sign_in_template(self, redirect):
+        password_sign_in_url = url_for("password_auth")
+        return self.TEMPLATE % dict(redirect=redirect, password_sign_in_url=password_sign_in_url)
 
     def sign_in(self, _db, request={}):
         email = request.get("email")
@@ -24,6 +35,7 @@ class PasswordAdminAuthenticationProvider(AdminAuthenticationProvider):
             if match:
                 return dict(
                     email=email,
+                    type=self.NAME,
                 ), redirect_url
 
         return INVALID_ADMIN_CREDENTIALS, None

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -36,6 +36,9 @@ from datetime import timedelta
 # the admin will have to log in again.
 app.permanent_session_lifetime = timedelta(hours=9)
 
+app.admin_email = None
+app.admin_auth_type = None
+
 @app.before_first_request
 def setup_admin(_db=None):
     if getattr(app, 'manager', None) is not None:
@@ -52,17 +55,18 @@ def setup_admin(_db=None):
     # the flask session object, but we can create a new
     # session object in order to extract the admin's email
     # and store it for later.
-    app.admin_email = None
     if not flask.session and flask.request:
         temp_session = app.open_session(flask.request)
         email = temp_session.get("admin_email")
-        if email:
+        type = temp_session.get("auth_type")
+        if email and type:
             app.admin_email = email
+            app.admin_auth_type = type
 
 def allows_admin_auth_setup(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        setting_up = (app.manager.admin_sign_in_controller.auth == None)
+        setting_up = (app.manager.admin_sign_in_controller.auth_providers == [])
         return f(*args, setting_up=setting_up, **kwargs)
     return decorated
 
@@ -82,7 +86,7 @@ def requires_admin(f):
             setting_up = False
 
         if not setting_up:
-            admin = app.manager.admin_sign_in_controller.authenticated_admin_from_request(app.admin_email)
+            admin = app.manager.admin_sign_in_controller.authenticated_admin_from_request(app.admin_email, app.admin_auth_type)
             if isinstance(admin, ProblemDetail):
                 return app.manager.admin_sign_in_controller.error_response(admin)
             elif isinstance(admin, Response):
@@ -122,7 +126,7 @@ def returns_json_or_response_or_problem_detail(f):
 def google_auth_callback():
     return app.manager.admin_sign_in_controller.redirect_after_google_sign_in()
 
-@app.route("/admin/sign_in_with_password", methods=["GET", "POST"])
+@app.route("/admin/sign_in_with_password", methods=["POST"])
 @returns_problem_detail
 def password_auth():
     return app.manager.admin_sign_in_controller.password_sign_in()

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1006,13 +1006,13 @@ class TestSignInController(AdminControllerTest):
             })
         )
 
-    def test_auth_providers(self):
+    def test_admin_auth_providers(self):
         with self.app.test_request_context('/admin'):
             ctrl = self.manager.admin_sign_in_controller
 
             # An admin exists, but they have no password and there's
             # no auth service set up.
-            eq_([], ctrl.auth_providers)
+            eq_([], ctrl.admin_auth_providers)
 
             # The auth service exists.
             create(
@@ -1020,29 +1020,29 @@ class TestSignInController(AdminControllerTest):
                 protocol=ExternalIntegration.GOOGLE_OAUTH,
                 goal=ExternalIntegration.ADMIN_AUTH_GOAL
             )
-            eq_(1, len(ctrl.auth_providers))
-            eq_(GoogleOAuthAdminAuthenticationProvider.NAME, ctrl.auth_providers[0].NAME)
+            eq_(1, len(ctrl.admin_auth_providers))
+            eq_(GoogleOAuthAdminAuthenticationProvider.NAME, ctrl.admin_auth_providers[0].NAME)
 
             # Here's another admin with a password.
             pw_admin, ignore = create(self._db, Admin, email="pw@nypl.org")
             pw_admin.password = "password"
-            eq_(2, len(ctrl.auth_providers))
+            eq_(2, len(ctrl.admin_auth_providers))
             eq_(set([GoogleOAuthAdminAuthenticationProvider.NAME, PasswordAdminAuthenticationProvider.NAME]),
-                set([provider.NAME for provider in ctrl.auth_providers]))
+                set([provider.NAME for provider in ctrl.admin_auth_providers]))
 
             # Only an admin with a password.
             self._db.delete(self.admin)
-            eq_(2, len(ctrl.auth_providers))
+            eq_(2, len(ctrl.admin_auth_providers))
             eq_(set([GoogleOAuthAdminAuthenticationProvider.NAME, PasswordAdminAuthenticationProvider.NAME]),
-                set([provider.NAME for provider in ctrl.auth_providers]))
+                set([provider.NAME for provider in ctrl.admin_auth_providers]))
 
             # No admins. Someone new could still log in with google if domains are
             # configured.
             self._db.delete(pw_admin)
-            eq_(1, len(ctrl.auth_providers))
-            eq_(GoogleOAuthAdminAuthenticationProvider.NAME, ctrl.auth_providers[0].NAME)
+            eq_(1, len(ctrl.admin_auth_providers))
+            eq_(GoogleOAuthAdminAuthenticationProvider.NAME, ctrl.admin_auth_providers[0].NAME)
 
-    def test_auth_provider(self):
+    def test_admin_auth_provider(self):
         with self.app.test_request_context('/admin'):
             ctrl = self.manager.admin_sign_in_controller
 
@@ -1053,11 +1053,11 @@ class TestSignInController(AdminControllerTest):
             )
 
             # We can find a google auth provider.
-            auth = ctrl.auth_provider(GoogleOAuthAdminAuthenticationProvider.NAME)
+            auth = ctrl.admin_auth_provider(GoogleOAuthAdminAuthenticationProvider.NAME)
             assert isinstance(auth, GoogleOAuthAdminAuthenticationProvider)
 
             # But not a password auth provider, since no admin has a password.
-            auth = ctrl.auth_provider(PasswordAdminAuthenticationProvider.NAME)
+            auth = ctrl.admin_auth_provider(PasswordAdminAuthenticationProvider.NAME)
             eq_(None, auth)
 
             # Here's another admin with a password.
@@ -1065,9 +1065,9 @@ class TestSignInController(AdminControllerTest):
             pw_admin.password = "password"
 
             # Now we can find both auth providers.
-            auth = ctrl.auth_provider(GoogleOAuthAdminAuthenticationProvider.NAME)
+            auth = ctrl.admin_auth_provider(GoogleOAuthAdminAuthenticationProvider.NAME)
             assert isinstance(auth, GoogleOAuthAdminAuthenticationProvider)
-            auth = ctrl.auth_provider(PasswordAdminAuthenticationProvider.NAME)
+            auth = ctrl.admin_auth_provider(PasswordAdminAuthenticationProvider.NAME)
             assert isinstance(auth, PasswordAdminAuthenticationProvider)
 
     def test_authenticated_admin_from_request(self):

--- a/tests/admin/test_google_oauth_admin_authentication_provider.py
+++ b/tests/admin/test_google_oauth_admin_authentication_provider.py
@@ -14,6 +14,7 @@ from api.admin.google_oauth_admin_authentication_provider import (
     DummyGoogleClient,
 )
 from core.model import (
+    Admin,
     ExternalIntegration,
     create,
 )
@@ -41,6 +42,7 @@ class TestGoogleOAuthAdminAuthenticationProvider(DatabaseTest):
         eq_('example@nypl.org', success['email'])
         default_credentials = json.dumps({"id_token": {"email": "example@nypl.org", "hd": "nypl.org"}})
         eq_(default_credentials, success['credentials'])
+        eq_(GoogleOAuthAdminAuthenticationProvider.NAME, success["type"])
 
         # Returns a problem detail when the oauth client library
         # raises an exception.
@@ -66,3 +68,34 @@ class TestGoogleOAuthAdminAuthenticationProvider(DatabaseTest):
         google = GoogleOAuthAdminAuthenticationProvider(auth_integration, "", test_mode=True)
 
         eq_(["nypl.org"], google.domains)
+
+    def test_staff_domains(self):
+        super(TestGoogleOAuthAdminAuthenticationProvider, self).setup()
+        auth_integration, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=ExternalIntegration.GOOGLE_OAUTH,
+            goal=ExternalIntegration.ADMIN_AUTH_GOAL
+        )
+
+        nypl_admin = create(self._db, Admin, email="admin@nypl.org")
+        bpl_admin = create(self._db, Admin, email="admin@bklynlibrary.org")
+
+        # If no domains are set, the admin must already exist in the db
+        # to be considered library staff.
+        google = GoogleOAuthAdminAuthenticationProvider(auth_integration, "", test_mode=True)
+
+        eq_(True, google.staff_email(self._db, "admin@nypl.org"))
+        eq_(True, google.staff_email(self._db, "admin@bklynlibrary.org"))
+        eq_(False, google.staff_email(self._db, "someone@nypl.org"))
+
+        # If domains are set, the admin's domain must match one of the domains.
+        auth_integration.set_setting("domains", json.dumps(["nypl.org"]))
+        eq_(True, google.staff_email(self._db, "admin@nypl.org"))
+        eq_(False, google.staff_email(self._db, "admin@bklynlibrary.org"))
+        eq_(True, google.staff_email(self._db, "someone@nypl.org"))
+
+        auth_integration.set_setting("domains", json.dumps(["nypl.org", "bklynlibrary.org"]))
+        eq_(True, google.staff_email(self._db, "admin@nypl.org"))
+        eq_(True, google.staff_email(self._db, "admin@bklynlibrary.org"))
+        eq_(True, google.staff_email(self._db, "someone@nypl.org"))
+

--- a/tests/admin/test_google_oauth_admin_authentication_provider.py
+++ b/tests/admin/test_google_oauth_admin_authentication_provider.py
@@ -13,6 +13,7 @@ from api.admin.google_oauth_admin_authentication_provider import (
     GoogleOAuthAdminAuthenticationProvider,
     DummyGoogleClient,
 )
+from api.admin.problem_details import INVALID_ADMIN_CREDENTIALS
 from core.model import (
     Admin,
     ExternalIntegration,
@@ -29,20 +30,27 @@ class TestGoogleOAuthAdminAuthenticationProvider(DatabaseTest):
             goal=ExternalIntegration.ADMIN_AUTH_GOAL
         )
         self.google = GoogleOAuthAdminAuthenticationProvider(auth_integration, "", test_mode=True)
+        auth_integration.set_setting("domains", json.dumps(["nypl.org"]))
 
         # Returns a problem detail when Google returns an error.
-        error_response, redirect = self.google.callback({'error' : 'access_denied'})
+        error_response, redirect = self.google.callback(self._db, {'error' : 'access_denied'})
         eq_(True, isinstance(error_response, ProblemDetail))
         eq_(400, error_response.status_code)
         eq_(True, error_response.detail.endswith('access_denied'))
         eq_(None, redirect)
 
         # Successful case creates a dict of admin details
-        success, redirect = self.google.callback({'code' : 'abc'})
+        success, redirect = self.google.callback(self._db, {'code' : 'abc'})
         eq_('example@nypl.org', success['email'])
         default_credentials = json.dumps({"id_token": {"email": "example@nypl.org", "hd": "nypl.org"}})
         eq_(default_credentials, success['credentials'])
         eq_(GoogleOAuthAdminAuthenticationProvider.NAME, success["type"])
+
+        # If domains are set, the admin's domain must match one of the domains.
+        auth_integration.set_setting("domains", json.dumps(["otherlibrary.org"]))
+        failure, ignore = self.google.callback(self._db, {'code' : 'abc'})
+        eq_(INVALID_ADMIN_CREDENTIALS, failure)
+        auth_integration.set_setting("domains", json.dumps(["nypl.org"]))
 
         # Returns a problem detail when the oauth client library
         # raises an exception.
@@ -50,7 +58,7 @@ class TestGoogleOAuthAdminAuthenticationProvider(DatabaseTest):
             def step2_exchange(self, auth_code):
                 raise GoogleClient.FlowExchangeError("mock error")
         self.google.dummy_client = ExceptionRaisingClient()
-        error_response, redirect = self.google.callback({'code' : 'abc'})
+        error_response, redirect = self.google.callback(self._db, {'code' : 'abc'})
         eq_(True, isinstance(error_response, ProblemDetail))
         eq_(400, error_response.status_code)
         eq_(True, error_response.detail.endswith('mock error'))
@@ -69,7 +77,7 @@ class TestGoogleOAuthAdminAuthenticationProvider(DatabaseTest):
 
         eq_(["nypl.org"], google.domains)
 
-    def test_staff_domains(self):
+    def test_staff_email(self):
         super(TestGoogleOAuthAdminAuthenticationProvider, self).setup()
         auth_integration, ignore = create(
             self._db, ExternalIntegration,

--- a/tests/admin/test_password_admin_authentication_provider.py
+++ b/tests/admin/test_password_admin_authentication_provider.py
@@ -28,10 +28,12 @@ class TestPasswordAdminAuthenticationProvider(DatabaseTest):
         # Both admins with passwords can sign in.
         admin_details, redirect = password_auth.sign_in(self._db, dict(email="admin1@nypl.org", password="pass1", redirect="foo"))
         eq_("admin1@nypl.org", admin_details.get("email"))
+        eq_(PasswordAdminAuthenticationProvider.NAME, admin_details.get("type"))
         eq_("foo", redirect)
 
         admin_details, redirect = password_auth.sign_in(self._db, dict(email="admin2@nypl.org", password="pass2", redirect="foo"))
         eq_("admin2@nypl.org", admin_details.get("email"))
+        eq_(PasswordAdminAuthenticationProvider.NAME, admin_details.get("type"))
         eq_("foo", redirect)
 
         # An admin can't sign in with an incorrect password..


### PR DESCRIPTION
This branch changes the admin authentication code so that both passwords and Google OAuth can be used on the same circ manager, and admins logging in with google can be managed individually instead of by domain.

Visiting an admin route will show a sign in page with a link to sign in with google, a form for logging in with a password, or both, depending on configuration.

It's no longer required to whitelist domains for logging in with google. If you don't want to whitelist an entire domain, you can add individual admins instead, and they will be able to choose whether to log in with google or their password if their email is a google account. Any admins that already existed will still be able to log in with google even if they don't have a password.
