### PR TITLE
Fixed links for open access books in a shared ODL collection

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1558,6 +1558,10 @@ class SharedCollectionController(CirculationManagerController):
     support it."""
     def info(self, collection_name):
         """Return an OPDS2 catalog-like document with a link to register."""
+        collection = get_one(self._db, Collection, name=collection_name)
+        if not collection:
+            return NO_SUCH_COLLECTION
+
         register_url = self.url_for('shared_collection_register',
                                     collection_name=collection_name)
         register_link = dict(href=register_url, rel='register')

--- a/migration/20180427-delete-borrow-links-for-open-access-books-from-shared-odl-collection.py
+++ b/migration/20180427-delete-borrow-links-for-open-access-books-from-shared-odl-collection.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""Due to a bug in version 2.2.0, borrow links for open-access books in a
+shared ODL collection were imported. This migration delete the links and
+their associated resources and representations."""
+import os
+import sys
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from sqlalchemy.orm import aliased
+from sqlalchemy import and_
+
+from core.model import (
+    Collection,
+    Hyperlink,
+    LicensePool,
+    Representation,
+    Resource,
+    production_session,
+)
+from api.odl import SharedODLAPI
+
+try:
+    _db = production_session()
+    for collection in Collection.by_protocol(_db, SharedODLAPI.NAME):
+        borrow_link = aliased(Hyperlink)
+        open_link = aliased(Hyperlink)
+
+        pools = _db.query(
+            LicensePool
+        ).join(
+            borrow_link,
+            LicensePool.identifier_id==borrow_link.identifier_id,
+        ).join(
+            open_link,
+            LicensePool.identifier_id==open_link.identifier_id,
+        ).join(
+            Resource,
+            borrow_link.resource_id==Resource.id,
+        ).join(
+            Representation,
+            Resource.representation_id==Representation.id,
+        ).filter(
+            and_(
+                LicensePool.collection_id==collection.id,
+                borrow_link.rel==Hyperlink.BORROW,
+                open_link.rel==Hyperlink.OPEN_ACCESS_DOWNLOAD,
+                Representation.media_type=='application/atom+xml;type=entry;profile=opds-catalog',
+            )
+        )
+
+        print "Deleting hyperlinks for %i license pools" % pools.count()
+        for pool in pools:
+            for link in pool.identifier.links:
+                if link.rel == Hyperlink.BORROW:
+                    resource = link.resource
+                    representation = resource.representation
+
+                    _db.delete(representation)
+                    _db.delete(link)
+                    _db.delete(resource)
+
+finally:
+    _db.commit()
+    _db.close()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2501,24 +2501,33 @@ class TestFeedController(CirculationControllerTest):
                 eq_(1, len(links))
                 eq_(Hyperlink.OPEN_ACCESS_DOWNLOAD, links[0].get("rel"))
 
-            # Shared collection with one book.
+            # Shared collection with two books.
             collection = MockODLWithConsolidatedCopiesAPI.mock_collection(self._db)
             self.english_2.license_pools[0].collection = collection
+            work = self._work(title="A", with_license_pool=True, collection=collection)
             self._db.flush()
             SessionManager.refresh_materialized_views(self._db)
             response = self.manager.opds_feeds.crawlable_collection_feed(
                 collection.name
             )
             feed = feedparser.parse(response.data)
-            eq_([self.english_2.title], [x['title'] for x in feed['entries']])
-            [entry] = feed.get("entries")
-            links = entry.get("links")
+            [entry1, entry2] = sorted(feed['entries'], key=lambda x: x['title'])
+            eq_(work.title, entry1["title"])
+            # The first title isn't open access, so it has a borrow link but no open access link.
+            links = entry1.get("links")
+            eq_(0, len([link for link in links if link.get("rel") == Hyperlink.OPEN_ACCESS_DOWNLOAD]))
             [borrow_link] = [link for link in links if link.get("rel") == Hyperlink.BORROW]
-            [open_access_link] = [link for link in links if link.get("rel") == Hyperlink.OPEN_ACCESS_DOWNLOAD]
-            pool = self.english_2.license_pools[0]
+            pool = work.license_pools[0]
             expected = "/collections/%s/%s/%s/borrow" % (urllib.quote(collection.name), urllib.quote(pool.identifier.type), urllib.quote(pool.identifier.identifier))
             assert expected in borrow_link.get("href")
-            eq_(self.english_2.license_pools[0].identifier.links[0].resource.url, open_access_link.get("href"))
+
+            eq_(self.english_2.title, entry2["title"])
+            links = entry2.get("links")
+            # The second title is open access, so it has an open access link but no borrow link.
+            eq_(0, len([link for link in links if link.get("rel") == Hyperlink.BORROW]))
+            [open_access_link] = [link for link in links if link.get("rel") == Hyperlink.OPEN_ACCESS_DOWNLOAD]
+            pool = self.english_2.license_pools[0]
+            eq_(pool.identifier.links[0].resource.url, open_access_link.get("href"))
 
         # The collection must exist.
         with self.app.test_request_context("/?size=1"):
@@ -2946,7 +2955,10 @@ class TestSharedCollectionController(ControllerTest):
             yield c
 
     def test_info(self):
-        with self.app.test_request_context("/", method="POST"):
+        with self.app.test_request_context("/"):
+            collection = self.manager.shared_collection_controller.info(self._str)
+            eq_(NO_SUCH_COLLECTION, collection)
+
             response = self.manager.shared_collection_controller.info(self.collection.name)
             eq_(200, response.status_code)
             assert response.headers.get("Content-Type").startswith("application/opds+json")

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -23,6 +23,7 @@ from core.model import (
     DataSource,
     DeliveryMechanism,
     ExternalIntegration,
+    Hyperlink,
     Library,
     PresentationCalculationPolicy,
     Representation,
@@ -1042,19 +1043,19 @@ class TestLibraryAnnotator(VendorIDTest):
         assert_raises(
             UnfulfillableWork,
             annotator.borrow_link,
-            identifier, None, [])
+            pool, None, [])
 
         assert_raises(
             UnfulfillableWork,
             annotator.borrow_link,
-            identifier, None, [kindle_mechanism])
+            pool, None, [kindle_mechanism])
 
         # If there's a fulfillable mechanism, everything's fine.
-        link = annotator.borrow_link(identifier, None, [epub_mechanism])
+        link = annotator.borrow_link(pool, None, [epub_mechanism])
         assert link != None
 
         link = annotator.borrow_link(
-            identifier, None, [epub_mechanism, kindle_mechanism]
+            pool, None, [epub_mechanism, kindle_mechanism]
         )
         assert link != None
 
@@ -1212,7 +1213,7 @@ class TestSharedCollectionAnnotator(DatabaseTest):
         given feed or entry, as well as its link 'type' value and parts
         of its 'href' value.
         """
-        def get_link_by_rel(rel):
+        def get_link_by_rel(rel, should_exist=True):
             try:
                 [link] = [x for x in entry['links'] if x['rel']==rel]
             except ValueError as e:
@@ -1250,8 +1251,15 @@ class TestSharedCollectionAnnotator(DatabaseTest):
         feed = self.get_parsed_feed([open_access_work, licensed_work])
         [open_access_entry, licensed_entry] = feed.entries
 
-        self.assert_link_on_entry(open_access_entry, rels=[OPDSFeed.BORROW_REL])
+        self.assert_link_on_entry(open_access_entry, rels=[Hyperlink.OPEN_ACCESS_DOWNLOAD])
         self.assert_link_on_entry(licensed_entry, rels=[OPDSFeed.BORROW_REL])
+
+        # The open access entry shouldn't have a borrow link, and the licensed entry
+        # shouldn't have an open access link.
+        links = [x for x in open_access_entry['links'] if x['rel']==OPDSFeed.BORROW_REL]
+        eq_(0, len(links))
+        links = [x for x in licensed_entry['links'] if x['rel']==Hyperlink.OPEN_ACCESS_DOWNLOAD]
+        eq_(0, len(links))
 
     def test_borrow_link_raises_unfulfillable_work(self):
         edition, pool = self._edition(with_license_pool=True)
@@ -1271,19 +1279,19 @@ class TestSharedCollectionAnnotator(DatabaseTest):
         assert_raises(
             UnfulfillableWork,
             annotator.borrow_link,
-            identifier, None, [])
+            pool, None, [])
 
         assert_raises(
             UnfulfillableWork,
             annotator.borrow_link,
-            identifier, None, [kindle_mechanism])
+            pool, None, [kindle_mechanism])
 
         # If there's a fulfillable mechanism, everything's fine.
-        link = annotator.borrow_link(identifier, None, [epub_mechanism])
+        link = annotator.borrow_link(pool, None, [epub_mechanism])
         assert link != None
 
         link = annotator.borrow_link(
-            identifier, None, [epub_mechanism, kindle_mechanism]
+            pool, None, [epub_mechanism, kindle_mechanism]
         )
         assert link != None
 


### PR DESCRIPTION
This branch fixes a bug reported by @datalogics-dans where borrow links from a shared ODL collection were being imported into other circ managers using the collection and displayed as open access links. I changed the shared collection feed to leave out borrow links for open access books since there's no need for them. I also added a migration to remove the links that were already imported and fixed #934.