### PR TITLE
Add error log on 401 response from OverDrive

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -131,6 +131,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI):
         if response.status_code == 401:
             if exception_on_401:
                 # This is our second try. Give up.
+                self.log.error("Exception on %s: %s", response.status_code, response.content)
                 raise Exception("Something's wrong with the patron OAuth Bearer Token!")
             else:
                 # Refresh the token and try again.


### PR DESCRIPTION
OverDrive returns a 401 code, but it is unclear what is exactly returned from OverDrive. There is evidently a problem with the OAuth Bearer Token. This PR aims to help diagnose such problems.

Ideally, this should not reveal information that is too sensitive, which may include patron information.