### PR TITLE
Disabled strict slashes for admin routes.

### DIFF
--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -579,8 +579,8 @@ def admin_sign_in_again():
         return redirect(app.manager.url_for('admin_sign_in', redirect=redirect_url))
     return flask.render_template_string(sign_in_again_template)
 
-@app.route('/admin/web')
-@app.route('/admin/web/')
+@app.route('/admin/web', strict_slashes=False)
+@app.route('/admin/web/', strict_slashes=False)
 @app.route('/admin/web/collection/<path:collection>/book/<path:book>')
 @app.route('/admin/web/collection/<path:collection>')
 @app.route('/admin/web/book/<path:book>')
@@ -588,8 +588,8 @@ def admin_sign_in_again():
 def admin_view(collection=None, book=None, etc=None, **kwargs):
     return app.manager.admin_view_controller(collection, book, path=etc)
 
-@app.route('/admin')
-@app.route('/admin/')
+@app.route('/admin', strict_slashes=False)
+@app.route('/admin/', strict_slashes=False)
 def admin_base(**kwargs):
     return redirect(app.manager.url_for('admin_view'))
 


### PR DESCRIPTION
This fixes #946 which turned out to be a real problem.

At first I thought removing the route without the slash would make flask redirect to the route with the slash, but it didn't fix the error.