### PR TITLE
In some circumstances, a title can be fulfilled when there is no underlying loan

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -509,16 +509,22 @@ class LibraryAuthenticator(object):
 
     @property
     def identifies_individuals(self):
-        """Does this library identify individual patrons?
+        """Does this library require that individual patrons be identified?
 
         Most libraries require authentication as an individual. Some
         libraries don't identify patrons at all; others may have a way
         of identifying the patron population without identifying
         individuals, such as an IP gate.
+
+        If some of a library's authentication mechanisms identify individuals,
+        and others do not, the library does not identify individuals.
         """
         if not self.supports_patron_authentication:
             return False
-        return any([x for x in self.providers if x.IDENTIFIES_INDIVIDUALS])
+        matches = list(self.providers)
+        return matches and all(
+            [x.IDENTIFIES_INDIVIDUALS for x in matches]
+        )
 
     @property
     def library(self):

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -508,6 +508,19 @@ class LibraryAuthenticator(object):
         return False
 
     @property
+    def identifies_individuals(self):
+        """Does this library identify individual patrons?
+
+        Most libraries require authentication as an individual. Some
+        libraries don't identify patrons at all; others may have a way
+        of identifying the patron population without identifying
+        individuals, such as an IP gate.
+        """
+        if not self.supports_patron_authentication:
+            return False
+        return any([x for x in self.providers if x.IDENTIFIES_INDIVIDUALS])
+
+    @property
     def library(self):
         return Library.by_id(self._db, self.library_id)
         
@@ -858,6 +871,11 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
     # Authentication for OPDS document to distinguish between
     # different types of authentication.
     FLOW_TYPE = None
+
+    # If an AuthenticationProvider authenticates patrons without identifying
+    # then as specific individuals (the way a geographic gate does),
+    # it should override this value and set it to False.
+    IDENTIFIES_INDIVIDUALS = True
 
     # Each authentication mechanism may have a list of SETTINGS that
     # must be configured for that mechanism, and may have a list of

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -623,6 +623,9 @@ class CirculationAPI(object):
         """Can this CirculationAPI deliver a copy of the given book
         to the given patron, even though the patron has no active loan?
 
+        In general this is not possible, but there are some
+        exceptions.
+
         :param patron: A Patron. This is probably None, indicating
         that someone is trying to fulfill a book without identifying
         themselves.
@@ -631,8 +634,8 @@ class CirculationAPI(object):
 
         :param delivery_mechanism: The LicensePoolDeliveryMechanism
         representing the requested format.
+
         """
-        # In general, this is not possible.
         return False
     
     def fulfill(self, patron, pin, licensepool, delivery_mechanism, sync_on_failure=True):

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -617,24 +617,20 @@ class CirculationAPI(object):
                 CirculationEvent.CM_CHECKOUT,
             )
 
-    def can_fulfill_without_loan(
-            self, patron, licensepool, delivery_mechanism
-    ):
-        """Can this CirculationAPI deliver a copy of the given book
-        to the given patron, even though the patron has no active loan?
+    def can_fulfill_without_loan(self, patron, lpdm):
+        """Can this CirculationAPI deliver the given book in the given format
+        to the given patron, even though the patron has no active
+        loan for that book?
 
         In general this is not possible, but there are some
-        exceptions.
+        exceptions, managed in subclasses.
 
         :param patron: A Patron. This is probably None, indicating
         that someone is trying to fulfill a book without identifying
         themselves.
 
-        :param licensepool: The LicensePool for the requested book.
-
         :param delivery_mechanism: The LicensePoolDeliveryMechanism
-        representing the requested format.
-
+        representing a format for a specific title.
         """
         return False
     

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -640,7 +640,6 @@ class CirculationAPI(object):
         return api.can_fulfill_without_loan(patron, pool, lpdm)
     
     def fulfill(self, patron, pin, licensepool, delivery_mechanism, sync_on_failure=True):
-
         """Fulfil a book that a patron has previously checked out.
 
         :param delivery_mechanism: A LicensePoolDeliveryMechanism

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -616,8 +616,25 @@ class CirculationAPI(object):
                 patron.library, licensepool,
                 CirculationEvent.CM_CHECKOUT,
             )
+
+    def can_fulfill_without_loan(
+            self, patron, licensepool, delivery_mechanism
+    ):
+        """Can this CirculationAPI deliver a copy of the given book
+        to the given patron, even though the patron has no active loan?
+
+        :param patron: A Patron. This is probably None, indicating
+        that someone is trying to fulfill a book without identifying
+        themselves.
+
+        :param licensepool: The LicensePool for the requested book.
+
+        :param delivery_mechanism: The LicensePoolDeliveryMechanism
+        representing the requested format.
+        """
     
     def fulfill(self, patron, pin, licensepool, delivery_mechanism, sync_on_failure=True):
+
         """Fulfil a book that a patron has previously checked out.
 
         :param delivery_mechanism: A LicensePoolDeliveryMechanism

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -632,6 +632,8 @@ class CirculationAPI(object):
         :param delivery_mechanism: The LicensePoolDeliveryMechanism
         representing the requested format.
         """
+        # In general, this is not possible.
+        return False
     
     def fulfill(self, patron, pin, licensepool, delivery_mechanism, sync_on_failure=True):
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -809,6 +809,8 @@ class OPDSFeedController(CirculationManagerController):
 class LoanController(CirculationManagerController):
 
     def get_patron_circ_objects(self, object_class, patron, license_pools):
+        if not patron:
+            return []
         pool_ids = [pool.id for pool in license_pools]
 
         return self._db.query(object_class).filter(
@@ -1020,7 +1022,9 @@ class LoanController(CirculationManagerController):
         """
         do_get = do_get or Representation.simple_http_get
 
-        patron = flask.request.patron
+        # Unlike most controller methods, this one does not require
+        # that the patron be authenticated.
+        patron = getattr(flask.request, 'patron', None)
         library = flask.request.library
         header = self.authorization_header()
         credential = self.manager.auth.get_credential_from_header(header)

--- a/api/controller.py
+++ b/api/controller.py
@@ -69,6 +69,7 @@ from core.model import (
     LicensePool,
     Loan,
     LicensePoolDeliveryMechanism,
+    Patron,
     PatronProfileStorage,
     Representation,
     Session,
@@ -1022,9 +1023,24 @@ class LoanController(CirculationManagerController):
         """
         do_get = do_get or Representation.simple_http_get
 
-        # Unlike most controller methods, this one does not require
-        # that the patron be authenticated.
-        patron = getattr(flask.request, 'patron', None)
+        # Unlike most controller methods, this one has different
+        # behavior whether or not the patron is authenticated. This is
+        # why we're about to do something we don't usually do--call
+        # authenticated_patron_from_request from within a controller
+        # method.
+        authentication_response = self.authenticated_patron_from_request()
+        if isinstance(authentication_response, Patron):
+            # The patron is authenticated.
+            patron = authentication_response
+        else:
+            # The patron is not authenticated, either due to bad credentials
+            # (in which case authentication_response is a Response)
+            # or due to an integration error with the auth provider (in
+            # which case it is a ProblemDetail).
+            #
+            # There's still a chance this request can succeed, but if not,
+            # we'll be sending out authentication_response.
+            patron = None
         library = flask.request.library
         header = self.authorization_header()
         credential = self.manager.auth.get_credential_from_header(header)
@@ -1048,12 +1064,23 @@ class LoanController(CirculationManagerController):
                 return mechanism
 
         if (not loan or not loan_license_pool) and not (
-                self.can_fulfill_without_loan(
-                    library, patron, requested_license_pool, mechanism)
-        ):
-            return NO_ACTIVE_LOAN.detailed(
-                _("You have no active loan for this title.")
+            self.can_fulfill_without_loan(
+                library, patron, requested_license_pool, mechanism
             )
+        ):
+            if patron:
+                # Since a patron was identified, the problem is they have
+                # no active loan.
+                return NO_ACTIVE_LOAN.detailed(
+                    _("You have no active loan for this title.")
+                )
+            else:
+                # Since no patron was identified, the problem is
+                # whatever problem was revealed by the earlier
+                # authenticated_patron_from_request() call -- either the
+                # patron didn't authenticate or there's a problem
+                # integrating with the auth provider.
+                return authentication_response
 
         if not mechanism:
             # See if the loan already has a mechanism set. We can use that.
@@ -1136,7 +1163,7 @@ class LoanController(CirculationManagerController):
         :param lpdm: A LicensePoolDeliveryMechanism.
         """
         authenticator = self.manager.auth.library_authenticators.get(library.short_name)
-        if authenticator.identifies_individuals:
+        if authenticator and authenticator.identifies_individuals:
             # This library identifies individual patrons, so there is
             # no reason to fulfill books without a loan. Even if the
             # books are free and the 'loans' are nominal, having a

--- a/api/controller.py
+++ b/api/controller.py
@@ -1130,7 +1130,7 @@ class LoanController(CirculationManagerController):
         # If library's authentication mechanism requires that
         # individual patrons identify themselves, then there is no way
         # to fulfill books without a loan.
-        authenticator = self.auth.library_authenticators.get(library.short_name)
+        authenticator = self.manager.auth.library_authenticators.get(library.short_name)
         if self.manager.auth is not None:
             # TODO: in the future there will be authentication
             # mechanisms, such as geo-gates, that don't identify

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -128,15 +128,24 @@ class OPDSForDistributorsAPI(BaseCirculationAPI):
                                  refresher_method=refresh,
                                  )
 
-    def can_fulfill_without_loan(
-            self, patron, licensepool, delivery_mechanism
-    ):
-        """Since OPDS For Distributors allows loans of indefinite length and
-        has no DRM, any book can be fulfilled without identifying the
-        patron, assuming the library's policies support it.
+    def can_fulfill_without_loan(self, patron, lpdm):
+        """Since OPDS For Distributors delivers books to the library rather
+        than creating loans, any book can be fulfilled without
+        identifying the patron, assuming the library's policies
+        allow it.
+
+        Just to be safe, though, we require that the
+        DeliveryMechanism's drm_scheme be either 'no DRM' or 'bearer
+        token', since other DRM schemes require identifying a patron.
         """
-        return delivery_mechanism delivery_mechanism.delivery_mechanism.drm_scheme==
-        return True
+        if not lpdm or not lpdm.delivery_mechanism:
+            return False
+        drm_scheme = lpdm.delivery_mechanism.drm_scheme
+        if drm_scheme in (
+            DeliveryMechanism.NO_DRM, DeliveryMechanism.BEARER_TOKEN
+        ):
+            return True
+        return False
 
     def checkin(self, patron, pin, licensepool):
         # Delete the patron's loan for this licensepool.

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -128,7 +128,7 @@ class OPDSForDistributorsAPI(BaseCirculationAPI):
                                  refresher_method=refresh,
                                  )
 
-    def can_fulfill_without_loan(self, patron, lpdm):
+    def can_fulfill_without_loan(self, patron, licensepool, lpdm):
         """Since OPDS For Distributors delivers books to the library rather
         than creating loans, any book can be fulfilled without
         identifying the patron, assuming the library's policies
@@ -186,7 +186,7 @@ class OPDSForDistributorsAPI(BaseCirculationAPI):
 
                 # Obtain a Credential with the information from our
                 # bearer token.
-                _db = Session.object_session(patron)
+                _db = Session.object_session(licensepool)
                 credential = self._get_token(_db)
 
                 # Build a application/vnd.librarysimplified.bearer-token

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -128,6 +128,16 @@ class OPDSForDistributorsAPI(BaseCirculationAPI):
                                  refresher_method=refresh,
                                  )
 
+    def can_fulfill_without_loan(
+            self, patron, licensepool, delivery_mechanism
+    ):
+        """Since OPDS For Distributors allows loans of indefinite length and
+        has no DRM, any book can be fulfilled without identifying the
+        patron, assuming the library's policies support it.
+        """
+        return delivery_mechanism delivery_mechanism.delivery_mechanism.drm_scheme==
+        return True
+
     def checkin(self, patron, pin, licensepool):
         # Delete the patron's loan for this licensepool.
         _db = Session.object_session(patron)

--- a/api/routes.py
+++ b/api/routes.py
@@ -349,7 +349,6 @@ def borrow(identifier_type, identifier, mechanism_id=None):
 @library_route('/works/<license_pool_id>/fulfill/<mechanism_id>')
 @has_library
 @allows_patron_web
-@requires_auth
 @returns_problem_detail
 def fulfill(license_pool_id, mechanism_id=None):
     return app.manager.loans.fulfill(license_pool_id, mechanism_id)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -734,6 +734,30 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         authenticator.oauth_providers_by_name[object()] = object()
         eq_(True, authenticator.supports_patron_authentication)
 
+    def test_identifies_individuals(self):
+        # This LibraryAuthenticator does not authenticate patrons at
+        # all, so it does not identify patrons as individuals.
+        authenticator = LibraryAuthenticator(
+            _db=self._db, library=self._default_library,
+        )
+
+        # This LibraryAuthenticator has two Authenticators, but
+        # neither of them identify patrons as individuals.
+        class MockAuthenticator(object):
+            NAME = "mock"
+            IDENTIFIES_INDIVIDUALS = False
+        basic = MockAuthenticator()
+        oauth = MockAuthenticator()
+        authenticator = LibraryAuthenticator(
+            _db=self._db, library=self._default_library,
+            basic_auth_provider=basic, oauth_providers=[oauth],
+            bearer_token_signing_secret=self._str
+        )
+        eq_(False, authenticator.identifies_individuals)
+
+        # Let's change that.
+        basic.IDENTIFIES_INDIVIDUALS = True
+        eq_(True, authenticator.identifies_individuals)
 
     def test_providers(self):
         integration = self._external_integration(self._str)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -755,9 +755,17 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         )
         eq_(False, authenticator.identifies_individuals)
 
-        # Let's change that.
+        # If some Authenticators identify individuals and some do not,
+        # the library as a whole does not (necessarily) identify
+        # individuals.
         basic.IDENTIFIES_INDIVIDUALS = True
+        eq_(False, authenticator.identifies_individuals)
+
+        # If every Authenticator identifies individuals, then so does
+        # the library as a whole.
+        oauth.IDENTIFIES_INDIVIDUALS = True
         eq_(True, authenticator.identifies_individuals)
+
 
     def test_providers(self):
         integration = self._external_integration(self._str)

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -18,6 +18,7 @@ from datetime import (
 
 from api.circulation_exceptions import *
 from api.circulation import (
+    BaseCirculationAPI,
     CirculationAPI,
     DeliveryMechanismInfo,
     FulfillmentInfo,
@@ -591,9 +592,8 @@ class TestCirculationAPI(DatabaseTest):
         working_lpdm.delivery_mechanism = irrelevant_delivery_mechanism
         assert_raises(FormatNotAvailable, self.circulation.fulfill_open_access,
                       self.pool, i_want_an_epub)
-        
-        
-    def test_fulfill_sends_analytics_event(self):
+
+    def test_fulfill(self):
         self.pool.loan_to(self.patron)
 
         fulfillment = self.pool.delivery_mechanisms[0]
@@ -611,6 +611,30 @@ class TestCirculationAPI(DatabaseTest):
         eq_(1, self.analytics.count)
         eq_(CirculationEvent.CM_FULFILL,
             self.analytics.event_type)
+
+    def test_fulfill_without_loan(self):
+        # By default, a title cannot be fulfilled unless there is an active
+        # loan for the title (tested above, in test_fulfill).
+        fulfillment = self.pool.delivery_mechanisms[0]
+        fulfillment.content = "Fulfilled."
+        fulfillment.content_link = None
+        self.remote.queue_fulfill(fulfillment)
+
+        def try_to_fulfill():
+            # Note that we're passing None for `patron`.
+            return self.circulation.fulfill(
+                None, '1234', self.pool, self.pool.delivery_mechanisms[0]
+            )
+
+        assert_raises(NoActiveLoan, try_to_fulfill)
+
+        # However, if CirculationAPI.can_fulfill_without_loan() says it's
+        # okay, the title will be fulfilled anyway.
+        def yes_we_can(*args, **kwargs):
+            return True
+        self.circulation.can_fulfill_without_loan = yes_we_can
+        result = try_to_fulfill()
+        eq_(fulfillment, result)
             
     def test_revoke_loan_sends_analytics_event(self):
         self.pool.loan_to(self.patron)
@@ -833,12 +857,38 @@ class TestCirculationAPI(DatabaseTest):
         eq_(False, complete)        
 
     def test_can_fulfill_without_loan(self):
-        """In general, a title cannot be fulfilled without an active loan.
-
-        See opds_for_distributors.py for an exception.
+        """Can a title can be fulfilled without an active loan?  It depends on
+        the BaseCirculationAPI implementation for that title's colelction.
         """
-        api = CirculationAPI(self._db, self._default_library)
-        eq_(False, api.can_fulfill_without_loan(object(), object()))
+        class Mock(BaseCirculationAPI):
+            def can_fulfill_without_loan(self, patron, pool, lpdm):
+                return "yep"
+
+        pool = self._licensepool(None)
+        circulation = CirculationAPI(self._db, self._default_library)
+        circulation.api_for_collection[pool.collection.id] = Mock()
+        eq_(
+            "yep",
+            circulation.can_fulfill_without_loan(None, pool, object())
+        )
+
+        # If format data is missing or the BaseCirculationAPI cannot
+        # be found, we assume the title cannot be fulfilled.
+        eq_(False, circulation.can_fulfill_without_loan(None, pool, None))
+        eq_(False, circulation.can_fulfill_without_loan(None, None, object()))
+
+        circulation.api_for_collection = {}
+        eq_(False, circulation.can_fulfill_without_loan(None, pool, None))
+
+
+class TestBaseCirculationAPI(object):
+
+    def test_can_fulfill_without_loan(self):
+        """By default, there is a blanket prohibition on fulfilling a title
+        when there is no active loan.
+        """
+        api = BaseCirculationAPI()
+        eq_(False, api.can_fulfill_without_loan(object(), object(), object()))
 
 
 class TestDeliveryMechanismInfo(DatabaseTest):

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -832,6 +832,13 @@ class TestCirculationAPI(DatabaseTest):
         eq_(0, len(holds))
         eq_(False, complete)        
 
+    def test_can_fulfill_without_loan(self):
+        """In general, a title cannot be fulfilled without an active loan.
+
+        See opds_for_distributors.py for an exception.
+        """
+        api = CirculationAPI(self._db, self._default_library)
+        eq_(False, api.can_fulfill_without_loan(object(), object()))
 
 class TestDeliveryMechanismInfo(DatabaseTest):
 

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -840,6 +840,7 @@ class TestCirculationAPI(DatabaseTest):
         api = CirculationAPI(self._db, self._default_library)
         eq_(False, api.can_fulfill_without_loan(object(), object()))
 
+
 class TestDeliveryMechanismInfo(DatabaseTest):
 
     def test_apply(self):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1379,15 +1379,60 @@ class TestLoanController(CirculationControllerTest):
 
             eq_(ALREADY_CHECKED_OUT, response)
 
-    def test_fulfill_fails_when_no_active_loan(self):
+    def test_fulfill_without_active_loan(self):
+
+        controller = self.manager.loans
+
+        # Most of the time, it is not possible to fulfill a title if the
+        # patron has no active loan for the title. This might be
+        # because the patron never checked out the book...
         with self.request_context_with_library(
                 "/", headers=dict(Authorization=self.valid_auth)):
-            self.manager.loans.authenticated_patron_from_request()
-            response = self.manager.loans.fulfill(
+            controller.authenticated_patron_from_request()
+            response = controller.fulfill(
                 self.pool.id, self.mech2.delivery_mechanism.id
             )
 
             eq_(NO_ACTIVE_LOAN.uri, response.uri)
+
+        # ...or it might be because there is no authenticated patron.
+        with self.request_context_with_library("/"):
+            response = controller.fulfill(
+                self.pool.id, self.mech2.delivery_mechanism.id
+            )
+
+            eq_(NO_ACTIVE_LOAN.uri, response.uri)
+
+        # However, if can_fulfill_without_loan returns True, then
+        # fulfill() will be called. If fulfill() returns a
+        # FulfillmentInfo, then the title is fulfilled, with no loan
+        # having been created.
+        #
+        # To that end, we'll mock can_fulfill_without_loan and fulfill.
+        def mock_can_fulfill_without_loan(*args, **kwargs):
+            return True
+
+        def mock_fulfill(*args, **kwargs):
+            return FulfillmentInfo(
+                self.collection,
+                self.pool.data_source.name,
+                self.pool.identifier.type,
+                self.pool.identifier.identifier,
+                None, "text/html", "here's your book",
+                datetime.datetime.utcnow(),
+            )
+        with self.request_context_with_library("/"):
+            # Note that this request, unlike the first one,
+            # has no authenticated patron.
+            controller.can_fulfill_without_loan = mock_can_fulfill_without_loan
+            controller.circulation.fulfill = mock_fulfill
+            response = controller.fulfill(
+                self.pool.id, self.mech2.delivery_mechanism.id
+            )
+
+            # But we're able to fulfill the book anyway.
+            eq_("here's your book", response.data)
+            eq_([], self._db.query(Loan).all())
 
     def test_revoke_loan(self):
          with self.request_context_with_library(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1384,7 +1384,7 @@ class TestLoanController(CirculationControllerTest):
                 "/", headers=dict(Authorization=self.valid_auth)):
             self.manager.loans.authenticated_patron_from_request()
             response = self.manager.loans.fulfill(
-                self.pool.id, self.mech2.id
+                self.pool.id, self.mech2.delivery_mechanism.id
             )
 
             eq_(NO_ACTIVE_LOAN.uri, response.uri)

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -27,6 +27,8 @@ from core.model import (
     Representation,
     RightsStatus,
 )
+from core.util.opds_writer import OPDSFeed
+
 
 class BaseOPDSForDistributorsTest(object):
     base_path = os.path.split(__file__)[0]
@@ -395,7 +397,9 @@ class TestOPDSForDistributorsReaperMonitor(DatabaseTest, BaseOPDSForDistributors
         class MockOPDSForDistributorsReaperMonitor(OPDSForDistributorsReaperMonitor):
             """An OPDSForDistributorsReaperMonitor that overrides _get."""
             def _get(self, url, headers):
-                return 200, {}, feed
+                return (
+                    200, {'content-type': OPDSFeed.ACQUISITION_FEED_TYPE}, feed
+                )
 
         data_source = DataSource.lookup(self._db, "Biblioboard", autocreate=True)
         collection = MockOPDSForDistributorsAPI.mock_collection(self._db)

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -58,24 +58,28 @@ class TestOPDSForDistributorsAPI(DatabaseTest):
         m = self.api.can_fulfill_without_loan
 
         # No LicensePoolDeliveryMechanism -> False
-        eq_(False, m(patron, None))
+        eq_(False, m(patron, pool, None))
+
+        # No LicensePool -> False (there can be multiple LicensePools for
+        # a single LicensePoolDeliveryMechanism).
+        eq_(False, m(patron, None, lpdm))
 
         # No DeliveryMechanism -> False
         old_dm = lpdm.delivery_mechanism
         lpdm.delivery_mechanism = None
-        eq_(False, m(patron, lpdm))
+        eq_(False, m(patron, pool, lpdm))
 
         # DRM mechanism requires identifying a specific patron -> False
         lpdm.delivery_mechanism = old_dm
         lpdm.delivery_mechanism.drm_scheme = DeliveryMechanism.ADOBE_DRM
-        eq_(False, m(patron, lpdm))
+        eq_(False, m(patron, pool, lpdm))
 
         # Otherwise -> True
         lpdm.delivery_mechanism.drm_scheme = DeliveryMechanism.NO_DRM
-        eq_(True, m(patron, lpdm))
+        eq_(True, m(patron, pool, lpdm))
 
         lpdm.delivery_mechanism.drm_scheme = DeliveryMechanism.BEARER_TOKEN
-        eq_(True, m(patron, lpdm))
+        eq_(True, m(patron, pool, lpdm))
 
     def test_get_token_success(self):
         # The API hasn't been used yet, so it will need to find the auth


### PR DESCRIPTION
This is the first half of my work on https://github.com/NYPL-Simplified/circulation/issues/945. The goal is to make the `fulfill` route work even when there is no underlying loan, in cases where this is both technically possible and allowed by library policy.

The main conceptual change here is in `LibraryAuthenticator`. I introduce the concept of whether an authentication mechanism "identifies individuals". An authentication mechanism identifies individuals if it is capable of recognizing the same patron across visits to the site. A library identifies individuals if all of its authentication mechanisms identify individuals.

Currently, all authentication mechanisms identify individuals. This means all libraries identify individuals except the ones with no authentication mechanisms at all. In the future we will probably be supporting authentication mechanisms such as IP and geographic gates, which control access but do not identify individuals across visits.

If a library does not identify individuals, then it can't create any loans, which means it's okay to fulfill titles when there is no underlying loan. The other piece of the puzzle is whether this is technically possible. Currently this is technically possible with OPDS For Distributors. (It's also possible for open-access collections, but those are already handled separately, not through the `fulfill` route.)

In addition to the unit tests, I've verified that this works with a real OPDS For Distributors collection on a library that has no patron authentication.

The other half of this work is making sure patrons of these libraries see links to the `fulfill` route when appropriate.