### PR TITLE
Passing an entry's data source id to its object and checking for that…

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1196,14 +1196,13 @@ class CustomListsController(AdminCirculationManagerController):
             pwid = entry.get("pwid")
             medium = entry.get("medium")
             language = entry.get("language")
-            data_source_id = entry.get("data_source_id")
+            data_source = entry.get("data_source")
 
-            if not type(data_source_id) == type(int()):
-                data_source = DataSource.lookup(self._db, data_source_id)
-                if data_source:
-                    data_source_id = data_source.id
-                else:
-                    data_source_id = None
+            data_source = DataSource.lookup(self._db, data_source)
+            if data_source:
+                data_source_id = data_source.id
+            else:
+                data_source_id = None
 
             query = self._db.query(
                 Work
@@ -1291,7 +1290,7 @@ class CustomListsController(AdminCirculationManagerController):
                                         medium=Edition.medium_to_additional_type.get(entry.edition.medium, None),
                                         url=url,
                                         language=entry.edition.language,
-                                        data_source_id=entry.edition.data_source_id
+                                        data_source=entry.edition.data_source.name
                     ))
             collections = []
             for collection in list.collections:

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.66"
+    "simplified-circulation-web": "0.0.67"
   }
 }

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1735,6 +1735,7 @@ class TestCustomListsController(AdminControllerTest):
         data_source = DataSource.lookup(self._db, DataSource.LIBRARY_STAFF)
         list, ignore = create(self._db, CustomList, name=self._str, library=self._default_library, data_source=data_source)
         edition = self._edition()
+
         [c1] = edition.author_contributors
         c1.display_name = self._str
         c2, ignore = self._contributor()
@@ -1755,6 +1756,7 @@ class TestCustomListsController(AdminControllerTest):
             eq_(2, len(entry.get("authors")))
             eq_(Edition.medium_to_additional_type[Edition.BOOK_MEDIUM], entry.get("medium"))
             eq_(edition.language, entry.get("language"))
+            eq_(edition.data_source_id, entry.get("data_source_id"))
             eq_(set([c1.display_name, c2.display_name]),
                 set(entry.get("authors")))
             eq_(1, len(response.get("collections")))
@@ -1799,7 +1801,8 @@ class TestCustomListsController(AdminControllerTest):
         self.add_to_materialized_view([w1, w2, w3])
 
         new_entries = [dict(pwid=work.presentation_edition.permanent_work_id,
-            medium=Edition.medium_to_additional_type[work.presentation_edition.medium]) for work in [w2, w3]]
+            medium=Edition.medium_to_additional_type[work.presentation_edition.medium],
+            data_source_id=work.presentation_edition.data_source_id) for work in [w2, w3]]
 
         c1 = self._collection()
         c1.libraries = [self._default_library]
@@ -1819,7 +1822,7 @@ class TestCustomListsController(AdminControllerTest):
             response = self.manager.admin_custom_lists_controller.custom_list(list.id)
         eq_(200, response.status_code)
         eq_(list.id, int(response.response[0]))
-        
+
         eq_("new name", list.name)
         eq_(set([w2, w3]),
             set([entry.work for entry in list.entries]))

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1756,7 +1756,7 @@ class TestCustomListsController(AdminControllerTest):
             eq_(2, len(entry.get("authors")))
             eq_(Edition.medium_to_additional_type[Edition.BOOK_MEDIUM], entry.get("medium"))
             eq_(edition.language, entry.get("language"))
-            eq_(edition.data_source_id, entry.get("data_source_id"))
+            eq_(edition.data_source.name, entry.get("data_source"))
             eq_(set([c1.display_name, c2.display_name]),
                 set(entry.get("authors")))
             eq_(1, len(response.get("collections")))
@@ -1802,7 +1802,7 @@ class TestCustomListsController(AdminControllerTest):
 
         new_entries = [dict(pwid=work.presentation_edition.permanent_work_id,
             medium=Edition.medium_to_additional_type[work.presentation_edition.medium],
-            data_source_id=work.presentation_edition.data_source_id) for work in [w2, w3]]
+            data_source=work.presentation_edition.data_source.name) for work in [w2, w3]]
 
         c1 = self._collection()
         c1.libraries = [self._default_library]


### PR DESCRIPTION
… value when making a query when adding an item to a list.

Fixes #938. I'm adding the data source id to each entry but on a POST the value may be a name like "Standard eBooks" instead of an id since that's the value I'm extracting from the opds feed in the UI. Looking up the data source id if the submitted `data_source_id` is not an integer.