### PR TITLE
Avoid reusing a list across method calls.

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -769,7 +769,8 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             _add_link(d)
         
     def acquisition_links(self, active_license_pool, active_loan, active_hold, active_fulfillment,
-                          feed, identifier, direct_fulfillment_delivery_mechanisms=[]):
+                          feed, identifier, direct_fulfillment_delivery_mechanisms=None):
+        direct_fulfillment_delivery_mechanisms = direct_fulfillment_delivery_mechanisms or []
         api = None
         if self.circulation and active_license_pool:
             api = self.circulation.api_for_license_pool(active_license_pool)


### PR DESCRIPTION
This was causing books to appear to have a large number of identical direct fulfillment delivery mechanisms, since the list object created in the method definition was having something added to it every time the method was called.