### PR TITLE
Mirrored urls are better for open access

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -330,11 +330,30 @@ class CirculationManagerAnnotator(Annotator):
     def open_access_link(self, lpdm):
         _db = Session.object_session(lpdm)
         url = cdnify(lpdm.resource.url)
-        kw = dict(rel=OPDSFeed.OPEN_ACCESS_REL, href=url)
+        kw = dict(rel=OPDSFeed.OPEN_ACCESS_REL, type='')
+
+        # Start off assuming that the URL associated with the
+        # LicensePoolDeliveryMechanism's Resource is the URL we should
+        # send for download purposes. This will be the case unless we
+        # previously mirrored that URL somewhere else.
+        href = lpdm.resource.url
 
         rep = lpdm.resource.representation
-        if rep and rep.media_type:
-            kw['type'] = rep.media_type
+        if rep:
+            if rep.media_type:
+                kw['type'] = rep.media_type
+            if rep.mirror_url:
+                # The Representation was mirrored to some other URL
+                # under our control. In this situation, Resource.url
+                # is probably the original, pre-mirror URL, and
+                # mirror_url should take precedence.
+                href = rep.mirror_url
+            elif rep.url:
+                # This is probably the same as the resource URL, but
+                # if they are different this one is probably preferable.
+                href = rep.url
+        kw['href'] = cdnify(href)
+
         link_tag = AcquisitionFeed.link(**kw)
         link_tag.attrib.update(self.rights_attributes(lpdm))
         always_available = OPDSFeed.makeelement(

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -92,6 +92,12 @@ class TestCirculationManagerAnnotator(DatabaseTest):
         # The resource URL associated with a LicensePoolDeliveryMechanism
         # becomes the `href` of an open-access `link` tag.
         [lpdm] = self.work.license_pools[0].delivery_mechanisms
+
+        # Temporarily disconnect the Resource's Representation so we
+        # can verify that this works even if there is no
+        # Representation.
+        representation = lpdm.resource.representation
+        lpdm.resource.representation = None
         lpdm.resource.url = "http://foo.com/thefile.epub"
         link_tag = self.annotator.open_access_link(lpdm)
         eq_(lpdm.resource.url, link_tag.get('href'))
@@ -111,6 +117,25 @@ class TestCirculationManagerAnnotator(DatabaseTest):
 
         link_url = link_tag.get('href')
         eq_("https://cdn.com/thefile.epub", link_url)
+
+        # If the Resource has a Representation that has been mirrored
+        # somewhere else, the mirror URL is used instead of the original
+        # Resource URL.
+        lpdm.resource.representation = representation
+        link_tag = self.annotator.open_access_link(lpdm)
+        eq_(representation.mirror_url, link_tag.get('href'))
+
+        # If the Representation exists but hasn't been mirrored,
+        # the Representation's original URL is used instead.
+        representation.mirror_url = None
+        representation.url = self._url
+        link_tag = self.annotator.open_access_link(lpdm)
+        eq_(representation.url, link_tag.get('href'))
+
+        # If neither is present, the Resource's original URL is used.
+        representation.url = None
+        link_tag = self.annotator.open_access_link(lpdm)
+        eq_(lpdm.resource.url, link_tag.get('href'))
 
     def test_default_lane_url(self):
         default_lane_url = self.annotator.default_lane_url()


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-288 by checking resource.representation.mirror_url and resource.representation.url in preference to resource.url, when generating open-access links. (resource.url will still be used if the others are not available).