### PR TITLE
Open access downloads go through the circ manager

### DIFF
--- a/api/admin/opds.py
+++ b/api/admin/opds.py
@@ -1,5 +1,6 @@
 from nose.tools import set_trace
 
+from sqlalchemy import and_
 from api.opds import LibraryAnnotator
 from core.opds import VerboseAnnotator
 from core.lane import Facets, Pagination
@@ -135,9 +136,13 @@ class AdminFeed(AcquisitionFeed):
         pagination = pagination or Pagination.default()
 
         q = _db.query(LicensePool).filter(
-            LicensePool.suppressed == True).order_by(
-                LicensePool.id
+            and_(
+                LicensePool.suppressed == True,
+                LicensePool.superceded == False,
             )
+        ).order_by(
+            LicensePool.id
+        )
         pools = pagination.apply(q).all()
 
         works = [pool.work for pool in pools]

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -162,7 +162,7 @@ class FulfillmentInfo(CirculationInfo):
 
     def __init__(self, collection, data_source_name, identifier_type,
                  identifier, content_link, content_type, content,
-                 content_expires, mirrored=False):
+                 content_expires):
         """Constructor.
 
         One and only one of `content_link` and `content` should be
@@ -188,8 +188,6 @@ class FulfillmentInfo(CirculationInfo):
             `content_type`).
         :param content_expires: A time after which the "next step"
             link or content will no longer be usable.
-        :param mirrored: Should be true if the content link points to a local
-            mirror of the content.
 
         """
         super(FulfillmentInfo, self).__init__(
@@ -199,7 +197,6 @@ class FulfillmentInfo(CirculationInfo):
         self.content_type = content_type
         self.content = content
         self.content_expires = content_expires
-        self.mirrored = mirrored
     
     def __repr__(self):
         if self.content:
@@ -749,19 +746,17 @@ class CirculationAPI(object):
             raise FormatNotAvailable()
 
         rep = fulfillment.resource.representation
-        if rep.mirror_url:
-            mirrored = True
-            content_link = cdnify(rep.mirror_url)
+        if rep:
+            content_link = cdnify(rep.mirror_url or rep.url)
         else:
-            mirrored = False
-            content_link = cdnify(rep.url)
+            content_link = cdnify(fulfillment.resource.url)
         media_type = rep.media_type
         return FulfillmentInfo(
             licensepool.collection, licensepool.data_source,
             identifier_type=licensepool.identifier.type,
             identifier=licensepool.identifier.identifier,
             content_link=content_link, content_type=media_type, content=None, 
-            content_expires=None, mirrored=mirrored
+            content_expires=None,
         )
 
     def revoke_loan(self, patron, pin, licensepool):

--- a/api/controller.py
+++ b/api/controller.py
@@ -1137,12 +1137,14 @@ class LoanController(CirculationManagerController):
                 # If we have a link to the content on a remote server, web clients may not
                 # be able to access it if the remote server does not support CORS requests.
 
-                # If we've mirrored the content locally, we can assume CORS is enabled.
-                if fulfillment.mirrored:
+                # If the pool is open access though, the web client can link directly to the
+                # file to download it, so it's safe to redirect.
+                if requested_license_pool.open_access:
                     return redirect(fulfillment.content_link)
 
                 # Otherwise, we need to fetch the content and return it instead
-                # of redirecting to it.
+                # of redirecting to it, since it may be downloaded through an
+                # indirect acquisition link.
                 try:
                     status_code, headers, content = do_get(fulfillment.content_link, headers=encoding_header)
                     headers = dict(headers)

--- a/api/controller.py
+++ b/api/controller.py
@@ -657,7 +657,7 @@ class OPDSFeedController(CirculationManagerController):
         feed = AcquisitionFeed.groups(
             self._db, title, url, lane, annotator, facets=facets
         )
-        return feed_response(feed.content)
+        return feed_response(feed)
 
     def feed(self, lane_identifier):
         """Build or retrieve a paginated acquisition feed."""
@@ -685,7 +685,7 @@ class OPDSFeedController(CirculationManagerController):
             facets=facets,
             pagination=pagination,
         )
-        return feed_response(feed.content)
+        return feed_response(feed)
 
     def crawlable_library_feed(self):
         """Build or retrieve a crawlable acquisition feed for the
@@ -749,7 +749,7 @@ class OPDSFeedController(CirculationManagerController):
             facets=facets,
             pagination=pagination,
         )
-        return feed_response(feed.content)
+        return feed_response(feed)
 
     def search(self, lane_identifier):
 
@@ -1136,7 +1136,13 @@ class LoanController(CirculationManagerController):
             if fulfillment.content_link:
                 # If we have a link to the content on a remote server, web clients may not
                 # be able to access it if the remote server does not support CORS requests.
-                # We need to fetch the content and return it instead of redirecting to it.
+
+                # If we've mirrored the content locally, we can assume CORS is enabled.
+                if fulfillment.mirrored:
+                    return redirect(fulfillment.content_link)
+
+                # Otherwise, we need to fetch the content and return it instead
+                # of redirecting to it.
                 try:
                     status_code, headers, content = do_get(fulfillment.content_link, headers=encoding_header)
                     headers = dict(headers)
@@ -1375,7 +1381,7 @@ class WorkController(CirculationManagerController):
             facets=facets, pagination=pagination,
             annotator=annotator, cache_type=CachedFeed.CONTRIBUTOR_TYPE
         )
-        return feed_response(unicode(feed.content))
+        return feed_response(unicode(feed))
 
     def permalink(self, identifier_type, identifier):
         """Serve an entry for a single book.
@@ -1436,7 +1442,7 @@ class WorkController(CirculationManagerController):
             self._db, lane.DISPLAY_NAME, url, lane, annotator=annotator,
             facets=facets
         )
-        return feed_response(unicode(feed.content))
+        return feed_response(unicode(feed))
 
     def recommendations(self, identifier_type, identifier, novelist_api=None):
         """Serve a feed of recommendations related to a given book."""
@@ -1473,7 +1479,7 @@ class WorkController(CirculationManagerController):
             facets=facets, pagination=pagination,
             annotator=annotator, cache_type=CachedFeed.RECOMMENDATIONS_TYPE
         )
-        return feed_response(unicode(feed.content))
+        return feed_response(unicode(feed))
 
     def report(self, identifier_type, identifier):
         """Report a problem with a book."""
@@ -1541,7 +1547,7 @@ class WorkController(CirculationManagerController):
             facets=facets, pagination=pagination,
             annotator=annotator, cache_type=CachedFeed.SERIES_TYPE
         )
-        return feed_response(unicode(feed.content))
+        return feed_response(unicode(feed))
 
 
 class ProfileController(CirculationManagerController):

--- a/api/opds.py
+++ b/api/opds.py
@@ -311,7 +311,7 @@ class CirculationManagerAnnotator(Annotator):
         if active_license_pool and active_license_pool.open_access:
             for lpdm in active_license_pool.delivery_mechanisms:
                 if lpdm.resource:
-                    open_access_links.append(self.open_access_link(lpdm))
+                    open_access_links.append(self.open_access_link(active_license_pool, lpdm))
 
         return [x for x in borrow_links + fulfill_links + open_access_links + revoke_links
                 if x is not None]
@@ -327,7 +327,7 @@ class CirculationManagerAnnotator(Annotator):
                      rel=OPDSFeed.ACQUISITION_REL):
         return None
 
-    def open_access_link(self, lpdm):
+    def open_access_link(self, pool, lpdm):
         _db = Session.object_session(lpdm)
         url = cdnify(lpdm.resource.url)
         kw = dict(rel=OPDSFeed.OPEN_ACCESS_REL, href=url)
@@ -900,6 +900,18 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             license_pool, active_loan, delivery_mechanism
         )
         link_tag.extend(children)
+        return link_tag
+
+    def open_access_link(self, pool, lpdm):
+        link_tag = super(LibraryAnnotator, self).open_access_link(pool, lpdm)
+        fulfill_url = self.url_for(
+            "fulfill",
+            license_pool_id=pool.id,
+            mechanism_id=lpdm.delivery_mechanism.id,
+            library_short_name=self.library.short_name,
+            _external=True
+        )
+        link_tag.attrib.update(dict(href=fulfill_url))
         return link_tag
 
     @classmethod

--- a/bin/repair/mirror_resources
+++ b/bin/repair/mirror_resources
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+"""Mirror resources that haven't been mirrored yet."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.scripts import MirrorResourcesScript
+MirrorResourcesScript().run()

--- a/scripts.py
+++ b/scripts.py
@@ -421,7 +421,7 @@ class CacheRepresentationPerLane(LaneSweeperScript):
         self.log.info("Generating feed(s) for %s", lane.full_identifier)
         cached_feeds = list(self.do_generate(lane))
         b = time.time()
-        total_size = sum(len(x.content) for x in cached_feeds if x)
+        total_size = sum(len(x) for x in cached_feeds if x)
         self.log.info(
             "Generated %d feed(s) for %s. Took %.2fsec to make %d bytes.",
             len(cached_feeds), lane.full_identifier, (b-a), total_size

--- a/tests/admin/test_opds.py
+++ b/tests/admin/test_opds.py
@@ -177,6 +177,12 @@ class TestOPDS(DatabaseTest):
         work2 = self._work(with_open_access_download=True)
         work2.license_pools[0].suppressed = True
 
+        # This work won't be included in the feed since its
+        # suppressed pool is superceded.
+        work3 = self._work(with_open_access_download=True)
+        work3.license_pools[0].suppressed = True
+        work3.license_pools[0].superceded = True
+
         pagination = Pagination(size=1)
         annotator = MockAnnotator(self._default_library)
         titles = [work1.title, work2.title]
@@ -217,6 +223,14 @@ class TestOPDS(DatabaseTest):
         eq_(annotator.suppressed_url(pagination), previous['href'])
         eq_(1, len(parsed['entries']))
         eq_(remaining_title, parsed['entries'][0]['title'])
+
+        # The third page is empty.
+        third_page = make_page(pagination.next_page.next_page)
+        parsed = feedparser.parse(unicode(third_page))
+        [previous] = self.links(parsed, 'previous')
+        eq_(annotator.suppressed_url(pagination.next_page), previous['href'])
+        eq_(0, len(parsed['entries']))
+        
 
 class MockAnnotator(AdminAnnotator):
 

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -560,7 +560,6 @@ class TestCirculationAPI(DatabaseTest):
         assert isinstance(result, FulfillmentInfo)
         eq_(result.content_link, link.resource.representation.mirror_url)
         eq_(result.content_type, i_want_an_epub.content_type)
-        eq_(result.mirrored, True)
 
         # Now, if we try to call fulfill() with the broken
         # LicensePoolDeliveryMechanism we get a result from the
@@ -571,7 +570,6 @@ class TestCirculationAPI(DatabaseTest):
         assert isinstance(result, FulfillmentInfo)
         eq_(result.content_link, link.resource.representation.mirror_url)
         eq_(result.content_type, i_want_an_epub.content_type)
-        eq_(result.mirrored, True)
         
         # We get the right result even if the code calling
         # fulfill_open_access() is incorrectly written and passes in
@@ -583,7 +581,6 @@ class TestCirculationAPI(DatabaseTest):
         assert isinstance(result, FulfillmentInfo)
         eq_(result.content_link, link.resource.representation.mirror_url)
         eq_(result.content_type, i_want_an_epub.content_type)
-        eq_(result.mirrored, True)
 
         # If we change the working LPDM so that it serves a different
         # media type than the one we're asking for, we're back to

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -558,8 +558,9 @@ class TestCirculationAPI(DatabaseTest):
             self.pool, broken_lpdm
         )
         assert isinstance(result, FulfillmentInfo)
-        eq_(result.content_link, link.resource.url)
+        eq_(result.content_link, link.resource.representation.mirror_url)
         eq_(result.content_type, i_want_an_epub.content_type)
+        eq_(result.mirrored, True)
 
         # Now, if we try to call fulfill() with the broken
         # LicensePoolDeliveryMechanism we get a result from the
@@ -568,8 +569,9 @@ class TestCirculationAPI(DatabaseTest):
             self.patron, '1234', self.pool, broken_lpdm
         )
         assert isinstance(result, FulfillmentInfo)
-        eq_(result.content_link, link.resource.url)
+        eq_(result.content_link, link.resource.representation.mirror_url)
         eq_(result.content_type, i_want_an_epub.content_type)
+        eq_(result.mirrored, True)
         
         # We get the right result even if the code calling
         # fulfill_open_access() is incorrectly written and passes in
@@ -579,8 +581,9 @@ class TestCirculationAPI(DatabaseTest):
             self.pool, broken_lpdm
         )
         assert isinstance(result, FulfillmentInfo)
-        eq_(result.content_link, link.resource.url)
+        eq_(result.content_link, link.resource.representation.mirror_url)
         eq_(result.content_type, i_want_an_epub.content_type)
+        eq_(result.mirrored, True)
 
         # If we change the working LPDM so that it serves a different
         # media type than the one we're asking for, we're back to
@@ -880,6 +883,9 @@ class TestCirculationAPI(DatabaseTest):
         circulation.api_for_collection = {}
         eq_(False, circulation.can_fulfill_without_loan(None, pool, None))
 
+        # An open access pool can be fulfilled even without the BaseCirculationAPI.
+        pool.open_access = True
+        eq_(True, circulation.can_fulfill_without_loan(None, pool, object()))
 
 class TestBaseCirculationAPI(object):
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1108,14 +1108,25 @@ class TestLoanController(CirculationControllerTest):
             # The mechanism we used has been registered with the loan.
             eq_(fulfillable_mechanism, loan.fulfillment)
 
-            # Set the representation to be unmirrored, so we have to make an
+            # Set the pool to be non-open-access, so we have to make an
             # external request to obtain the book.
-            fulfillable_mechanism.resource.representation.mirror_url = None
+            self.pool.open_access = False
 
             http = DummyHTTPClient()
 
+            fulfillment = FulfillmentInfo(
+                self.pool.collection,
+                self.pool.data_source,
+                self.pool.identifier.type,
+                self.pool.identifier.identifier,
+                content_link=fulfillable_mechanism.resource.url,
+                content_type=fulfillable_mechanism.resource.representation.media_type,
+                content=None,
+                content_expires=None)
+
             # Now that we've set a mechanism, we can fulfill the loan
             # again without specifying a mechanism.
+            self.manager.d_circulation.queue_fulfill(self.pool, fulfillment)
             http.queue_response(200, content="I am an ACSM file")
 
             response = self.manager.loans.fulfill(
@@ -1138,6 +1149,7 @@ class TestLoanController(CirculationControllerTest):
             # If the remote server fails, we get a problem detail.
             def doomed_get(url, headers, **kwargs):
                 raise RemoteIntegrationException("fulfill service", "Error!")
+            self.manager.d_circulation.queue_fulfill(self.pool, fulfillment)
 
             response = self.manager.loans.fulfill(
                 self.pool.id, do_get=doomed_get

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -91,9 +91,10 @@ class TestCirculationManagerAnnotator(DatabaseTest):
     def test_open_access_link(self):
         # The resource URL associated with a LicensePoolDeliveryMechanism
         # becomes the `href` of an open-access `link` tag.
-        [lpdm] = self.work.license_pools[0].delivery_mechanisms
+        pool = self.work.license_pools[0]
+        [lpdm] = pool.delivery_mechanisms
         lpdm.resource.url = "http://foo.com/thefile.epub"
-        link_tag = self.annotator.open_access_link(lpdm)
+        link_tag = self.annotator.open_access_link(pool, lpdm)
         eq_(lpdm.resource.url, link_tag.get('href'))
 
         # The dcterms:rights attribute may provide a more detailed
@@ -107,7 +108,7 @@ class TestCirculationManagerAnnotator(DatabaseTest):
             config[Configuration.INTEGRATIONS][ExternalIntegration.CDN] = {
                 'foo.com' : 'https://cdn.com/'
             }
-            link_tag = self.annotator.open_access_link(lpdm)
+            link_tag = self.annotator.open_access_link(pool, lpdm)
 
         link_url = link_tag.get('href')
         eq_("https://cdn.com/thefile.epub", link_url)
@@ -1182,7 +1183,7 @@ class TestLibraryAnnotator(VendorIDTest):
         eq_('http://librarysimplified.org/terms/rel/revoke', revoke.attrib.get("rel"))
         assert "fulfill" in fulfill.attrib.get("href")
         eq_('http://opds-spec.org/acquisition', fulfill.attrib.get("rel"))
-        eq_(work1.license_pools[0].delivery_mechanisms[0].resource.url, open_access.attrib.get("href"))
+        assert 'fulfill' in open_access.attrib.get("href")
         eq_('http://opds-spec.org/acquisition/open-access', open_access.attrib.get("rel"))
 
         loan2_links = annotator.acquisition_links(


### PR DESCRIPTION
The main change in this branch is to use fulfill links that don't require authentication rather than direct links for open access content. This enables the circ manager to track open access downloads.