### PR TITLE
Use public_url instead of mirror_url whenever possible

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -747,7 +747,7 @@ class CirculationAPI(object):
 
         rep = fulfillment.resource.representation
         if rep:
-            content_link = cdnify(rep.mirror_url or rep.url)
+            content_link = cdnify(rep.public_url)
         else:
             content_link = cdnify(fulfillment.resource.url)
         media_type = rep.media_type

--- a/api/opds.py
+++ b/api/opds.py
@@ -342,16 +342,7 @@ class CirculationManagerAnnotator(Annotator):
         if rep:
             if rep.media_type:
                 kw['type'] = rep.media_type
-            if rep.mirror_url:
-                # The Representation was mirrored to some other URL
-                # under our control. In this situation, Resource.url
-                # is probably the original, pre-mirror URL, and
-                # mirror_url should take precedence.
-                href = rep.mirror_url
-            elif rep.url:
-                # This is probably the same as the resource URL, but
-                # if they are different this one is probably preferable.
-                href = rep.url
+            href = rep.public_url
         kw['href'] = cdnify(href)
 
         link_tag = AcquisitionFeed.link(**kw)

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -558,7 +558,7 @@ class TestCirculationAPI(DatabaseTest):
             self.pool, broken_lpdm
         )
         assert isinstance(result, FulfillmentInfo)
-        eq_(result.content_link, link.resource.representation.mirror_url)
+        eq_(result.content_link, link.resource.representation.public_url)
         eq_(result.content_type, i_want_an_epub.content_type)
 
         # Now, if we try to call fulfill() with the broken
@@ -568,7 +568,7 @@ class TestCirculationAPI(DatabaseTest):
             self.patron, '1234', self.pool, broken_lpdm
         )
         assert isinstance(result, FulfillmentInfo)
-        eq_(result.content_link, link.resource.representation.mirror_url)
+        eq_(result.content_link, link.resource.representation.public_url)
         eq_(result.content_type, i_want_an_epub.content_type)
         
         # We get the right result even if the code calling
@@ -579,7 +579,7 @@ class TestCirculationAPI(DatabaseTest):
             self.pool, broken_lpdm
         )
         assert isinstance(result, FulfillmentInfo)
-        eq_(result.content_link, link.resource.representation.mirror_url)
+        eq_(result.content_link, link.resource.representation.public_url)
         eq_(result.content_type, i_want_an_epub.content_type)
 
         # If we change the working LPDM so that it serves a different

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1103,7 +1103,7 @@ class TestLoanController(CirculationControllerTest):
                 self.pool.id, fulfillable_mechanism.delivery_mechanism.id,
             )
             eq_(302, response.status_code)
-            eq_(fulfillable_mechanism.resource.representation.mirror_url, response.headers.get("Location"))
+            eq_(fulfillable_mechanism.resource.representation.public_url, response.headers.get("Location"))
 
             # The mechanism we used has been registered with the loan.
             eq_(fulfillable_mechanism, loan.fulfillment)
@@ -2686,7 +2686,7 @@ class TestFeedController(CirculationControllerTest):
             eq_(0, len([link for link in links if link.get("rel") == Hyperlink.BORROW]))
             [open_access_link] = [link for link in links if link.get("rel") == Hyperlink.OPEN_ACCESS_DOWNLOAD]
             pool = self.english_2.license_pools[0]
-            eq_(pool.identifier.links[0].resource.representation.mirror_url, open_access_link.get("href"))
+            eq_(pool.identifier.links[0].resource.representation.public_url, open_access_link.get("href"))
 
         # The collection must exist.
         with self.app.test_request_context("/?size=1"):

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -349,14 +349,12 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         [mechanism] = pool.delivery_mechanisms
         eq_(RightsStatus.IN_COPYRIGHT, mechanism.rights_status.uri)
 
-        # The DeliveryMechanism is set as mirrored, but its 'mirror
-        # URL' is the same as the original URL. This is not the best
-        # outcome--it happens in Identifier.add_link--but it should be
-        # okay.
-
-        eq_('http://www.feedbooks.com/book/677.epub',
-            mechanism.resource.representation.mirror_url
-        )
+        # The DeliveryMechanism has a Representation but the Representation
+        # has not been set as mirrored, because nothing was uploaded.
+        rep = mechanism.resource.representation
+        eq_('http://www.feedbooks.com/book/677.epub', rep.url)
+        eq_(None, rep.mirror_url)
+        eq_(None, rep.mirror_exception)
 
         # The pool is not marked as open-access because although it
         # has open-access links, they're not licensed under terms we

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -119,22 +119,14 @@ class TestCirculationManagerAnnotator(DatabaseTest):
         link_url = link_tag.get('href')
         eq_("https://cdn.com/thefile.epub", link_url)
 
-        # If the Resource has a Representation that has been mirrored
-        # somewhere else, the mirror URL is used instead of the original
-        # Resource URL.
+        # If the Resource has a Representation, the public URL is used
+        # instead of the original Resource URL.
         lpdm.resource.representation = representation
         link_tag = self.annotator.open_access_link(pool, lpdm)
-        eq_(representation.mirror_url, link_tag.get('href'))
+        eq_(representation.public_url, link_tag.get('href'))
 
-        # If the Representation exists but hasn't been mirrored,
-        # the Representation's original URL is used instead.
-        representation.mirror_url = None
-        representation.url = self._url
-        link_tag = self.annotator.open_access_link(pool, lpdm)
-        eq_(representation.url, link_tag.get('href'))
-
-        # If neither is present, the Resource's original URL is used.
-        representation.url = None
+        # If there is no Representation, the Resource's original URL is used.
+        lpdm.resource.representation = None
         link_tag = self.annotator.open_access_link(pool, lpdm)
         eq_(lpdm.resource.url, link_tag.get('href'))
 


### PR DESCRIPTION
This is the circulation component for https://github.com/NYPL-Simplified/server_core/pull/876. It is part of https://jira.nypl.org/browse/SIMPLY-297.

Basically we want to use public_url instead of mirror_url unless we are specifically checking whether the representation has been mirrored (which, here, basically only happens in tests).