### PR TITLE
Cached OPDS entries need to be completed with Identifier-specific information

### DIFF
--- a/api/admin/opds.py
+++ b/api/admin/opds.py
@@ -23,7 +23,7 @@ class AdminAnnotator(LibraryAnnotator):
     def annotate_work_entry(self, work, active_license_pool, edition, identifier, feed, entry):
 
         super(AdminAnnotator, self).annotate_work_entry(work, active_license_pool, edition, identifier, feed, entry)
-        VerboseAnnotator.annotate_work_entry(work, active_license_pool, edition, identifier, feed, entry)
+        VerboseAnnotator.add_ratings(work, entry)
 
         # Find staff rating and add a tag for it.
         for measurement in identifier.measurements:

--- a/api/opds.py
+++ b/api/opds.py
@@ -145,7 +145,7 @@ class CirculationManagerAnnotator(Annotator):
                 CirculationManagerAnnotator, self).active_licensepool_for(work)
 
     def annotate_work_entry(self, work, active_license_pool, edition, identifier, feed, entry, updated=None):
-        Annotator.annotate_work_entry(
+        super(CirculationManagerAnnotator, self).annotate_work_entry(
             work, active_license_pool, edition, identifier, feed, entry, updated
         )
         active_loan = self.active_loans_by_work.get(work)

--- a/api/opds.py
+++ b/api/opds.py
@@ -3,6 +3,7 @@ import copy
 import logging
 from nose.tools import set_trace
 from flask import url_for
+from flask_babel import lazy_gettext as _
 from lxml import etree
 from collections import defaultdict
 import uuid
@@ -436,13 +437,14 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         return self._top_level_title
 
     def permalink_for(self, work, license_pool, identifier):
-        return self.url_for(
+        url = self.url_for(
             'permalink',
             identifier_type=identifier.type,
             identifier=identifier.identifier,
             library_short_name=self.library.short_name,
             _external=True
         )
+        return url, OPDSFeed.ENTRY_TYPE
 
     def groups_url(self, lane, facets=None):
         lane_identifier = self._lane_identifier(lane)
@@ -536,16 +538,6 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         updated = None
         if isinstance(self.lane, CrawlableCustomListBasedLane) and isinstance(work, BaseMaterializedWork):
             updated = max(work.last_update_time, work.first_appearance, work.availability_time)
-
-        # First, add a permalink.
-        feed.add_link_to_entry(
-            entry, 
-            rel='alternate',
-            type=OPDSFeed.ENTRY_TYPE,
-            href=self.permalink_for(
-                work, active_license_pool, identifier
-            )
-        )
 
         # Add a link for reporting problems.
         feed.add_link_to_entry(

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -349,14 +349,12 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         [mechanism] = pool.delivery_mechanisms
         eq_(RightsStatus.IN_COPYRIGHT, mechanism.rights_status.uri)
 
-        # The DeliveryMechanism is set as mirrored, but its 'mirror
-        # URL' is the same as the original URL. This is not the best
-        # outcome--it happens in Identifier.add_link--but it should be
-        # okay.
-
+        # The DeliveryMechanism has a Resource associated with it,
+        # but the Representation's mirror_url is not set because the
+        # resource was never mirrored.
         eq_('http://www.feedbooks.com/book/677.epub',
-            mechanism.resource.representation.mirror_url
-        )
+            mechanism.resource.representation.url)
+        eq_(None, mechanism.resource.representation.mirror_url)
 
         # The pool is not marked as open-access because although it
         # has open-access links, they're not licensed under terms we

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -468,9 +468,12 @@ class TestLibraryAnnotator(VendorIDTest):
         eq_(entry['id'], pool.identifier.urn)
 
         [(alternate, type)] = [(x['href'], x['type']) for x in entry['links'] if x['rel'] == 'alternate']
-        permalink = self.annotator.permalink_for(work, pool, pool.identifier)
+        permalink, permalink_type = self.annotator.permalink_for(
+            work, pool, pool.identifier
+        )
         eq_(alternate, permalink)
         eq_(OPDSFeed.ENTRY_TYPE, type)
+        eq_(permalink_type, type)
 
         # Make sure we are using the 'permalink' controller -- we were using
         # 'work' and that was wrong.
@@ -531,7 +534,7 @@ class TestLibraryAnnotator(VendorIDTest):
             library_identifies_patrons=True
         )
         feed = AcquisitionFeed(self._db, "test", "url", [], annotator)
-        entry = feed._make_entry_xml(work, None, edition, identifier)
+        entry = feed._make_entry_xml(work, edition)
         annotator.annotate_work_entry(
             work, None, edition, identifier, feed, entry
         )

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -495,7 +495,7 @@ class TestLibraryAnnotator(VendorIDTest):
                 library_identifies_patrons=auth
             )
             feed = AcquisitionFeed(self._db, "test", "url", [], annotator)
-            entry = feed._make_entry_xml(work, pool, edition, identifier)
+            entry = feed._make_entry_xml(work, edition)
             annotator.annotate_work_entry(
                 work, pool, edition, identifier, feed, entry
             )


### PR DESCRIPTION
This is the metadata portion of https://jira.nypl.org/browse/SIMPLY-273. OPDS entries from the cache can't be served as-is, because they only contain bibliographic information about the Work. They need to be completed with information about the Identifier that was requested.