### PR TITLE
Add an <updated> tag to each entry in the age gate.

### DIFF
--- a/api/custom_index.py
+++ b/api/custom_index.py
@@ -2,6 +2,7 @@
 something other than the default.
 """
 
+import datetime
 from nose.tools import set_trace
 
 from flask import Response
@@ -185,10 +186,12 @@ class COPPAGate(CustomIndexView):
         E = OPDSFeed.E
         content_tag = E.content(type="text")
         content_tag.text = unicode(content)
+        now = datetime.datetime.utcnow()
         entry = E.entry(
             E.id(href),
             E.title(unicode(title)),
             content_tag,
+            E.updated(OPDSFeed._strftime(now))
         )
         OPDSFeed.add_link_to_entry(
             entry, href=href, rel="subsection",

--- a/api/custom_index.py
+++ b/api/custom_index.py
@@ -152,6 +152,7 @@ class COPPAGate(CustomIndexView):
         # An entry for grown-ups.
         feed = OPDSFeed(title=library.name, url=base_url)
         opds = feed.feed
+
         yes_url = url_for(
             'acquisition_groups',
             library_short_name=library.short_name,
@@ -178,6 +179,9 @@ class COPPAGate(CustomIndexView):
         # the link to its authentication document.
         if annotator:
             annotator.annotate_feed(feed, None)
+
+        now = datetime.datetime.utcnow()
+        opds.append(OPDSFeed.E.updated(OPDSFeed._strftime(now)))
         return feed
 
     @classmethod

--- a/tests/test_custom_index.py
+++ b/tests/test_custom_index.py
@@ -242,7 +242,8 @@ class TestCOPPAGate(DatabaseTest):
                 '<id>some href</id>',
                 '<title>some title</title>',
                 '<content type="text">some content</content>',
-                '<link href="some href" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="subsection"/>'
+                '<link href="some href" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="subsection"/>',
+                '<updated',
         ):
             assert expect in entry
 

--- a/tests/test_custom_index.py
+++ b/tests/test_custom_index.py
@@ -223,12 +223,13 @@ class TestCOPPAGate(DatabaseTest):
         assert "<gate/>" in feed
         eq_(2, feed.count("<entry/>"))
 
-        # There's also a self link, a title and an ID, which were
-        # inserted by the OPDSFeed constructor.
+        # There's also a self link, a title, an ID, and an updated
+        # time, which were inserted by the OPDSFeed constructor.
         index = mock_url_for("index", self._default_library.short_name)
         assert ('<link href="%s" rel="self"/>' % index) in feed
         assert ("<title>%s</title>" % self._default_library.name) in feed
-        assert ('<id>%s</id>' % index)
+        assert ('<id>%s</id>' % index) in feed
+        assert '<updated>' in feed
 
     def test_navigation_entry(self):
         """navigation_entry creates an OPDS entry with a subsection link."""


### PR DESCRIPTION
This addresses https://jira.nypl.org/browse/SIMPLY-318. Without this required field, SimplyE refuses to process an OPDS entry.

I also added <updated> to the feed, just to be safe -- the Atom spec requires it on the feed level as well.