### PR TITLE
Changed list controllers to use identifiers instead of pwids.

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1440,38 +1440,22 @@ class CustomListsController(AdminCirculationManagerController):
         old_entries = [x for x in list.entries if x.edition]
         membership_change = False
         for entry in entries:
-            pwid = entry.get("pwid")
-            medium = entry.get("medium")
-            language = entry.get("language")
-            data_source = entry.get("data_source")
+            urn = entry.get("identifier_urn")
 
-            data_source = DataSource.lookup(self._db, data_source)
-            if data_source:
-                data_source_id = data_source.id
-            else:
-                data_source_id = None
-
+            identifier, ignore = Identifier.parse_urn(self._db, urn)
             query = self._db.query(
                 Work
             ).join(
                 Edition, Edition.id==Work.presentation_edition_id
+            ).join(
+                LicensePool, LicensePool.work_id==Work.id
+            ).join(
+                Collection, LicensePool.collection_id==Collection.id
             ).filter(
-                Edition.permanent_work_id==pwid
+                Edition.primary_identifier_id==identifier.id
+            ).filter(
+                Collection.id.in_([c.id for c in library.all_collections])
             )
-
-            if data_source_id:
-                query = query.filter(
-                    Edition.data_source_id==data_source_id
-                )
-            if medium:
-                query = query.filter(
-                    Edition.medium==Edition.additional_type_to_medium[medium]
-                )
-            if language:
-                query = query.filter(
-                    Edition.language==LanguageCodes.iso_639_2_for_locale(language)
-                )
-
             work = query.one()
 
             if work:
@@ -1479,9 +1463,9 @@ class CustomListsController(AdminCirculationManagerController):
                 if entry_is_new:
                     membership_change = True
 
-        new_pwids = [entry.get("pwid") for entry in entries]
+        new_urns = [entry.get("identifier_urn") for entry in entries]
         for entry in old_entries:
-            if entry.edition.permanent_work_id not in new_pwids:
+            if entry.edition.primary_identifier.urn not in new_urns:
                 list.remove_entry(entry.edition)
                 membership_change = True
 
@@ -1531,13 +1515,12 @@ class CustomListsController(AdminCirculationManagerController):
                         identifier=entry.edition.primary_identifier.identifier,
                         library_short_name=library.short_name,
                     )
-                    entries.append(dict(pwid=entry.edition.permanent_work_id,
+                    entries.append(dict(identifier_urn=entry.edition.primary_identifier.urn,
                                         title=entry.edition.title,
                                         authors=[author.display_name for author in entry.edition.author_contributors],
                                         medium=Edition.medium_to_additional_type.get(entry.edition.medium, None),
                                         url=url,
                                         language=entry.edition.language,
-                                        data_source=entry.edition.data_source.name
                     ))
             collections = []
             for collection in list.collections:

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1446,13 +1446,11 @@ class CustomListsController(AdminCirculationManagerController):
             query = self._db.query(
                 Work
             ).join(
-                Edition, Edition.id==Work.presentation_edition_id
-            ).join(
                 LicensePool, LicensePool.work_id==Work.id
             ).join(
                 Collection, LicensePool.collection_id==Collection.id
             ).filter(
-                Edition.primary_identifier_id==identifier.id
+                LicensePool.identifier_id==identifier.id
             ).filter(
                 Collection.id.in_([c.id for c in library.all_collections])
             )

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.68"
+    "simplified-circulation-web": "0.0.69"
   }
 }

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1987,7 +1987,7 @@ class TestCustomListsController(AdminControllerTest):
         with self.request_context_with_library_and_admin("/", method="POST"):
             flask.request.form = MultiDict([
                 ("name", "List"),
-                ("entries", json.dumps([dict(pwid=work.presentation_edition.permanent_work_id)])),
+                ("entries", json.dumps([dict(identifier_urn=work.presentation_edition.primary_identifier.urn)])),
                 ("collections", json.dumps([collection.id])),
             ])
 
@@ -2024,12 +2024,11 @@ class TestCustomListsController(AdminControllerTest):
             eq_(1, response.get("entry_count"))
             eq_(1, len(response.get("entries")))
             [entry] = response.get("entries")
-            eq_(edition.permanent_work_id, entry.get("pwid"))
+            eq_(edition.primary_identifier.urn, entry.get("identifier_urn"))
             eq_(edition.title, entry.get("title"))
             eq_(2, len(entry.get("authors")))
             eq_(Edition.medium_to_additional_type[Edition.BOOK_MEDIUM], entry.get("medium"))
             eq_(edition.language, entry.get("language"))
-            eq_(edition.data_source.name, entry.get("data_source"))
             eq_(set([c1.display_name, c2.display_name]),
                 set(entry.get("authors")))
             eq_(1, len(response.get("collections")))
@@ -2073,9 +2072,9 @@ class TestCustomListsController(AdminControllerTest):
         list.add_entry(w2)
         self.add_to_materialized_view([w1, w2, w3])
 
-        new_entries = [dict(pwid=work.presentation_edition.permanent_work_id,
-            medium=Edition.medium_to_additional_type[work.presentation_edition.medium],
-            data_source=work.presentation_edition.data_source.name) for work in [w2, w3]]
+        new_entries = [dict(identifier_urn=work.presentation_edition.primary_identifier.urn,
+                            medium=Edition.medium_to_additional_type[work.presentation_edition.medium])
+                       for work in [w2, w3]]
 
         c1 = self._collection()
         c1.libraries = [self._default_library]


### PR DESCRIPTION
@EdwinGuzman I gave you some bad advice when you were working on the bugs related to adding works to lists. I originally used pwids because they were convenient to get from the OPDS feed and I thought they were unique enough, but that keeps causing problems. The latest problem is that sometimes the data source in the OPDS entry and license pool doesn't match the data source on the edition, so the query doesn't find anything. @leonardr suggested using identifiers instead, which should be unique enough and makes more sense than having to keep adding more filters and joins to the query.