### PR TITLE
Convert uploaded cover images to RGB mode before drawing on them.

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1067,6 +1067,10 @@ class WorkController(AdminCirculationManagerController):
             author = ""
 
         if title_position in self.TITLE_POSITIONS:
+            # Convert image to 'RGB' mode if it's not already, so drawing on it works.
+            if image.mode != 'RGB':
+                image = image.convert("RGB")
+
             draw = ImageDraw.Draw(image)
             image_width, image_height = image.size
 
@@ -1123,7 +1127,7 @@ class WorkController(AdminCirculationManagerController):
 
             del draw
 
-        return True
+        return image
 
     def preview_book_cover(self, identifier_type, identifier):
         """Return a preview of the submitted cover image information."""
@@ -1148,10 +1152,7 @@ class WorkController(AdminCirculationManagerController):
         if isinstance(result, ProblemDetail):
             return result
         if title_position and title_position in self.TITLE_POSITIONS:
-            # Convert image to 'RGB' mode if it's not already, so drawing on it works.
-            if image.mode != 'RGB':
-                image = image.convert("RGB")
-            self._process_cover_image(work, image, title_position)
+            image = self._process_cover_image(work, image, title_position)
 
         buffer = StringIO()
         image.save(buffer, format="PNG")
@@ -1216,11 +1217,7 @@ class WorkController(AdminCirculationManagerController):
             if not original_href:
                 original_href = Hyperlink.generic_uri(data_source, work.presentation_edition.primary_identifier, Hyperlink.IMAGE, content=original_content)
                 
-            # Convert image to 'RGB' mode if it's not already, so drawing on it works.
-            if image.mode != 'RGB':
-                image = image.convert("RGB")
-
-            self._process_cover_image(work, image, title_position)
+            image = self._process_cover_image(work, image, title_position)
 
             original_rights_explanation = None
             if rights_uri != RightsStatus.IN_COPYRIGHT:

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1148,6 +1148,9 @@ class WorkController(AdminCirculationManagerController):
         if isinstance(result, ProblemDetail):
             return result
         if title_position and title_position in self.TITLE_POSITIONS:
+            # Convert image to 'RGB' mode if it's not already, so drawing on it works.
+            if image.mode != 'RGB':
+                image = image.convert("RGB")
             self._process_cover_image(work, image, title_position)
 
         buffer = StringIO()
@@ -1213,6 +1216,10 @@ class WorkController(AdminCirculationManagerController):
             if not original_href:
                 original_href = Hyperlink.generic_uri(data_source, work.presentation_edition.primary_identifier, Hyperlink.IMAGE, content=original_content)
                 
+            # Convert image to 'RGB' mode if it's not already, so drawing on it works.
+            if image.mode != 'RGB':
+                image = image.convert("RGB")
+
             self._process_cover_image(work, image, title_position)
 
             original_rights_explanation = None

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1138,7 +1138,7 @@ class TestWorkController(AdminControllerTest):
         processed = Image.open(path)
 
         # Without a title position, the image won't be changed.
-        self.manager.admin_work_controller._process_cover_image(work, processed, "none")
+        processed = self.manager.admin_work_controller._process_cover_image(work, processed, "none")
 
         image_histogram = original.histogram()
         expected_histogram = processed.histogram()
@@ -1150,7 +1150,7 @@ class TestWorkController(AdminControllerTest):
         # Here the title and author are added in the center. Compare the result
         # with a pre-generated version.
         processed = Image.open(path)
-        self.manager.admin_work_controller._process_cover_image(work, processed, "center")
+        processed = self.manager.admin_work_controller._process_cover_image(work, processed, "center")
 
         path = os.path.join(resource_path, "blue_with_title_author.png")
         expected_image = Image.open(path)
@@ -1206,7 +1206,7 @@ class TestWorkController(AdminControllerTest):
             # Modify the image to ensure it gets a different generic URI.
             image.thumbnail((500, 500))
             process_called_with.append((work, image, position))
-            return True
+            return image
         old_process = self.manager.admin_work_controller._process_cover_image
         self.manager.admin_work_controller._process_cover_image = mock_process
 


### PR DESCRIPTION
Michelle Bickert found a bug where images with mode "L" (black and white with 8-bit pixels) caused an exception in PIL when drawing a rectangle:

```
self._process_cover_image(work, image, title_position)\n  File \"/Users/aslagle/dev/circulation/api/admin/controller.py\", line 1114, in _process_cover_image\n    fill=(255,255,255))\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/PIL/ImageDraw.py\", line 191, in rectangle\n    ink, fill = self._getink(outline, fill)\n  File \"/Users/aslagle/dev/circulation/env/lib/python2.7/site-packages/PIL/ImageDraw.py\", line 118, in _getink\n    fill = self.draw.draw_ink(fill, self.mode)\nTypeError: function takes exactly 1 argument (3 given)", "message": "Exception in web app: function takes exactly 1 argument (3 given)"
```
I don't really understand this but converting the image to 'RGB' mode first avoids it.
