### PR TITLE
The language of a Feedbooks collection is its external account id, since that's what distinguishes them from each other.

### DIFF
--- a/api/feedbooks.py
+++ b/api/feedbooks.py
@@ -14,6 +14,7 @@ from core.opds_import import (
     OPDSXMLParser,
 )
 from core.model import (
+    Collection,
     DataSource,
     ExternalIntegration,
     Hyperlink,
@@ -27,7 +28,6 @@ from core.util.epub import EpubAccessor
 class FeedbooksOPDSImporter(OPDSImporter):
 
     REALLY_IMPORT_KEY = 'really_import'
-    LANGUAGE_KEY = 'language'
     REPLACEMENT_CSS_KEY = 'replacement_css'
 
     NAME = ExternalIntegration.FEEDBOOKS
@@ -45,7 +45,7 @@ class FeedbooksOPDSImporter(OPDSImporter):
           "default": "false"
         },
         {
-            "key": LANGUAGE_KEY,
+            "key": Collection.EXTERNAL_ACCOUNT_ID_KEY,
             "label": _("Import books in this language"),
             "description": _("Feedbooks offers separate feeds for different languages. Each one can be made into a separate collection."),
             "type": "select",
@@ -83,7 +83,7 @@ class FeedbooksOPDSImporter(OPDSImporter):
         if not really_import:
             raise Exception("Refusing to instantiate a Feedbooks importer because it's configured to not actually do an import.")
 
-        self.language = integration.setting(self.LANGUAGE_KEY).value
+        self.language = collection.external_account_id
 
         super(FeedbooksOPDSImporter, self).__init__(_db, collection, **kwargs)
 
@@ -452,7 +452,5 @@ class FeedbooksImportMonitor(OPDSImportMonitor):
 
         This is the base URL plus the language setting.
         """
-        language = collection.external_integration.setting(
-            FeedbooksOPDSImporter.LANGUAGE_KEY
-        ).value_or_default('en')
+        language = collection.external_account_id or 'en'
         return FeedbooksOPDSImporter.BASE_OPDS_URL % dict(language=language)

--- a/migration/20180604-feedbooks-language-is-external-account-id.sql
+++ b/migration/20180604-feedbooks-language-is-external-account-id.sql
@@ -1,0 +1,23 @@
+-- For each FeedBooks language, copy the value of the 'language' setting
+-- to the collection's external_account_id.
+update collections set external_account_id='en' where id in (
+ select c.id from collections c join externalintegrations e on c.external_integration_id=e.id join configurationsettings cs on cs.external_integration_id=e.id where e.protocol='FeedBooks' and cs.key='language' and cs.value='en'
+);
+update collections set external_account_id='fr' where id in (
+ select c.id from collections c join externalintegrations e on c.external_integration_id=e.id join configurationsettings cs on cs.external_integration_id=e.id where e.protocol='FeedBooks' and cs.key='language' and cs.value='fr'
+);
+update collections set external_account_id='de' where id in (
+ select c.id from collections c join externalintegrations e on c.external_integration_id=e.id join configurationsettings cs on cs.external_integration_id=e.id where e.protocol='FeedBooks' and cs.key='language' and cs.value='de'
+);
+update collections set external_account_id='it' where id in (
+ select c.id from collections c join externalintegrations e on c.external_integration_id=e.id join configurationsettings cs on cs.external_integration_id=e.id where e.protocol='FeedBooks' and cs.key='language' and cs.value='it'
+);
+update collections set external_account_id='es' where id in (
+ select c.id from collections c join externalintegrations e on c.external_integration_id=e.id join configurationsettings cs on cs.external_integration_id=e.id where e.protocol='FeedBooks' and cs.key='language' and cs.value='es'
+);
+
+-- Delete all FeedBooks language settings.
+delete from configurationsettings where id in (
+ select cs.id from configurationsettings cs join externalintegrations e on cs.external_integration_id=e.id where cs.key='language' and e.protocol='FeedBooks'
+);
+


### PR DESCRIPTION
Without this, all FeedBooks collections end up with the same unique_account_id, which mushes them all together on the metadata wrangler.

This fixes https://jira.nypl.org/browse/SIMPLY-327.