### PR TITLE
Give more helpful error messages when there's a problem negotiating the OPDS For Distributors authentication process.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1440,7 +1440,6 @@ class WorkController(CirculationManagerController):
             pagination=pagination,
         )
 
-        set_trace()
         feed = AcquisitionFeed.groups(
             self._db, lane.DISPLAY_NAME, url, lane, annotator=annotator,
             facets=facets

--- a/api/controller.py
+++ b/api/controller.py
@@ -1440,6 +1440,7 @@ class WorkController(CirculationManagerController):
             pagination=pagination,
         )
 
+        set_trace()
         feed = AcquisitionFeed.groups(
             self._db, lane.DISPLAY_NAME, url, lane, annotator=annotator,
             facets=facets

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -955,7 +955,7 @@ class SeriesLane(DynamicLane):
         self.series = series_name
         display_name = self.series
 
-        if parent and isinstance(parent, WorkBasedLane):
+        if parent and parent.source_audience and isinstance(parent, WorkBasedLane):
             # In an attempt to secure the accurate series, limit the
             # listing to the source's audience sourced from parent data.
             audiences = [parent.source_audience]

--- a/api/opds.py
+++ b/api/opds.py
@@ -623,10 +623,12 @@ class LibraryAnnotator(CirculationManagerAnnotator):
 
         if work.audience == Classifier.AUDIENCE_CHILDREN:
             audiences = [Classifier.AUDIENCE_CHILDREN]
-        if work.audience == Classifier.AUDIENCE_YOUNG_ADULT:
+        elif work.audience == Classifier.AUDIENCE_YOUNG_ADULT:
             audiences = Classifier.AUDIENCES_JUVENILE
-        if work.audience in Classifier.AUDIENCES_ADULT:
+        elif work.audience in Classifier.AUDIENCES_ADULT:
             audiences = list(Classifier.AUDIENCES)
+        else:
+            audiences = []
 
         audience_key=None
         if audiences:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2266,6 +2266,7 @@ class TestWorkController(CirculationControllerTest):
             )
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
+        set_trace()
         eq_(5, len(feed['entries']))
 
         def collection_link(entry):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -43,6 +43,7 @@ from api.authenticator import (
 from core.app_server import (
     load_lending_policy
 )
+from core.classifier import Classifier
 from core.config import CannotLoadConfiguration
 from core.external_search import DummyExternalSearchIndex
 from core.metadata_layer import Metadata
@@ -69,6 +70,7 @@ from core.model import (
     Complaint,
     Library,
     SessionManager,
+    Subject,
     CachedFeed,
     Work,
     CirculationEvent,
@@ -2244,8 +2246,16 @@ class TestWorkController(CirculationControllerTest):
 
         same_series_work = self._work(
             title="ZZZ", authors="ZZZ ZZZ", with_license_pool=True,
-            series="Around the World", data_source_name=DataSource.OVERDRIVE)
+            series="Around the World", data_source_name=DataSource.OVERDRIVE
+        )
         same_series_work.presentation_edition.series_position = 0
+        # Classify this work under a Subject that indicates an adult
+        # audience, so that when we recalculate its presentation there
+        # will be evidence for audience=Adult.  Otherwise
+        # recalculating the presentation will set audience=None.
+        self.work.license_pools[0].identifier.classify(
+            self.edition.data_source, Subject.OVERDRIVE, "Law"
+        )
         self.work.calculate_presentation(
             PresentationCalculationPolicy(regenerate_opds_entries=True),
             DummyExternalSearchIndex()
@@ -2266,7 +2276,6 @@ class TestWorkController(CirculationControllerTest):
             )
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
-        set_trace()
         eq_(5, len(feed['entries']))
 
         def collection_link(entry):
@@ -2274,7 +2283,9 @@ class TestWorkController(CirculationControllerTest):
             return link['title'], link['href']
 
         # This feed contains five books: one recommended,
-        # one in the same series, and two by the same author.
+        # two in the same series, and two by the same author.
+        # One of the 'same series' books is the same title as the
+        # 'same author' book.
         recommendations = []
         same_series = []
         same_contributor = []

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -2,6 +2,7 @@ from nose.tools import (
     set_trace,
     eq_,
     assert_raises,
+    assert_raises_regexp,
 )
 import datetime
 import os
@@ -139,7 +140,11 @@ class TestOPDSForDistributorsAPI(DatabaseTest):
     def test_get_token_errors(self):
         no_auth_document = '<feed></feed>'
         self.api.queue_response(200, content=no_auth_document)
-        assert_raises(LibraryAuthorizationFailedException, self.api._get_token, self._db)
+        assert_raises_regexp(
+            LibraryAuthorizationFailedException,
+            "No authentication document link found in http://opds",
+            self.api._get_token, self._db
+        )
 
         feed = '<feed><link rel="http://opds-spec.org/auth/document" href="http://authdoc"/></feed>'
         self.api.queue_response(200, content=feed)
@@ -147,7 +152,11 @@ class TestOPDSForDistributorsAPI(DatabaseTest):
             "authentication": []
         })
         self.api.queue_response(200, content=auth_doc_without_client_credentials)
-        assert_raises(LibraryAuthorizationFailedException, self.api._get_token, self._db)
+        assert_raises_regexp(
+            LibraryAuthorizationFailedException,
+            "Could not find any credential-based authentication mechanisms in http://authdoc",
+            self.api._get_token, self._db
+        )
 
         self.api.queue_response(200, content=feed)
         auth_doc_without_links = json.dumps({
@@ -156,7 +165,11 @@ class TestOPDSForDistributorsAPI(DatabaseTest):
             }]
         })
         self.api.queue_response(200, content=auth_doc_without_links)
-        assert_raises(LibraryAuthorizationFailedException, self.api._get_token, self._db)
+        assert_raises_regexp(
+            LibraryAuthorizationFailedException,
+            "Could not find any authentication links in http://authdoc",
+            self.api._get_token, self._db
+        )
 
         self.api.queue_response(200, content=feed)
         auth_doc = json.dumps({
@@ -171,7 +184,11 @@ class TestOPDSForDistributorsAPI(DatabaseTest):
         self.api.queue_response(200, content=auth_doc)
         token_response = json.dumps({"error": "unexpected error"})
         self.api.queue_response(200, content=token_response)
-        assert_raises(LibraryAuthorizationFailedException, self.api._get_token, self._db)
+        assert_raises_regexp(
+            LibraryAuthorizationFailedException,
+            "Document retrieved from http://authenticate is not a bearer token: {.*unexpected error.*}",
+            self.api._get_token, self._db
+        )
 
     def test_checkin(self):
         # The patron has two loans, one from this API's collection and
@@ -324,7 +341,7 @@ class TestOPDSForDistributorsAPI(DatabaseTest):
             collection=other_collection,
         )
         p3.loan_to(patron)
-        
+
         activity = self.api.patron_activity(patron, "1234")
         eq_(2, len(activity))
         [l1, l2] = activity


### PR DESCRIPTION
The test changes are necessary to bring circulation up to date with a change in the classifier, which now sets Work.audience=None if there's no evidence for any particular audience.