### PR TITLE
Implement integration self-tests

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -4,8 +4,8 @@ from config import (
     CannotLoadConfiguration,
     IntegrationException,
 )
-from core.external_integration import (
-    HasSelfTest,
+from core.selftest import (
+    HasSelfTests,
 )
 from core.opds import OPDSFeed
 from core.model import (
@@ -1217,7 +1217,7 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
         raise NotImplementedError()
 
 
-class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTest):
+class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
     """Verify a username/password, obtained through HTTP Basic Auth, with
     a remote source of truth.
     """
@@ -1469,7 +1469,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTest):
             )
 
 
-    def self_test(self, _db):
+    def run_self_tests(self, _db):
         patron_test = self.run_test(
             "Authenticating test patron", self.testing_patron_or_bust, _db
         )

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1458,16 +1458,18 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
         raising CannotLoadConfiguration if none is configured.
         """
         if self.test_username is None:
-            raise CannotLoadConfiguration("No test identifier is configured.")
+            raise CannotLoadConfiguration(
+                "No test patron identifier is configured."
+            )
 
         patron, password = self.testing_patron(_db)
         if not patron:
             # We ran to completion but ended up with no patron.
             raise IntegrationException(
-                "Remote refused to authenticate the test patron.",
+                "Remote declined to authenticate the test patron.",
                 "The patron may not exist or its password may be wrong."
             )
-
+        return patron, password
 
     def run_self_tests(self, _db):
         patron_test = self.run_test(

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1471,7 +1471,10 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
             )
         return patron, password
 
-    def run_self_tests(self, _db):
+    def _run_self_tests(self, _db):
+        """Verify the credentials of the test patron for this integration,
+        and update its metadata.
+        """
         patron_test = self.run_test(
             "Authenticating test patron", self.testing_patron_or_bust, _db
         )

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1449,7 +1449,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
         :return: A 2-tuple (Patron, password)
         """
         if self.test_username is None:
-            return None, None
+            return self.test_username, self.test_password
         header = dict(username=self.test_username, password=self.test_password)
         return self.authenticated_patron(_db, header), self.test_password
 

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2,6 +2,10 @@ from nose.tools import set_trace
 from config import (
     Configuration,
     CannotLoadConfiguration,
+    IntegrationException,
+)
+from core.external_integration import (
+    HasSelfTest,
 )
 from core.opds import OPDSFeed
 from core.model import (
@@ -1213,7 +1217,7 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
         raise NotImplementedError()
 
 
-class BasicAuthenticationProvider(AuthenticationProvider):
+class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTest):
     """Verify a username/password, obtained through HTTP Basic Auth, with
     a remote source of truth.
     """
@@ -1444,10 +1448,42 @@ class BasicAuthenticationProvider(AuthenticationProvider):
 
         :return: A 2-tuple (Patron, password)
         """
-        if self.test_username is None or self.test_password is None:
+        if self.test_username is None:
             return None, None
         header = dict(username=self.test_username, password=self.test_password)
         return self.authenticated_patron(_db, header), self.test_password
+
+    def testing_patron_or_bust(self, _db):
+        """Look up the Patron object reserved for testing purposes,
+        raising CannotLoadConfiguration if none is configured.
+        """
+        if self.test_username is None:
+            raise CannotLoadConfiguration("No test identifier is configured.")
+
+        patron, password = self.testing_patron(_db)
+        if not patron:
+            # We ran to completion but ended up with no patron.
+            raise IntegrationException(
+                "Remote refused to authenticate the test patron.",
+                "The patron may not exist or its password may be wrong."
+            )
+
+
+    def self_test(self, _db):
+        patron_test = self.run_test(
+            "Authenticating test patron", self.testing_patron_or_bust, _db
+        )
+        yield patron_test
+
+        if not patron_test.success:
+            # We can't run the rest of the tests.
+            return
+
+        patron, password = patron_test.result
+        yield self.run_test(
+            "Syncing patron metadata", self.update_patron_metadata,
+            patron
+        )
     
     def authenticate(self, _db, credentials):
         """Turn a set of credentials into a Patron object.

--- a/api/circulation_exceptions.py
+++ b/api/circulation_exceptions.py
@@ -1,5 +1,6 @@
 from flask_babel import lazy_gettext as _
 
+from core.config import IntegrationException
 from core.problem_details import (
     INTEGRATION_ERROR,
     INTERNAL_SERVER_ERROR,
@@ -7,14 +8,14 @@ from core.problem_details import (
 from problem_details import *
 
 
-class CirculationException(Exception):
+class CirculationException(IntegrationException):
     """An exception occured when carrying out a circulation operation.
 
     `status_code` is the status code that should be returned to the patron.
     """
     status_code = 400
 
-class InternalServerError(Exception):
+class InternalServerError(IntegrationException):
     status_code = 500
 
     def as_problem_detail_document(self, debug=False):

--- a/api/circulation_exceptions.py
+++ b/api/circulation_exceptions.py
@@ -15,6 +15,11 @@ class CirculationException(IntegrationException):
     """
     status_code = 400
 
+    def __init__(self, message=None, debug_info=None):
+        message = message or self.__class__.__name__
+        super(CirculationException, self).__init__(message, debug_info)
+
+
 class InternalServerError(IntegrationException):
     status_code = 500
 

--- a/api/config.py
+++ b/api/config.py
@@ -7,6 +7,7 @@ from flask_babel import lazy_gettext as _
 from core.config import (
     Configuration as CoreConfiguration,
     CannotLoadConfiguration,
+    IntegrationException,
     empty_config as core_empty_config,
     temp_config as core_temp_config,
 )

--- a/api/nyt.py
+++ b/api/nyt.py
@@ -196,6 +196,7 @@ class NYTBestSellerList(list):
         self.frequency = timedelta(frequency)
         self.items_by_isbn = dict()
         self.metadata_client = metadata_client
+        self.log = logging.getLogger("NYT Best-seller list %s" % self.name)
 
     @property
     def all_dates(self):

--- a/api/nyt.py
+++ b/api/nyt.py
@@ -145,7 +145,7 @@ class NYTBestSellerAPI(NYTAPI, HasSelfTests):
             )
         else:
             raise IntegrationException(
-                "Unknown API error", diagnostic
+                "Unknown API error (status %s)" % status, diagnostic
             )
 
     def list_of_lists(self, max_age=LIST_OF_LISTS_MAX_AGE):

--- a/api/nyt.py
+++ b/api/nyt.py
@@ -105,7 +105,7 @@ class NYTBestSellerAPI(NYTAPI, HasSelfTests):
                 )
         self.metadata_client = metadata_client
 
-    def run_self_tests(self, _db):
+    def _run_self_tests(self, _db):
         yield self.run_test(
             "Getting list of best-seller lists", self.list_of_lists
         )

--- a/api/nyt.py
+++ b/api/nyt.py
@@ -12,11 +12,13 @@ from sqlalchemy.orm.exc import (
 )
 from flask_babel import lazy_gettext as _
 
-from config import CannotLoadConfiguration
+from config import (
+    CannotLoadConfiguration,
+    IntegrationException,
+)
 
 from core.external_integration import (
     HasSelfTest,
-    IntegrationSetupException,
 )
 from core.opds_import import MetadataWranglerOPDSLookup
 from core.metadata_layer import (
@@ -103,7 +105,7 @@ class NYTBestSellerAPI(NYTAPI, HasSelfTest):
                 )
         self.metadata_client = metadata_client
 
-    def self_test(self):
+    def self_test(self, _db):
         yield self.run_test(
             "Getting list of best-seller lists", self.list_of_lists
         )
@@ -137,12 +139,12 @@ class NYTBestSellerAPI(NYTAPI, HasSelfTest):
         )
 
         if status == 403:
-            raise IntegrationSetupException(
+            raise IntegrationException(
                 "API authentication failed",
                 "API key is most likely wrong. %s" % diagnostic
             )
         else:
-            raise IntegrationSetupException(
+            raise IntegrationException(
                 "Unknown API error", diagnostic
             )
 
@@ -178,7 +180,6 @@ class NYTBestSellerAPI(NYTAPI, HasSelfTest):
         for date in list.all_dates:
             self.update(list, date, self.HISTORICAL_LIST_MAX_AGE)
             self._db.commit()
-NYTBestSellerAPI.register_self_test()
 
 
 class NYTBestSellerList(list):

--- a/api/nyt.py
+++ b/api/nyt.py
@@ -83,15 +83,13 @@ class NYTBestSellerAPI(NYTAPI, HasSelfTests):
             message = "No ExternalIntegration found for the NYT."
             raise CannotLoadConfiguration(message)
 
-        if not integration.password:
-            message = "NYT integration improperly configured."
-            raise CannotLoadConfiguration(message)
-
         return cls(_db, api_key=integration.password, **kwargs)
 
     def __init__(self, _db, api_key=None, do_get=None, metadata_client=None):
         self.log = logging.getLogger("NYT API")
         self._db = _db
+        if not api_key:
+            raise CannotLoadConfiguration("No NYT API key is specified")
         self.api_key = api_key
         self.do_get = do_get or Representation.simple_http_get
         if not metadata_client:

--- a/api/nyt.py
+++ b/api/nyt.py
@@ -17,8 +17,8 @@ from config import (
     IntegrationException,
 )
 
-from core.external_integration import (
-    HasSelfTest,
+from core.selftest import (
+    HasSelfTests,
 )
 from core.opds_import import MetadataWranglerOPDSLookup
 from core.metadata_layer import (
@@ -49,7 +49,7 @@ class NYTAPI(object):
         return d.strftime(self.DATE_FORMAT)
 
 
-class NYTBestSellerAPI(NYTAPI, HasSelfTest):
+class NYTBestSellerAPI(NYTAPI, HasSelfTests):
     
     PROTOCOL = ExternalIntegration.NYT
     GOAL = ExternalIntegration.METADATA_GOAL
@@ -105,7 +105,7 @@ class NYTBestSellerAPI(NYTAPI, HasSelfTest):
                 )
         self.metadata_client = metadata_client
 
-    def self_test(self, _db):
+    def run_self_tests(self, _db):
         yield self.run_test(
             "Getting list of best-seller lists", self.list_of_lists
         )

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -24,6 +24,7 @@ from core.model import (
     Identifier
 )
 
+from core.external_integration import HasSelfTest
 from core.monitor import (
     CollectionMonitor,
 )
@@ -32,7 +33,7 @@ from core.util.http import HTTP
 from circulation_exceptions import *
 
 
-class OdiloAPI(BaseOdiloAPI, BaseCirculationAPI):
+class OdiloAPI(BaseOdiloAPI, BaseCirculationAPI, HasSelfTest):
     NAME = ExternalIntegration.ODILO
     DESCRIPTION = _("Integrate an Odilo library collection.")
     SETTINGS = [

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -72,7 +72,7 @@ class OdiloAPI(BaseOdiloAPI, BaseCirculationAPI, HasSelfTests):
             )
         )
 
-    def run_self_tests(self, _db):
+    def _run_self_tests(self, _db):
         result = self.run_test(
             "Obtaining a sitewide access token", self.check_creds,
             force_refresh=True

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -73,10 +73,16 @@ class OdiloAPI(BaseOdiloAPI, BaseCirculationAPI, HasSelfTests):
         )
 
     def run_self_tests(self, _db):
-        yield self.run_test(
+        result = self.run_test(
             "Obtaining a sitewide access token", self.check_creds,
             force_refresh=True
         )
+        yield result
+        if not result.success:
+            # We couldn't get a sitewide token, so there is no
+            # point in continuing.
+            return
+
         for result in self.default_patrons(self.collection):
             if isinstance(result, SelfTestResult):
                 yield result

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -24,7 +24,7 @@ from core.model import (
     Identifier
 )
 
-from core.external_integration import HasSelfTest
+from core.selftest import HasSelfTests
 from core.monitor import (
     CollectionMonitor,
 )
@@ -33,7 +33,7 @@ from core.util.http import HTTP
 from circulation_exceptions import *
 
 
-class OdiloAPI(BaseOdiloAPI, BaseCirculationAPI, HasSelfTest):
+class OdiloAPI(BaseOdiloAPI, BaseCirculationAPI, HasSelfTests):
     NAME = ExternalIntegration.ODILO
     DESCRIPTION = _("Integrate an Odilo library collection.")
     SETTINGS = [
@@ -68,6 +68,10 @@ class OdiloAPI(BaseOdiloAPI, BaseCirculationAPI, HasSelfTest):
                 collection, api_class=self
             )
         )
+
+    def run_self_tests(self, _db):
+        set_trace()
+        pass
 
     def patron_request(self, patron, pin, url, extra_headers={}, data=None, exception_on_401=False, method=None):
         """Make an HTTP request on behalf of a patron.

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -269,7 +269,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
         if not found_checkout:
             raise NoActiveLoan(
                 "Cannot fulfill %s - patron %s/%s has no such checkout." % (
-                    item_oneclick_, patron.authorization_identifier,
+                    item_oneclick_id, patron.authorization_identifier,
                     patron_oneclick_id
                 )
             )

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -143,8 +143,12 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
             return True
 
         # should never happen
-        raise CirculationException("Unknown error %s/%s checking in %s.", patron.authorization_identifier, 
-            patron_oneclick_id, item_oneclick_id)
+        raise CirculationException(
+            "Unknown error %s/%s checking in %s." % (
+                patron.authorization_identifier, patron_oneclick_id,
+                item_oneclick_id
+            )
+        )
 
 
     def checkout(self, patron, pin, licensepool, internal_format):
@@ -263,8 +267,12 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
                 found_checkout = checkout
                 break
         if not found_checkout:
-            raise NoActiveLoan("Cannot fulfill %s - patron %s/%s has no such checkout.", item_oneclick_id, 
-                patron.authorization_identifier, patron_oneclick_id)
+            raise NoActiveLoan(
+                "Cannot fulfill %s - patron %s/%s has no such checkout." % (
+                    item_oneclick_, patron.authorization_identifier,
+                    patron_oneclick_id
+                )
+            )
 
         return found_checkout.fulfillment_info
 
@@ -337,8 +345,12 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI):
             return True
 
         # should never happen
-        raise CirculationException("Unknown error %s/%s releasing %s.", patron.authorization_identifier, 
-            patron_oneclick_id, item_oneclick_id)
+        raise CirculationException(
+            "Unknown error %s/%s releasing %s." % (
+                patron.authorization_identifier, patron_oneclick_id,
+                item_oneclick_id
+            )
+        )
 
     @property
     def default_circulation_replacement_policy(self):

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -69,7 +69,7 @@ class OPDSForDistributorsAPI(BaseCirculationAPI, HasSelfTests):
         self.feed_url = collection.external_account_id
         self.auth_url = None
 
-    def run_self_tests(self, _db):
+    def _run_self_tests(self, _db):
         """Try to get a token."""
         yield self.run_test(
             "Negotiate a fulfillment token", self._get_token, _db

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -26,7 +26,7 @@ from core.model import (
     get_one_or_create,
 )
 from core.metadata_layer import FormatData
-from core.external_integration import HasSelfTest
+from core.selftest import HasSelfTests
 from circulation import (
     BaseCirculationAPI,
     LoanInfo,
@@ -40,7 +40,7 @@ from core.testing import (
 from config import IntegrationException
 from circulation_exceptions import *
 
-class OPDSForDistributorsAPI(BaseCirculationAPI, HasSelfTest):
+class OPDSForDistributorsAPI(BaseCirculationAPI, HasSelfTests):
     NAME = "OPDS for Distributors"
     DESCRIPTION = _("Import books from a distributor that requires authentication to get the OPDS feed and download books.")
 
@@ -69,7 +69,7 @@ class OPDSForDistributorsAPI(BaseCirculationAPI, HasSelfTest):
         self.feed_url = collection.external_account_id
         self.auth_url = None
 
-    def self_test(self, _db):
+    def run_self_tests(self, _db):
         """Try to get a token."""
         yield self.run_test(
             "Negotiate a fulfillment token", self._get_token, _db

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -138,7 +138,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
             url = self._all_products_link
             status, headers, body = self.get(url, {})
             body = json.loads(body)
-            return "%d item(s) in collection." % body['totalItems']
+            return "%d item(s) in collection" % body['totalItems']
         yield self.run_test(
             "Counting size of collection", _count_books
         )

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -112,7 +112,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
                 collection, api_class=self
             )
         )
-                
+
     def run_self_tests(self, _db):
         result = self.run_test(
             "Checking global Client Authentication privileges",

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -113,7 +113,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
             )
         )
 
-    def run_self_tests(self, _db):
+    def _run_self_tests(self, _db):
         result = self.run_test(
             "Checking global Client Authentication privileges",
             self.check_creds, force_refresh=True

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -232,8 +232,8 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
                 message += '/' + error
             diagnostic = None
             if error == 'Requested record not found':
-                diagnostic = "The patron failed Overdrive's cross-check against the library's ILS."
-            raise PatronAuthorizationFailedException(message, diagnostic)
+                debug = "The patron failed Overdrive's cross-check against the library's ILS."
+            raise PatronAuthorizationFailedException(message, debug)
         return credential
 
     def checkout(self, patron, pin, licensepool, internal_format):

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -15,7 +15,7 @@ from circulation import (
     FulfillmentInfo,
     BaseCirculationAPI,
 )
-from core.external_integration import HasSelfTest
+from core.selftest import HasSelfTests
 from core.overdrive import (
     OverdriveAPI as BaseOverdriveAPI,
     OverdriveRepresentationExtractor,
@@ -50,7 +50,7 @@ from core.scripts import Script
 from circulation_exceptions import *
 from core.analytics import Analytics
 
-class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTest):
+class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
 
     NAME = ExternalIntegration.OVERDRIVE
     DESCRIPTION = _("Integrate an Overdrive collection. For an Overdrive Advantage collection, select the consortium's Overdrive collection as the parent.")
@@ -129,7 +129,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTest):
                 patron, password = auth.testing_patron(_db)
             yield (library, patron, pin)
                 
-    def self_test(self, _db):
+    def run_self_tests(self, _db):
         yield self.run_test(
             "Testing checking Client Authentication privileges", 
             self.check_creds, force_refresh=True

--- a/api/selftest.py
+++ b/api/selftest.py
@@ -1,0 +1,65 @@
+from nose.tools import set_trace
+from sqlalchemy.orm.session import Session
+
+from authenticator import LibraryAuthenticator
+from core.config import IntegrationException
+from core.selftest import (
+    HasSelfTests as CoreHasSelfTests,
+    SelfTestResult,
+)
+
+
+class HasSelfTests(CoreHasSelfTests):
+    """Circulation-specific enhancements for HasSelfTests.
+
+    Circulation self-tests frequently need to test the ability to act
+    on behalf of a specific patron.
+    """
+
+    def default_patrons(self, collection):
+        """Find a usable default Patron for each of the libraries associated
+        with the given Collection.
+
+        :yield: A sequence of (Library, Patron, password) 3-tuples.
+            Yields (SelfTestFailure, None, None) if the Collection is not
+            associated with any libraries, if a library does not
+            have a default patron configured, or if there is an
+            exception acquiring a library's default patron.
+        """
+        _db = Session.object_session(collection)
+        if not collection.libraries:
+            yield self.test_failure(
+                "Acquiring test patron credentials.",
+                "Collection is not associated with any libraries.",
+                "Add the collection to a library that has a patron authentication service."
+            )
+        
+        for library in collection.libraries:
+            name = library.name
+            task = "Acquiring test patron credentials for library %s" % library.name
+            try:
+                library_authenticator = LibraryAuthenticator.from_config(
+                    _db, library
+                )
+                patron = password = None
+                auth = library_authenticator.basic_auth_provider
+                if auth:
+                    patron, password = auth.testing_patron(_db)
+
+                if not patron:
+                    yield self.test_failure(
+                        task,
+                        "Library has no test patron configured.",
+                        "You can specify a test patron when you configure the library's patron authentication service."
+                    )
+                    continue
+
+                yield (library, patron, password)
+            except IntegrationException, e:
+                yield self.test_failure(task, e)
+            except Exception, e:
+                yield self.test_failure(
+                    task, "Exception getting default patron: %r" % e
+                )
+
+

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1612,7 +1612,7 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         # value as testing_patron()
         eq_(value, present_patron.testing_patron_or_bust(self._db))
 
-    def test_run_self_tests(self):
+    def test__run_self_tests(self):
         _db = object()
         class CantAuthenticateTestPatron(BasicAuthenticationProvider):
             def __init__(self):
@@ -1624,7 +1624,7 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         # If we can't authenticate a test patron, the rest of the tests
         # aren't even run.
         provider = CantAuthenticateTestPatron()
-        [result] = list(provider.run_self_tests(_db))
+        [result] = list(provider._run_self_tests(_db))
         eq_(_db, provider.called_with)
         eq_(False, result.success)
         eq_("Nope", result.exception.message)
@@ -1647,7 +1647,7 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
                 return "some metadata"
 
         provider = Mock("patron", "password")
-        [get_patron, update_metadata] = provider.run_self_tests(object())
+        [get_patron, update_metadata] = provider._run_self_tests(object())
         eq_("Authenticating test patron", get_patron.name)
         eq_(True, get_patron.success)
         eq_((provider.patron, provider.password), get_patron.result)

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -212,7 +212,7 @@ class TestCirculationAPI(DatabaseTest):
         # This is the expected behavior in most cases--you tried to
         # renew the loan and failed because it's not time yet.
         self.remote.queue_checkout(CannotRenew())
-        assert_raises_regexp(CannotRenew, '^$', self.borrow)
+        assert_raises_regexp(CannotRenew, 'CannotRenew', self.borrow)
 
     def test_attempt_renew_with_local_loan_and_no_available_copies(self):
         """We have a local loan and a remote loan but the patron tried to

--- a/tests/test_nyt.py
+++ b/tests/test_nyt.py
@@ -83,7 +83,7 @@ class TestNYTBestSellerAPI(NYTBestSellerAPITest):
         # It has to have the api key in its 'password' setting.
         assert_raises_regexp(
             CannotLoadConfiguration, 
-            "NYT integration improperly configured.",
+            "No NYT API key is specified.",
             NYTBestSellerAPI.from_config, self._db
         )
 

--- a/tests/test_nyt.py
+++ b/tests/test_nyt.py
@@ -113,7 +113,7 @@ class TestNYTBestSellerAPI(NYTBestSellerAPITest):
             def list_of_lists(self):
                 return "some lists"
 
-        [list_test] = Mock().run_self_tests(object())
+        [list_test] = Mock()._run_self_tests(object())
         eq_("Getting list of best-seller lists", list_test.name)
         eq_(True, list_test.success)
         eq_("some lists", list_test.result)

--- a/tests/test_odilo.py
+++ b/tests/test_odilo.py
@@ -80,12 +80,12 @@ class OdiloAPITest(DatabaseTest):
 
 class TestOdiloAPI(OdiloAPITest):
 
-    def test_run_self_tests(self):
-        """Verify that OdiloAPI.run_self_tests() calls the right
+    def test__run_self_tests(self):
+        """Verify that OdiloAPI._run_self_tests() calls the right
         methods.
         """
         class Mock(MockOdiloAPI):
-            "Mock every method used by OdiloAPI.run_self_tests."
+            "Mock every method used by OdiloAPI._run_self_tests."
 
             def __init__(self, _db, collection):
                 """Stop the default constructor from running."""
@@ -128,7 +128,7 @@ class TestOdiloAPI(OdiloAPITest):
         # Now that everything is set up, run the self-test.
         api = Mock(self._db, self.collection)
         results = sorted(
-            api.run_self_tests(self._db), key=lambda x: x.name
+            api._run_self_tests(self._db), key=lambda x: x.name
         )
         token_failure, token_success, sitewide = results
 
@@ -167,18 +167,16 @@ class TestOdiloAPI(OdiloAPITest):
     def test_run_self_tests_short_circuit(self):
         """If OdiloAPI.check_creds can't get credentials, the rest of
         the self-tests aren't even run.
-        """
 
-        # NOTE: this isn't as foolproof as it seems. If there's a
-        # problem getting the credentials, that problem will most
-        # likely happen during the OdiloAPI constructor, and
-        # we won't even get a chance to run the tests.
+        This probably doesn't matter much, because if check_creds doesn't
+        work we won't be able to instantiate the OdiloAPI class.
+        """
         def explode(*args, **kwargs):
             raise Exception("Failure!")
         self.api.check_creds = explode
 
         # Only one test will be run.
-        [check_creds] = self.api.run_self_tests(self._db)
+        [check_creds] = self.api._run_self_tests(self._db)
         eq_("Failure!", check_creds.exception.message)
 
 

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -47,7 +47,7 @@ class TestOPDSForDistributorsAPI(DatabaseTest):
         self.collection = MockOPDSForDistributorsAPI.mock_collection(self._db)
         self.api = MockOPDSForDistributorsAPI(self._db, self.collection)
 
-    def test_run_self_tests(self):
+    def test__run_self_tests(self):
         """The self-test for OPDSForDistributorsAPI just tries to negotiate
         a fulfillment token.
         """
@@ -60,7 +60,7 @@ class TestOPDSForDistributorsAPI(DatabaseTest):
                 return "a token"
 
         api = Mock()
-        [result] = api.run_self_tests(self._db)
+        [result] = api._run_self_tests(self._db)
         eq_(self._db, api.called_with)
         eq_("Negotiate a fulfillment token", result.name)
         eq_(True, result.success)

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -47,6 +47,25 @@ class TestOPDSForDistributorsAPI(DatabaseTest):
         self.collection = MockOPDSForDistributorsAPI.mock_collection(self._db)
         self.api = MockOPDSForDistributorsAPI(self._db, self.collection)
 
+    def test_run_self_tests(self):
+        """The self-test for OPDSForDistributorsAPI just tries to negotiate
+        a fulfillment token.
+        """
+        class Mock(OPDSForDistributorsAPI):
+            def __init__(self):
+                pass
+
+            def _get_token(self, _db):
+                self.called_with = _db
+                return "a token"
+
+        api = Mock()
+        [result] = api.run_self_tests(self._db)
+        eq_(self._db, api.called_with)
+        eq_("Negotiate a fulfillment token", result.name)
+        eq_(True, result.success)
+        eq_("a token", result.result)
+
     def test_can_fulfill_without_loan(self):
         """A book made available through OPDS For Distributors can be
         fulfilled with no underlying loan, if its delivery mechanism

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -82,8 +82,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         methods.
         """
         class Mock(MockOverdriveAPI):
-
-            # Mock every method used by OverdriveAPI.run_self_tests.
+            "Mock every method used by OverdriveAPI.run_self_tests."
 
             # First we will call check_creds() to get a fresh credential.
             mock_credential = object()
@@ -102,7 +101,7 @@ class TestOverdriveAPI(OverdriveAPITest):
                 return 200, {}, json.dumps(dict(totalItems=2010))
 
             # Finally, for every library associated with this
-            # collection, we'll call get_patron_credential using
+            # collection, we'll call get_patron_credential() using
             # the credentials of that library's test patron.
             mock_patron_credential = object()
             get_patron_credential_called_with = []
@@ -188,7 +187,7 @@ class TestOverdriveAPI(OverdriveAPITest):
 
         # Only one test will be run.
         [check_creds] = self.api.run_self_tests(self._db)
-        eq_("Failure!", check_creds.exception.message)        
+        eq_("Failure!", check_creds.exception.message)
 
     def test_default_notification_email_address(self):
         """Test the ability of the Overdrive API to detect an email address

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -77,12 +77,12 @@ class OverdriveAPITest(DatabaseTest):
 
 class TestOverdriveAPI(OverdriveAPITest):
 
-    def test_run_self_tests(self):
-        """Verify that OverdriveAPI.run_self_tests() calls the right
+    def test__run_self_tests(self):
+        """Verify that OverdriveAPI._run_self_tests() calls the right
         methods.
         """
         class Mock(MockOverdriveAPI):
-            "Mock every method used by OverdriveAPI.run_self_tests."
+            "Mock every method used by OverdriveAPI._run_self_tests."
 
             # First we will call check_creds() to get a fresh credential.
             mock_credential = object()
@@ -128,7 +128,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         # Now that everything is set up, run the self-test.
         api = Mock(self._db, self.collection)
         results = sorted(
-            api.run_self_tests(self._db), key=lambda x: x.name
+            api._run_self_tests(self._db), key=lambda x: x.name
         )
         [no_patron_credential, default_patron_credential,
          global_privileges, collection_size, advantage] = results
@@ -175,18 +175,16 @@ class TestOverdriveAPI(OverdriveAPITest):
     def test_run_self_tests_short_circuit(self):
         """If OverdriveAPI.check_creds can't get credentials, the rest of
         the self-tests aren't even run.
-        """
 
-        # NOTE: this isn't as foolproof as it seems. If there's a
-        # problem getting the credentials, that problem will most
-        # likely happen during the OverdriveAPI constructor, and
-        # we won't even get a chance to run the tests.
+        This probably doesn't matter much, because if check_creds doesn't
+        work we won't be able to instantiate the OverdriveAPI class.
+        """
         def explode(*args, **kwargs):
             raise Exception("Failure!")
         self.api.check_creds = explode
 
         # Only one test will be run.
-        [check_creds] = self.api.run_self_tests(self._db)
+        [check_creds] = self.api._run_self_tests(self._db)
         eq_("Failure!", check_creds.exception.message)
 
     def test_default_notification_email_address(self):

--- a/tests/test_selftest.py
+++ b/tests/test_selftest.py
@@ -1,0 +1,81 @@
+"""Test circulation-specific extensions to the self-test infrastructure."""
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+
+from core.testing import DatabaseTest
+from core.model import (
+    ExternalIntegration,
+)
+
+from api.authenticator import BasicAuthenticationProvider
+from api.selftest import (
+    HasSelfTests,
+    SelfTestResult,
+)
+
+class TestHasSelfTests(DatabaseTest):
+
+    def test_default_patrons(self):
+        """Some self-tests must run with a patron's credentials.  The
+        default_patrons() method finds the default Patron for every
+        Library associated with a given Collection.
+        """
+        h = HasSelfTests()
+
+        # This collection is not in any libraries, so there's no way
+        # to test it.
+        not_in_library = self._collection()
+        [result] = h.default_patrons(not_in_library)
+        eq_("Acquiring test patron credentials.", result.name)
+        eq_(False, result.success)
+        eq_("Collection is not associated with any libraries.",
+            result.exception.message)
+        eq_(
+            "Add the collection to a library that has a patron authentication service.",
+            result.exception.debug_message
+        )
+
+        # This collection is in two libraries.
+        collection = self._default_collection
+
+        # This library has no default patron set up.
+        no_default_patron = self._library()
+        collection.libraries.append(no_default_patron)
+
+        # This library has a default patorn set up.
+        integration = self._external_integration(
+            "api.simple_authentication", ExternalIntegration.PATRON_AUTH_GOAL,
+            libraries=[self._default_library]
+        )
+        p = BasicAuthenticationProvider
+        integration.setting(p.TEST_IDENTIFIER).value = "username1"
+        integration.setting(p.TEST_PASSWORD).value = "password1"
+
+        # Calling default_patrons on the Collection returns one result for
+        # each Library that uses that Collection.
+
+        results = list(h.default_patrons(collection))
+        eq_(2, len(results))
+        [failure] = [x for x in results if isinstance(x, SelfTestResult)]
+        [success] = [x for x in results if x != failure]
+
+        # A SelfTestResult indicating failure was returned for the
+        # library without a test patron, since the test cannot proceed with
+        # a test patron.
+        eq_(False, failure.success)
+        eq_(
+            "Acquiring test patron credentials for library %s" % no_default_patron.name,
+            failure.name
+        )
+        eq_("Library has no test patron configured.", failure.exception.message)
+        eq_("You can specify a test patron when you configure the library's patron authentication service.", failure.exception.debug_message)
+
+        # The test patron for the library that has one was looked up,
+        # and the test can proceed using this patron.
+        library, patron, password = success
+        eq_(self._default_library, library)
+        eq_("username1", patron.authorization_identifier)
+        eq_("password1", password)
+


### PR DESCRIPTION
This branch implements basic self-tests for five integrations:

* BasicAuthenticationProvider (any ILS system that uses HTTP Basic Auth, notably SIP2 and Millenium Patron)
* Overdrive
* Odilo
* OPDS For Distributors
* The NYT best-seller API

More will follow; these are the ones that were necessary for me to convince myself that the architecture is sound and can handle both simple and complex cases.