### PR TITLE
Lanes.media is not currently used

### DIFF
--- a/api/lanes.py
+++ b/api/lanes.py
@@ -258,7 +258,7 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     common_args = dict(
         languages=languages,
-        media=[Edition.BOOK_MEDIUM]
+        media=None
     )
     adult_common_args = dict(common_args)
     adult_common_args['audiences'] = ADULT

--- a/migration/20180619-lanes-have-no-media-type.sql
+++ b/migration/20180619-lanes-have-no-media-type.sql
@@ -1,0 +1,7 @@
+-- The lanes.media column is no longer set by default -- the same lanes are
+-- present for both ebooks and audiobooks, and an EntryPoint is used to
+-- filter them.
+--
+-- We're not removing lanes.media altogether because it might be useful
+-- as a way of dividing up sublanes for other entry points.
+update lanes set media=null;

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -71,8 +71,9 @@ class TestLaneCreation(DatabaseTest):
             # They all are restricted to English and Spanish.
             eq_(x.languages, languages)
 
-            # They only contain books.
-            eq_([Edition.BOOK_MEDIUM], x.media)
+            # They have no restrictions on media type -- that's handled
+            # with entry points.
+            eq_(None, x.media)
 
         eq_(
             ['Fiction', 'Nonfiction', 'Young Adult Fiction',


### PR DESCRIPTION
This branch changes the contents of `lanes` to reflect the fact that we don't currently restrict lanes to specific media types. This is theoretically possible, and may be useful in the future, but for now we're solely using entrypoints for this, and the lanes themselves should not have any restrictions on media type.