### PR TITLE
Allow library to configure email addresses for DMCA complaints and configuration problem reports

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -3471,6 +3471,15 @@ class SettingsController(AdminCirculationManagerController):
         # OPDS Authentication document.
         self._db.commit()
 
+        payload = dict(url=auth_document_url)
+        # Find the email address the administrator should use if they notice
+        # a problem with the way the library is using an integration.
+        contact = Configuration.configuration_contact_uri(library)
+        if contact:
+            payload['contact'] = contact
+
+
+
         auth_document_url = self.url_for(
             "authentication_document",
             library_short_name=library.short_name

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -3471,22 +3471,20 @@ class SettingsController(AdminCirculationManagerController):
         # OPDS Authentication document.
         self._db.commit()
 
+        auth_document_url = self.url_for(
+            "authentication_document",
+            library_short_name=library.short_name
+        )
         payload = dict(url=auth_document_url)
+
         # Find the email address the administrator should use if they notice
         # a problem with the way the library is using an integration.
         contact = Configuration.configuration_contact_uri(library)
         if contact:
             payload['contact'] = contact
-
-
-
-        auth_document_url = self.url_for(
-            "authentication_document",
-            library_short_name=library.short_name
-        )
         # Allow 401 so we can provide a more useful error message.
         response = do_post(
-            register_url, dict(url=auth_document_url), timeout=60,
+            register_url, payload, timeout=60,
             allowed_response_codes=["2xx", "3xx", "401"],
         )
         if isinstance(response, ProblemDetail):

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -779,6 +779,18 @@ class LibraryAuthenticator(object):
             dict(rel="start", href=index_url, 
                  type=OPDSFeed.ACQUISITION_FEED_TYPE)
         )
+
+        # If there is a Designated Agent email address, add it as a
+        # link.
+        designated_agent_uri = Configuration.copyright_designated_agent_uri(
+            library
+        )
+        if designated_agent_uri:
+            links.append(
+                dict(rel=Configuration.COPYRIGHT_DESIGNATED_AGENT_REL,
+                     href=designated_agent_uri
+                )
+            )
                 
         # Add a rel="help" link for every type of URL scheme that
         # leads to library-specific help.

--- a/api/config.py
+++ b/api/config.py
@@ -145,13 +145,13 @@ class Configuration(CoreConfiguration):
         },
         {
             "key": COPYRIGHT_DESIGNATED_AGENT_EMAIL,
-            "label": _("Patrons of this library should use this email address to send a DMCA notification (or other copyright complaint) to the library.<br/>If no value is specified here, the general patron support email address will be used."),
+            "label": _("Patrons of this library should use this email address to send a DMCA notification (or other copyright complaint) to the library.<br/>If no value is specified here, the general patron support address will be used."),
             "optional": True,
         },
         {
             "key": CONFIGURATION_CONTACT_EMAIL,
             "label": _("A point of contact for the organization reponsible for configuring this library."),
-            "description": _("This email address will be shared as part of integrations that you set up through this interface. It will not be shared with the general public. This gives the administrator of a library registry a way to contact you about problems with this library's configuration. "),
+            "description": _("This email address will be shared as part of integrations that you set up through this interface. It will not be shared with the general public. This gives the administrator of the remote integration a way to contact you about problems with this library's use of that integration.<br/>If no value is specified here, the general patron support address will be used."),
             "optional": True,
         },
         {
@@ -414,15 +414,30 @@ class Configuration(CoreConfiguration):
             yield type, value
 
     @classmethod
-    def copyright_designated_agent_uri(cls, library):
-        for setting in [
-            Configuration.COPYRIGHT_DESIGNATED_AGENT_EMAIL,
-            Configuration.HELP_EMAIL
-        ]:
+    def _email_uri_with_fallback(cls, library, key):
+        """Try to find a certain email address configured for the given
+        purpose. If not available, use the general patron support
+        address.
+
+        :param key: The specific email address to look for.
+        """
+        for setting in [key, Configuration.HELP_EMAIL]:
             value = ConfigurationSetting.for_library(setting, library).value
             if not value:
                 continue
             return cls._as_mailto(value)
+
+    @classmethod
+    def copyright_designated_agent_uri(cls, library):
+        return self._email_uri_with_fallback(
+            Configuration.COPYRIGHT_DESIGNATED_AGENT_EMAIL
+        )
+
+    @classmethod
+    def configuration_contact_uri(cls, library):
+        return self._email_uri_with_fallback(
+            Configuration.CONFIGURATION_CONTACT_EMAIL
+        )
 
         
 @contextlib.contextmanager

--- a/api/config.py
+++ b/api/config.py
@@ -430,13 +430,13 @@ class Configuration(CoreConfiguration):
     @classmethod
     def copyright_designated_agent_uri(cls, library):
         return self._email_uri_with_fallback(
-            Configuration.COPYRIGHT_DESIGNATED_AGENT_EMAIL
+            library, Configuration.COPYRIGHT_DESIGNATED_AGENT_EMAIL
         )
 
     @classmethod
     def configuration_contact_uri(cls, library):
-        return self._email_uri_with_fallback(
-            Configuration.CONFIGURATION_CONTACT_EMAIL
+        return cls._email_uri_with_fallback(
+            library, Configuration.CONFIGURATION_CONTACT_EMAIL
         )
 
         

--- a/api/config.py
+++ b/api/config.py
@@ -429,7 +429,7 @@ class Configuration(CoreConfiguration):
 
     @classmethod
     def copyright_designated_agent_uri(cls, library):
-        return self._email_uri_with_fallback(
+        return cls._email_uri_with_fallback(
             library, Configuration.COPYRIGHT_DESIGNATED_AGENT_EMAIL
         )
 


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-465. It introduces two new per-library configuration settings. 

`copyright_designated_agent_email_address` is the email address a patron should use if they want to file a DMCA takedown notice with the library. I guess this happens when you see your book in a library's collection and you know the library didn't legitimately license it from a distributor??? It seems silly but we gotta have it. It defaults to the address patrons would use to contact the library for any other reason, and it  the Authentication For OPDS document links to it under a custom `rel`.

`configuration_contact_email_address` is the email address that the manager of an integration (metadata wrangler or library registry) should use to contact the entity that configured the circulation manager. This may be someone at the library, or it may be someone at a service provider who set up the circulation manager on behalf of the library. It also defaults to the library's patron contact address, but it is not made available in the Authentication For OPDS document. Instead, it's provided in the payload sent to a metadata wrangler/circulation manager as part of registration. This ensures that the general public never sees an email address that might not be directly associated with the library.