### PR TITLE
A library may be registered with a registry in a 'testing' stage or in a 'production' stage.

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -3385,7 +3385,7 @@ class SettingsController(AdminCirculationManagerController):
 
             integration_id = flask.request.form.get("integration_id")
             library_short_name = flask.request.form.get("library_short_name")
-            state = flask.request.form.get("registration_state")
+            stage = flask.request.form.get("registration_stage")
 
             integration = get_one(self._db, ExternalIntegration,
                                   goal=ExternalIntegration.DISCOVERY_GOAL,
@@ -3401,7 +3401,7 @@ class SettingsController(AdminCirculationManagerController):
             status = ConfigurationSetting.for_library_and_externalintegration(
                 self._db, LIBRARY_REGISTRATION_STATUS, library, integration)
             status.value = FAILURE
-            registered = self._register_library(integration.url, library, integration, state=state, do_get=do_get, do_post=do_post, key=key)
+            registered = self._register_library(integration.url, library, integration, stage=stage, do_get=do_get, do_post=do_post, key=key)
             if isinstance(registered, ProblemDetail):
                 return registered
             status.value = SUCCESS
@@ -3422,20 +3422,20 @@ class SettingsController(AdminCirculationManagerController):
             )
         return shared_secret
 
-    # A library may be registered in a 'testing' state or a
-    # 'production' state.
+    # A library may be registered in a 'testing' stage or a
+    # 'production' stage.
     #
     # TODO: For now, the default is 'production' because there is no
-    # UI for specifying which state to use.  Once there is such a UI,
-    # the default registration state should be changed to 'testing'.
-    TESTING_REGISTRATION_STATE = "testing"
-    PRODUCTION_REGISTRATION_STATE = "production"
-    DEFAULT_REGISTRATION_STATE = PRODUCTION_REGISTRATION_STATE
-    VALID_REGISTRATION_STATES = [TESTING_REGISTRATION_STATE,
-                                 PRODUCTION_REGISTRATION_STATE]
+    # UI for specifying which stage to use.  Once there is such a UI,
+    # the default registration stage should be changed to 'testing'.
+    TESTING_REGISTRATION_STAGE = "testing"
+    PRODUCTION_REGISTRATION_STAGE = "production"
+    DEFAULT_REGISTRATION_STAGE = PRODUCTION_REGISTRATION_STAGE
+    VALID_REGISTRATION_STAGES = [TESTING_REGISTRATION_STAGE,
+                                 PRODUCTION_REGISTRATION_STAGE]
 
     def _register_library(self, catalog_url, library, integration,
-                          state=None, do_get=HTTP.debuggable_get,
+                          stage=None, do_get=HTTP.debuggable_get,
                           do_post=HTTP.debuggable_post, key=None):
         """Attempt to register a library with an external service,
         such as a library registry or a shared collection on another
@@ -3444,8 +3444,8 @@ class SettingsController(AdminCirculationManagerController):
         Note: this method does a commit in order to set a public
         key for the external service to request.
         """
-        if state not in self.VALID_REGISTRATION_STATES:
-            state = self.DEFAULT_REGISTRATION_STATE
+        if stage not in self.VALID_REGISTRATION_STAGES:
+            stage = self.DEFAULT_REGISTRATION_STAGE
         response = do_get(catalog_url)
         if isinstance(response, ProblemDetail):
             return response
@@ -3491,7 +3491,7 @@ class SettingsController(AdminCirculationManagerController):
             "authentication_document",
             library_short_name=library.short_name
         )
-        payload = dict(url=auth_document_url, state=state)
+        payload = dict(url=auth_document_url, stage=stage)
 
         # Find the email address the administrator should use if they notice
         # a problem with the way the library is using an integration.

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -5838,7 +5838,7 @@ class TestSettingsController(AdminControllerTest):
             flask.request.form = MultiDict([
                 ("integration_id", discovery_service.id),
                 ("library_short_name", library.short_name),
-                ("registration_state", controller.TESTING_REGISTRATION_STATE)
+                ("registration_stage", controller.TESTING_REGISTRATION_STAGE)
             ])
             self.responses.append(MockRequestsResponse(200, content='{}'))
             feed = '<feed><link rel="register" href="register url"/></feed>'
@@ -5859,9 +5859,9 @@ class TestSettingsController(AdminControllerTest):
             # to contact us if there are problems.
             eq_("mailto:configproblems@library.org", body['contact'])
 
-            # We also asked to be registered in a 'testing' state as opposed
+            # We also asked to be registered in a 'testing' stage as opposed
             # to immediately going into production.
-            eq_(controller.TESTING_REGISTRATION_STATE, body["state"])
+            eq_(controller.TESTING_REGISTRATION_STAGE, body["stage"])
 
             # This registry doesn't support short client tokens and doesn't have a vendor id,
             # so no settings were added to it.
@@ -5879,7 +5879,7 @@ class TestSettingsController(AdminControllerTest):
             flask.request.form = MultiDict([
                 ("integration_id", discovery_service.id),
                 ("library_short_name", library.short_name),
-                ("registration_state", controller.PRODUCTION_REGISTRATION_STATE)
+                ("registration_stage", controller.PRODUCTION_REGISTRATION_STAGE)
             ])
             # Generate a key in advance so we can mock the registry's encrypted response.
             key = RSA.generate(1024)
@@ -5904,9 +5904,10 @@ class TestSettingsController(AdminControllerTest):
 
             url, [body], kwargs = self.requests.pop(0)
             eq_("register url", url)
-            # This time we asked that the library be immediately
-            # registered in a production state.
-            eq_(controller.PRODUCTION_REGISTRATION_STATE, body['state'])
+
+            # This time we asked that the library go into production
+            # immediately.
+            eq_(controller.PRODUCTION_REGISTRATION_STAGE, body['stage'])
 
             # The vendor id and short client token settings were stored.
             eq_("vendorid", discovery_service.setting(AuthdataUtility.VENDOR_ID_KEY).value)

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -5832,29 +5832,36 @@ class TestSettingsController(AdminControllerTest):
             Configuration.CONFIGURATION_CONTACT_EMAIL, library
         ).value = "configproblems@library.org"
 
+        controller = self.manager.admin_settings_controller
+
         with self.request_context_with_admin("/", method="POST"):
             flask.request.form = MultiDict([
                 ("integration_id", discovery_service.id),
                 ("library_short_name", library.short_name),
+                ("registration_state", controller.TESTING_REGISTRATION_STATE)
             ])
             self.responses.append(MockRequestsResponse(200, content='{}'))
             feed = '<feed><link rel="register" href="register url"/></feed>'
             headers = { 'Content-Type': 'application/atom+xml;profile=opds-catalog;kind=navigation' }
             self.responses.append(MockRequestsResponse(200, content=feed, headers=headers))
 
-            response = self.manager.admin_settings_controller.discovery_service_library_registrations(do_get=self.do_request, do_post=self.do_request)
+            response = controller.discovery_service_library_registrations(do_get=self.do_request, do_post=self.do_request)
 
             eq_(200, response.status_code)
-            [req1, req2] = self.requests
-            eq_("registry url", req1[0])
+            url, body, kwargs = self.requests.pop(0)
+            eq_("registry url", url)
 
-            url, [body], kwargs = req2
+            url, [body], kwargs = self.requests.pop(0)
             eq_("register url", url)
 
             # When we sent the location of our authentication document to
             # the 'registry', we provided an email address the registry can use
             # to contact us if there are problems.
             eq_("mailto:configproblems@library.org", body['contact'])
+
+            # We also asked to be registered in a 'testing' state as opposed
+            # to immediately going into production.
+            eq_(controller.TESTING_REGISTRATION_STATE, body["state"])
 
             # This registry doesn't support short client tokens and doesn't have a vendor id,
             # so no settings were added to it.
@@ -5872,6 +5879,7 @@ class TestSettingsController(AdminControllerTest):
             flask.request.form = MultiDict([
                 ("integration_id", discovery_service.id),
                 ("library_short_name", library.short_name),
+                ("registration_state", controller.PRODUCTION_REGISTRATION_STATE)
             ])
             # Generate a key in advance so we can mock the registry's encrypted response.
             key = RSA.generate(1024)
@@ -5888,10 +5896,17 @@ class TestSettingsController(AdminControllerTest):
             headers = { 'Content-Type': 'application/opds+json' }
             self.responses.append(MockRequestsResponse(200, content=feed, headers=headers))
 
-            response = self.manager.admin_settings_controller.discovery_service_library_registrations(do_get=self.do_request, do_post=self.do_request, key=key)
+            response = controller.discovery_service_library_registrations(do_get=self.do_request, do_post=self.do_request, key=key)
 
             eq_(200, response.status_code)
-            eq_(["registry url", "register url"], [x[0] for x in self.requests[2:]])
+            url, body, kwargs = self.requests.pop(0)
+            eq_("registry url", url)
+
+            url, [body], kwargs = self.requests.pop(0)
+            eq_("register url", url)
+            # This time we asked that the library be immediately
+            # registered in a production state.
+            eq_(controller.PRODUCTION_REGISTRATION_STATE, body['state'])
 
             # The vendor id and short client token settings were stored.
             eq_("vendorid", discovery_service.setting(AuthdataUtility.VENDOR_ID_KEY).value)


### PR DESCRIPTION
This branch changes the controller that registers a library with a registry so that the admin can say whether they want the library to be registered for testing or for production.

I've updated the [https://github.com/NYPL-Simplified/Simplified/wiki/OPDS-Directory-Registration-Protocol](OPDS Directory Registration Protocol) to accommodate this addition as well as the recent 'contact email' addition. Both of the new fields are optional.

The registry side of this is not implemented yet. The most likely implementation is that the _library's_ desired stage ("testing" or "production") will be tracked separately from the _registry's_ desired stage ("registered", "approved", or "rejected"). A library will only show up in the production feed if it is in production/approved. A library in testing/registered, testing/approved, or production/registered will show up in the testing feed. A library in */rejected will not show up in any feeds at all.