### PR TITLE
Custom patron catalogs

### DIFF
--- a/api/custom_index.py
+++ b/api/custom_index.py
@@ -1,5 +1,9 @@
 """A custom index view customizes a library's 'front page' to serve
 something other than the default.
+
+This code is DEPRECATED; you probably want a CustomPatronCatalog instead.
+We're keeping it around because existing iOS versions of SimplyE need the
+OPDS navigation feed it generates.
 """
 
 import datetime

--- a/api/custom_patron_catalog.py
+++ b/api/custom_patron_catalog.py
@@ -1,0 +1,234 @@
+"""A custom patron catalog annotates a library's authentication
+document to describe an unusual setup.
+"""
+
+import datetime
+from nose.tools import set_trace
+
+from flask import Response
+from flask_babel import lazy_gettext as _
+
+from sqlalchemy.orm.session import Session
+
+from config import CannotLoadConfiguration
+from core.app_server import cdn_url_for
+from core.model import (
+    get_one,
+)
+from core.lane import Lane
+from core.model import (
+    ConfigurationSetting,
+    ExternalIntegration,
+)
+from core.util.opds_writer import OPDSFeed
+
+class CustomPatronCatalog(object):
+    """An annotator for a library's authentication document.
+
+    Any subclass of this class must define PROTOCOL and must be
+    passed into a CustomPatronCatalog.register() call after the class
+    definition is complete.
+
+    A subclass of this class will be stored in the
+    LibraryAuthenticator. CustomPatronCatalogs should not store
+    any objects obtained from the database without disconnecting them
+    from their session.
+    """
+    BY_PROTOCOL = {}
+
+    GOAL = "custom_patron_catalog"
+
+    @classmethod
+    def register(self, view_class):
+        protocol = view_class.PROTOCOL
+        if protocol in self.BY_PROTOCOL:
+            raise ValueError("Duplicate patron catalog for protocol: %s" % protocol)
+        self.BY_PROTOCOL[protocol] = view_class
+
+    @classmethod
+    def unregister(self, view_class):
+        """Remove a CustomPatronCatalog from consideration.
+        Only used in tests.
+        """
+        del self.BY_PROTOCOL[view_class.PROTOCOL]
+
+    @classmethod
+    def for_library(cls, library):
+        """Find the appropriate CustomPatronCatalog for the given library."""
+        _db = Session.object_session(library)
+        integration = ExternalIntegration.one_for_library_and_goal(
+            _db, library, cls.GOAL
+        )
+        if not integration:
+            return None
+        protocol = integration.protocol
+        if not protocol in cls.BY_PROTOCOL:
+            raise CannotLoadConfiguration(
+                "Unregistered custom patron catalog protocol: %s" % protocol
+            )
+        view_class = cls.BY_PROTOCOL[protocol]
+        return view_class(library, integration)
+
+    def __init__(self, library, integration):
+        raise NotImplementedError()
+
+    def annotate_authentication_document(self, library, doc, url_for):
+        """Modify the library's authentication document.
+
+        :param library: A Library
+        :param doc: A dictionary representing the library's
+            default authentication document.
+        :param url_for: An implementation of Flask url_for,
+            used to generate URLs.
+        :return: A dictionary representing the library's
+            default authentication document. It's okay to modify
+            `doc` and return the modified version.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def _load_lane(cls, library, lane_id):
+        """Make sure the Lane with the given ID actually exists and is
+        associated with the given Library.
+        """
+        _db = Session.object_session(library)
+        lane = get_one(_db, Lane, id=lane_id)
+        if not lane:
+            raise CannotLoadConfiguration("No lane with ID: %s" % lane_id)
+        if lane.library != library:
+            raise CannotLoadConfiguration(
+                "Lane %d is for the wrong library (%s, I need %s)" %
+                (lane.id, lane.library.name, library.name)
+            )
+        return lane
+
+    @classmethod
+    def replace_link(cls, doc, rel, **kwargs):
+        """Remove all links with the given relation and replace them
+        with the given link.
+
+        :param doc: An authentication document. Will be modified in place.
+        :param rel: Remove links with this relation.
+        :param kwargs: Add a new link with these attributes.
+        :return: A modified authentication document.
+        """
+        links = [x for x in doc['links'] if x['rel'] != rel]
+        links.append(dict(rel=rel, **kwargs))
+        doc['links'] = links
+        return doc
+
+
+class CustomRootLane(CustomPatronCatalog):
+    """Send library patrons to a lane other than the root lane."""
+    PROTOCOL = "Custom Root Lane"
+
+    LANE = "lane"
+
+    SETTINGS = [
+        { "key": LANE,
+          "label": _("Send patrons to the lane with this ID."),
+        },
+    ]
+
+    def __init__(self, library, integration):
+        _db = Session.object_session(library)
+        m = ConfigurationSetting.for_library_and_externalintegration
+        lane_id = m(_db, self.LANE, library, integration)
+
+        # We don't want to store the Lane objects long-term, but we do need
+        # to make sure the lane ID corresponds to a real lane for the
+        # right library.
+        self.lane_id = lane_id.int_value
+        lane = self._load_lane(library, self.lane_id)
+
+    def annotate_authentication_document(self, library, doc, url_for):
+        """Replace the 'start' link with a link to the configured Lane."""
+        root_url = url_for(
+            "acquisition_groups", library_short_name=library.name,
+            lane_identifier=self.lane_id
+        )
+        self.replace_link(
+            doc, 'start', href=root_url, type=OPDSFeed.ACQUISITION_FEED_TYPE
+        )
+        return doc
+CustomPatronCatalog.register(CustomRootLane)
+
+
+class COPPAGate(CustomPatronCatalog):
+
+    PROTOCOL = "COPPA Age Gate"
+
+    AUTHENTICATION_TYPE = "http://librarysimplified.org/terms/authentication/gate/coppa"
+    AUTHENTICATION_YES_REL = "http://librarysimplified.org/terms/rel/authentication/restriction-met"
+    AUTHENTICATION_NO_REL = "http://librarysimplified.org/terms/rel/authentication/restriction-not-met"
+
+    REQUIREMENT_MET_LANE = "requirement_met_lane"
+    REQUIREMENT_NOT_MET_LANE = "requirement_not_met_lane"
+
+    SETTINGS = [
+        { "key": REQUIREMENT_MET_LANE,
+          "label": _("ID of lane for patrons who are 13 or older"),
+        },
+        { "key": REQUIREMENT_NOT_MET_LANE,
+          "label": _("ID of lane for patrons who are under 13"),
+        },
+    ]
+
+    def __init__(self, library, integration):
+        _db = Session.object_session(library)
+        m = ConfigurationSetting.for_library_and_externalintegration
+        yes_lane_id = m(_db, self.REQUIREMENT_MET_LANE, library, integration)
+        no_lane_id = m(_db, self.REQUIREMENT_NOT_MET_LANE, library, integration)
+
+        # We don't want to store the Lane objects long-term, but we do need
+        # to make sure the lane IDs correspond to real lanes for the
+        # right library.
+        self.yes_lane_id = yes_lane_id.int_value
+        self.no_lane_id = no_lane_id.int_value
+        yes_lane = self._load_lane(library, self.yes_lane_id)
+        no_lane = self._load_lane(library, self.no_lane_id)
+
+    def annotate_authentication_document(self, library, doc, url_for):
+        """Replace the 'start' link and add a custom authentication
+        mechanism.
+        """
+
+        # A lane for grown-ups.
+        yes_url = url_for(
+            'acquisition_groups', library_short_name=library.short_name,
+            lane_identifier=self.yes_lane_id
+        )
+
+        # A lane for children.
+        no_url = url_for(
+            'acquisition_groups', library_short_name=library.short_name,
+            lane_identifier=self.no_lane_id
+        )
+
+        # Replace the 'start' link with the childrens link. Any client
+        # that doesn't understand the extensions will be safe from
+        # grown-up content.
+        feed = OPDSFeed.ACQUISITION_FEED_TYPE
+        self.replace_link(doc, 'start', href=no_url, type=feed)
+
+        # Add a custom authentication technique that
+        # explains the COPPA gate.
+        links = [
+            dict(rel=self.AUTHENTICATION_YES_REL, href=yes_url,
+                 type=feed),
+            dict(rel=self.AUTHENTICATION_NO_REL, href=yes_url,
+                 type=feed),
+        ]
+
+        authentication = dict(
+            type=self.AUTHENTICATION_TYPE,
+            links=links
+        )
+
+        # It's an academic question whether this is replacing the existing
+        # auth mechanisms or just adding another one, but for the moment
+        # let's go with "adding another one".
+        doc.setdefault('authentication', []).append(authentication)
+        return doc
+CustomPatronCatalog.register(COPPAGate)
+

--- a/api/custom_patron_catalog.py
+++ b/api/custom_patron_catalog.py
@@ -216,7 +216,7 @@ class COPPAGate(CustomPatronCatalog):
         links = [
             dict(rel=self.AUTHENTICATION_YES_REL, href=yes_url,
                  type=feed),
-            dict(rel=self.AUTHENTICATION_NO_REL, href=yes_url,
+            dict(rel=self.AUTHENTICATION_NO_REL, href=no_url,
                  type=feed),
         ]
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -509,10 +509,10 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         # Only a basic auth provider.
         millenium = self._external_integration(
             "api.millenium_patron", ExternalIntegration.PATRON_AUTH_GOAL,
+            libraries=[self._default_library]
         )
         millenium.url = "http://url/"
         auth = LibraryAuthenticator.from_config(self._db, self._default_library)
-        self._default_library.integrations.append(millenium)
 
         assert auth.basic_auth_provider != None
         assert isinstance(auth.basic_auth_provider, MilleniumPatronAPI)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -511,9 +511,8 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             "api.millenium_patron", ExternalIntegration.PATRON_AUTH_GOAL,
         )
         millenium.url = "http://url/"
-        self._default_library.integrations.append(millenium)
-
         auth = LibraryAuthenticator.from_config(self._db, self._default_library)
+        self._default_library.integrations.append(millenium)
 
         assert auth.basic_auth_provider != None
         assert isinstance(auth.basic_auth_provider, MilleniumPatronAPI)
@@ -551,6 +550,27 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         assert isinstance(clever, CleverAuthenticationAPI)
         eq_(analytics, clever.analytics)
             
+    def test_with_custom_patron_catalog(self):
+        """Instantiation of a LibraryAuthenticator may
+        include instantiation of a CustomPatronCatalog.
+        """
+        mock_catalog = object()
+        class MockCustomPatronCatalog(object):
+            @classmethod
+            def for_library(self, library):
+                self.called_with = library
+                return mock_catalog
+
+        authenticator = LibraryAuthenticator.from_config(
+            self._db, self._default_library,
+            custom_catalog_source=MockCustomPatronCatalog
+        )
+        eq_(self._default_library, MockCustomPatronCatalog.called_with)
+
+        # The custom patron catalog is stored as
+        # authentication_document_annotator.
+        eq_(mock_catalog, authenticator.authentication_document_annotator)
+
     def test_config_succeeds_when_no_providers_configured(self):
         """You can call from_config even when there are no authentication
         providers configured.
@@ -1035,6 +1055,17 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             bearer_token_signing_secret='secret'
         )
 
+        class MockAuthenticationDocumentAnnotator(object):
+            def annotate_authentication_document(
+                self, library, doc, url_for
+            ):
+                self.called_with = library, doc, url_for
+                doc['modified'] = 'Kilroy was here'
+                return doc
+
+        annotator = MockAuthenticationDocumentAnnotator()
+        authenticator.authentication_document_annotator = annotator
+
         # We're about to call url_for, so we must create an
         # application context.
         os.environ['AUTOINITIALIZE'] = "False"
@@ -1183,6 +1214,11 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             [agent] = [x for x in doc['links'] if x['rel'] == copyright_rel]
             eq_("mailto:dmca@library.org", agent["href"])
 
+            # The annotator's annotate_authentication_document method
+            # was called and successfully modified the authentication
+            # document.
+            eq_((library, doc, url_for), annotator.called_with)
+            eq_('Kilroy was here', doc['modified'])
             
             # While we're in this context, let's also test
             # create_authentication_headers.

--- a/tests/test_custom_patron_catalog.py
+++ b/tests/test_custom_patron_catalog.py
@@ -118,6 +118,7 @@ class TestCustomPatronCatalog(DatabaseTest):
             dict(rel="leave-me-alone", href="link2"),
             dict(rel="replace-me", href="link4", type="text/html"),
         ]
+        eq_(doc['links'], links)
 
 
 class TestCustomRootLane(DatabaseTest):

--- a/tests/test_custom_patron_catalog.py
+++ b/tests/test_custom_patron_catalog.py
@@ -1,0 +1,271 @@
+from nose.tools import (
+    assert_raises_regexp,
+    eq_,
+    set_trace,
+)
+from lxml import etree
+
+from flask import Response
+
+from core.model import ConfigurationSetting
+
+from core.util.opds_writer import OPDSFeed
+
+from api.config import CannotLoadConfiguration
+from api.custom_patron_catalog import (
+    COPPAGate,
+    CustomPatronCatalog,
+    CustomRootLane,
+)
+
+from . import DatabaseTest
+
+class TestCustomPatronCatalog(DatabaseTest):
+
+    def test_register(self):
+        c = CustomPatronCatalog
+        old_registry = c.BY_PROTOCOL
+        c.BY_PROTOCOL = {}
+
+        class Mock1(object):
+            PROTOCOL = "A protocol"
+
+        class Mock2(object):
+            PROTOCOL = "A protocol"
+
+        c.register(Mock1)
+        eq_(Mock1, c.BY_PROTOCOL[Mock1.PROTOCOL])
+
+        assert_raises_regexp(
+            ValueError,
+            "Duplicate patron catalog for protocol: A protocol",
+            c.register, Mock2
+        )
+        c.BY_PROTOCOL = old_registry
+
+    def test_default_registry(self):
+        """Verify the default contents of the registry."""
+        eq_(
+            {
+                COPPAGate.PROTOCOL : COPPAGate,
+                CustomRootLane.PROTOCOL : CustomRootLane,
+            },
+            CustomPatronCatalog.BY_PROTOCOL
+        )
+
+    def test_for_library(self):
+        m = CustomPatronCatalog.for_library
+
+        # Set up a mock CustomPatronCatalog so we can watch it being
+        # instantiated.
+        class MockCustomPatronCatalog(object):
+            PROTOCOL = self._str
+            def __init__(self, library, integration):
+                self.instantiated_with = (library, integration)
+        CustomPatronCatalog.register(MockCustomPatronCatalog)
+
+        # By default, a library has no CustomPatronCatalog.
+        eq_(None, m(self._default_library))
+
+        # But if a library has an ExternalIntegration that corresponds
+        # to a registered CustomPatronCatalog...
+        integration = self._external_integration(
+            MockCustomPatronCatalog.PROTOCOL, CustomPatronCatalog.GOAL,
+            libraries=[self._default_library]
+        )
+
+        # A CustomPatronCatalog of the appropriate class is instantiated
+        # and returned.
+        view = m(self._default_library)
+        assert isinstance(view, MockCustomPatronCatalog)
+        eq_((self._default_library, integration), view.instantiated_with)
+
+    def test__load_lane(self):
+        """Test the _load_lane helper method."""
+        library1 = self._library()
+        library2 = self._library()
+        lane = self._lane(library=library1)
+        m = CustomPatronCatalog._load_lane
+
+        eq_(lane, m(library1, lane.id))
+
+        assert_raises_regexp(
+            CannotLoadConfiguration,
+            "No lane with ID", m, library1, -2
+        )
+
+        assert_raises_regexp(
+            CannotLoadConfiguration,
+            "is for the wrong library", m, library2, lane.id
+        )
+
+    def test_replace_link(self):
+        """Test the replace_link helper method."""
+        links = [
+            dict(rel="replace-me", href="link1"),
+            dict(rel="leave-me-alone", href="link2"),
+            dict(rel="replace-me", href="link3"),
+        ]
+        doc = dict(ignoreme=True, links=links)
+
+        MockCustomPatronCatalog.replace_link(
+            doc, "replace-me", href="link4", type="text/html"
+        )
+
+        # Both replace-me links have been removed, and a a new link
+        # with the same relation has been added.
+        links = [
+            dict(rel="leave-me-alone", href="link2"),
+            dict(rel="replace-me", href="link4", type="text/html"),
+        ]
+
+
+class TestCustomRootLane(DatabaseTest):
+    """Test a CustomPatronCatalog which modifies the 'start' URL."""
+
+    def setup(self):
+        super(TestCustomRootLane, self).setup()
+        # Configure a CustomRootLane for the default library.
+        self.integration = self._external_integration(
+            CustomRootLane.PROTOCOL, CustomPatronCatalog.GOAL,
+            libraries=[self._default_library]
+        )
+        self.lane = self._lane()
+        m = ConfigurationSetting.for_library_and_externalintegration
+        m(
+            self._db, CustomRootLane.LANE, self._default_library,
+            self.integration
+        ).value = self.lane.id
+
+    def test_annotate_authentication_document(self):
+
+        class MockCustomRootLane(CustomRootLane):
+            def replace_link(self, doc, rel, **kwargs):
+                self.replace_link_called_with = (doc, rel, kwargs)
+                doc['modified'] = True
+
+            def url_for(self, view, library_short_name, lane_identifier):
+                self.url_for_called_with = (
+                    view, library_short_name, lane_identifier
+                )
+                return "new-root"
+
+        library = self._default_library
+        custom_root = MockCustomRootLane(library, self.integration)
+
+        doc = dict()
+        new_doc = custom_root.annotate_authentication_document(
+            library, doc, custom_root.url_for
+        )
+
+        # The authentication document was modified in place.
+        eq_(doc, new_doc)
+        eq_(dict(modified=True), doc)
+
+        # url_for was called with the expected arguments, and it
+        # returned 'new-root', seen above.
+        eq_(("acquisition_groups", library, custom_root.lane_id),
+            custom_root.url_for_called_with)
+
+        # replace_link was called with the result of calling url_for.
+        eq_(
+            (doc, 'start',
+             dict(href="new-root", type=OPDSFeed.ACQUISITION_FEED_TYPE)
+            ),
+            custom_root.replace_link_called_with
+        )
+
+
+class TestCOPPAGate(DatabaseTest):
+
+    def setup(self):
+        super(TestCOPPAGate, self).setup()
+        # Configure a COPPAGate for the default library.
+        self.integration = self._external_integration(
+            COPPAGate.PROTOCOL, CustomPatronCatalog.GOAL,
+            libraries=[self._default_library]
+        )
+        self.lane1 = self._lane()
+        self.lane2 = self._lane()
+        m = ConfigurationSetting.for_library_and_externalintegration
+        m(
+            self._db, COPPAGate.REQUIREMENT_MET_LANE, self._default_library,
+            self.integration
+        ).value = self.lane1.id
+        m(
+            self._db, COPPAGate.REQUIREMENT_NOT_MET_LANE, self._default_library,
+            self.integration
+        ).value = self.lane2.id
+
+    def test_annotate_authentication_document(self):
+        """Test the ability of a COPPAGate to modify an Authentication
+        For OPDS document.
+        """
+        class MockCOPPAGate(COPPAGate):
+            url_for_called_with = []
+            def replace_link(self, doc, rel, **kwargs):
+                self.replace_link_called_with = (doc, rel, kwargs)
+
+            def url_for(self, view, library_short_name, lane_identifier):
+                self.url_for_called_with.append(
+                    (view, library_short_name, lane_identifier)
+                )
+                return view + "/" + str(lane_identifier)
+        library = self._default_library
+        gate = MockCOPPAGate(library, self.integration)
+
+        doc = {}
+        library = self._default_library
+        modified = gate.annotate_authentication_document(
+            library, doc, gate.url_for
+        )
+
+        # url_for was called twice, to make the lane links for
+        # the adults' section and the kids' section.
+        [yes_call, no_call] = gate.url_for_called_with
+        eq_(
+            ("acquisition_groups", library.name, gate.yes_lane_id),
+            yes_call
+        )
+        eq_(
+            ("acquisition_groups", library.name, gate.no_lane_id),
+            no_call
+        )
+
+        # These are the possible return values of our mocked url_for.
+        yes_url = "acquisition_groups/%s" % gate.yes_lane_id
+        no_url = "acquisition_groups/%s" % gate.no_lane_id
+
+        # The document was modified in place.
+        eq_(doc, modified)
+
+        # An authentication mechanism was added to the document.
+        [authentication] = doc.pop('authentication')
+
+        # No other changes were made to the document.
+        eq_({}, doc)
+
+        # The authentication mechanism is a COPPA age gate,
+        eq_(gate.AUTHENTICATION_TYPE, authentication['type'])
+
+        # Each one was added as a link to the authentication mechanism.
+        yes_link, no_link = authentication['links']
+        for link in (yes_link, no_link):
+            eq_(OPDSFeed.ACQUISITION_FEED_TYPE, link['type'])
+
+        eq_(gate.AUTHENTICATION_YES_REL, yes_link['rel'])
+        eq_(yes_url, yes_link['href'])
+
+        eq_(gate.AUTHENTICATION_NO_REL, no_link['rel'])
+        eq_(no_url, no_link['href'])
+
+        # replace_link was called to replace the rel='start' link,
+        # with the link to the kids' section. Because that method was
+        # mocked, it didn't actually modify the document.
+        eq_(
+            (doc, 'start',
+             dict(href=no_url, type=OPDSFeed.ACQUISITION_FEED_TYPE)
+            ),
+            gate.replace_link_called_with
+        )
+        pass

--- a/tests/test_custom_patron_catalog.py
+++ b/tests/test_custom_patron_catalog.py
@@ -108,7 +108,7 @@ class TestCustomPatronCatalog(DatabaseTest):
         ]
         doc = dict(ignoreme=True, links=links)
 
-        MockCustomPatronCatalog.replace_link(
+        CustomPatronCatalog.replace_link(
             doc, "replace-me", href="link4", type="text/html"
         )
 
@@ -164,7 +164,7 @@ class TestCustomRootLane(DatabaseTest):
 
         # url_for was called with the expected arguments, and it
         # returned 'new-root', seen above.
-        eq_(("acquisition_groups", library, custom_root.lane_id),
+        eq_(("acquisition_groups", library.name, custom_root.lane_id),
             custom_root.url_for_called_with)
 
         # replace_link was called with the result of calling url_for.


### PR DESCRIPTION
This is a replacement for https://github.com/NYPL-Simplified/circulation/pull/995, which I abandoned after a Slack conversation.

Rather than trying to get "library root redirects to a specific lane" working, I've created a new concept called the "custom patron catalog". This code is based on CustomIndex, but it's in a separate file with its own test. This is because I intend this concept to replace the "custom index" concept. We can't replace it yet because iOS versions of SimplyE need the OPDS navigation feed generated by the custom index.

The custom patron catalog is a customizable bit of code that modifies a library's Authentication for OPDS document. Since this document is (will be) the point of entry for SimplyE and other patron-facing interfaces, this lets us customize the behavior of those interfaces without changing the behavior of other views which might be needed by other clients, such as the admin interface.

This branch includes two custom patron catalogs. The `CustomRootLane` lets a library modify the `start` link to tell patron-facing clients that the entry point for the library is the feed for a particular lane. The `COPPAGate` lets a library add a custom authentication mechanism that tells clients to go to one lane if they're under 13 and another lane if they're 13 or up.