### PR TITLE
Test registration

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -3370,11 +3370,14 @@ class SettingsController(AdminCirculationManagerController):
 
     def discovery_service_library_registrations(
             self, do_get=HTTP.debuggable_get,
-            do_post=HTTP.debuggable_post, key=None
+            do_post=HTTP.debuggable_post, key=None,
+            registration_class=None
     ):
         """List the libraries that have been registered with a specific
         RemoteRegistry, and allow the admin to register a library with
         a RemoteRegistry.
+
+        :param registration_class: Mock class to use instead of Registration.
         """
 
         self.require_system_admin()
@@ -3420,7 +3423,7 @@ class SettingsController(AdminCirculationManagerController):
             if not library:
                 return NO_SUCH_LIBRARY
 
-            registration = Registration(registry, library)
+            registration = registration_class(registry, library)
             registered = registration.push(
                 stage, self.url_for, do_get=do_get, do_post=do_post, key=key
             )

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -2433,8 +2433,10 @@ class SettingsController(AdminCirculationManagerController):
         else:
             return Response(unicode(collection.id), 200)
 
-    def collection_library_registrations(self, do_get=HTTP.debuggable_get,
-                                 do_post=HTTP.debuggable_post, key=None):
+    def collection_library_registrations(
+            self, do_get=HTTP.debuggable_get, do_post=HTTP.debuggable_post,
+            key=None, registration_class=Registration
+    ):
         self.require_system_admin()
         # TODO: This method might be able to share code with discovery_service_library_registrations.
         shared_collection_provider_apis = [SharedODLAPI]
@@ -2474,7 +2476,7 @@ class SettingsController(AdminCirculationManagerController):
                 return NO_SUCH_LIBRARY
 
             registry = RemoteRegistry(collection.external_integration)
-            registration = Registration(registry, library)
+            registration = registration_class(registry, library)
             registered = registration.push(
                 Registration.PRODUCTION_STAGE, self.url_for,
                 catalog_url=collection.external_account_id,

--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -2437,8 +2437,14 @@ class SettingsController(AdminCirculationManagerController):
             self, do_get=HTTP.debuggable_get, do_post=HTTP.debuggable_post,
             key=None, registration_class=Registration
     ):
+        """Use the ODPS Directory Registration Protocol to register a
+        Collection with its remote source of truth.
+
+        :param registration_class: Mock class to use instead of Registration.
+        """
         self.require_system_admin()
-        # TODO: This method might be able to share code with discovery_service_library_registrations.
+        # TODO: This method can share some code with
+        # discovery_service_library_registrations.
         shared_collection_provider_apis = [SharedODLAPI]
 
         if flask.request.method == "GET":

--- a/api/registry.py
+++ b/api/registry.py
@@ -201,9 +201,13 @@ class Registration(object):
 
         # Set a public key for the library.
         encryptor = self._set_public_key(key)
+        if isinstance(encryptor, ProblemDetail):
+            return encryptor
 
         # Build the document we'll be sending to the registration URL.
         payload = self._create_registration_payload(url_for, stage)
+        if isinstance(payload, ProblemDetail):
+            return payload
 
         # Send the document.
         response = self._send_registration_request(

--- a/api/registry.py
+++ b/api/registry.py
@@ -220,7 +220,11 @@ class Registration(object):
         # Process the result.
         return self._process_registration_result(catalog, encryptor, stage)
 
-    def _extract_catalog_information(self, response):
+    OPDS_1_PREFIX = "application/atom+xml;profile=opds-catalog"
+    OPDS_2_TYPE = "application/opds+json"
+
+    @classmethod
+    def _extract_catalog_information(cls, response):
         """From an OPDS catalog, extract information that's essential to
         kickstarting the OPDS Directory Registration Protocol.
 
@@ -231,12 +235,12 @@ class Registration(object):
         """
         # The catalog URL must be either an OPDS 2 catalog or an OPDS 1 feed.
         type = response.headers.get("Content-Type")
-        if type and type.startswith('application/opds+json'):
+        if type and type.startswith(cls.OPDS_2_TYPE):
             # This is an OPDS 2 catalog.
             catalog = json.loads(response.content)
             links = catalog.get("links", [])
             vendor_id = catalog.get("metadata", {}).get("adobe_vendor_id")
-        elif type and type.startswith("application/atom+xml;profile=opds-catalog"):
+        elif type and type.startswith(cls.OPDS_1_PREFIX):
             # This is an OPDS 1 feed.
             feed = feedparser.parse(response.content)
             links = feed.get("feed", {}).get("links", [])
@@ -298,7 +302,8 @@ class Registration(object):
             payload['contact'] = contact
 
 
-    def _send_registration_request(self, register_url, payload, do_post):
+    @classmethod
+    def _send_registration_request(cls, register_url, payload, do_post):
         """Send the request that actually kicks off the OPDS Directory
         Registration Protocol.
 

--- a/api/registry.py
+++ b/api/registry.py
@@ -89,9 +89,9 @@ class Registration(object):
 
     # A library may be registered in a 'testing' stage or a
     # 'production' stage. This represents the _library's_ opinion
-    # about whether it's ready for production. The library won't
-    # actually show up in production feeds until the _registry_ also
-    # thinks it should.
+    # about whether the integration is ready for production. The
+    # library won't actually be in production (whatever that means for
+    # a given integration) until the _remote_ also thinks it should.
     #
     # TODO: Registration through the admin interface always happens in
     # 'production' because there is no UI for specifying which stage

--- a/api/registry.py
+++ b/api/registry.py
@@ -15,7 +15,10 @@ from core.model import (
 )
 from core.scripts import LibraryInputScript
 from core.util.http import HTTP
-from core.util.problem_detail import ProblemDetail
+from core.util.problem_detail import (
+    ProblemDetail,
+    JSON_MEDIA_TYPE as PROBLEM_DETAIL_JSON_MEDIA_TYPE,
+)
 
 from api.adobe_vendor_id import AuthdataUtility
 from api.config import Configuration

--- a/api/registry.py
+++ b/api/registry.py
@@ -350,6 +350,10 @@ class Registration(object):
         # credentials for future authenticated communication,
         # e.g. through Short Client Tokens or authenticated API
         # requests.
+        if not isinstance(catalog, dict):
+            return INTEGRATION_ERROR.detailed(
+                _("Remote service served %(representation)r, which I can't make sense of as an OPDS document.", representation=catalog)
+            )
         metadata = catalog.get("metadata", {})
         short_name = metadata.get("short_name")
         shared_secret = metadata.get("shared_secret")

--- a/api/registry.py
+++ b/api/registry.py
@@ -257,7 +257,7 @@ class Registration(object):
             return REMOTE_INTEGRATION_FAILED.detailed(_("The service at %(url)s did not provide a register link.", url=response.url))
         return register_url, vendor_id
 
-    def _set_public_key(self, key):
+    def _set_public_key(self, key=None):
         """Set the public key for this library. This key will be published in
         the library's Authentication For OPDS document, allowing the
         remote registry to sign a shared secret for it.

--- a/api/registry.py
+++ b/api/registry.py
@@ -300,7 +300,7 @@ class Registration(object):
         contact = Configuration.configuration_contact_uri(self.library)
         if contact:
             payload['contact'] = contact
-
+        return payload
 
     @classmethod
     def _send_registration_request(cls, register_url, payload, do_post):

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -5781,7 +5781,6 @@ class TestLibraryRegistration(SettingsControllerTest):
         # registration process.
         self.admin.remove_role(AdminRole.SYSTEM_ADMIN)
         with self.request_context_with_admin("/", method="POST"):
-            flask.request.form = form
             assert_raises(AdminNotAuthorized, m,
                           do_get=self.do_request, do_post=self.do_request)
         self.admin.add_role(AdminRole.SYSTEM_ADMIN)

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -103,6 +103,10 @@ from core.external_search import ExternalSearchIndex
 
 class AdminControllerTest(CirculationControllerTest):
 
+    # Automatically creating books before the test wastes time -- we
+    # don't need them.
+    BOOKS = []
+
     def setup(self):
         super(AdminControllerTest, self).setup()
         ConfigurationSetting.sitewide(self._db, Configuration.SECRET_KEY).value = "a secret"
@@ -311,6 +315,10 @@ class TestAdminCirculationManagerController(AdminControllerTest):
             self.manager.admin_work_controller.require_librarian(self._default_library)
 
 class TestWorkController(AdminControllerTest):
+
+    # Unlike most of these controllers, we do want to have a book
+    # automatically created as part of setup.
+    BOOKS = CirculationControllerTest.BOOKS
 
     def setup(self):
         super(TestWorkController, self).setup()
@@ -2508,6 +2516,10 @@ class TestLanesController(AdminControllerTest):
             assert 0 < self._db.query(Lane).filter(Lane.library==library).count()
 
 class TestDashboardController(AdminControllerTest):
+
+    # Unlike most of these controllers, we do want to have a book
+    # automatically created as part of setup.
+    BOOKS = CirculationControllerTest.BOOKS
 
     def test_circulation_events(self):
         [lp] = self.english_1.license_pools

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -263,6 +263,15 @@ class TestRegistration(DatabaseTest):
         results = registration._process_registration_result_called_with
         eq_(("you did it!", "an encryptor", stage), results)
 
+        # If a nonexistent stage is provided a ProblemDetail is the result.
+        result = registration.push(
+            "no such stage", url_for, catalog_url, registration.mock_do_get,
+            do_post, key
+        )
+        eq_(INVALID_INPUT.uri, result.uri)
+        eq_('"no such stage" is not a valid registration stage',
+            result.detail)
+
         # Now in reverse order, let's replace the mocked methods so
         # that they return ProblemDetail documents. This tests that if
         # there is a failure at any stage, the ProblemDetail is
@@ -315,6 +324,8 @@ class TestRegistration(DatabaseTest):
         registration._extract_catalog_information = fail
         problem = cause_problem()
         eq_("could not extract catalog information", problem.detail)
+
+        # Lastly, test some other 
 
     def test__decrypt_shared_secret(self):
         key = RSA.generate(2048)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -130,6 +130,43 @@ class TestRegistration(DatabaseTest):
         eq_("new status", reg2.status_field.value)
         eq_("new stage", reg2.stage_field.value)
 
+    def test_setting(self):
+        m = self.registration.setting
+
+        def _find(key):
+            """Find a ConfigurationSetting associated with the library.
+
+            This is necessary because ConfigurationSetting.value
+            creates _two_ ConfigurationSettings, one associated with
+            the library and one not associated with any library, to
+            store the default value.
+            """
+            values = [
+                x for x in self.registration.integration.settings
+                if x.library and x.key==key
+            ]
+            if len(values) == 1:
+                return values[0]
+            return None
+
+        # Calling setting() creates a ConfigurationSetting object
+        # associated with the library.
+        setting = m("key")
+        eq_("key", setting.key)
+        eq_(None, setting.value)
+        eq_(self._default_library, setting.library)
+        eq_(setting, _find("key"))
+
+        # You can specify a default value, which is used only if the
+        # current value is None.
+        setting2 = m("key", "default")
+        eq_(setting, setting2)
+        eq_("default", setting.value)
+
+        setting3 = m("key", "default2")
+        eq_(setting, setting3)
+        eq_("default", setting.value)
+
     def test__decrypt_shared_secret(self):
         key = RSA.generate(2048)
         encryptor = PKCS1_OAEP.new(key)


### PR DESCRIPTION
This branch removes a bunch of test code from tests/admin/test_controller.py because the code that used to be there is now in `Registration.push`. This branch also adds complete test coverage of `Registration.push` and everything else in `registry.py`.

Unfortunately this doesn't speed up tests as much as I thought. The controller tests are slow not because mocking up a fake request is slow, but because test setup is slow. This branch gets rid of a lot of mock requests, but it only removes one test for two different controllers (in each case by moving the "success" test, which is now very tiny, to the end of all the "failure" tests). This is still good for a couple seconds improvement, but if we want to speed up test time we should look into speeding up `setup`.

I did find one easy win: most of the admin controller tests don't need to have a Work created as part of setup, and getting rid of that knocked about twenty seconds off the run time. (Run time for tests/admin/test_controller.py is still well over two minutes, so there's plenty of space to improve.)