### PR TITLE
Implement a script to register libraries with a registry in bulk

### DIFF
--- a/api/custom_index.py
+++ b/api/custom_index.py
@@ -68,7 +68,7 @@ class CustomIndexView(object):
         protocol = integration.protocol
         if not protocol in cls.BY_PROTOCOL:
             raise CannotLoadConfiguration(
-                "Unregistered custom index protocol: %s" % name
+                "Unregistered custom index protocol: %s" % protocol
             )
         view_class = cls.BY_PROTOCOL[protocol]
         return view_class(library, integration)

--- a/bin/configuration/register_library
+++ b/bin/configuration/register_library
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+"""Push the configurations of one or more libraries to a library registry."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+from api.registry import LibraryRegistrationScript
+LibraryRegistrationScript().run()


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1012.
The new script will register any number of libraries with a given registry, in either the 'production' or 'testing' stages.