### PR TITLE
Update Novelist document format

### DIFF
--- a/api/novelist.py
+++ b/api/novelist.py
@@ -477,6 +477,8 @@ class NoveListAPI(object):
         i1 = aliased(Identifier)
         i2 = aliased(Identifier)
         roles = list(Contributor.AUTHOR_ROLES)
+        # TODO: We should handle the Narrator role properly, by
+        # setting the 'narrator' field in the NoveList API document.
         # roles.append(Contributor.NARRATOR_ROLE)
 
         isbnQuery = select(

--- a/api/novelist.py
+++ b/api/novelist.py
@@ -87,7 +87,7 @@ class NoveListAPI(object):
 
     medium_to_book_format_type_values = {
         Edition.BOOK_MEDIUM : u"EBook",
-        Edition.AUDIO_MEDIUM : u"AudiobookFormat",
+        Edition.AUDIO_MEDIUM : u"Audiobook",
     }
 
     @classmethod
@@ -477,7 +477,7 @@ class NoveListAPI(object):
         i1 = aliased(Identifier)
         i2 = aliased(Identifier)
         roles = list(Contributor.AUTHOR_ROLES)
-        roles.append(Contributor.NARRATOR_ROLE)
+        # roles.append(Contributor.NARRATOR_ROLE)
 
         isbnQuery = select(
             [i1.identifier, i1.type, i2.identifier,

--- a/api/novelist.py
+++ b/api/novelist.py
@@ -549,6 +549,8 @@ class NoveListAPI(object):
 
         # If we encounter an existing ISBN and its role is "Primary Author",
         # then that value overrides the existing Author property.
+        #
+        # TODO: add 'narrator' field when we encounter a Narrator role.
         if isbn == currentIdentifier and existingItem:
             if role == Contributor.PRIMARY_AUTHOR_ROLE:
                 existingItem['author'] = author
@@ -559,15 +561,12 @@ class NoveListAPI(object):
             # initially given to us.
             title = object[3]
             mediaType = self.medium_to_book_format_type_values.get(object[4], "")
-            narrator = object[6] if role == Contributor.NARRATOR_ROLE else ""
-
             newItem = dict(
                 isbn=isbn,
                 title=title,
                 mediaType=mediaType,
                 author=author,
                 role=role,
-                narrator=narrator
             )
             return (isbn, existingItem, newItem, True)
 

--- a/tests/test_novelist.py
+++ b/tests/test_novelist.py
@@ -368,11 +368,11 @@ class TestNoveListAPI(DatabaseTest):
         items = self.novelist.get_items_from_query(self._default_library)
 
         item = dict(
-            Author=contributor[0]._sort_name,
-            Title=edition.title,
-            MediaType=self.novelist.medium_to_book_format_type_values.get(edition.medium, ""),
-            ISBN=edition.primary_identifier.identifier,
-            Narrator=""
+            author=contributor[0]._sort_name,
+            title=edition.title,
+            mediaType=self.novelist.medium_to_book_format_type_values.get(edition.medium, ""),
+            isbn=edition.primary_identifier.identifier,
+            narrator=""
         )
 
         eq_(items, [item])
@@ -403,12 +403,12 @@ class TestNoveListAPI(DatabaseTest):
         eq_(existingItem, None)
         eq_(
             newItem,
-            {"ISBN": "23456",
-            "MediaType": "EBook",
-            "Title": "Title 1",
-            "Role": "Author",
-            "Author": "Author 1",
-            "Narrator": ""}
+            {"isbn": "23456",
+            "mediaType": "EBook",
+            "title": "Title 1",
+            "role": "Author",
+            "author": "Author 1",
+            "narrator": ""}
         )
         eq_(addItem, True)
 
@@ -417,12 +417,12 @@ class TestNoveListAPI(DatabaseTest):
         )
         eq_(currentIdentifier, item_from_query[2])
         eq_(existingItem,
-            {"ISBN": "23456",
-            "MediaType": "EBook",
-            "Title": "Title 1",
-            "Author": "Author 2",
-            "Role": "Primary Author",
-            "Narrator": ""}
+            {"isbn": "23456",
+            "mediaType": "EBook",
+            "title": "Title 1",
+            "author": "Author 2",
+            "role": "Primary Author",
+            "narrator": ""}
         )
         eq_(newItem, None)
         eq_(addItem, False)
@@ -453,19 +453,19 @@ class TestNoveListAPI(DatabaseTest):
         result = self.novelist.make_novelist_data_object(bad_data)
 
         eq_(result, {
-            "Customer": "library:yep",
-            "Records": []
+            "customer": "library:yep",
+            "records": []
         })
 
         data = [
-            {"ISBN":"12345", "MediaType": "http://schema.org/EBook", "Title": "Book 1", "Author": "Author 1" },
-            {"ISBN":"12346", "MediaType": "http://schema.org/EBook", "Title": "Book 2", "Author": "Author 2" },
+            {"isbn":"12345", "mediaType": "http://schema.org/EBook", "title": "Book 1", "author": "Author 1" },
+            {"isbn":"12346", "mediaType": "http://schema.org/EBook", "title": "Book 2", "author": "Author 2" },
         ]
         result = self.novelist.make_novelist_data_object(data)
 
         eq_(result, {
-            "Customer": "library:yep",
-            "Records": data
+            "customer": "library:yep",
+            "records": data
         })
 
     def mockHTTPPut(self, *args, **kwargs):

--- a/tests/test_novelist.py
+++ b/tests/test_novelist.py
@@ -372,7 +372,6 @@ class TestNoveListAPI(DatabaseTest):
             title=edition.title,
             mediaType=self.novelist.medium_to_book_format_type_values.get(edition.medium, ""),
             isbn=edition.primary_identifier.identifier,
-            narrator=""
         )
 
         eq_(items, [item])
@@ -408,7 +407,7 @@ class TestNoveListAPI(DatabaseTest):
             "title": "Title 1",
             "role": "Author",
             "author": "Author 1",
-            "narrator": ""}
+            }
         )
         eq_(addItem, True)
 
@@ -422,7 +421,7 @@ class TestNoveListAPI(DatabaseTest):
             "title": "Title 1",
             "author": "Author 2",
             "role": "Primary Author",
-            "narrator": ""}
+            }
         )
         eq_(newItem, None)
         eq_(addItem, False)


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1045. There was a performance problem which turned out not to be an issue, but the NoveList API has updated their document format and we were still using the old format.

While updating the document format I discovered that we don't handle the Narrator role correctly. A book with a narrator was showing up with no author. Since Novelist considers 'narrator' an optional field, I've taken 'narrator' out altogether rather than put in the extra work to get it working -- we can always add it later and I just want to get this release out.