### PR TITLE
Implement and test a very basic command-line script to run collection self-tests.

### DIFF
--- a/bin/informational/run-self-tests
+++ b/bin/informational/run-self-tests
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""Run self tests on every one of a library's integrations that supports
+self-tests.
+"""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+from api.selftest import RunSelfTestsScript
+RunSelfTestsScript().run()


### PR DESCRIPTION
Since Edwin is on vacation, I wrote this really cheap branch, which will let us do a release without https://github.com/NYPL-Simplified/circulation-web/pull/164. It adds a command-line script that runs self-tests for every collection in a given library, and prints the results to standard output. Without the web interface, it will be a bit more difficult to help libraries diagnose their configuration problems, but once they run the script most problems should be pretty clear.

In addition to writing the unit tests, I've run this on NYPL's collections, with good results.