### PR TITLE
Update adobe_account_id_reset to take a library

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -599,8 +599,8 @@ class CacheOPDSGroupFeedPerLane(CacheRepresentationPerLane):
 class AdobeAccountIDResetScript(PatronInputScript):
 
     @classmethod
-    def arg_parser(cls):
-        parser = PatronInputScript.arg_parser()
+    def arg_parser(cls, _db):
+        parser = super(AdobeAccountIDResetScript, cls).arg_parser(_db)
         parser.add_argument(
             '--delete',
             help="Actually delete credentials as opposed to showing what would happen.",


### PR DESCRIPTION
Update the adobe_account_id_reset to take a shortname to disambiguate patrons that have the same ID in differnet libraries.

This depends on https://github.com/NYPL-Simplified/server_core/pull/910