### PR TITLE
Remove trailing whitespace

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -1756,7 +1756,7 @@ class DashboardController(AdminCirculationManagerController):
                 available_licenses=available_license_count,
             )
 
-        
+
         for library in self._db.query(Library):
             # Only include libraries this admin has librarian access to.
             if not flask.request.admin or not flask.request.admin.is_librarian(library):

--- a/api/admin/opds.py
+++ b/api/admin/opds.py
@@ -182,4 +182,4 @@ class AdminFeed(AcquisitionFeed):
 
         annotator.annotate_feed(feed)
         return unicode(feed)
-            
+

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -385,14 +385,14 @@ NO_CUSTOM_LISTS_FOR_LANE = pd(
     status_code=400,
     title=_("No custom lists for lane"),
     detail=_("A custom lane must have at least one associated list."),
-)    
+)
 
 LANE_WITH_PARENT_AND_DISPLAY_NAME_ALREADY_EXISTS = pd(
     "http://librarysimplified.org/terms/problem/lane-with-parent-and-display-name-already-exists",
     status_code=400,
     title=_("Lane with parent and display name already exists"),
     detail=_("You cannot create a lane with the same parent and display name as an existing lane."),
-)    
+)
 
 CANNOT_SHOW_LANE_WITH_HIDDEN_PARENT = pd(
     "http://librarysimplified.org/terms/problem/cannot-show-lane-with-hidden-parent",

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -84,7 +84,7 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
     """
     DEVICE_ID_LIST_MEDIA_TYPE = "vnd.librarysimplified/drm-device-id-list"
     PLAIN_TEXT_HEADERS = {"Content-Type" : "text/plain"}
-    
+
     @property
     def link_template_header(self):
         """Generate the Link Template that explains how to deregister
@@ -100,7 +100,7 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
     def _request_handler(self, patron):
         """Create a DeviceManagementRequestHandler for the appropriate
         Credential of the given Patron.
-       
+
         :return: A DeviceManagementRequestHandler
         """
         if not patron:
@@ -110,13 +110,13 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
             patron
         )
         return DeviceManagementRequestHandler(credential)
-    
+
     def device_id_list_handler(self):
         """Manage the list of device IDs associated with an Adobe ID."""
         handler = self._request_handler(flask.request.patron)
         if isinstance(handler, ProblemDetail):
             return handler
-        
+
         device_ids = self.DEVICE_ID_LIST_MEDIA_TYPE
         if flask.request.method=='GET':
             # Serve a list of device IDs.
@@ -141,9 +141,9 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
         return METHOD_NOT_ALLOWED.detailed(
             _("Only GET and POST are supported.")
         )
-        
+
     def device_id_handler(self, device_id):
-        """Manage one of the device IDs associated with an Adobe ID."""       
+        """Manage one of the device IDs associated with an Adobe ID."""
         handler = self._request_handler(getattr(flask.request, 'patron', None))
         if isinstance(handler, ProblemDetail):
             return handler
@@ -156,7 +156,7 @@ class DeviceManagementProtocolController(BaseCirculationManagerController):
         if isinstance(output, ProblemDetail):
             return output
         return Response(output, 200, self.PLAIN_TEXT_HEADERS)
-    
+
 
 class AdobeVendorIDRequestHandler(object):
 
@@ -174,7 +174,7 @@ class AdobeVendorIDRequestHandler(object):
 </accountInfoResponse>"""
 
     AUTH_ERROR_TYPE = "AUTH"
-    ACCOUNT_INFO_ERROR_TYPE = "ACCOUNT_INFO"   
+    ACCOUNT_INFO_ERROR_TYPE = "ACCOUNT_INFO"
 
     ERROR_RESPONSE_TEMPLATE = '<error xmlns="http://ns.adobe.com/adept" data="E_%(vendor_id)s_%(type)s %(message)s"/>'
 
@@ -245,10 +245,10 @@ class AdobeVendorIDRequestHandler(object):
 
 class DeviceManagementRequestHandler(object):
     """Handle incoming requests for the DRM Device Management Protocol."""
-        
+
     def __init__(self, credential):
         self.credential = credential
-        
+
     def device_list(self):
         return "\n".join(
             sorted(
@@ -267,7 +267,7 @@ class DeviceManagementRequestHandler(object):
             if device_id:
                 self.credential.register_drm_device_identifier(device_id)
         return 'Success'
-            
+
     def deregister_device(self, device_id):
         self.credential.deregister_drm_device_identifier(device_id)
         return 'Success'
@@ -369,7 +369,7 @@ class AdobeVendorIDModel(object):
         """
         if not patron:
             return None, None
-        
+
         # First, find or create a Credential containing the patron's
         # anonymized key into the DelegatedPatronIdentifier database.
         adobe_account_id_patron_identifier_credential = self.get_or_create_patron_identifier_credential(
@@ -384,7 +384,7 @@ class AdobeVendorIDModel(object):
             self._db, Credential, patron=patron, data_source=self.data_source,
             type=self.VENDOR_ID_UUID_TOKEN_TYPE
         )
-        
+
         if old_style_adobe_account_id_credential:
             # The value of the old-style credential will become the
             # default value of the DelegatedPatronIdentifier, assuming
@@ -397,7 +397,7 @@ class AdobeVendorIDModel(object):
             # using the default mechanism.
             new_value = None
 
-        # Look up or create a DelegatedPatronIdentifier using the 
+        # Look up or create a DelegatedPatronIdentifier using the
         # anonymized patron identifier we just looked up or created.
         utility = AuthdataUtility.from_config(patron.library, self._db)
         return self.to_delegated_patron_identifier_uuid(
@@ -417,7 +417,7 @@ class AdobeVendorIDModel(object):
         UUID and their human-readable label, creating a Credential
         object to hold the UUID if necessary.
         """
-        username = authorization_data.get('username') 
+        username = authorization_data.get('username')
         password = authorization_data.get('password')
         if username and not password:
             # The absence of a password indicates the username might
@@ -434,7 +434,7 @@ class AdobeVendorIDModel(object):
             uuid, label = self.short_client_token_lookup(username, password)
             if uuid and label:
                 return uuid, label
-        
+
         # Last ditch effort: try a normal username/password lookup.
         # This should almost never be used.
         patron = self.authenticator.authenticated_patron(
@@ -457,7 +457,7 @@ class AdobeVendorIDModel(object):
         """
         if not authdata:
             return None, None
-        
+
         library_uri = foreign_patron_identifier = None
         utility = AuthdataUtility.from_config(self.library, self._db)
         if utility:
@@ -470,7 +470,7 @@ class AdobeVendorIDModel(object):
             except Exception, e:
                 # Not a problem -- we'll try the old system.
                 pass
-            
+
         if library_uri and foreign_patron_identifier:
             # We successfully decoded the authdata as a JWT. We know
             # which library the patron is from and which (hopefully
@@ -506,7 +506,7 @@ class AdobeVendorIDModel(object):
                 # This didn't work--either the incoming data was wrong
                 # or this technique wasn't the right one to use.
                 pass
-            
+
         if library_uri and foreign_patron_identifier:
             # We successfully decoded the authdata as a short client
             # token. We know which library the patron is from and
@@ -546,7 +546,7 @@ class AdobeVendorIDModel(object):
     def patron_from_authdata_lookup(self, authdata):
         """Look up a patron by their persistent authdata token."""
         credential = Credential.lookup_by_token(
-            self._db, self.data_source, self.AUTHDATA_TOKEN_TYPE, 
+            self._db, self.data_source, self.AUTHDATA_TOKEN_TYPE,
             authdata, allow_persistent_token=True
         )
         if not credential:
@@ -583,7 +583,7 @@ class AdobeVendorIDModel(object):
 class AuthdataUtility(object):
 
     """Generate authdata JWTs as per the Vendor ID Service spec:
-    https://docs.google.com/document/d/1j8nWPVmy95pJ_iU4UTC-QgHK2QhDUSdQ0OQTFR2NE_0    
+    https://docs.google.com/document/d/1j8nWPVmy95pJ_iU4UTC-QgHK2QhDUSdQ0OQTFR2NE_0
 
     Capable of encoding JWTs (for this library), and decoding them
     (from this library and potentially others).
@@ -600,9 +600,9 @@ class AuthdataUtility(object):
     # the patron needs to reset their Adobe account ID) with no
     # consequences other than losing their currently checked-in books.
     ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER = "Identifier for Adobe account ID purposes"
-    
+
     ALGORITHM = 'HS256'
-   
+
     def __init__(self, vendor_id, library_uri, library_short_name, secret,
                  other_libraries={}):
         """Basic constructor.
@@ -663,7 +663,7 @@ class AuthdataUtility(object):
                 )
             self.library_uris_by_short_name[short_name] = uri
             self.secrets_by_library_uri[uri] = secret
-        
+
         self.log = logging.getLogger("Adobe authdata utility")
 
         self.short_token_signer = HMACAlgorithm(HMACAlgorithm.SHA256)
@@ -747,7 +747,7 @@ class AuthdataUtility(object):
             )
         return cls(vendor_id, library_uri, library_short_name, secret,
                    other_libraries)
-        
+
     def encode(self, patron_identifier):
         """Generate an authdata JWT suitable for putting in an OPDS feed, where
         it can be picked up by a client and sent to the delegation
@@ -794,7 +794,7 @@ class AuthdataUtility(object):
         """Undoes adobe_base64_encode."""
         encoded = str.replace(":", "+").replace(";", "/").replace("@", "=")
         return base64.decodestring(encoded)
-    
+
     def decode(self, authdata):
         """Decode and verify an authdata JWT from one of the libraries managed
         by `secrets_by_library`.
@@ -829,7 +829,7 @@ class AuthdataUtility(object):
         # If we got to this point there is at least one exception
         # in the list.
         raise exceptions[-1]
-                
+
     def _decode(self, authdata):
         # First, decode the authdata without checking the signature.
         decoded = jwt.decode(
@@ -869,7 +869,7 @@ class AuthdataUtility(object):
             self.short_name, patron_identifier, expires
         )
         return self.vendor_id, authdata
-    
+
     def _encode_short_client_token(self, library_short_name,
                                    patron_identifier, expires):
         base = library_short_name + "|" + str(expires) + "|" + patron_identifier
@@ -886,7 +886,7 @@ class AuthdataUtility(object):
                 "Password portion of short client token exceeds 76 characters; Adobe will probably truncate it."
             )
         return base + "|" + signature
-            
+
     def decode_short_client_token(self, token):
         """Attempt to interpret a 'username' and 'password' as a short
         client token identifying a patron of a specific library.
@@ -902,7 +902,7 @@ class AuthdataUtility(object):
 
         username, password = token.rsplit('|', 1)
         return self.decode_two_part_short_client_token(username, password)
-        
+
     def decode_two_part_short_client_token(self, username, password):
         """Decode a short client token that has already been split into
         two parts.
@@ -930,7 +930,7 @@ class AuthdataUtility(object):
             raise ValueError(
                 "Token %s has empty patron identifier" % token
             )
-       
+
         if not library_short_name in self.library_uris_by_short_name:
             raise ValueError(
                 "I don't know how to handle tokens from library \"%s\"" % library_short_name
@@ -955,14 +955,14 @@ class AuthdataUtility(object):
         # Sign the token and check against the provided signature.
         key = self.short_token_signer.prepare_key(secret)
         actual_signature = self.short_token_signer.sign(token, key)
-        
+
         if actual_signature != supposed_signature:
             raise ValueError(
                 "Invalid signature for %s." % token
             )
 
         return library_uri, patron_identifier
-        
+
     EPOCH = datetime.datetime(1970, 1, 1)
 
     @classmethod
@@ -979,7 +979,7 @@ class AuthdataUtility(object):
         20161102-adobe-id-is-delegated-patron-identifier.py.
         """
         import uuid
-        
+
         _db = Session.object_session(patron)
         credential = get_one(
             _db, Credential,
@@ -1016,15 +1016,15 @@ class VendorIDLibraryConfigurationScript(Script):
     def arg_parser(cls):
         parser = argparse.ArgumentParser()
         parser.add_argument(
-            '--website-url', 
+            '--website-url',
             help="The URL to this library's patron-facing website (not their circulation manager), e.g. \"https://nypl.org/\". This is used to uniquely identify a library."
         )
         parser.add_argument(
-            '--short-name', 
+            '--short-name',
             help="The short name the library will use in Short Client Tokens, e.g. \"NYNYPL\"."
         )
         parser.add_argument(
-            '--secret', 
+            '--secret',
             help="The secret the library will use to sign Short Client Tokens."
         )
         return parser
@@ -1080,7 +1080,7 @@ class VendorIDLibraryConfigurationScript(Script):
             short_name, secret = other_libraries[chosen_website]
             self.explain(output, other_libraries, chosen_website)
         other_libraries[chosen_website] = [args.short_name, args.secret]
-        
+
         output.write("New configuration:\n")
         self.explain(output, other_libraries, chosen_website)
         setting.value = json.dumps(other_libraries)
@@ -1101,21 +1101,21 @@ class ShortClientTokenLibraryConfigurationScript(Script):
     def arg_parser(cls):
         parser = argparse.ArgumentParser()
         parser.add_argument(
-            '--website-url', 
+            '--website-url',
             help="The URL to this library's patron-facing website (not their circulation manager), e.g. \"https://nypl.org/\". This is used to uniquely identify a library.",
             required=True,
         )
         parser.add_argument(
-            '--vendor-id', 
+            '--vendor-id',
             help="The name of the vendor ID the library will use. The default of 'NYPL' is probably what you want.",
             default='NYPL'
         )
         parser.add_argument(
-            '--short-name', 
+            '--short-name',
             help="The short name the library will use in Short Client Tokens, e.g. \"NYBPL\".",
         )
         parser.add_argument(
-            '--secret', 
+            '--secret',
             help="The secret the library will use to sign Short Client Tokens.",
         )
         return parser
@@ -1175,9 +1175,9 @@ class ShortClientTokenLibraryConfigurationScript(Script):
             vendor_id_s.value = vendor_id
             username_s.value = short_name
             password_s.value = secret
-        
+
         output.write(
-            "Current Short Client Token configuration for %s:\n" 
+            "Current Short Client Token configuration for %s:\n"
             % website_url
         )
         output.write(" Vendor ID: %s\n" % vendor_id_s.value)

--- a/api/annotations.py
+++ b/api/annotations.py
@@ -78,7 +78,7 @@ class AnnotationWriter(object):
         container["total"] = len(annotations)
         container["first"] = cls.annotation_page_for(patron, identifier=identifier, with_context=False)
         return container, latest_timestamp
-        
+
 
     @classmethod
     def annotation_page_for(cls, patron, identifier=None, with_context=True):
@@ -131,7 +131,7 @@ class AnnotationParser(object):
     def parse(cls, _db, data, patron):
         if patron.synchronize_annotations != True:
             return PATRON_NOT_OPTED_IN_TO_ANNOTATION_SYNC
-        
+
         try:
             data = json.loads(data)
             data = jsonld.expand(data)
@@ -154,7 +154,7 @@ class AnnotationParser(object):
         source = source[0].get('@id')
 
         identifier, ignore = Identifier.parse_urn(_db, source)
-        
+
         motivation = data.get("http://www.w3.org/ns/oa#motivatedBy")
         if not motivation or not len(motivation) == 1:
             return INVALID_ANNOTATION_MOTIVATION

--- a/api/app.py
+++ b/api/app.py
@@ -5,7 +5,7 @@ import urlparse
 
 import flask
 from flask import (
-    Flask, 
+    Flask,
     Response,
     redirect,
 )

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -96,7 +96,7 @@ class PatronData(object):
     # Patron was asked to return an item so someone else could borrow it,
     # but didn't return the item.
     RECALL_OVERDUE = 'recall overdue'
-    
+
     def __init__(self,
                  permanent_id=None,
                  authorization_identifier=None,
@@ -128,7 +128,7 @@ class PatronData(object):
 
         The circulation manager does the best it can to maintain
         continuity of the patron's identity in the face of changes to
-        this list. The two assumptions made are: 
+        this list. The two assumptions made are:
 
         1) A patron tends to pick one of their authorization
         identifiers and stick with it until it stops working, rather
@@ -181,11 +181,11 @@ class PatronData(object):
         self.block_reason = block_reason
         self.library_identifier = library_identifier
         self.complete = complete
-        
+
         # We do not store personal_name in the database, but we provide
         # it to the client if possible.
         self.personal_name = personal_name
-        
+
         # We do not store email address in the database, but we need
         # to have it available for notifications.
         self.email_address = email_address
@@ -202,13 +202,13 @@ class PatronData(object):
 
     @fines.setter
     def fines(self, value):
-        """When setting patron fines, only store the numeric portion of 
+        """When setting patron fines, only store the numeric portion of
         a Money object.
         """
         if isinstance(value, Money):
             value = value.amount
         self._fines = value
-    
+
     def apply(self, patron):
         """Take the portion of this data that can be stored in the database
         and write it to the given Patron record.
@@ -260,7 +260,7 @@ class PatronData(object):
                 # We don't know what's going on and we need to sync
                 # with the remote ASAP.
                 patron.last_external_sync = None
-           
+
         # Note that we do not store personal_name or email_address in the
         # database model.
         if self.complete:
@@ -277,7 +277,7 @@ class PatronData(object):
             # Unset a previous value.
             value = None
         setattr(patron, field_name, value)
-        
+
     def get_or_create_patron(self, _db, library_id, analytics=None):
         """Create a Patron with this information.
 
@@ -307,7 +307,7 @@ class PatronData(object):
         :param analytics: Analytics instance to track the new patron
             creation event.
         """
-        
+
         # We must be very careful when checking whether the patron
         # already exists because three different fields might be in use
         # as the patron identifier.
@@ -428,7 +428,7 @@ class Authenticator(object):
 class LibraryAuthenticator(object):
     """Use the registered AuthenticationProviders to turn incoming
     credentials into Patron objects.
-    """    
+    """
 
     @classmethod
     def from_config(cls, _db, library, analytics=None, custom_catalog_source=CustomPatronCatalog):
@@ -466,7 +466,7 @@ class LibraryAuthenticator(object):
                     exc_info=e
                 )
                 authenticator.initialization_exceptions[integration.id] = e
-                
+
         if authenticator.oauth_providers_by_name:
             # NOTE: this will immediately commit the database session,
             # which may not be what you want during a test. To avoid
@@ -546,7 +546,7 @@ class LibraryAuthenticator(object):
     @property
     def library(self):
         return Library.by_id(self._db, self.library_id)
-        
+
     def assert_ready_for_oauth(self):
         """If this LibraryAuthenticator has OAuth providers, ensure that it
         also has a secret it can use to sign bearer tokens.
@@ -555,14 +555,14 @@ class LibraryAuthenticator(object):
             raise CannotLoadConfiguration(
                 "OAuth providers are configured, but secret for signing bearer tokens is not."
             )
-                
+
     def register_provider(self, integration, analytics=None):
         """Turn an ExternalIntegration object into an AuthenticationProvider
         object, and register it.
 
         :param integration: An ExternalIntegration that configures
         a way of authenticating patrons.
-        """           
+        """
         if integration.goal != integration.PATRON_AUTH_GOAL:
             raise CannotLoadConfiguration(
                 "Was asked to register an integration with goal=%s as though it were a way of authenticating patrons." % integration.goal
@@ -573,7 +573,7 @@ class LibraryAuthenticator(object):
             raise CannotLoadConfiguration(
                 "Was asked to register an integration with library %s, which doesn't use it." % library.name
             )
-        
+
         module_name = integration.protocol
         if not module_name:
             # This should be impossible since protocol is not nullable.
@@ -613,7 +613,7 @@ class LibraryAuthenticator(object):
                 "Two basic auth providers configured"
             )
         self.basic_auth_provider = provider
-        
+
     def register_oauth_provider(self, provider):
         already_registered = self.oauth_providers_by_name.get(
             provider.NAME
@@ -625,7 +625,7 @@ class LibraryAuthenticator(object):
                 )
             )
         self.oauth_providers_by_name[provider.NAME] = provider
-        
+
     @property
     def providers(self):
         """An iterator over all registered AuthenticationProviders."""
@@ -633,7 +633,7 @@ class LibraryAuthenticator(object):
             yield self.basic_auth_provider
         for provider in self.oauth_providers_by_name.values():
             yield provider
-        
+
     def authenticated_patron(self, _db, header):
         """Go from an Authorization header value to a Patron object.
 
@@ -692,7 +692,7 @@ class LibraryAuthenticator(object):
             credential = provider.get_credential_from_header(header)
             if credential is not None:
                 break
-            
+
         return credential
 
     def oauth_provider_lookup(self, provider_name):
@@ -789,7 +789,7 @@ class LibraryAuthenticator(object):
         index_url = url_for("index", _external=True,
                             library_short_name=library.short_name)
         links.append(
-            dict(rel="start", href=index_url, 
+            dict(rel="start", href=index_url,
                  type=OPDSFeed.ACQUISITION_FEED_TYPE)
         )
 
@@ -804,7 +804,7 @@ class LibraryAuthenticator(object):
                      href=designated_agent_uri
                 )
             )
-                
+
         # Add a rel="help" link for every type of URL scheme that
         # leads to library-specific help.
         for type, uri in Configuration.help_uris(library):
@@ -823,7 +823,7 @@ class LibraryAuthenticator(object):
             Configuration.LOGO, library).value
         if logo:
             links.append(dict(rel="logo", type="image/png", href=logo))
-                
+
         library_name = self.library_name or unicode(_("Library"))
         auth_doc_url = self.authentication_document_url(library)
         doc = AuthenticationForOPDSDocument(
@@ -858,7 +858,7 @@ class LibraryAuthenticator(object):
             Configuration.PUBLIC_KEY, library).value
         if public_key:
             doc["public_key"] = dict(type="RSA", value=public_key)
-        
+
         # Add feature flags to signal to clients what features they should
         # offer.
         enabled = []
@@ -1008,7 +1008,7 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
     LIBRARY_IDENTIFIER_RESTRICTION_TYPE_PREFIX = 'prefix'
     LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING = 'string'
     LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST = 'list'
-    
+
     LIBRARY_SETTINGS = [
         { "key": EXTERNAL_TYPE_REGULAR_EXPRESSION,
           "label": _("External Type Regular Expression"),
@@ -1058,7 +1058,7 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
 
     def __init__(self, library, integration, analytics=None):
         """Basic constructor.
-        
+
         :param library: Patrons authenticated through this provider
         are associated with this Library. Don't store this object!
         It's associated with a scoped database session. Just pull
@@ -1152,7 +1152,7 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
                 return True
 
         return False
-    
+
     def enforce_library_identifier_restriction(self, identifier, patrondata):
         """Does the given patron match the configured library identifier restriction?"""
         if not self.library_identifier_restriction_type or self.library_identifier_restriction_type == self.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_NONE:
@@ -1175,13 +1175,13 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
             return patrondata
         else:
             return False
-    
+
     def library(self, _db):
         return Library.by_id(_db, self.library_id)
 
     def external_integration(self, _db):
         return get_one(_db, ExternalIntegration, id=self.external_integration_id)
-    
+
     def authenticated_patron(self, _db, header):
         """Go from a WWW-Authenticate header (or equivalent) to a Patron object.
 
@@ -1233,7 +1233,7 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
             # The regular expression matched but didn't contain any groups.
             # This is a configuration error; do nothing.
             return
-            
+
         patron.external_type = groups[0]
 
     def authenticate(self, _db, header):
@@ -1257,7 +1257,7 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
         :return: The patron's password, or None if not available.
         """
         return None
-    
+
     def remote_patron_lookup(self, patron_or_patrondata):
         """Ask the remote for detailed information about a patron's account.
 
@@ -1284,8 +1284,8 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
         raise ValueError(
             "Unexpected object %r passed into remote_patron_lookup." %
             patron_or_patrondata
-        )       
-    
+        )
+
     def _authentication_flow_document(self, _db):
         """Create a Authentication Flow object for use in an Authentication for
         OPDS document.
@@ -1339,7 +1339,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
     AUTHENTICATION_REALM = _("Library card")
     FLOW_TYPE = "http://opds-spec.org/auth/basic"
     NAME = 'Generic Basic Authentication provider'
-   
+
     # By default, patron identifiers can only contain alphanumerics and
     # a few other characters. By default, there are no restrictions on
     # passwords.
@@ -1350,7 +1350,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
     # Configuration settings that are common to all Basic Auth-type
     # authentication techniques.
     #
-    
+
     # Identifiers can be presumed invalid if they don't match
     # this regular expression.
     IDENTIFIER_REGULAR_EXPRESSION = u'identifier_regular_expression'
@@ -1373,7 +1373,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
     # supported length.
     IDENTIFIER_MAXIMUM_LENGTH = u"identifier_maximum_length"
     PASSWORD_MAXIMUM_LENGTH = u"password_maximum_length"
-    
+
     # The client should use a certain string when asking for a patron's
     # "identifier" and "password"
     IDENTIFIER_LABEL = u'identifier_label'
@@ -1403,7 +1403,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
     IDENTIFIER_BARCODE_FORMAT = "identifier_barcode_format"
     BARCODE_FORMAT_CODABAR = "Codabar" # Constant defined in the extension
     BARCODE_FORMAT_NONE = ""
-    
+
     # These identifier and password are supposed to be valid
     # credentials.  If there's a problem using them, there's a problem
     # with the authenticator or with the way we have it configured.
@@ -1479,12 +1479,12 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
           "optional": True,
         },
     ] + AuthenticationProvider.SETTINGS
-    
+
     # Used in the constructor to signify that the default argument
     # value for the class should be used (as distinct from None, which
     # indicates that no value should be used.)
     class_default = object()
-    
+
     def __init__(self, library, integration, analytics=None):
         """Create a BasicAuthenticationProvider.
 
@@ -1515,7 +1515,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
         if password_regular_expression:
             password_regular_expression = re.compile(
                 password_regular_expression
-            )            
+            )
         self.password_re = password_regular_expression
 
         self.test_username = integration.setting(self.TEST_IDENTIFIER).value
@@ -1533,7 +1533,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
         self.identifier_barcode_format = integration.setting(
             self.IDENTIFIER_BARCODE_FORMAT
         ).value or self.BARCODE_FORMAT_NONE
-        
+
         self.identifier_label = (
             integration.setting(self.IDENTIFIER_LABEL).value
             or self.DEFAULT_IDENTIFIER_LABEL
@@ -1596,7 +1596,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
             "Syncing patron metadata", self.update_patron_metadata,
             patron
         )
-    
+
     def authenticate(self, _db, credentials):
         """Turn a set of credentials into a Patron object.
 
@@ -1637,7 +1637,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
         # if it does, that Patron's authorization_identifier might be
         # different from the `username` passed in as part of the
         # credentials.
-        
+
         # First, try to look up the Patron object in our database.
         patron = self.local_patron_lookup(_db, username, patrondata)
         if patron:
@@ -1645,7 +1645,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
             # with whatever we just got from remote.
             self.apply_patrondata(patrondata, patron)
             return patron
-        
+
         # We didn't find them. Now the question is: _why_ didn't the
         # patron show up locally? Have we never seen them before or
         # has their authorization identifier changed?
@@ -1679,7 +1679,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
             patron, is_new = patrondata.get_or_create_patron(
                 _db, self.library_id, analytics=self.analytics
             )
-            
+
         # The lookup failed in the first place either because the
         # Patron did not exist on the local side, or because one of
         # the patron's identifiers changed. Either way, we need to
@@ -1710,7 +1710,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
         if not isinstance(header, dict):
             return None
         return header.get('password', None)
-    
+
     def server_side_validation(self, username, password):
         """Do these credentials even look right?
 
@@ -1733,12 +1733,12 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
                 )
             if self.password_maximum_length:
                 valid = valid and password and (len(password) <= self.password_maximum_length)
-        
+
         if self.identifier_maximum_length:
             valid = valid and (len(username) <= self.identifier_maximum_length)
 
         return valid
-    
+
     def remote_authenticate(self, username, password):
         """Does the source of truth approve of these credentials?
 
@@ -1806,7 +1806,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
             patron = get_one(_db, Patron, **lookup)
             if patron:
                 # We found them!
-                break            
+                break
 
         if not patron and username:
             # This is a Basic Auth username, but it might correspond
@@ -1832,7 +1832,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
     @property
     def authentication_header(self):
         return 'Basic realm="%s"' % self.AUTHENTICATION_REALM
-    
+
     def _authentication_flow_document(self, _db):
         """Create a Authentication Flow object for use in an Authentication for
         OPDS document.
@@ -1865,7 +1865,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
                           password=password_inputs)
         )
 
-    
+
 class OAuthAuthenticationProvider(AuthenticationProvider):
 
     # NOTE: Each subclass must define URI as per
@@ -1907,9 +1907,9 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
     # Clever OAuth provider:
     #
     # EXTERNAL_AUTHENTICATE_URL = "https://clever.com/oauth/authorize?response_type=code&client_id=%(client_id)s&redirect_uri=%(oauth_callback_url)s&state=%(state)s"
-    
+
     FLOW_TYPE = "http://librarysimplified.org/authtype/OAuth-with-intermediary"
-   
+
     # After verifying the patron's OAuth credentials, we send them a
     # token. This configuration setting controls how long they can use
     # that token before we check their OAuth credentials again.
@@ -1932,7 +1932,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
         return ConfigurationSetting.sitewide_secret(
             _db, cls.BEARER_TOKEN_SIGNING_SECRET
         )
-        
+
     def __init__(self, library, integration, analytics=None):
         """Initialize this OAuthAuthenticationProvider.
 
@@ -1946,7 +1946,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
             pull normal Python objects out of it.
         :param client_id: An ID given to us by the OAuth provider, used
             to distinguish between us and its other clients.
-        :param client_secret: A secret key given to us by the OAuth 
+        :param client_secret: A secret key given to us by the OAuth
             provider, used to validate that we are who we say we are.
         :param token_expiration_days: This many days may elapse before
             we ask the patron to go through the OAuth validation
@@ -1960,7 +1960,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
         self.token_expiration_days = integration.setting(
             self.OAUTH_TOKEN_EXPIRATION_DAYS
         ).int_value or self.DEFAULT_TOKEN_EXPIRATION_DAYS
-        
+
     def authenticated_patron(self, _db, token):
         """Go from an OAuth provider token to an authenticated Patron.
 
@@ -1994,7 +1994,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
         return Credential.temporary_token_create(
             _db, data_source, self.TOKEN_TYPE, patron, duration, token
         )
-    
+
     def remote_patron_lookup(self, patron_or_patrondata):
         """Ask the remote for detailed information about a patron's account.
 
@@ -2053,7 +2053,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
         token = self.remote_exchange_code_for_access_token(_db, code)
         if isinstance(token, ProblemDetail):
             return token
-        
+
         # Now that we have a bearer token, use it to look up patron
         # information.
         patrondata = self.remote_patron_lookup(token)
@@ -2070,7 +2070,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
             # This patron was able to validate with the OAuth provider,
             # but they are not a patron of _this_ library.
             return PATRON_OF_ANOTHER_LIBRARY
-            
+
         # Convert the PatronData into a Patron object.
         patron, is_new = patrondata.get_or_create_patron(
             _db, self.library_id, analytics=self.analytics
@@ -2101,14 +2101,14 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
         PatronData.
         """
         raise NotImplementedError()
-    
+
     def _internal_authenticate_url(self, _db):
         """A patron who wants to log in should hit this URL on the circulation
-        manager. They'll be redirected to the OAuth provider, which will 
+        manager. They'll be redirected to the OAuth provider, which will
         take care of it.
         """
         library = self.library(_db)
-        
+
         return url_for('oauth_authenticate', _external=True,
                        provider=self.NAME,
                        library_short_name=library.short_name)
@@ -2145,7 +2145,7 @@ class OAuthController(object):
     """A controller for handling requests that are part of the OAuth
     credential dance.
     """
-    
+
     def __init__(self, authenticator):
         self.authenticator = authenticator
 
@@ -2159,7 +2159,7 @@ class OAuthController(object):
         redirected to.
         """
         return url_for('oauth_callback', library_short_name=library_short_name, _external=True)
-        
+
     def oauth_authentication_redirect(self, params, _db):
         """Redirect an unauthenticated patron to the authentication URL of the
         appropriate OAuth provider.
@@ -2188,7 +2188,7 @@ class OAuthController(object):
         `params['state']`, with the bearer token encoded into the
         fragment identifier as `access_token` and useful information
         about the patron encoded into the fragment identifier as
-        `patron_info`. For example, if params is 
+        `patron_info`. For example, if params is
 
             dict(state="http://oauthprovider.org/success")
 
@@ -2226,7 +2226,7 @@ class OAuthController(object):
                 client_redirect_uri, response
             )
         provider_token, patron, patrondata = response
-        
+
         # Turn the provider token into a bearer token we can give to
         # the patron.
         simplified_token = self.authenticator.create_bearer_token(
@@ -2245,7 +2245,7 @@ class OAuthController(object):
         encoded into the fragment identifier.
         """
         return redirect(self._error_uri(redirect_uri, pd))
-    
+
     def _error_uri(self, redirect_uri, pd):
         """Encode the given ProblemDetail into the fragment identifier
         of the given URI.

--- a/api/axis.py
+++ b/api/axis.py
@@ -14,7 +14,7 @@ from core.axis import (
 
 from core.metadata_layer import (
     CirculationData,
-    ReplacementPolicy, 
+    ReplacementPolicy,
 )
 
 from core.monitor import (
@@ -134,10 +134,10 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI, HasSelfTests
 
     def checkout(self, patron, pin, licensepool, internal_format):
 
-        url = self.base_url + "checkout/v2" 
+        url = self.base_url + "checkout/v2"
         title_id = licensepool.identifier.identifier
         patron_id = patron.authorization_identifier
-        args = dict(titleId=title_id, patronId=patron_id, 
+        args = dict(titleId=title_id, patronId=patron_id,
                     format=internal_format)
         response = self.request(url, data=args, method="POST")
         try:
@@ -154,7 +154,7 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI, HasSelfTests
         identifier = licensepool.identifier
         # This should include only one 'activity'.
         activities = self.patron_activity(patron, pin, licensepool.identifier)
-        
+
         for loan in activities:
             if not isinstance(loan, LoanInfo):
                 continue
@@ -163,7 +163,7 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI, HasSelfTests
                 continue
             # We've found the remote loan corresponding to this
             # license pool.
-            fulfillment = loan.fulfillment_info            
+            fulfillment = loan.fulfillment_info
             if not fulfillment or not isinstance(fulfillment, FulfillmentInfo):
                 raise CannotFulfill()
             return fulfillment
@@ -180,7 +180,7 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI, HasSelfTests
                 patron, pin
             )
 
-        url = self.base_url + "addtoHold/v2" 
+        url = self.base_url + "addtoHold/v2"
         identifier = licensepool.identifier
         title_id = identifier.identifier
         patron_id = patron.authorization_identifier
@@ -190,7 +190,7 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI, HasSelfTests
         hold_info = HoldResponseParser(licensepool.collection).process_all(
             response.content)
         if not hold_info.identifier:
-            # The Axis 360 API doesn't return the identifier of the 
+            # The Axis 360 API doesn't return the identifier of the
             # item that was placed on hold, so we have to fill it in
             # based on our own knowledge.
             hold_info.identifier_type = identifier.type
@@ -219,7 +219,7 @@ class Axis360API(BaseAxis360API, Authenticator, BaseCirculationAPI, HasSelfTests
         else:
             title_ids = None
         availability = self.availability(
-            patron_id=patron.authorization_identifier, 
+            patron_id=patron.authorization_identifier,
             title_ids=title_ids)
         return list(AvailabilityResponseParser(self.collection).process_all(
             availability.content))
@@ -314,7 +314,7 @@ class Axis360CirculationMonitor(CollectionMonitor):
     SERVICE_NAME = "Axis 360 Circulation Monitor"
     INTERVAL_SECONDS = 60
     DEFAULT_BATCH_SIZE = 50
-    
+
     PROTOCOL = ExternalIntegration.AXIS_360
 
     DEFAULT_START_TIME = datetime(1970, 1, 1)
@@ -365,7 +365,7 @@ class Axis360CirculationMonitor(CollectionMonitor):
             bibliographic.apply(edition, self.collection, replace=policy)
 
         if new_license_pool or new_edition:
-            # At this point we have done work equivalent to that done by 
+            # At this point we have done work equivalent to that done by
             # the Axis360BibliographicCoverageProvider. Register that the
             # work has been done so we don't have to do it again.
             identifier = edition.primary_identifier
@@ -373,7 +373,7 @@ class Axis360CirculationMonitor(CollectionMonitor):
             self.bibliographic_coverage_provider.add_coverage_record_for(
                 identifier
             )
-            
+
         return edition, license_pool
 
 
@@ -388,7 +388,7 @@ class AxisCollectionReaper(IdentifierSweepMonitor):
     SERVICE_NAME = "Axis Collection Reaper"
     INTERVAL_SECONDS = 3600*12
     PROTOCOL = ExternalIntegration.AXIS_360
-    
+
     def __init__(self, _db, collection, api_class=Axis360API):
         super(AxisCollectionReaper, self).__init__(_db, collection)
         if isinstance(api_class, Axis360API):
@@ -439,7 +439,7 @@ class ResponseParser(Axis360Parser):
         3112 : CannotFulfill,
         3113 : CannotLoan,
         (3113, "Title ID is not available for checkout") : NoAvailableCopies,
-        3114 : PatronLoanLimitReached, 
+        3114 : PatronLoanLimitReached,
         3115 : LibraryInvalidInputException, # Missing DRM format
         3117 : LibraryInvalidInputException, # Invalid DRM format
         3118 : LibraryInvalidInputException, # Invalid Patron credentials
@@ -460,7 +460,7 @@ class ResponseParser(Axis360Parser):
 
     def __init__(self, collection):
         self.collection = collection
-            
+
     def raise_exception_on_error(self, e, ns, custom_error_classes={}):
         """Raise an error if the given lxml node represents an Axis 360 error
         condition.
@@ -589,7 +589,7 @@ class HoldReleaseResponseParser(ResponseParser):
         *Info object, so there's no need to do any post-processing.
         """
         return i
-        
+
     def process_one(self, e, namespaces):
         # There's no data to gather here. Either there was an error
         # or we were successful.
@@ -598,7 +598,7 @@ class HoldReleaseResponseParser(ResponseParser):
         return True
 
 class AvailabilityResponseParser(ResponseParser):
-   
+
     def process_all(self, string):
         for info in super(AvailabilityResponseParser, self).process_all(
                 string, "//axis:title", self.NS):
@@ -652,7 +652,7 @@ class AvailabilityResponseParser(ResponseParser):
                 data_source_name=DataSource.AXIS_360,
                 identifier_type=self.id_type,
                 identifier=axis_identifier,
-                start_date=None, 
+                start_date=None,
                 end_date=end_date,
                 hold_position=0
             )

--- a/api/base_controller.py
+++ b/api/base_controller.py
@@ -10,7 +10,7 @@ class BaseCirculationManagerController(object):
     """Define minimal standards for a circulation manager controller,
     mainly around authentication.
     """
-    
+
     def __init__(self, manager):
         """:param manager: A CirculationManager object."""
         self.manager = manager
@@ -90,12 +90,12 @@ class BaseCirculationManagerController(object):
         has been changed and needs to be updated.
         """
         self.manager.reload_settings_if_changed()
-        
+
         if library_short_name:
             library = Library.lookup(self._db, short_name=library_short_name)
         else:
             library = Library.default(self._db)
-        
+
         if not library:
             return LIBRARY_NOT_FOUND
         flask.request.library = library

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -178,7 +178,7 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI, HasSelfTests):
     TEMPLATE = "<%(request_type)s><ItemId>%(item_id)s</ItemId><PatronId>%(patron_id)s</PatronId></%(request_type)s>"
 
     def checkout(
-            self, patron_obj, patron_password, licensepool, 
+            self, patron_obj, patron_password, licensepool,
             delivery_mechanism
     ):
 
@@ -199,7 +199,7 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI, HasSelfTests):
         patron_identifier = patron_obj.authorization_identifier
         args = dict(request_type='CheckoutRequest',
                     item_id=bibliotheca_id, patron_id=patron_identifier)
-        body = self.TEMPLATE % args 
+        body = self.TEMPLATE % args
         response = self.request('checkout', body, method="PUT")
         if response.status_code == 201:
             # New loan
@@ -265,24 +265,24 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI, HasSelfTests):
     def get_fulfillment_file(self, patron_id, bibliotheca_id):
         args = dict(request_type='ACSMRequest',
                    item_id=bibliotheca_id, patron_id=patron_id)
-        body = self.TEMPLATE % args 
+        body = self.TEMPLATE % args
         return self.request('GetItemACSM', body, method="PUT")
 
     def get_audio_fulfillment_file(self, patron_id, bibliotheca_id):
-        args = dict(request_type='AudioFulfillmentRequest', 
+        args = dict(request_type='AudioFulfillmentRequest',
                     item_id=bibliotheca_id, patron_id=patron_id)
-        body = self.TEMPLATE % args 
+        body = self.TEMPLATE % args
         return self.request('GetItemAudioFulfillment', body, method="POST")
-    
+
     def checkin(self, patron, pin, licensepool):
         patron_id = patron.authorization_identifier
         item_id = licensepool.identifier.identifier
         args = dict(request_type='CheckinRequest',
                    item_id=item_id, patron_id=patron_id)
-        body = self.TEMPLATE % args 
+        body = self.TEMPLATE % args
         return self.request('checkin', body, method="PUT")
 
-    def place_hold(self, patron, pin, licensepool, 
+    def place_hold(self, patron, pin, licensepool,
                    hold_notification_email=None):
         """Place a hold.
 
@@ -292,7 +292,7 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI, HasSelfTests):
         item_id = licensepool.identifier.identifier
         args = dict(request_type='PlaceHoldRequest',
                    item_id=item_id, patron_id=patron_id)
-        body = self.TEMPLATE % args 
+        body = self.TEMPLATE % args
         response = self.request('placehold', body, method="PUT")
         if response.status_code in (200, 201):
             start_date = datetime.datetime.utcnow()
@@ -301,7 +301,7 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI, HasSelfTests):
                 licensepool.collection, DataSource.BIBLIOTHECA,
                 licensepool.identifier.type,
                 licensepool.identifier.identifier,
-                start_date=start_date, 
+                start_date=start_date,
                 end_date=end_date,
                 hold_position=None
             )
@@ -316,10 +316,10 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI, HasSelfTests):
 
     def release_hold(self, patron, pin, licensepool):
         patron_id = patron.authorization_identifier
-        item_id = licensepool.identifier.identifier        
+        item_id = licensepool.identifier.identifier
         args = dict(request_type='CancelHoldRequest',
                    item_id=item_id, patron_id=patron_id)
-        body = self.TEMPLATE % args 
+        body = self.TEMPLATE % args
         response = self.request('cancelhold', body, method="PUT")
         if response.status_code in (200, 404):
             return True
@@ -329,8 +329,8 @@ class BibliothecaAPI(BaseBibliothecaAPI, BaseCirculationAPI, HasSelfTests):
     def apply_circulation_information_to_licensepool(self, circ, pool, analytics=None):
         """Apply the output of CirculationParser.process_one() to a
         LicensePool.
-        
-        TODO: It should be possible to have CirculationParser yield 
+
+        TODO: It should be possible to have CirculationParser yield
         CirculationData objects instead and to replace this code with
         CirculationData.apply(pool)
         """
@@ -514,7 +514,7 @@ class CirculationParser(BibliothecaParser):
 
         identifiers[Identifier.BIBLIOTHECA_ID] = value("ItemId")
         identifiers[Identifier.ISBN] = value("ISBN13")
-        
+
         item[LicensePool.licenses_owned] = intvalue("TotalCopies")
         try:
             item[LicensePool.licenses_available] = intvalue("AvailableCopies")
@@ -560,7 +560,7 @@ class ErrorParser(BibliothecaParser):
     loan_limit_reached = re.compile(
         "Patron cannot loan more than [0-9]+ document"
     )
-    
+
     hold_limit_reached = re.compile(
         "Patron cannot have more than [0-9]+ hold"
     )
@@ -662,7 +662,7 @@ class PatronCirculationParser(BibliothecaParser):
     def __init__(self, collection, *args, **kwargs):
         super(PatronCirculationParser, self).__init__(*args, **kwargs)
         self.collection = collection
-    
+
     def process_all(self, string):
         parser = etree.XMLParser()
         root = etree.parse(StringIO(string), parser)
@@ -806,7 +806,7 @@ class BibliothecaCirculationSweep(IdentifierSweepMonitor):
         else:
             self.api = api_class(_db, collection)
         self.analytics = Analytics(_db)
-    
+
     def process_items(self, identifiers):
         identifiers_by_bibliotheca_id = dict()
         bibliotheca_ids = set()
@@ -849,7 +849,7 @@ class BibliothecaCirculationSweep(IdentifierSweepMonitor):
                 pool.last_checked = now
 
     def _process_circulation_data(
-        self, circ, identifiers_by_bibliotheca_id, 
+        self, circ, identifiers_by_bibliotheca_id,
         identifiers_not_mentioned_by_bibliotheca
     ):
         """Process a single CirculationData object retrieved from
@@ -876,12 +876,12 @@ class BibliothecaCirculationSweep(IdentifierSweepMonitor):
 
             for library in self.collection.libraries:
                 self.analytics.collect_event(
-                    library, pool, CirculationEvent.DISTRIBUTOR_TITLE_ADD, 
+                    library, pool, CirculationEvent.DISTRIBUTOR_TITLE_ADD,
                     datetime.datetime.utcnow()
                 )
         else:
             [pool] = pools
-                
+
         self.api.apply_circulation_information_to_licensepool(
             circ, pool, self.analytics
         )
@@ -897,7 +897,7 @@ class BibliothecaEventMonitor(CollectionMonitor):
     But when a new book comes on the scene, this is where we first
     find out about it. When this happens, we create a LicensePool and
     immediately ensure that we get coverage from the
-    BibliothecaBibliographicCoverageProvider. 
+    BibliothecaBibliographicCoverageProvider.
 
     But getting up-to-date circulation data for that new book requires
     either that we process further events, or that we encounter it in
@@ -908,7 +908,7 @@ class BibliothecaEventMonitor(CollectionMonitor):
     DEFAULT_START_TIME = datetime.timedelta(365*3)
     PROTOCOL = ExternalIntegration.BIBLIOTHECA
 
-    def __init__(self, _db, collection, api_class=BibliothecaAPI, 
+    def __init__(self, _db, collection, api_class=BibliothecaAPI,
                  cli_date=None, analytics=None):
         self.analytics = analytics or Analytics(_db)
         super(BibliothecaEventMonitor, self).__init__(_db, collection)
@@ -1011,7 +1011,7 @@ class BibliothecaEventMonitor(CollectionMonitor):
                      start_time, end_time, internal_event_type):
         # Find or lookup the LicensePool for this event.
         license_pool, is_new = LicensePool.for_foreign_id(
-            self._db, self.api.source, Identifier.BIBLIOTHECA_ID, 
+            self._db, self.api.source, Identifier.BIBLIOTHECA_ID,
             bibliotheca_id, collection=self.collection
         )
 

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -59,7 +59,7 @@ class CirculationInfo(object):
     def collection(self, _db):
         """Find the Collection to which this object belongs."""
         return Collection.by_id(_db, self.collection_id)
-    
+
     def license_pool(self, _db):
         """Find the LicensePool model object corresponding to this object."""
         collection = self.collection(_db)
@@ -68,7 +68,7 @@ class CirculationInfo(object):
             collection=collection
         )
         return pool
-        
+
     def fd(self, d):
         # Stupid method to format a date
         if not d:
@@ -197,7 +197,7 @@ class FulfillmentInfo(CirculationInfo):
         self.content_type = content_type
         self.content = content
         self.content_expires = content_expires
-    
+
     def __repr__(self):
         if self.content:
             blength = len(self.content)
@@ -241,7 +241,7 @@ class LoanInfo(CirculationInfo):
         f = "%Y/%m/%d"
         return "<LoanInfo for %s/%s, start=%s end=%s>%s" % (
             self.identifier_type, self.identifier,
-            self.fd(self.start_date), self.fd(self.end_date), 
+            self.fd(self.start_date), self.fd(self.end_date),
             fulfillment
         )
 
@@ -253,9 +253,9 @@ class HoldInfo(CirculationInfo):
     :param identifier_type Ex.: Identifier.ONECLICK_ID.
     :param identifier Expected to be the unicode string of the isbn, etc..
     :param start_date When the patron made the reservation.
-    :param end_date When reserved book is expected to become available.  Expected to be passed in 
+    :param end_date When reserved book is expected to become available.  Expected to be passed in
         date, not unicode format.
-    :param hold_position  Patron's place in the hold line.  
+    :param hold_position  Patron's place in the hold line.
         When not available, default to be passed is None, which is equivalent to "first in line".
     """
 
@@ -273,7 +273,7 @@ class HoldInfo(CirculationInfo):
     def __repr__(self):
         return "<HoldInfo for %s/%s, start=%s end=%s, position=%s>" % (
             self.identifier_type, self.identifier,
-            self.fd(self.start_date), self.fd(self.end_date), 
+            self.fd(self.start_date), self.fd(self.end_date),
             self.hold_position
         )
 
@@ -293,7 +293,7 @@ class CirculationAPI(object):
         :param library: A Library object representing the library
           whose circulation we're concerned with.
 
-        :param analytics: An Analytics object for tracking 
+        :param analytics: An Analytics object for tracking
           circulation events.
 
         :param api_map: A dictionary mapping Collection protocols to
@@ -340,7 +340,7 @@ class CirculationAPI(object):
     @property
     def library(self):
         return Library.by_id(self._db, self.library_id)
-                    
+
     @property
     def default_api_map(self):
         """When you see a Collection that implements protocol X, instantiate
@@ -386,14 +386,14 @@ class CirculationAPI(object):
                hold_notification_email=None):
         """Either borrow a book or put it on hold. Don't worry about fulfilling
         the loan yet.
-        
+
         :return: A 3-tuple (`Loan`, `Hold`, `is_new`). Either `Loan`
         or `Hold` must be None, but not both.
         """
         # Short-circuit the request if the patron lacks borrowing
         # privileges.
-        PatronUtility.assert_borrowing_privileges(patron)        
-        
+        PatronUtility.assert_borrowing_privileges(patron)
+
         now = datetime.datetime.utcnow()
         if licensepool.open_access:
             # We can 'loan' open-access content ourselves just by
@@ -406,7 +406,7 @@ class CirculationAPI(object):
             return loan, None, is_new
 
         # Okay, it's not an open-access book. This means we need to go
-        # to an external service to get the book. 
+        # to an external service to get the book.
         #
         # This also means that our internal model of whether this book
         # is currently on loan or on hold might be wrong.
@@ -421,7 +421,7 @@ class CirculationAPI(object):
 
         if must_set_delivery_mechanism and not delivery_mechanism:
             raise DeliveryMechanismMissing()
-    
+
         content_link = content_expires = None
 
         internal_format = api.internal_format(delivery_mechanism)
@@ -436,7 +436,7 @@ class CirculationAPI(object):
              self._db, Loan, patron=patron, license_pool=licensepool,
              on_multiple='interchangeable'
         )
-        
+
         loan_info = None
         hold_info = None
         if existing_loan:
@@ -488,7 +488,7 @@ class CirculationAPI(object):
             except AlreadyCheckedOut:
                 # This is good, but we didn't get the real loan info.
                 # Just fake it.
-                identifier = licensepool.identifier            
+                identifier = licensepool.identifier
                 loan_info = LoanInfo(
                     licensepool.collection,
                     licensepool.data_source,
@@ -589,7 +589,7 @@ class CirculationAPI(object):
         hold, is_new = licensepool.on_hold_to(
             patron,
             hold_info.start_date or now,
-            hold_info.end_date, 
+            hold_info.end_date,
             hold_info.hold_position,
             hold_info.external_identifier,
         )
@@ -641,7 +641,7 @@ class CirculationAPI(object):
         if not api:
             return False
         return api.can_fulfill_without_loan(patron, pool, lpdm)
-    
+
     def fulfill(self, patron, pin, licensepool, delivery_mechanism, sync_on_failure=True):
         """Fulfil a book that a patron has previously checked out.
 
@@ -676,7 +676,7 @@ class CirculationAPI(object):
         if loan and loan.fulfillment is not None and not loan.fulfillment.compatible_with(delivery_mechanism):
             raise DeliveryMechanismConflict(
                 _("You already fulfilled this loan as %(loan_delivery_mechanism)s, you can't also do it as %(requested_delivery_mechanism)s",
-                  loan_delivery_mechanism=loan.fulfillment.delivery_mechanism.name, 
+                  loan_delivery_mechanism=loan.fulfillment.delivery_mechanism.name,
                   requested_delivery_mechanism=delivery_mechanism.delivery_mechanism.name)
             )
 
@@ -755,7 +755,7 @@ class CirculationAPI(object):
             licensepool.collection, licensepool.data_source,
             identifier_type=licensepool.identifier.type,
             identifier=licensepool.identifier.identifier,
-            content_link=content_link, content_type=media_type, content=None, 
+            content_link=content_link, content_type=media_type, content=None,
             content_expires=None,
         )
 
@@ -888,7 +888,7 @@ class CirculationAPI(object):
                         l = holds
                     else:
                         self.log.warn(
-                            "value %r from patron_activity is neither a loan nor a hold.", 
+                            "value %r from patron_activity is neither a loan nor a hold.",
                             i
                         )
                     if l is not None:
@@ -1052,7 +1052,7 @@ class BaseCirculationAPI(object):
     # distributor which includes ebooks and allows clients to specify
     # their own loan lengths.
     EBOOK_LOAN_DURATION_SETTING = {
-        "key" : Collection.EBOOK_LOAN_DURATION_KEY, 
+        "key" : Collection.EBOOK_LOAN_DURATION_KEY,
         "label": _("Ebook Loan Duration (in Days)"),
         "default": Collection.STANDARD_DEFAULT_LOAN_PERIOD,
         "description": _("When a patron uses SimplyE to borrow an ebook from this collection, SimplyE will ask for a loan that lasts this number of days. This must be equal to or less than the maximum loan duration negotiated with the distributor.")
@@ -1061,7 +1061,7 @@ class BaseCirculationAPI(object):
     # Add to LIBRARY_SETTINGS if your circulation API is for a
     # distributor which includes audiobooks and allows clients to
     # specify their own loan lengths.
-    AUDIOBOOK_LOAN_DURATION_SETTING = { 
+    AUDIOBOOK_LOAN_DURATION_SETTING = {
         "key" : Collection.AUDIOBOOK_LOAN_DURATION_KEY,
         "label": _("Audiobook Loan Duration (in Days)"),
         "default": Collection.STANDARD_DEFAULT_LOAN_PERIOD,
@@ -1072,10 +1072,10 @@ class BaseCirculationAPI(object):
     # distributor with a default loan period negotiated out-of-band,
     # such that the circulation manager cannot _specify_ the length of
     # a loan.
-    DEFAULT_LOAN_DURATION_SETTING = { 
-        "key": Collection.EBOOK_LOAN_DURATION_KEY, 
+    DEFAULT_LOAN_DURATION_SETTING = {
+        "key": Collection.EBOOK_LOAN_DURATION_KEY,
         "label": _("Default Loan Period (in Days)"),
-        "optional": True, 
+        "optional": True,
         "type": "number",
         "default": Collection.STANDARD_DEFAULT_LOAN_PERIOD,
         "description": _("Until it hears otherwise from the distributor, this server will assume that any given loan for this library from this collection will last this number of days. This number is usually a negotiated value between the library and the distributor. This only affects estimates&mdash;it cannot affect the actual length of loans.")
@@ -1136,7 +1136,7 @@ class BaseCirculationAPI(object):
         ).value
 
     def checkin(self, patron, pin, licensepool):
-        """  Return a book early.  
+        """  Return a book early.
 
         :param patron: a Patron object for the patron who wants
         to check out the book.

--- a/api/circulation_exceptions.py
+++ b/api/circulation_exceptions.py
@@ -80,10 +80,10 @@ class CannotLoan(CirculationException):
     status_code = 500
 
 class OutstandingFines(CannotLoan):
-    """The patron has outstanding fines above the limit in the library's 
+    """The patron has outstanding fines above the limit in the library's
     policy."""
     status_code = 403
-    
+
 class AuthorizationExpired(CannotLoan):
     """The patron's authorization has expired."""
     status_code = 403
@@ -91,7 +91,7 @@ class AuthorizationExpired(CannotLoan):
     def as_problem_detail_document(self, debug=False):
         """Return a suitable problem detail document."""
         return EXPIRED_CREDENTIALS
-    
+
 class AuthorizationBlocked(CannotLoan):
     """The patron's authorization is blocked for some reason other than
     fines or an expired card.
@@ -104,7 +104,7 @@ class AuthorizationBlocked(CannotLoan):
         """Return a suitable problem detail document."""
         return BLOCKED_CREDENTIALS
 
-    
+
 class PatronLoanLimitReached(CannotLoan):
     status_code = 403
 

--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -84,7 +84,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
 
     # Begin implementations of OAuthAuthenticationProvider abstract
     # methods.
-    
+
     def oauth_callback(self, _db, code):
         """Verify the incoming parameters with the OAuth provider. Exchange
         the authorization code for an access token. Create or look up
@@ -111,13 +111,13 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
         token = self.remote_exchange_code_for_bearer_token(_db, code)
         if isinstance(token, ProblemDetail):
             return token
-        
+
         # Now that we have a bearer token, use it to look up patron
         # information.
         patrondata = self.remote_patron_lookup(token)
         if isinstance(patrondata, ProblemDetail):
             return patrondata
-        
+
         # Convert the PatronData into a Patron object.
         patron, is_new = patrondata.get_or_create_patron(_db, self.library_id)
 
@@ -167,7 +167,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
                 library.short_name
             )
         )
-        
+
     def remote_patron_lookup(self, token):
         """Use a bearer token to look up detailed patron information.
 
@@ -194,7 +194,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
 
         user_link = [l for l in links if l['rel'] == 'canonical'][0]['uri']
         user = self._get(self.CLEVER_API_BASE_URL + user_link, bearer_headers)
-        
+
         user_data = user['data']
         school_id = user_data['school']
         school = self._get(
@@ -230,7 +230,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
             complete=True
         )
         return patrondata
-   
+
     def _get_token(self, payload, headers):
         response = HTTP.post_with_timeout(
             self.CLEVER_TOKEN_URL, json.dumps(payload), headers=headers

--- a/api/config.py
+++ b/api/config.py
@@ -33,7 +33,7 @@ class Configuration(CoreConfiguration):
     # A short description of the library, used in its Authentication
     # for OPDS document.
     LIBRARY_DESCRIPTION = 'library_description'
-    
+
     # The name of the per-library setting that sets the maximum amount
     # of fines a patron can have before losing lending privileges.
     MAX_OUTSTANDING_FINES = u"max_outstanding_fines"
@@ -84,7 +84,7 @@ class Configuration(CoreConfiguration):
     # Settings for geographic areas associated with the library.
     LIBRARY_FOCUS_AREA = "focus_area"
     LIBRARY_SERVICE_AREA = "service_area"
-   
+
     # Names of the library-wide link settings.
     TERMS_OF_SERVICE = 'terms-of-service'
     PRIVACY_POLICY = 'privacy-policy'
@@ -105,7 +105,7 @@ class Configuration(CoreConfiguration):
     # These are link relations that are valid in Authentication for
     # OPDS documents but are not registered with IANA.
     AUTHENTICATION_FOR_OPDS_LINKS = ['register']
-    
+
     # We support three different ways of integrating help processes.
     # All three of these will be sent out as links with rel='help'
     HELP_EMAIL = 'help-email'
@@ -121,7 +121,7 @@ class Configuration(CoreConfiguration):
     # a shared secret with a library registry. The setting is automatically generated
     # and not editable by admins.
     PUBLIC_KEY = "public-key"
-    
+
     SITEWIDE_SETTINGS = CoreConfiguration.SITEWIDE_SETTINGS + [
         {
             "key": BEARER_TOKEN_SIGNING_SECRET,
@@ -291,15 +291,15 @@ class Configuration(CoreConfiguration):
             "label": _("Other major languages represented in this library's collection"),
             "type": "list",
             "description": LANGUAGE_DESCRIPTION,
-        },        
+        },
         {
             "key": TINY_COLLECTION_LANGUAGES,
             "label": _("Other languages in this library's collection"),
             "type": "list",
             "description": LANGUAGE_DESCRIPTION,
-        },        
+        },
     ]
-    
+
     @classmethod
     def lending_policy(cls):
         return cls.policy(cls.LENDING_POLICY)
@@ -325,7 +325,7 @@ class Configuration(CoreConfiguration):
             cls.estimate_language_collections_for_library(library)
             value = setting.json_value
         return value
-    
+
     @classmethod
     def large_collection_languages(cls, library):
         return cls._collection_languages(
@@ -350,13 +350,13 @@ class Configuration(CoreConfiguration):
             cls.MAX_OUTSTANDING_FINES, library
         ).value
         return MoneyUtility.parse(max_fines)
-    
+
     @classmethod
     def load(cls, _db=None):
         CoreConfiguration.load(_db)
         cls.instance = CoreConfiguration.instance
         return cls.instance
-        
+
     @classmethod
     def estimate_language_collections_for_library(cls, library):
         """Guess at appropriate values for the given library for
@@ -396,7 +396,7 @@ class Configuration(CoreConfiguration):
             # English collection and nothing else.
             large.append('eng')
             return result
-        
+
         # The single most common language always gets a large
         # collection.
         #
@@ -412,9 +412,9 @@ class Configuration(CoreConfiguration):
             else:
                 bucket = tiny
             bucket.append(language)
-            
-        return result        
-        
+
+        return result
+
     @classmethod
     def _as_mailto(cls, value):
         """Turn an email address into a mailto: URI."""
@@ -469,7 +469,7 @@ class Configuration(CoreConfiguration):
             library, Configuration.CONFIGURATION_CONTACT_EMAIL
         )
 
-        
+
 @contextlib.contextmanager
 def empty_config():
     with core_empty_config({}, [CoreConfiguration, Configuration]) as i:

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -58,14 +58,14 @@ class ReaperImporter(OPDSImporter):
     """
     SUCCESS_STATUS_CODES = [200, 404]
 
-    
+
 class OPDSImportCoverageProvider(CollectionCoverageProvider):
     """Provide coverage for identifiers by looking them up, in batches,
     using the Simplified lookup protocol.
     """
     DEFAULT_BATCH_SIZE = 25
     OPDS_IMPORTER_CLASS = OPDSImporter
-    
+
     def __init__(self, collection, lookup_client, **kwargs):
         """Constructor.
 
@@ -76,7 +76,7 @@ class OPDSImportCoverageProvider(CollectionCoverageProvider):
 
     def process_batch(self, batch):
         """Perform a Simplified lookup and import the resulting OPDS feed."""
-        (imported_editions, pools, works, 
+        (imported_editions, pools, works,
          error_messages_by_id) = self.lookup_and_import_batch(batch)
 
         results = []
@@ -347,7 +347,7 @@ class MetadataWranglerCollectionReaper(BaseMetadataWranglerCoverageProvider):
         # 'reaper' coverage record for the same Identifier.
         reaper_coverage = aliased(CoverageRecord)
         qu = self._db.query(CoverageRecord).join(
-            reaper_coverage, 
+            reaper_coverage,
             CoverageRecord.identifier_id==reaper_coverage.identifier_id
 
         # The CoverageRecords were selecting are 'import' records.
@@ -396,7 +396,7 @@ class MetadataUploadCoverageProvider(BaseMetadataWranglerCoverageProvider):
                 results.append(work)
         feed = AcquisitionFeed(self._db, "Metadata Upload Feed", "", works, None)
         self.lookup_client.add_with_metadata(feed)
-        
+
         # We grant coverage for all identifiers if the upload doesn't raise an exception.
         return results
 
@@ -405,7 +405,7 @@ class MockOPDSImportCoverageProvider(OPDSImportCoverageProvider):
 
     SERVICE_NAME = "Mock Provider"
     DATA_SOURCE_NAME = DataSource.OA_CONTENT_SERVER
-    
+
     def __init__(self, collection, *args, **kwargs):
         super(MockOPDSImportCoverageProvider, self).__init__(
             collection, None, *args, **kwargs

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -38,12 +38,12 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
     # are valid.
     DEFAULT_IDENTIFIER_REGULAR_EXPRESSION = '^[A-Za-z0-9@]+$'
     DEFAULT_PASSWORD_REGULAR_EXPRESSION = '^[0-9]+$'
-    
+
     SETTINGS = [
         { "key": ExternalIntegration.URL, "label": _("URL") },
         { "key": ExternalIntegration.PASSWORD, "label": _("Key") },
     ] + BasicAuthenticationProvider.SETTINGS
-    
+
     log = logging.getLogger("First Book authentication API")
 
     def __init__(self, library_id, integration, analytics=None, root=None):
@@ -59,7 +59,7 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
                 url += '&'
             else:
                 url += '?'
-            root = url + 'key=' + key 
+            root = url + 'key=' + key
         self.root = root
 
     # Begin implementation of BasicAuthenticationProvider abstract
@@ -80,7 +80,7 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
             permanent_id=username,
             authorization_identifier=username,
         )
-   
+
     # End implementation of BasicAuthenticationProvider abstract methods.
 
     def remote_pin_test(self, barcode, pin):
@@ -102,7 +102,7 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
         if self.SUCCESS_MESSAGE in response.content:
             return True
         return False
-    
+
     def request(self, url):
         """Make an HTTP request.
 
@@ -122,7 +122,7 @@ class MockFirstBookAuthenticationAPI(FirstBookAuthenticationAPI):
     SUCCESS = '"Valid Code Pin Pair"'
     FAILURE = '{"code":404,"message":"Access Code Pin Pair not found"}'
 
-    def __init__(self, library, integration, valid={}, bad_connection=False, 
+    def __init__(self, library, integration, valid={}, bad_connection=False,
                  failure_status_code=None):
         super(MockFirstBookAuthenticationAPI, self).__init__(
             library, integration, root="http://example.com/"
@@ -132,7 +132,7 @@ class MockFirstBookAuthenticationAPI(FirstBookAuthenticationAPI):
         self.valid = valid
         self.bad_connection = bad_connection
         self.failure_status_code = failure_status_code
-        
+
     def request(self, url):
         if self.bad_connection:
             # Simulate a bad connection.

--- a/api/google_analytics_provider.py
+++ b/api/google_analytics_provider.py
@@ -45,7 +45,7 @@ class GoogleAnalyticsProvider(object):
     LIBRARY_SETTINGS = [
         { "key": TRACKING_ID, "label": _("Tracking ID") },
     ]
-    
+
     def __init__(self, integration, library=None):
         _db = Session.object_session(integration)
         if not library:
@@ -95,12 +95,12 @@ class GoogleAnalyticsProvider(object):
                 })
         # urlencode doesn't like unicode strings so we convert them to utf8
         fields = {k: unicodedata.normalize("NFKD", unicode(v)).encode("utf8") for k, v in fields.iteritems()}
-        
+
         params = re.sub(r"=None(&?)", r"=\1", urllib.urlencode(fields))
         self.post(self.url, params)
 
     def post(self, url, params):
         response = HTTP.post_with_timeout(url, params)
 
-        
+
 Provider = GoogleAnalyticsProvider

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -171,7 +171,7 @@ def lane_from_genres(_db, library, genres, display_name=None,
             sublane_priority = 0
             for subgenre in genre.get("subgenres", []):
                 sublanes.append(lane_from_genres(
-                        _db, library, [subgenre], 
+                        _db, library, [subgenre],
                         priority=sublane_priority, **extra_args))
                 sublane_priority += 1
 
@@ -233,10 +233,10 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
 
     * A "%(language)s YA Fiction" lane containing sublanes for the
       most popular YA fiction genres.
-    
+
     * A "%(language)s YA Nonfiction" lane containing sublanes for the
       most popular YA fiction genres.
-    
+
     * A "%(language)s Children and Middle Grade" lane containing
       sublanes for childrens' books at different age levels.
 

--- a/api/marc.py
+++ b/api/marc.py
@@ -32,7 +32,7 @@ class MARCExtractor(object):
         re.compile(",\s+graf,"),
         re.compile(",\s+author."),
     ]
-    
+
     @classmethod
     def parse(cls, file, data_source_name):
         reader = MARCReader(file)
@@ -46,7 +46,7 @@ class MARCExtractor(object):
             publisher = record.publisher()
             if publisher.endswith(','):
                 publisher = publisher[:-1]
-            
+
             links = []
             summary = record.notes()[0]['a']
 
@@ -90,9 +90,9 @@ class MARCExtractor(object):
                 )
                 for author in author_names
             ]
-                    
-                    
-                
+
+
+
             metadata_records.append(Metadata(
                 data_source=data_source_name,
                 title=title,

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -43,7 +43,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
     PERSONAL_NAME_FIELD = 'PATRN NAME[pn]'
     EMAIL_ADDRESS_FIELD = 'EMAIL ADDR[pz]'
     EXPIRATION_DATE_FORMAT = '%m-%d-%y'
-    
+
     MULTIVALUE_FIELDS = set(['NOTE[px]', BARCODE_FIELD])
 
     DEFAULT_CURRENCY = "USD"
@@ -52,7 +52,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
     # finding the "correct" identifier in a patron's record, even if
     # it means they end up with no identifier at all.
     IDENTIFIER_BLACKLIST = 'identifier_blacklist'
-    
+
     # A configuration value for whether or not to validate the SSL certificate
     # of the Millenium Patron API server.
     VERIFY_CERTIFICATE = "verify_certificate"
@@ -65,7 +65,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
     # The field to use when seeing which values of MBLOCK[p56] mean a patron
     # is blocked. By default, any value other than '-' indicates a block.
     BLOCK_TYPES = 'block_types'
-    
+
     AUTHENTICATION_MODES = [
         PIN_AUTHENTICATION_MODE, FAMILY_NAME_AUTHENTICATION_MODE
     ]
@@ -87,7 +87,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
           "description": _("Identifiers containing any of these strings are ignored when finding the 'correct' " +
                            "identifier for a patron's record, even if it means they end up with no identifier at all. " +
                            "If librarians invalidate library cards by adding strings like \"EXPIRED\" or \"INVALID\" " +
-                           "on to the beginning of the card number, put those strings here so the Circulation Manager " + 
+                           "on to the beginning of the card number, put those strings here so the Circulation Manager " +
                            "knows they do not represent real card numbers."),
           "optional": True },
         { "key": AUTHENTICATION_MODE, "label": _("Authentication Mode"),
@@ -145,7 +145,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
 
         auth_mode = integration.setting(
             self.AUTHENTICATION_MODE).value or self.PIN_AUTHENTICATION_MODE
-        
+
         if auth_mode not in self.AUTHENTICATION_MODES:
             raise CannotLoadConfiguration(
                 "Unrecognized Millenium Patron API authentication mode: %s." % auth_mode
@@ -153,13 +153,13 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         self.auth_mode = auth_mode
 
         self.block_types = integration.setting(self.BLOCK_TYPES).value or None
-        
+
     # Begin implementation of BasicAuthenticationProvider abstract
     # methods.
 
     def _request(self, path):
         """Make an HTTP request and parse the response."""
-    
+
     def remote_authenticate(self, username, password):
         """Does the Millenium Patron API approve of these credentials?
 
@@ -227,11 +227,11 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         url = self.root + path
         response = self.request(url)
         return self.patron_dump_to_patrondata(identifier, response.content)
-        
-    
+
+
     # End implementation of BasicAuthenticationProvider abstract
     # methods.
-    
+
     def request(self, url, *args, **kwargs):
         """Actually make an HTTP request. This method exists only so the mock
         can override it.
@@ -253,7 +253,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
             # We are looking for a specific value, and we found it
             return PatronData.UNKNOWN_BLOCK
 
-        if not block_types:        
+        if not block_types:
             # Apply the default rules.
             if not mblock_value or mblock_value.strip() in ('', '-'):
                 # This patron is not blocked at all.
@@ -269,10 +269,10 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
 
         # The patron does not have one of those types, so is not blocked.
         return PatronData.NO_VALUE
-        
+
     def patron_dump_to_patrondata(self, current_identifier, content):
         """Convert an HTML patron dump to a PatronData object.
-        
+
         :param current_identifier: Either the authorization identifier
         the patron just logged in with, or the one currently
         associated with their Patron record. Keeping track of this
@@ -280,7 +280,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         identifier out from under them.
 
         :param content: The HTML document containing the patron dump.
-        """       
+        """
         # If we don't see these fields, erase any previous value
         # rather than leaving the old value in place. This shouldn't
         # happen (unless the expiration date changes to an invalid
@@ -289,7 +289,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         username = authorization_expires = personal_name = PatronData.NO_VALUE
         email_address = fines = external_type = PatronData.NO_VALUE
         block_reason = PatronData.NO_VALUE
-        
+
         potential_identifiers = []
         for k, v in self._extract_text_nodes(content):
             if k == self.BARCODE_FIELD:
@@ -355,7 +355,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         # added one. In the absence of any other information, it's the
         # one we should choose.
         potential_identifiers.reverse()
-        
+
         authorization_identifiers = potential_identifiers
         if not authorization_identifiers:
             authorization_identifiers = PatronData.NO_VALUE
@@ -380,7 +380,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
             complete=True
         )
         return data
-   
+
     def _extract_text_nodes(self, content):
         """Parse the HTML representations sent by the Millenium Patron API."""
         for line in content.split("\n"):
@@ -411,7 +411,7 @@ class MockMilleniumPatronAPI(MilleniumPatronAPI):
         username="alice",
         authorization_expires = datetime.datetime(2015, 4, 1)
     )
-    
+
     # This user's card still has ten days on it.
     the_future = datetime.datetime.utcnow() + datetime.timedelta(days=10)
     user2 = PatronData(
@@ -449,5 +449,5 @@ class MockMilleniumPatronAPI(MilleniumPatronAPI):
             if u.authorization_identifier == look_for:
                 return u
         return None
-            
+
 AuthenticationProvider = MilleniumPatronAPI

--- a/api/monitor.py
+++ b/api/monitor.py
@@ -274,7 +274,7 @@ class LoanlikeReaperMonitor(ReaperMonitor):
         source_of_truth_subquery = self._db.query(self.MODEL_CLASS.id).join(
             self.MODEL_CLASS.license_pool).join(
                 LicensePool.collection).join(
-                    ExternalIntegration, 
+                    ExternalIntegration,
                     Collection.external_integration_id==ExternalIntegration.id
                 ).filter(
                     source_of_truth

--- a/api/nyt.py
+++ b/api/nyt.py
@@ -50,7 +50,7 @@ class NYTAPI(object):
 
 
 class NYTBestSellerAPI(NYTAPI, HasSelfTests):
-    
+
     PROTOCOL = ExternalIntegration.NYT
     GOAL = ExternalIntegration.METADATA_GOAL
     NAME = _("NYT Best Seller API")
@@ -67,7 +67,7 @@ class NYTBestSellerAPI(NYTAPI, HasSelfTests):
 
     LIST_NAMES_URL = BASE_URL + "/names.json"
     LIST_URL = BASE_URL + ".json?list=%s"
-    
+
     LIST_OF_LISTS_MAX_AGE = timedelta(days=1)
     LIST_MAX_AGE = timedelta(days=1)
     HISTORICAL_LIST_MAX_AGE = timedelta(days=365)
@@ -210,7 +210,7 @@ class NYTBestSellerList(list):
         while date >= end:
             yield date
             old_date = date
-            date = date - self.frequency  
+            date = date - self.frequency
             if old_date > end and date < end:
                 # We overshot the end date.
                 yield end
@@ -235,14 +235,14 @@ class NYTBestSellerList(list):
                 # should never happen.
                 self.log.error("No identifier for %r", li_data)
                 item = None
-                continue              
+                continue
 
             # This is the date the *best-seller list* was published,
             # not the date the book was published.
             list_date = NYTAPI.parse_date(li_data['published_date'])
             if not item.first_appearance or list_date < item.first_appearance:
-                item.first_appearance = list_date 
-            if (not item.most_recent_appearance 
+                item.first_appearance = list_date
+            if (not item.most_recent_appearance
                 or list_date > item.most_recent_appearance):
                 item.most_recent_appearance = list_date
 
@@ -250,7 +250,7 @@ class NYTBestSellerList(list):
         """Turn this NYTBestSeller list into a CustomList object."""
         data_source = DataSource.lookup(_db, DataSource.NYT)
         l, was_new = get_one_or_create(
-            _db, 
+            _db,
             CustomList,
             data_source=data_source,
             foreign_identifier=self.foreign_identifier,
@@ -268,7 +268,7 @@ class NYTBestSellerList(list):
         the current state of the NYTBestSeller list.
         """
         db = Session.object_session(custom_list)
-    
+
         # Add new items to the list.
         for i in self:
             list_item, was_new = i.to_custom_list_entry(
@@ -312,11 +312,11 @@ class NYTBestSellerListTitle(TitleFromExternalList):
             # other books in the same series, as well as ISBNs that
             # are just wrong. Assign these equivalencies at a low
             # level of confidence.
-            for isbn in d.get('isbns', []): 
+            for isbn in d.get('isbns', []):
                 isbn13 = isbn.get('isbn13', None)
                 if isbn13:
-                    other_isbns.append( 
-                        IdentifierData(Identifier.ISBN, isbn13, 0.50) 
+                    other_isbns.append(
+                        IdentifierData(Identifier.ISBN, isbn13, 0.50)
                     )
 
 
@@ -332,7 +332,7 @@ class NYTBestSellerListTitle(TitleFromExternalList):
 
         metadata = Metadata(
             data_source=DataSource.NYT,
-            title=title, 
+            title=title,
             language='eng',
             published=published_date,
             publisher=publisher,

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -173,7 +173,7 @@ class OdiloAPI(BaseOdiloAPI, BaseCirculationAPI, HasSelfTests):
 
         :param pin: The patron's alleged password.
 
-        :param licensepool: Identifier of the book to be checked out is 
+        :param licensepool: Identifier of the book to be checked out is
         attached to this licensepool.
 
         :param internal_format: Represents the patron's desired book format.

--- a/api/odl.py
+++ b/api/odl.py
@@ -713,7 +713,7 @@ class ODLWithConsolidatedCopiesAPI(BaseCirculationAPI, BaseSharedCollectionAPI):
         # but we don't need it - we compute that based on the circulation
         # manager's internal state instead.
         available = copy_info.get("available")
-            
+
         identifier_data = IdentifierData(Identifier.URI, identifier)
         circulation_data = CirculationData(
             data_source=self.data_source_name,
@@ -1262,7 +1262,7 @@ class SharedODLAPI(BaseCirculationAPI):
         ).filter(
             Hold.patron==patron
         )
-        
+
         activity = []
         for loan in loans:
             info_url = loan.external_identifier

--- a/api/oneclick.py
+++ b/api/oneclick.py
@@ -9,7 +9,7 @@ import uuid
 from flask_babel import lazy_gettext as _
 
 from circulation import (
-    BaseCirculationAPI, 
+    BaseCirculationAPI,
     FulfillmentInfo,
     HoldInfo,
     LoanInfo,
@@ -32,7 +32,7 @@ from core.oneclick import (
 )
 
 from core.metadata_layer import (
-    CirculationData, 
+    CirculationData,
     FormatData,
     ReplacementPolicy,
 )
@@ -47,7 +47,7 @@ from core.model import (
     Edition,
     ExternalIntegration,
     Hyperlink,
-    Identifier, 
+    Identifier,
     Library,
     LicensePool,
     Patron,
@@ -82,7 +82,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
         { "key": Collection.EXTERNAL_ACCOUNT_ID_KEY, "label": _("Library ID") },
         { "key": ExternalIntegration.URL, "label": _("URL"), "default": BaseOneClickAPI.PRODUCTION_BASE_URL },
     ] + BASE_SETTINGS
-    
+
     # The loan duration must be specified when connecting a library to an
     # RBdigital account, but if it's not specified, try one week.
     DEFAULT_LOAN_DURATION = 7
@@ -96,14 +96,14 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
     )
     my_ebook_setting.update(default=DEFAULT_LOAN_DURATION)
     LIBRARY_SETTINGS = BaseCirculationAPI.LIBRARY_SETTINGS + [
-        my_audiobook_setting, 
+        my_audiobook_setting,
         my_ebook_setting
     ]
 
     EXPIRATION_DATE_FORMAT = '%Y-%m-%d'
 
     log = logging.getLogger("OneClick Patron API")
-   
+
     def __init__(self, *args, **kwargs):
         super(OneClickAPI, self).__init__(*args, **kwargs)
         self.bibliographic_coverage_provider = (
@@ -187,7 +187,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
 
         :param patron: a Patron object for the patron who wants to return the book.
         :param pin: The patron's password (not used).
-        :param licensepool: The Identifier of the book to be checked out is 
+        :param licensepool: The Identifier of the book to be checked out is
         attached to this licensepool.
 
         :return True on success, raises circulation exceptions on failure.
@@ -198,7 +198,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
         resp_dict = self.circulate_item(patron_id=patron_oneclick_id, item_id=item_oneclick_id, return_item=True)
 
         if resp_dict.get('message') == 'success':
-            self.log.debug("Patron %s/%s returned item %s.", patron.authorization_identifier, 
+            self.log.debug("Patron %s/%s returned item %s.", patron.authorization_identifier,
                 patron_oneclick_id, item_oneclick_id)
             return True
 
@@ -217,7 +217,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
 
         :param patron: a Patron object for the patron who wants to check out the book.
         :param pin: The patron's password (not used).
-        :param licensepool: The Identifier of the book to be checked out is 
+        :param licensepool: The Identifier of the book to be checked out is
         attached to this licensepool.
         :param internal_format: Represents the patron's desired book format.  Ignored for now.
 
@@ -246,7 +246,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
         if not resp_dict or ('error_code' in resp_dict):
             return None
 
-        self.log.debug("Patron %s/%s checked out item %s with transaction id %s.", patron.authorization_identifier, 
+        self.log.debug("Patron %s/%s checked out item %s with transaction id %s.", patron.authorization_identifier,
             patron_oneclick_id, item_oneclick_id, resp_dict['transactionId'])
 
         expires = today + datetime.timedelta(days=days)
@@ -341,13 +341,13 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
     def place_hold(self, patron, pin, licensepool, notification_email_address):
         """Place a book on hold.
 
-        Note: If the requested book is available for checkout, OneClick will respond 
-        with a "success" to the hold request.  Then, at the next database clean-up sweep, 
-        OneClick will automatically convert the hold record to a checkout record. 
+        Note: If the requested book is available for checkout, OneClick will respond
+        with a "success" to the hold request.  Then, at the next database clean-up sweep,
+        OneClick will automatically convert the hold record to a checkout record.
 
         :param patron: a Patron object for the patron who wants to check out the book.
         :param pin: The patron's password (not used).
-        :param licensepool: The Identifier of the book to be checked out is 
+        :param licensepool: The Identifier of the book to be checked out is
         attached to this licensepool.
         :param internal_format: Represents the patron's desired book format.  Ignored for now.
 
@@ -365,7 +365,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
             self.log.error("Item hold request failed: %r", e, exc_info=e)
             raise CannotHold(e.message)
 
-        self.log.debug("Patron %s/%s reserved item %s with transaction id %s.", patron.authorization_identifier, 
+        self.log.debug("Patron %s/%s reserved item %s with transaction id %s.", patron.authorization_identifier,
             patron_oneclick_id, item_oneclick_id, resp_obj)
 
         today = datetime.datetime.now()
@@ -389,7 +389,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
 
         :param patron: a Patron object for the patron who wants to return the book.
         :param pin: The patron's password (not used).
-        :param licensepool: The Identifier of the book to be checked out is 
+        :param licensepool: The Identifier of the book to be checked out is
         attached to this licensepool.
 
         :return True on success, raises circulation exceptions on failure.
@@ -400,7 +400,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
         resp_dict = self.circulate_item(patron_id=patron_oneclick_id, item_id=item_oneclick_id, hold=True, return_item=True)
 
         if resp_dict.get('message') == 'success':
-            self.log.debug("Patron %s/%s released hold %s.", patron.authorization_identifier, 
+            self.log.debug("Patron %s/%s released hold %s.", patron.authorization_identifier,
                 patron_oneclick_id, item_oneclick_id)
             return True
 
@@ -430,14 +430,14 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
         If the book has never been seen before, a new LicensePool
         will be created for the book.
 
-        The book's LicensePool will be updated with current approximate 
-        circulation information (we can tell if it's available, but 
-        not how many copies). 
-        Bibliographic coverage will be ensured for the OneClick Identifier. 
+        The book's LicensePool will be updated with current approximate
+        circulation information (we can tell if it's available, but
+        not how many copies).
+        Bibliographic coverage will be ensured for the OneClick Identifier.
         Work will be created for the LicensePool and set as presentation-ready.
 
         :param isbn the identifier OneClick uses
-        :param availability boolean denoting if book can be lent to patrons 
+        :param availability boolean denoting if book can be lent to patrons
         :param medium: The name OneClick uses for the book's medium.
         """
 
@@ -466,8 +466,8 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
         # at least one license to it.
         licenses_owned = 1
 
-        if (not is_new_pool and 
-            license_pool.licenses_owned == licenses_owned and 
+        if (not is_new_pool and
+            license_pool.licenses_owned == licenses_owned and
             license_pool.licenses_available == licenses_available):
             # Optimization: Nothing has changed, so don't even bother
             # calling CirculationData.apply()
@@ -498,16 +498,16 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
 
         if delivery_type:
             formats.append(FormatData(delivery_type, drm_scheme))
-        
+
         circulation_data = CirculationData(
-            data_source=DataSource.RB_DIGITAL, 
-            primary_identifier=license_pool.identifier, 
+            data_source=DataSource.RB_DIGITAL,
+            primary_identifier=license_pool.identifier,
             licenses_owned=licenses_owned,
             licenses_available=licenses_available,
             formats=formats,
         )
 
-        policy = policy or self.default_circulation_replacement_policy        
+        policy = policy or self.default_circulation_replacement_policy
         license_pool, circulation_changed = circulation_data.apply(
             self._db,
             self.collection,
@@ -515,12 +515,12 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
         )
 
         return license_pool, is_new_pool, circulation_changed
-        
+
 
     def update_availability(self, licensepool):
         """Update the availability information for a single LicensePool.
         Part of the CirculationAPI interface.
-        Inactive for now, because we'd have to request and go through all availabilities 
+        Inactive for now, because we'd have to request and go through all availabilities
         from OneClick just to pick the one licensepool we want.
         """
         pass
@@ -532,7 +532,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
         format.
         """
         return delivery_mechanism
-    
+
 ### Patron account handling
 
     def patron_remote_identifier(self, patron):
@@ -614,7 +614,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
                 patron_oneclick_id = patron_info.get('patronId')
 
         if not patron_oneclick_id:
-            raise RemotePatronCreationFailedException(action + 
+            raise RemotePatronCreationFailedException(action +
                 ": http=" + str(response.status_code) + ", response=" + response.text)
         return patron_oneclick_id
 
@@ -650,8 +650,8 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
     def get_patron_checkouts(self, patron_id):
         """
         Gets the books and audio the patron currently has checked out.
-        Obtains fulfillment info for each item -- the way to fulfill a book 
-        is to get this list of possibilities first, and then call individual 
+        Obtains fulfillment info for each item -- the way to fulfill a book
+        is to get this list of possibilities first, and then call individual
         fulfillment endpoints on the individual items.
 
         :param patron_id OneClick internal id for the patron.
@@ -701,7 +701,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
             ).date()
 
         identifier, made_new = Identifier.for_foreign_id(
-            self._db, foreign_identifier_type=Identifier.RB_DIGITAL_ID, 
+            self._db, foreign_identifier_type=Identifier.RB_DIGITAL_ID,
             foreign_id=isbn, autocreate=False
         )
         if not identifier:
@@ -712,7 +712,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
         fulfillment_info = RBFulfillmentInfo(
             self,
             DataSource.RB_DIGITAL,
-            identifier, 
+            identifier,
             item,
         )
 
@@ -825,8 +825,8 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
 
     ''' -------------------------- Validation Handling -------------------------- '''
     def validate_item(self, licensepool):
-        """ Are we performing operations on a book that exists and can be 
-        uniquely identified? 
+        """ Are we performing operations on a book that exists and can be
+        uniquely identified?
         """
         item_oneclick_id = None
         media = None
@@ -843,8 +843,8 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
 
     def validate_response(self, response, message, action=""):
         """ OneClick tries to communicate statuses and errors through http codes.
-        Malformed url requests will throw a 500, non-existent ids will get a 404, 
-        trying an action like checkout on a patron/item combo that's blocked 
+        Malformed url requests will throw a 500, non-existent ids will get a 404,
+        trying an action like checkout on a patron/item combo that's blocked
         (like if the item is already checked out, for example) will get a 409, etc..
         Further details are usually elaborated on in the "message" field of the response.
 
@@ -888,13 +888,13 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
                     raise NotCheckedOut(action + ": " + message)
                 else:
                     raise CannotReturn(action + ": " + message)
-                
+
             if response.status_code == 404:
                 raise NotFoundOnRemote(action + ": " + message)
 
             if response.status_code == 400:
                 raise InvalidInputException(action + ": " + message)
-            
+
         elif message:
             if message == 'success':
                 # There is no additional information to be had.
@@ -908,7 +908,7 @@ class OneClickAPI(BaseOneClickAPI, BaseCirculationAPI, HasSelfTests):
 
 
     def queue_response(self, status_code, headers={}, content=None):
-        """ Allows smoother faster creation of unit tests by letting 
+        """ Allows smoother faster creation of unit tests by letting
         us live-test as we write. """
         pass
 
@@ -936,7 +936,7 @@ class RBFulfillmentInfo(object):
         self._content_type = None
         self._content = None
         self._content_expires = None
-        
+
     @property
     def content_link(self):
         self.fetch()
@@ -982,7 +982,7 @@ class RBFulfillmentInfo(object):
                 file_format = Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE
             self._content_type = file_format
             individual_download_url = file.get('downloadUrl', None)
-            
+
         if self._content_type == Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE:
             # We have an audiobook.
             self._content = self.process_audiobook_manifest(self.raw_data)
@@ -1039,7 +1039,7 @@ class MockOneClickAPI(BaseMockOneClickAPI, OneClickAPI):
                     (Collection.EBOOK_LOAN_DURATION_KEY, 2)
             ):
                 ConfigurationSetting.for_library_and_externalintegration(
-                    _db, key, library, 
+                    _db, key, library,
                     collection.external_integration
                 ).value = value
         return collection
@@ -1057,7 +1057,7 @@ class OneClickCirculationMonitor(CollectionMonitor):
     DEFAULT_BATCH_SIZE = 50
 
     PROTOCOL = ExternalIntegration.RB_DIGITAL
-    
+
     def __init__(self, _db, collection, batch_size=None, api_class=OneClickAPI,
                  api_class_kwargs={}):
         super(OneClickCirculationMonitor, self).__init__(_db, collection)
@@ -1105,7 +1105,7 @@ class OneClickCirculationMonitor(CollectionMonitor):
     def run_once(self, start, cutoff):
         ebook_count = self.process_availability(media_type='eBook')
         eaudio_count = self.process_availability(media_type='eAudio')
-        
+
         self.log.info("Processed %d ebooks and %d audiobooks.", ebook_count, eaudio_count)
 
 
@@ -1155,7 +1155,7 @@ class AudiobookManifest(CoreAudiobookManifest):
         download_url = self.raw.get('downloadUrl')
         if download_url:
             self.add_link(
-                download_url, 'alternate', 
+                download_url, 'alternate',
                 type=Representation.guess_media_type(download_url)
             )
 

--- a/api/onix.py
+++ b/api/onix.py
@@ -156,7 +156,7 @@ class ONIXExtractor(object):
         'Z02': Contributor.UNKNOWN_ROLE, # 'Honored/dedicated to'
         'Z99': Contributor.UNKNOWN_ROLE, # Other creative responsibility
     }
-    
+
     @classmethod
     def parse(cls, file, data_source_name):
         metadata_records = []
@@ -183,7 +183,7 @@ class ONIXExtractor(object):
             imprint = parser.text_of_optional_subtag(record, 'publishingdetail/imprint/b079')
             if imprint == publisher:
                 imprint = None
-           
+
             publishing_date = parser.text_of_optional_subtag(record, 'publishingdetail/publishingdate/b306')
             issued = None
             if publishing_date:
@@ -205,7 +205,7 @@ class ONIXExtractor(object):
                 if type in cls.SUBJECT_TYPES:
                     subjects.append(SubjectData(cls.SUBJECT_TYPES[type],
                                                 parser.text_of_subtag(tag, 'b069')))
-                    
+
             audience_tags = parser._xpath(record, 'descriptivedetail/audience/b204')
             audiences = []
             for tag in audience_tags:

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -279,7 +279,7 @@ class OPDSForDistributorsImporter(OPDSImporter):
                         rights_uri=RightsStatus.IN_COPYRIGHT,
                     )
                 )
-        
+
 
 class OPDSForDistributorsImportMonitor(OPDSImportMonitor):
     """Monitor an OPDS feed that requires or allows authentication,

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -247,14 +247,14 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
 
         :param pin: The patron's alleged password.
 
-        :param licensepool: Identifier of the book to be checked out is 
+        :param licensepool: Identifier of the book to be checked out is
         attached to this licensepool.
 
         :param internal_format: Represents the patron's desired book format.
 
         :return: a LoanInfo object.
         """
-        
+
         identifier = licensepool.identifier
         overdrive_id=identifier.identifier
         headers = {"Content-Type": "application/json"}
@@ -293,7 +293,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
             # Try to extract the expiration date from the response.
             expires = self.extract_expiration_date(response.json())
 
-        # Create the loan info. We don't know the expiration 
+        # Create the loan info. We don't know the expiration
         loan = LoanInfo(
             licensepool.collection,
             licensepool.data_source.name,
@@ -322,14 +322,14 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
             if self.perform_early_return(patron, pin, loan):
                 # No need for the fallback strategy.
                 return
-            
+
         # Our fallback strategy is to DELETE the checkout endpoint.
         # We do this if no loan can be found, no delivery mechanism is
         # recorded, the delivery mechanism uses DRM, we are unable to
         # locate the return URL, or we encounter a problem using the
         # return URL.
         #
-        # The only case where this is likely to work is when the 
+        # The only case where this is likely to work is when the
         # loan exists but has not been locked to a delivery mechanism.
         overdrive_id = licensepool.identifier.identifier
         url = self.CHECKOUT_ENDPOINT % dict(
@@ -456,8 +456,8 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
             licensepool.identifier.type,
             licensepool.identifier.identifier,
             content_link=url,
-            content_type=media_type, 
-            content=None, 
+            content_type=media_type,
+            content=None,
             content_expires=None
         )
 
@@ -520,7 +520,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
 
         download_response = self.patron_request(patron, pin, download_link)
         return self.extract_content_link(download_response.json())
-        
+
     def extract_content_link(self, content_link_gateway_json):
         link = content_link_gateway_json['links']['contentlink']
         return link['href'], link['type']
@@ -577,7 +577,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
 
     @classmethod
     def _pd(cls, d):
-        """Stupid method to parse a date.""" 
+        """Stupid method to parse a date."""
         if not d:
             return d
         return datetime.datetime.strptime(d, cls.TIME_FORMAT)
@@ -639,7 +639,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
         overdrive_identifier = checkout['reserveId'].lower()
         start = cls._pd(checkout.get('checkoutDate'))
         end = cls._pd(checkout.get('expires'))
-        
+
         usable_formats = []
 
         # If a format is already locked in, it will be in formats.
@@ -730,7 +730,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
         headers, document = self.fill_out_form(
             reserveId=overdrive_id, emailAddress=notification_email_address)
         response = self.patron_request(
-            patron, pin, self.HOLDS_ENDPOINT, headers, 
+            patron, pin, self.HOLDS_ENDPOINT, headers,
             document)
         if response.status_code == 400:
             error = response.json()
@@ -747,7 +747,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
                     licensepool.data_source.name,
                     licensepool.identifier.type,
                     licensepool.identifier.identifier,
-                    start_date=start_date, 
+                    start_date=start_date,
                     end_date=None,
                     hold_position=position
                 )
@@ -905,10 +905,10 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
             self._db, self.source, license_pool.identifier.type,
             license_pool.identifier.identifier)
 
-        # If the pool does not already have a presentation edition, 
+        # If the pool does not already have a presentation edition,
         # and if this edition is newly made, then associate pool and edition
         # as presentation_edition
-        if ((not license_pool.presentation_edition) and is_new_edition): 
+        if ((not license_pool.presentation_edition) and is_new_edition):
             edition_changed = license_pool.set_presentation_edition()
 
         if is_new_pool:
@@ -990,7 +990,7 @@ class MockOverdriveAPI(BaseMockOverdriveAPI, OverdriveAPI):
         original_data[-1]['_patron'] = patron
         original_data[-1]['_pin'] = patron
         return response
-    
+
 
 class OverdriveCirculationMonitor(CollectionMonitor):
     """Maintain LicensePools for recently changed Overdrive titles. Create
@@ -1006,7 +1006,7 @@ class OverdriveCirculationMonitor(CollectionMonitor):
     # strict chronological order, but if you see 100 consecutive books
     # that haven't changed, you're probably done.
     MAXIMUM_CONSECUTIVE_UNCHANGED_BOOKS = None
-    
+
     def __init__(self, _db, collection, api_class=OverdriveAPI):
         """Constructor."""
         super(OverdriveCirculationMonitor, self).__init__(_db, collection)
@@ -1015,7 +1015,7 @@ class OverdriveCirculationMonitor(CollectionMonitor):
             self.MAXIMUM_CONSECUTIVE_UNCHANGED_BOOKS
         )
         self.analytics = Analytics(_db)
-        
+
     def recently_changed_ids(self, start, cutoff):
         return self.api.recently_changed_ids(start, cutoff)
 
@@ -1047,7 +1047,7 @@ class OverdriveCirculationMonitor(CollectionMonitor):
             else:
                 consecutive_unchanged_books += 1
                 if (self.maximum_consecutive_unchanged_books
-                    and consecutive_unchanged_books >= 
+                    and consecutive_unchanged_books >=
                     self.maximum_consecutive_unchanged_books):
                     # We're supposed to stop this run after finding a
                     # run of books that have not changed, and we have
@@ -1069,7 +1069,7 @@ class FullOverdriveCollectionMonitor(OverdriveCirculationMonitor):
     """
     SERVICE_NAME = "Overdrive Collection Overview"
     INTERVAL_SECONDS = 3600*4
-    
+
     def recently_changed_ids(self, start, cutoff):
         """Ignore the dates and return all IDs."""
         return self.api.all_ids()
@@ -1082,7 +1082,7 @@ class OverdriveCollectionReaper(IdentifierSweepMonitor):
     SERVICE_NAME = "Overdrive Collection Reaper"
     INTERVAL_SECONDS = 3600*4
     PROTOCOL = ExternalIntegration.OVERDRIVE
-    
+
     def __init__(self, _db, collection, api_class=OverdriveAPI):
         super(OverdriveCollectionReaper, self).__init__(_db, collection)
         self.api = api_class(_db, collection)
@@ -1090,14 +1090,14 @@ class OverdriveCollectionReaper(IdentifierSweepMonitor):
     def process_item(self, identifier):
         self.api.update_licensepool(identifier.identifier)
 
-        
+
 class RecentOverdriveCollectionMonitor(OverdriveCirculationMonitor):
     """Monitor recently changed books in the Overdrive collection."""
 
     SERVICE_NAME = "Reverse Chronological Overdrive Collection Monitor"
     INTERVAL_SECONDS = 60
     MAXIMUM_CONSECUTIVE_UNCHANGED_BOOKS=100
-    
+
 
 class OverdriveFormatSweep(IdentifierSweepMonitor):
     """Check the current formats of every Overdrive book
@@ -1116,7 +1116,7 @@ class OverdriveFormatSweep(IdentifierSweepMonitor):
         for pool in pools:
             self.api.update_formats(pool)
 
-        
+
 class OverdriveAdvantageAccountListScript(Script):
 
     def run(self):
@@ -1149,7 +1149,7 @@ class OverdriveAdvantageAccountListScript(Script):
         for i in advantage_accounts:
             self.explain_advantage_collection(collection)
             print
-            
+
     def explain_advantage_collection(self, collection):
         """Explain a single Overdrive Advantage collection."""
         parent_collection, child = i.to_collection(_db)

--- a/api/selftest.py
+++ b/api/selftest.py
@@ -47,7 +47,7 @@ class HasSelfTests(CoreHasSelfTests):
                 "Collection is not associated with any libraries.",
                 "Add the collection to a library that has a patron authentication service."
             )
-        
+
         for library in collection.libraries:
             name = library.name
             task = "Acquiring test patron credentials for library %s" % library.name

--- a/api/shared_collection.py
+++ b/api/shared_collection.py
@@ -19,8 +19,8 @@ from core.config import CannotLoadConfiguration
 from core.util.http import HTTP
 
 class SharedCollectionAPI(object):
-    """Logic for circulating books to patrons of libraries on other 
-    circulation managers. This can be used for something like ODL where the 
+    """Logic for circulating books to patrons of libraries on other
+    circulation managers. This can be used for something like ODL where the
     circulation manager is responsible for managing loans and holds rather
     than the distributor, or potentially for inter-library loans for other
     collection types.
@@ -177,7 +177,7 @@ class SharedCollectionAPI(object):
         fulfillment = api.fulfill_for_external_library(client, loan, mechanism)
         if not fulfillment or not (fulfillment.content_link or fulfillment.content):
             raise CannotFulfill()
-        
+
         if loan.fulfillment is None and not mechanism.delivery_mechanism.is_streaming:
             __transaction = self._db.begin_nested()
             loan.fulfillment = mechanism
@@ -223,6 +223,6 @@ class BaseSharedCollectionAPI(object):
 
     def fulfill_for_external_library(self, client, loan, mechanism):
         raise NotImplementedError()
-        
+
     def release_hold_from_external_library(self, client, hold):
         raise NotImplementedError()

--- a/api/simple_authentication.py
+++ b/api/simple_authentication.py
@@ -52,7 +52,7 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
         if additional_identifiers:
             for identifier in additional_identifiers:
                 self.test_identifiers += [identifier, identifier + "_username"]
-        
+
     def remote_authenticate(self, username, password):
         "Fake 'remote' authentication."
         if not username or (self.collects_password and not password):
@@ -81,7 +81,7 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
     # methods.
 
     def valid_patron(self, username, password):
-        """Is this patron associated with the given password in 
+        """Is this patron associated with the given password in
         the given dictionary?
         """
         if self.collects_password:

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -20,7 +20,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
     PORT = "port"
     LOCATION_CODE = "location code"
     FIELD_SEPARATOR = "field separator"
-    
+
     SETTINGS = [
         { "key": ExternalIntegration.URL, "label": _("Server") },
         { "key": PORT, "label": _("Port") },
@@ -31,7 +31,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
           "default": "|",
         },
     ] + BasicAuthenticationProvider.SETTINGS
-    
+
     # Map the reasons why SIP2 might report a patron is blocked to the
     # protocol-independent block reason used by PatronData.
     SPECIFIC_BLOCK_REASONS = {
@@ -201,7 +201,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             fee_limit = MoneyUtility.parse(info['fee_limit']).amount
             if fee_limit and patrondata.fines > fee_limit:
                 patrondata.block_reason = PatronData.EXCESSIVE_FINES
-        
+
         return patrondata
 
     @classmethod
@@ -215,7 +215,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             except ValueError, e:
                 continue
         return date_value
-        
+
     # NOTE: It's not necessary to implement remote_patron_lookup
     # because authentication gets patron data as a side effect.
 

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -47,7 +47,7 @@ class fixed(object):
         self.length = length
 
     def consume(self, data, in_progress):
-        """Remove the value of this field from the beginning of the 
+        """Remove the value of this field from the beginning of the
         input string, and store it in the given dictionary.
 
         :param in_progress: A dictionary mapping field names to
@@ -60,7 +60,7 @@ class fixed(object):
         value = data[:self.length]
         in_progress[self.internal_name] = value
         return data[self.length:]
-        
+
     @classmethod
     def _add(cls, internal_name, *args, **kwargs):
         obj = cls(internal_name, *args, **kwargs)
@@ -86,7 +86,7 @@ class named(object):
         self.req=required
         self.length = length
         self.allow_multiple = allow_multiple
-        
+
     @property
     def required(self):
         """Create a variant of this field which is required.
@@ -126,7 +126,7 @@ class named(object):
     def _add(cls, internal_name, *args, **kwargs):
         obj = cls(internal_name, *args, **kwargs)
         setattr(cls, internal_name, obj)
-        
+
 named._add("institution_id", "AO")
 named._add("patron_identifier", "AA")
 named._add("personal_name", "AE")
@@ -178,7 +178,7 @@ class Constants(object):
     UNKNOWN_LANGUAGE = "000"
     ENGLISH = "001"
 
-    
+
 class SIPClient(Constants):
 
     log = logging.getLogger("SIPClient")
@@ -232,7 +232,7 @@ class SIPClient(Constants):
         RECALL_OVERDUE,
         TOO_MANY_ITEMS_BILLED
     ]
-    
+
     def __init__(self, target_server, target_port, login_user_id=None,
                  login_password=None, location_code=None, separator=None,
                  connect=True):
@@ -275,23 +275,23 @@ class SIPClient(Constants):
         # a unit test and don't actually want to use a server.
         if connect:
             self.connect()
-        
+
     def login(self, *args, **kwargs):
         """Log in to the SIP server."""
         return self.make_request(
             self.login_message, self.login_response_parser,
             *args, **kwargs
         )
-    
+
     def patron_information(self, *args, **kwargs):
-        """Get information about a patron, possibly also verifying their 
+        """Get information about a patron, possibly also verifying their
         password.
         """
         return self.make_request(
             self.patron_information_request, self.patron_information_parser,
             *args, **kwargs
         )
-            
+
     def connect(self):
         """Create a socket connection to a SIP server."""
         with self.socket_lock:
@@ -321,10 +321,10 @@ class SIPClient(Constants):
         self.sequence_number = 0
         if self.must_log_in:
             self.logged_in = False
-    
+
     def make_request(self, message_creator, parser, *args, **kwargs):
         """Send a request to a SIP server and parse the response.
-        
+
         :param message_creator: A function that creates the message to send.
         :param parser: A function that parses the response message.
         """
@@ -335,7 +335,7 @@ class SIPClient(Constants):
 
     def _make_request(self, message_creator, parser, *args, **kwargs):
         """Send a request to a SIP server and parse the response.
-        
+
         :param message_creator: A function that creates the message to send.
         :param parser: A function that parses the response message.
         """
@@ -352,7 +352,7 @@ class SIPClient(Constants):
             if response['login_ok'] != '1':
                 raise IOError("Error logging in: %r" % response)
             self.logged_in = True
-        
+
         original_message = message_creator(*args, **kwargs)
         message_with_checksum = self.append_checksum(original_message)
         parsed = None
@@ -370,7 +370,7 @@ class SIPClient(Constants):
                 else:
                     self.connect()
                     return self.make_request(
-                        message_creator, parser, 
+                        message_creator, parser,
                         *args, fail_on_network_error=True, **kwargs
                     )
             try:
@@ -383,7 +383,7 @@ class SIPClient(Constants):
                     original_message, include_sequence_number=False
                 )
         return parsed
-        
+
 
     def login_message(self, login_user_id, login_password, location_code="",
                       uid_algorithm="0",
@@ -395,7 +395,7 @@ class SIPClient(Constants):
         )
         if location_code:
             message = message + self.separator + "CP" + location_code
-        return message      
+        return message
 
     def login_response_parser(self, message):
         """Parse the response from a login message."""
@@ -411,7 +411,7 @@ class SIPClient(Constants):
             language=None, summary=None, start_item="", end_item=""
     ):
         """
-        A superset of patron status request.  
+        A superset of patron status request.
 
         Format of message to send to ILS:
         63<language><transaction date><summary><institution id><patron identifier>
@@ -434,7 +434,7 @@ class SIPClient(Constants):
         message = (code + language + timestamp + summary
                    + "AO" + institution_id + self.separator +
                    "AA" + patron_identifier + self.separator +
-                   "AC" + terminal_password 
+                   "AC" + terminal_password
         )
         if patron_password:
             message += self.separator + "AD" + patron_password
@@ -443,14 +443,14 @@ class SIPClient(Constants):
     def patron_information_parser(self, data):
         """
         Parse the message sent in response to a patron information request.
-        
+
         Format of message expected from ILS:
         64<patron status><language><transaction date><hold items count><overdue items count>
         <charged items count><fine items count><recall items count><unavailable holds count>
         <institution id><patron identifier><personal name><hold items limit><overdue items limit>
         <charged items limit><valid patron><valid patron password><currency type><fee amount>
         <fee limit><items><home address><e-mail address><home phone number><screen message><print line>
-        
+
         patron status: 14-char, required
         language: 3-char, req
         transaction date: 18-char, YYYYMMDDZZZZHHMMSS, required
@@ -551,7 +551,7 @@ class SIPClient(Constants):
         fields_by_sip_code = dict()
 
         required_fields_not_seen = set()
-        
+
         # We've been given a list of unnamed fixed-width fields (which
         # must appear at the front) followed by a list of named
         # fields. Named fields must appear after the fixed-width
@@ -569,7 +569,7 @@ class SIPClient(Constants):
                 fields_by_sip_code[field.sip_code] = field
                 if field.req:
                     required_fields_not_seen.add(field)
-                
+
         # We now have a list of named fields separated by
         # self.separator.  Use separator_re to split the data in a way
         # that minimizes the chances that embedded separators (which
@@ -610,7 +610,7 @@ class SIPClient(Constants):
                         required_fields_not_seen.remove(field)
             i += 2
             field = fields_by_sip_code
-                
+
         # If a named field is required and never showed up, sound the alarm.
         for field in required_fields_not_seen:
             self.log.error(
@@ -618,9 +618,9 @@ class SIPClient(Constants):
                 field.sip_code
             )
         return parsed
-    
+
     def consume_status_code(self, data, expected, in_progress):
-        """Pull the status code (the first two characters) off the 
+        """Pull the status code (the first two characters) off the
         given response string, and verify that it's as expected.
         """
         status_code = data[:2]
@@ -652,12 +652,12 @@ class SIPClient(Constants):
             value = status_string[i] != ' '
             status[field] = value
         return status
-    
+
     def now(self):
         """Return the current time, formatted as SIP expects it."""
         now = datetime.datetime.utcnow()
         return datetime.datetime.strftime(now, "%Y%m%d0000%H%M%S")
-    
+
     def summary(self, hold_items=False, overdue_items=False,
                 charged_items=False, fine_items=False, recall_items=False,
                 unavailable_holds=False):
@@ -685,19 +685,19 @@ class SIPClient(Constants):
                 summary
             )
         return summary
-    
+
     def send(self, data):
         """Send a message over the socket and update the sequence index."""
         data = data + '\r'
         return self.do_send(data)
-            
+
     def do_send(self, data):
         """Actually send data over the socket.
 
         This method exists only to be subclassed by MockSIPClient.
         """
         self.socket.send(data)
-            
+
     def read_message(self, max_size=1024*1024):
         """Read a SIP2 message from the socket connection.
 
@@ -717,7 +717,7 @@ class SIPClient(Constants):
                 raise IOError("SIP2 response too large.")
 
         return data
-  
+
     def append_checksum(self, text, include_sequence_number=True):
         """Calculates checksum for passed-in message, and returns the message
         with the checksum appended.
@@ -727,21 +727,21 @@ class SIPClient(Constants):
         checksum, and increment the sequence number. If this is false,
         do not include or increment the sequence number.
 
-        When error checking is enabled between the ACS and the SC, 
+        When error checking is enabled between the ACS and the SC,
         each SC->ACS message is labeled with a sequence number (0, 1, 2, ...).
-        When responding, the ACS tells the SC which sequence message it's 
+        When responding, the ACS tells the SC which sequence message it's
         responding to.
         """
 
         text += self.separator
-        
+
         if include_sequence_number:
             text += "AY" + str(self.sequence_number)
             # Sequence numbers range from 0-9 and wrap around.
             self.sequence_number += 1
             if self.sequence_number > 9:
                 self.sequence_number = 0
-            
+
         # Finally, add the checksum.
         text += "AZ"
 
@@ -751,20 +751,20 @@ class SIPClient(Constants):
         check = check + ord('\0')
         check = (check ^ 0xFFFF) + 1
 
-        checksum = "%4.4X" % (check)  
-       
-        # Note that the checksum doesn't have the pipe character 
+        checksum = "%4.4X" % (check)
+
+        # Note that the checksum doesn't have the pipe character
         # before its AZ tag.  This is as should be.
         text += checksum
 
-        return text      
+        return text
 
 
 class MockSIPClient(SIPClient):
     """A SIP client that relies on canned responses rather than a socket
     connection.
     """
-    
+
     def __init__(self, login_user_id=None, login_password=None, separator="|"):
         self.status = []
         super(MockSIPClient, self).__init__(
@@ -773,7 +773,7 @@ class MockSIPClient(SIPClient):
         )
         self.requests = []
         self.responses = []
-        
+
     def queue_response(self, response):
         self.responses.append(response)
 
@@ -782,16 +782,16 @@ class MockSIPClient(SIPClient):
         # connection-specific variables.
         self.status.append("Creating new socket connection.")
         self.reset_connection_state()
-        
+
     def do_send(self, data):
         self.requests.append(data)
-    
+
     def read_message(self):
         """Read a response message off the queue."""
         response = self.responses[0]
         self.responses = self.responses[1:]
         return response
-        
+
 
 class CannotSendMockSIPClient(MockSIPClient):
     """A MockSIPClient that can never send data."""

--- a/api/testing.py
+++ b/api/testing.py
@@ -38,7 +38,7 @@ class VendorIDTest(DatabaseTest):
     """
 
     TEST_VENDOR_ID = u"vendor id"
-    
+
     def initialize_adobe(self, vendor_id_library, short_token_libraries=[]):
         """Initialize an Adobe Vendor ID integration and a
         Short Client Token integration with a number of libraries.
@@ -76,7 +76,7 @@ class VendorIDTest(DatabaseTest):
         # we build the 'other_libraries' setting we'll apply to the
         # Adobe Vendor ID integration.
         other_libraries = dict()
-            
+
         # Every library in the system can generate Short Client
         # Tokens.
         for library in short_token_libraries:
@@ -104,7 +104,7 @@ class VendorIDTest(DatabaseTest):
         self.adobe_vendor_id.set_setting(
             AuthdataUtility.OTHER_LIBRARIES_KEY, other_libraries
         )
-        
+
 
 class MockRemoteAPI(BaseCirculationAPI):
     def __init__(self, set_delivery_mechanism_at, can_revoke_hold_when_reserved):
@@ -115,7 +115,7 @@ class MockRemoteAPI(BaseCirculationAPI):
         self.availability_updated_for = []
 
     def checkout(
-            self, patron_obj, patron_password, licensepool, 
+            self, patron_obj, patron_password, licensepool,
             delivery_mechanism
     ):
         # Should be a LoanInfo.
@@ -124,8 +124,8 @@ class MockRemoteAPI(BaseCirculationAPI):
     def update_availability(self, licensepool):
         """Simply record the fact that update_availability was called."""
         self.availability_updated_for.append(licensepool)
-                
-    def place_hold(self, patron, pin, licensepool, 
+
+    def place_hold(self, patron, pin, licensepool,
                    hold_notification_email=None):
         # Should be a HoldInfo.
         return self._return_or_raise('hold')

--- a/api/util/patron.py
+++ b/api/util/patron.py
@@ -5,7 +5,7 @@ from api.circulation_exceptions import *
 
 class PatronUtility(object):
     """Apply circulation-specific logic to Patron model objects."""
-    
+
     @classmethod
     def needs_external_sync(cls, patron):
         """Could this patron stand to have their metadata synced with the
@@ -19,7 +19,7 @@ class PatronUtility(object):
         if not patron.last_external_sync:
             # This patron has never been synced.
             return True
-        
+
         now = datetime.datetime.utcnow()
         if cls.has_borrowing_privileges(patron):
             # A patron who has borrowing privileges gets synced every twelve
@@ -53,7 +53,7 @@ class PatronUtility(object):
         """Raise an exception unless the patron currently has borrowing
         privileges.
 
-        :raise AuthorizationExpired: If the patron's authorization has 
+        :raise AuthorizationExpired: If the patron's authorization has
         expired.
 
         :raise OutstandingFines: If the patron has too many outstanding
@@ -77,7 +77,7 @@ class PatronUtility(object):
                 # manager is not configured to make that deduction.
                 raise OutstandingFines()
             raise AuthorizationBlocked()
-    
+
     @classmethod
     def authorization_is_active(cls, patron):
         """Return True unless the patron's authorization has expired."""

--- a/app.py
+++ b/app.py
@@ -4,6 +4,6 @@ import sys
 url = None
 if len(sys.argv) > 1:
     url = sys.argv[1]
-    
+
 if __name__ == "__main__":
     app.run(url)

--- a/integration_tests/benchmark_feed_queries.py
+++ b/integration_tests/benchmark_feed_queries.py
@@ -274,7 +274,7 @@ def urls_from_query(query, pages, size):
             base_url, query['language'], query['category'], urlencode(query['params'])), safe=':/?=&')
         urls.append(url)
     return urls
-        
+
 threads = [QueryTimingThread(urls=urls_from_query(random.choice(queries), pages, size)) for i in range(thread_count)]
 
 for t in threads:

--- a/integration_tests/test_borrow.py
+++ b/integration_tests/test_borrow.py
@@ -33,8 +33,8 @@ class TestBorrow(CirculationIntegrationTest):
         fulfill_url = fulfill_links[0].href
         fulfill_response = requests.get(fulfill_url, auth=HTTPBasicAuth(self.test_username, self.test_password))
         eq_(200, fulfill_response.status_code)
-        
-        
+
+
         revoke_links = [link for link in links if link.rel == "http://librarysimplified.org/terms/rel/revoke"]
         eq_(1, len(revoke_links))
         revoke_url = revoke_links[0].href

--- a/integration_tests/test_hold.py
+++ b/integration_tests/test_hold.py
@@ -14,7 +14,7 @@ class TestHold(CirculationIntegrationTest):
     def test_hold(self):
         if 'TEST_IDENTIFIER' in os.environ:
             overdrive_id = os.environ['TEST_IDENTIFIER']
-        else:        
+        else:
             # Yes Please has a large hold queue
             overdrive_id = "0abe1ed3-f117-4b7c-a6b0-857a2e7d227b"
 
@@ -33,7 +33,7 @@ class TestHold(CirculationIntegrationTest):
         links = entry['links']
         fulfill_links = [link for link in links if link.rel == "http://opds-spec.org/acquisition"]
         eq_(0, len(fulfill_links))
-        
+
         revoke_links = [link for link in links if link.rel == "http://librarysimplified.org/terms/rel/revoke"]
         eq_(1, len(revoke_links))
         revoke_url = revoke_links[0].href

--- a/migration/20150929-1-set_delivery_mechanism_for_3m_books.py
+++ b/migration/20150929-1-set_delivery_mechanism_for_3m_books.py
@@ -18,7 +18,7 @@ class SetDeliveryMechanismMonitor(IdentifierSweepMonitor):
 
     def __init__(self, _db, interval_seconds=None):
         super(SetDeliveryMechanismMonitor, self).__init__(
-            _db, "20150929 migration - Set delivery mechanism for 3M books", 
+            _db, "20150929 migration - Set delivery mechanism for 3M books",
             interval_seconds, batch_size=10)
         self.api = ThreeMAPI(_db)
         self.metadata_client = SimplifiedOPDSLookup(
@@ -40,5 +40,5 @@ class SetDeliveryMechanismMonitor(IdentifierSweepMonitor):
                 format.drm_scheme,
                 format.link
             )
-    
+
 RunMonitorScript(SetDeliveryMechanismMonitor).run()

--- a/migration/20150929-2-set_delivery_mechanism_for_axis_books.py
+++ b/migration/20150929-2-set_delivery_mechanism_for_axis_books.py
@@ -18,7 +18,7 @@ class SetDeliveryMechanismMonitor(IdentifierSweepMonitor):
 
     def __init__(self, _db, interval_seconds=None):
         super(SetDeliveryMechanismMonitor, self).__init__(
-            _db, "20150929 migration - Set delivery mechanism for Axis books", 
+            _db, "20150929 migration - Set delivery mechanism for Axis books",
             interval_seconds, batch_size=10)
         self.api = Axis360API(_db)
 
@@ -45,5 +45,5 @@ class SetDeliveryMechanismMonitor(IdentifierSweepMonitor):
                 )
         else:
             print "Book not in collection: %s" % identifier.identifier
-    
+
 RunMonitorScript(SetDeliveryMechanismMonitor).run()

--- a/migration/20150929-3-set_delivery_mechanism_for_overdrive_books.py
+++ b/migration/20150929-3-set_delivery_mechanism_for_overdrive_books.py
@@ -18,7 +18,7 @@ class SetDeliveryMechanismMonitor(IdentifierSweepMonitor):
 
     def __init__(self, _db, interval_seconds=None):
         super(SetDeliveryMechanismMonitor, self).__init__(
-            _db, "20150929 migration - Set delivery mechanism for Overdrive books", 
+            _db, "20150929 migration - Set delivery mechanism for Overdrive books",
             interval_seconds, batch_size=10)
         self.api = OverdriveAPI(_db)
 
@@ -41,5 +41,5 @@ class SetDeliveryMechanismMonitor(IdentifierSweepMonitor):
                 format.drm_scheme,
                 format.link
             )
-    
+
 RunMonitorScript(SetDeliveryMechanismMonitor).run()

--- a/migration/20150929-4-set_delivery_mechanism_for_gutenberg_books.py
+++ b/migration/20150929-4-set_delivery_mechanism_for_gutenberg_books.py
@@ -19,7 +19,7 @@ class SetDeliveryMechanismMonitor(IdentifierSweepMonitor):
 
     def __init__(self, _db, interval_seconds=None):
         super(SetDeliveryMechanismMonitor, self).__init__(
-            _db, "20150929 migration - Set delivery mechanism for Gutenberg books", 
+            _db, "20150929 migration - Set delivery mechanism for Gutenberg books",
             interval_seconds, batch_size=10)
 
     def identifier_query(self):

--- a/migration/20150930-fix-wikidata-ids-treated-as-names.py
+++ b/migration/20150930-fix-wikidata-ids-treated-as-names.py
@@ -11,8 +11,8 @@ package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
 
 from core.model import (
-    production_session, 
-    Contributor, 
+    production_session,
+    Contributor,
 )
 
 _db = production_session()
@@ -24,7 +24,7 @@ print contributors.count()
 for contributor in contributors:
     display_name, family_name = contributor.default_names()
     print "%s/%s: %s => %s, %s => %s" % (
-        contributor.id, 
+        contributor.id,
         contributor.name,
         contributor.display_name, display_name,
         contributor.family_name, family_name

--- a/migration/20160331-add-alias-for-new-index.py
+++ b/migration/20160331-add-alias-for-new-index.py
@@ -4,7 +4,7 @@ Add an alias to a new search index.
 
 Process for creating and switching to the new index:
 Deploy the new code.
-Run this migration, which creates a new index ("-v2") and an alias ("-current") 
+Run this migration, which creates a new index ("-v2") and an alias ("-current")
 based on the current index name.
 Run `bin/repair/search_index <new_index_name>`.
 Change the config file to point to the alias instead of the old index name.

--- a/migration/20170224-2-copy-collection-configuration-into-database.py
+++ b/migration/20170224-2-copy-collection-configuration-into-database.py
@@ -111,7 +111,7 @@ def convert_one_click(_db, library):
     url = config.get('url')
     ebook_loan_length = config.get('ebook_loan_length')
     eaudio_loan_length = config.get('eaudio_loan_length')
-    
+
     collection, ignore = get_one_or_create(
         _db, Collection,
         protocol=Collection.ONE_CLICK,
@@ -123,7 +123,7 @@ def convert_one_click(_db, library):
     collection.external_integration.url = url
     collection.external_integration.set_setting("ebook_loan_length", ebook_loan_length)
     collection.external_integration.set_setting("eaudio_loan_length", eaudio_loan_length)
-    
+
 def convert_content_server(_db, library):
     config = Configuration.integration("Content Server")
     if not config:

--- a/migration/20170713-13-move-authentication-configuration-to-external-integrations.py
+++ b/migration/20170713-13-move-authentication-configuration-to-external-integrations.py
@@ -54,9 +54,9 @@ def make_patron_auth_integration(_db, provider):
         integration.setting(BasicAuthenticationProvider.IDENTIFIER_REGULAR_EXPRESSION).value = identifier_re
     if password_re:
         integration.setting(BasicAuthenticationProvider.PASSWORD_REGULAR_EXPRESSION).value = password_re
-    
+
     return integration
-        
+
 def convert_millenium(_db, integration, provider):
 
     # Cross-check MilleniumPatronAPI.__init__ to see how these values
@@ -70,7 +70,7 @@ def convert_millenium(_db, integration, provider):
     if auth_mode:
         integration.setting(MilleniumPatronAPI.AUTHENTICATION_MODE
         ).value = auth_mode
-    
+
 def convert_sip(_db, integration, provider):
     # Cross-check SIP2AuthenticationProvider.__init__ to see how these values
     # are pulled from the ExternalIntegration.
@@ -90,7 +90,7 @@ def convert_sip(_db, integration, provider):
 
 def convert_firstbook(_db, integration, provider):
     # Cross-check FirstBookAuthenticationAPI.__init__ to see how these values
-    # are pulled from the ExternalIntegration.    
+    # are pulled from the ExternalIntegration.
     integration.url = provider.get('url')
     integration.password = provider.get('key')
 
@@ -122,7 +122,7 @@ try:
     )
     if bearer_token_signing_secret:
         secret_setting.value = bearer_token_signing_secret
-    
+
     for provider in auth_conf.get('providers'):
         integration = make_patron_auth_integration(_db, provider)
         module = provider.get('module')
@@ -137,7 +137,7 @@ try:
         else:
             log.warn("I don't know how to convert a provider of type %s. Conversion is probably incomplete." % module)
         integrations.append(integration)
-        
+
     # Add each integration to each library.
     library = Library.default(_db)
     for library in _db.query(Library):

--- a/migration/20170713-15-move-library-configuration-to-configurationsettings.py
+++ b/migration/20170713-15-move-library-configuration-to-configurationsettings.py
@@ -39,7 +39,7 @@ try:
     secret_setting.value = secret_key
 
     libraries = _db.query(Library).all()
-    
+
     # Copy default email address into each library.
     key = 'default_notification_email_address'
     value = Configuration.get(key)
@@ -71,7 +71,7 @@ try:
             if value:
                 for library in libraries:
                     library.setting(variable).value = json.dumps(value)
-    
+
     # Copy facet configuration
     facet_policy = Configuration.policy("facets", default={})
     enabled = facet_policy.get("enabled", {})
@@ -81,7 +81,7 @@ try:
             library.enabled_facets_setting(k).value = json.dumps(v)
         for k, v in default.items():
             library.default_facet_setting(k).value = v
-            
+
     # Copy external type regular expression into each authentication
     # mechanism for each library.
     key = 'external_type_regular_expression'
@@ -93,7 +93,7 @@ try:
                     continue
                 ConfigurationSetting.for_library_and_externalintegration(
                     _db, key, library, integration).value = value
-                
+
 finally:
     _db.commit()
     _db.close()

--- a/migration/20170714-add-collection-id-to-licensepools.py
+++ b/migration/20170714-add-collection-id-to-licensepools.py
@@ -36,7 +36,7 @@ try:
         log_change(fast_query_count(qu), collection)
         _db.commit()
 
-    # Some LicensePools may be associated with the a duplicate or 
+    # Some LicensePools may be associated with the a duplicate or
     # outdated Bibliotheca DataSource. Find them.
     bibliotheca = DataSource.lookup(_db, DataSource.BIBLIOTHECA)
     old_sources = _db.query(DataSource.id).filter(

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -1206,7 +1206,7 @@ class TestWorkController(AdminControllerTest):
             assert_raises(AdminNotAuthorized,
                           self.manager.admin_work_controller.preview_book_cover,
                           identifier.type, identifier.identifier)
-        
+
 
     def test_change_book_cover(self):
         # Mock image processing which has been tested in other methods.
@@ -1361,7 +1361,7 @@ class TestWorkController(AdminControllerTest):
                           identifier.type, identifier.identifier)
 
         self.manager.admin_work_controller._process_cover_image = old_process
-        
+
     def test_custom_lists_get(self):
         staff_data_source = DataSource.lookup(self._db, DataSource.LIBRARY_STAFF)
         list, ignore = create(self._db, CustomList, name=self._str, library=self._default_library, data_source=staff_data_source)

--- a/tests/admin/test_google_oauth_admin_authentication_provider.py
+++ b/tests/admin/test_google_oauth_admin_authentication_provider.py
@@ -85,7 +85,7 @@ class TestGoogleOAuthAdminAuthenticationProvider(DatabaseTest):
         ConfigurationSetting.for_library_and_externalintegration(
             self._db, "domains", self._default_library, auth_integration
         ).value = json.dumps(["nypl.org"])
-        
+
         google = GoogleOAuthAdminAuthenticationProvider(auth_integration, "", test_mode=True)
 
         eq_(["nypl.org"], google.domains.keys())

--- a/tests/admin/test_opds.py
+++ b/tests/admin/test_opds.py
@@ -70,7 +70,7 @@ class TestOPDS(DatabaseTest):
     def test_feed_includes_edit_link(self):
         work = self._work(with_open_access_download=True)
         lp = work.license_pools[0]
- 
+
         feed = AcquisitionFeed(self._db, "test", "url", [work], AdminAnnotator(None, self._default_library, test_mode=True))
         [entry] = feedparser.parse(unicode(feed))['entries']
         [edit_link] = [x for x in entry['links'] if x['rel'] == "edit"]
@@ -79,7 +79,7 @@ class TestOPDS(DatabaseTest):
     def test_feed_includes_change_cover_link(self):
         work = self._work(with_open_access_download=True)
         lp = work.license_pools[0]
- 
+
         feed = AcquisitionFeed(self._db, "test", "url", [work], AdminAnnotator(None, self._default_library, test_mode=True))
         [entry] = feedparser.parse(unicode(feed))['entries']
 
@@ -251,7 +251,7 @@ class TestOPDS(DatabaseTest):
         [previous] = self.links(parsed, 'previous')
         eq_(annotator.suppressed_url(pagination.next_page), previous['href'])
         eq_(0, len(parsed['entries']))
-        
+
 
 class MockAnnotator(AdminAnnotator):
 

--- a/tests/admin/test_password_admin_authentication_provider.py
+++ b/tests/admin/test_password_admin_authentication_provider.py
@@ -45,7 +45,7 @@ class TestPasswordAdminAuthenticationProvider(DatabaseTest):
         admin_details, redirect = password_auth.sign_in(self._db, dict(email="admin1@nypl.org", password="pass2", redirect="foo"))
         eq_(INVALID_ADMIN_CREDENTIALS, admin_details)
         eq_(None, redirect)
-        
+
         # The admin with no password can't sign in.
         admin_details, redirect = password_auth.sign_in(self._db, dict(email="admin3@nypl.org", redirect="foo"))
         eq_(INVALID_ADMIN_CREDENTIALS, admin_details)

--- a/tests/clever/test_clever.py
+++ b/tests/clever/test_clever.py
@@ -45,16 +45,16 @@ class MockAPI(CleverAuthenticationAPI):
 
 class TestCleverAuthenticationAPI(DatabaseTest):
 
-    
+
     def setup(self):
         super(TestCleverAuthenticationAPI, self).setup()
-        
+
         self.api = MockAPI(self._default_library, self.mock_integration)
         os.environ['AUTOINITIALIZE'] = "False"
         from api.app import app
         del os.environ['AUTOINITIALIZE']
         self.app = app
-        
+
     @property
     def mock_integration(self):
         """Make a fake ExternalIntegration that can be used to configure
@@ -68,7 +68,7 @@ class TestCleverAuthenticationAPI(DatabaseTest):
         )
         integration.setting(MockAPI.OAUTH_TOKEN_EXPIRATION_DAYS).value = 20
         return integration
-        
+
     def test_authenticated_patron(self):
         """An end-to-end test of authenticated_patron()."""
         eq_(None, self.api.authenticated_patron(self._db, "not a valid token"))
@@ -108,13 +108,13 @@ class TestCleverAuthenticationAPI(DatabaseTest):
         with self.app.test_request_context("/"):
             payload = self.api._remote_exchange_payload(self._db, "a code")
 
-            expect_uri = url_for("oauth_callback", 
+            expect_uri = url_for("oauth_callback",
                                  library_short_name=self._default_library.name,
                                  _external=True)
             eq_('authorization_code', payload['grant_type'])
             eq_(expect_uri, payload['redirect_uri'])
             eq_('a code', payload['code'])
-        
+
     def test_remote_patron_lookup_unsupported_user_type(self):
         self.api.queue_response(dict(type='district_admin', data=dict(id='1234')))
         token = self.api.remote_patron_lookup("token")
@@ -179,7 +179,7 @@ class TestCleverAuthenticationAPI(DatabaseTest):
         with self.app.test_request_context("/"):
             response = self.api.oauth_callback(self._db, dict(code="teacher code"))
             credential, patron, patrondata = response
-        
+
         # The bearer token was turned into a Credential.
         expect_credential, ignore = self.api.create_token(
             self._db, patron, "bearer token"
@@ -193,7 +193,7 @@ class TestCleverAuthenticationAPI(DatabaseTest):
         # The PatronData includes information that can't be stored
         # in the Patron record.
         eq_("Abcd", patrondata.personal_name)
-        
+
     def test_oauth_callback_problem_detail_if_bad_token(self):
         self.api.queue_response(dict(something_else="not a token"))
         with self.app.test_request_context("/"):
@@ -208,7 +208,7 @@ class TestCleverAuthenticationAPI(DatabaseTest):
             response = self.api.oauth_callback(self._db, dict(code="teacher code"))
         assert isinstance(response, ProblemDetail)
         eq_(INVALID_CREDENTIALS.uri, response.uri)
-    
+
     def test_external_authenticate_url(self):
         """Verify that external_authenticate_url is generated properly.
         """

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -17,7 +17,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
     # an extra step of indirection, because it lets us use as a
     # starting point the actual (albeit redacted) SIP2 messages we
     # receive from servers.
-    
+
     sierra_valid_login = "64              000201610210000142637000000000000000000000000AOnypl |AA12345|AESHELDON, ALICE|BZ0030|CA0050|CB0050|BLY|CQY|BV0|CC15.00|BEfoo@example.com|AY1AZD1B7"
     sierra_excessive_fines = "64              000201610210000142637000000000000000000000000AOnypl |AA12345|AESHELDON, ALICE|BZ0030|CA0050|CB0050|BLY|CQY|BV20.00|CC15.00|BEfoo@example.com|AY1AZD1B7"
     sierra_invalid_login = "64Y  YYYYYYYYYYY000201610210000142725000000000000000000000000AOnypl |AA12345|AESHELDON, ALICE|BZ0030|CA0050|CB0050|BLY|CQN|BV0|CC15.00|BEfoo@example.com|AFInvalid PIN entered.  Please try again or see a staff member for assistance.|AFThere are unresolved issues with your account.  Please see a staff member for assistance.|AY1AZ91A8"
@@ -30,7 +30,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
     evergreen_inactive_account = "64YYYY          00020161021    143028000000000000000000000000AE|AA12345|BLN|AOBiblioTest|AY2AZ0000"
 
     polaris_valid_pin = "64              00120161121    143327000000000000000000000000AO3|AA25891000331441|AEFalk, Jen|BZ0050|CA0075|CB0075|BLY|CQY|BHUSD|BV9.25|CC9.99|BD123 Charlotte Hall, MD 20622|BEfoo@bar.com|BF501-555-1212|BC19710101    000000|PA1|PEHALL|PSSt. Mary's|U1|U2|U3|U4|U5|PZ20622|PX20180609    235959|PYN|FA0.00|AFPatron status is ok.|AGPatron status is ok.|AY2AZ94F3"
-        
+
     polaris_wrong_pin = "64YYYY          00120161121    143157000000000000000000000000AO3|AA25891000331441|AEFalk, Jen|BZ0050|CA0075|CB0075|BLY|CQN|BHUSD|BV9.25|CC9.99|BD123 Charlotte Hall, MD 20622|BEfoo@bar.com|BF501-555-1212|BC19710101    000000|PA1|PEHALL|PSSt. Mary's|U1|U2|U3|U4|U5|PZ20622|PX20180609    235959|PYN|FA0.00|AFInvalid patron password. Passwords do not match.|AGInvalid patron password.|AY2AZ87B4"
 
     polaris_expired_card = "64YYYY          00120161121    143430000000000000000000000000AO3|AA25891000224613|AETester, Tess|BZ0050|CA0075|CB0075|BLY|CQY|BHUSD|BV0.00|CC9.99|BD|BEfoo@bar.com|BF|BC19710101    000000|PA1|PELEON|PSSt. Mary's|U1|U2|U3|U4|U5|PZ|PX20161025    235959|PYY|FA0.00|AFPatron has blocks.|AGPatron has blocks.|AY2AZA4F8"
@@ -56,7 +56,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         eq_("pass1", client.login_password)
         eq_("\t", client.separator)
         eq_("server.com", client.target_server)
-        
+
         # Default port is 6001.
         eq_(6001, client.target_port)
 
@@ -64,7 +64,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         integration.setting(p.PORT).value = "1234"
         provider = p(self._default_library, integration, connect=False)
         eq_(1234, provider.client.target_port)
-        
+
     def test_remote_authenticate(self):
         integration = self._external_integration(self._str)
         client = MockSIPClient()
@@ -82,7 +82,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         eq_(None, patrondata.authorization_expires)
         eq_(None, patrondata.external_type)
         eq_(PatronData.NO_VALUE, patrondata.block_reason)
-        
+
         client.queue_response(self.sierra_invalid_login)
         eq_(None, auth.remote_authenticate("user", "pass"))
 
@@ -93,7 +93,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         client.queue_response(self.sierra_excessive_fines)
         patrondata = auth.remote_authenticate("user", "pass")
         eq_(PatronData.EXCESSIVE_FINES, patrondata.block_reason)
-        
+
         # A patron with an expired card.
         client.queue_response(self.evergreen_expired_card)
         patrondata = auth.remote_authenticate("user", "pass")
@@ -116,7 +116,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         eq_(datetime(2019, 10, 04), patrondata.authorization_expires)
 
         # We happen to know that this patron can't borrow books due to
-        # excessive fines, but that information doesn't show up as a 
+        # excessive fines, but that information doesn't show up as a
         # block, because Evergreen doesn't also provide the
         # fine limit. This isn't a big deal -- we'll pick it up later
         # when we apply the site policy.
@@ -134,7 +134,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         client.queue_response(self.evergreen_card_reported_lost)
         patrondata = auth.remote_authenticate("user", "pass")
         eq_(PatronData.CARD_REPORTED_LOST, patrondata.block_reason)
-        
+
         # Some examples taken from a Polaris instance.
         client.queue_response(self.polaris_valid_pin)
         patrondata = auth.remote_authenticate("user", "pass")
@@ -148,12 +148,12 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         client.queue_response(self.polaris_wrong_pin)
         patrondata = auth.remote_authenticate("user", "pass")
         eq_(None, patrondata)
-        
+
         client.queue_response(self.polaris_expired_card)
         patrondata = auth.remote_authenticate("user", "pass")
         eq_(datetime(2016, 10, 25, 23, 59, 59),
             patrondata.authorization_expires)
-        
+
         client.queue_response(self.polaris_excess_fines)
         patrondata = auth.remote_authenticate("user", "pass")
         eq_(11.50, patrondata.fines)
@@ -236,7 +236,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
             provider.remote_authenticate,
             "username", "password",
         )
-        
+
     def test_parse_date(self):
         parse = SIP2AuthenticationProvider.parse_date
         eq_(datetime(2011, 1, 2), parse("20110102"))

--- a/tests/sip/test_client.py
+++ b/tests/sip/test_client.py
@@ -108,13 +108,13 @@ class TestNetworkError(object):
         # When we try to send any data through the client, we get an
         # IOError.
         assert_raises(IOError, sip.login, 'username', 'password', 'location')
-        
+
         # But after the initial failure we created a new socket
         # connection and sent the data again, so at least we tried.
         expect = ['Creating new socket connection.',
                   "I was unable to send data."] * 2
         eq_(expect, sip.status)
-        
+
     def test_retry_on_initial_timeout(self):
         sip = CannotReceiveMockSIPClient()
 
@@ -132,7 +132,7 @@ class TestNetworkError(object):
 
 
 class TestLogin(object):
-       
+
     def test_login_success(self):
         sip = MockSIPClient()
         sip.queue_response('941')
@@ -151,7 +151,7 @@ class TestLogin(object):
         # message.
         eq_(False, sip.logged_in)
         eq_(True, sip.must_log_in)
-        
+
         sip.queue_response('941')
         sip.queue_response('64Y                201610050000114734                        AOnypl |AA12345|AENo Name|BLN|AFYour library card number cannot be located.  Please see a staff member for assistance.|AY1AZC9DE')
         response = sip.patron_information('patron_identifier')
@@ -162,7 +162,7 @@ class TestLogin(object):
 
         # We're logged in.
         eq_(True, sip.logged_in)
-        
+
         # We ended up with the right data.
         eq_('12345', response['patron_identifier'])
 
@@ -170,7 +170,7 @@ class TestLogin(object):
         sip.connect()
         eq_(False, sip.logged_in)
         eq_(0, sip.sequence_number)
-        
+
     def test_login_failure_interrupts_other_request(self):
         sip = MockSIPClient('user_id', 'password')
         sip.queue_response('940')
@@ -178,7 +178,7 @@ class TestLogin(object):
         # We don't even get a chance to make the patron information request
         # because our login attempt fails.
         assert_raises(IOError,  sip.patron_information, 'patron_identifier')
-        
+
     def test_login_does_not_happen_implicitly_when_user_id_and_password_not_specified(self):
         sip = MockSIPClient()
 
@@ -192,7 +192,7 @@ class TestLogin(object):
         # One request was made.
         eq_(1, len(sip.requests))
         eq_(1, sip.sequence_number)
-        
+
         # We ended up with the right data.
         eq_('12345', response['patron_identifier'])
 
@@ -201,7 +201,7 @@ class TestPatronResponse(object):
 
     def setup(self):
         self.sip = MockSIPClient()
-    
+
     def test_incorrect_card_number(self):
         self.sip.queue_response("64Y                201610050000114734                        AOnypl |AA240|AENo Name|BLN|AFYour library card number cannot be located.|AY1AZC9DE")
         response = self.sip.patron_information('identifier')
@@ -215,11 +215,11 @@ class TestPatronResponse(object):
         parsed = response['patron_status_parsed']
         eq_(True, parsed['charge privileges denied'])
         eq_(False, parsed['too many items charged'])
-        
+
     def test_hold_items(self):
         "A patron has multiple items on hold."
         self.sip.queue_response("64              000201610050000114837000300020002000000000000AOnypl |AA233|AEBAR, FOO|BZ0030|CA0050|CB0050|BLY|CQY|BV0|CC15.00|AS123|AS456|AS789|BEFOO@BAR.COM|AY1AZC848")
-        response = self.sip.patron_information('identifier')        
+        response = self.sip.patron_information('identifier')
         eq_('0003', response['hold_items_count'])
         eq_(['123', '456', '789'], response['hold_items'])
 
@@ -241,7 +241,7 @@ class TestPatronResponse(object):
         # The ZZ field is an unknown extension and is captured under
         # its SIP code.
         eq_(["foo"], response['ZZ'])
-       
+
     def test_embedded_pipe(self):
         """In most cases we can handle data even if it contains embedded
         instances of the separator character.
@@ -269,7 +269,7 @@ class TestPatronResponse(object):
             "login_id", "login_password", "location_code"
         )
         assert with_code.endswith("COlogin_password|CPlocation_code")
-        
+
     def test_patron_password_is_optional(self):
         without_password = self.sip.patron_information_request(
             "patron_identifier"

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -21,7 +21,7 @@ from api.annotations import (
 from api.problem_details import *
 
 class AnnotationTest(DatabaseTest):
-    
+
     def _patron(self):
         """Create a test patron who has opted in to annotation sync."""
         patron = super(AnnotationTest, self)._patron()
@@ -30,7 +30,7 @@ class AnnotationTest(DatabaseTest):
 
 
 class TestAnnotationWriter(AnnotationTest, ControllerTest):
-   
+
     def test_annotations_for(self):
         patron = self._patron()
 
@@ -125,7 +125,7 @@ class TestAnnotationWriter(AnnotationTest, ControllerTest):
             container, timestamp = AnnotationWriter.annotation_container_for(patron)
             eq_(0, container['total'])
             eq_(None, timestamp)
-        
+
     def test_annotation_container_for_with_identifier(self):
         patron = self._patron()
         identifier = self._identifier()
@@ -197,7 +197,7 @@ class TestAnnotationWriter(AnnotationTest, ControllerTest):
             container, timestamp = AnnotationWriter.annotation_container_for(patron, identifier)
             eq_(0, container['total'])
             eq_(None, timestamp)
-        
+
     def test_annotation_page_for(self):
         patron = self._patron()
 
@@ -347,10 +347,10 @@ class TestAnnotationParser(AnnotationTest):
         self.pool = self._licensepool(None)
         self.identifier = self.pool.identifier
         self.patron = self._patron()
-        
+
     def _sample_jsonld(self, motivation=Annotation.IDLING):
         data = dict()
-        data["@context"] = [AnnotationWriter.JSONLD_CONTEXT, 
+        data["@context"] = [AnnotationWriter.JSONLD_CONTEXT,
                             {'ls': Annotation.LS_NAMESPACE}]
         data["type"] = "Annotation"
         motivation = motivation.replace(Annotation.LS_NAMESPACE, 'ls:')
@@ -487,7 +487,7 @@ class TestAnnotationParser(AnnotationTest):
         annotation3 = AnnotationParser.parse(self._db, data_json, self.patron)
         assert annotation3 != annotation
         eq_(2, len(self.patron.annotations))
-        
+
     def test_parse_jsonld_with_invalid_motivation(self):
         self.pool.loan_to(self.patron)
 
@@ -498,7 +498,7 @@ class TestAnnotationParser(AnnotationTest):
         annotation = AnnotationParser.parse(self._db, data_json, self.patron)
 
         eq_(INVALID_ANNOTATION_MOTIVATION, annotation)
-        
+
     def test_parse_jsonld_with_no_loan(self):
         data = self._sample_jsonld()
         data_json = json.dumps(data)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -81,12 +81,12 @@ class MockAuthenticationProvider(object):
 
     def authenticate(self, _db, header):
         return self.patron
-           
+
 
 class MockBasicAuthenticationProvider(
         BasicAuthenticationProvider,
         MockAuthenticationProvider
-):   
+):
     """A mock basic authentication provider for use in testing the overall
     authentication process.
     """
@@ -116,14 +116,14 @@ class MockBasic(BasicAuthenticationProvider):
         super(MockBasic, self).__init__(library, integration, analytics)
         self.patrondata = patrondata
         self.remote_patron_lookup_patrondata = remote_patron_lookup_patrondata
-        
+
     def remote_authenticate(self, username, password):
         return self.patrondata
 
     def remote_patron_lookup(self, patrondata):
         return self.remote_patron_lookup_patrondata
 
-    
+
 class MockOAuthAuthenticationProvider(
         OAuthAuthenticationProvider,
         MockAuthenticationProvider
@@ -170,7 +170,7 @@ class MockOAuth(OAuthAuthenticationProvider):
 class AuthenticatorTest(DatabaseTest):
 
     def mock_basic(self, *args, **kwargs):
-        """Convenience method to instantiate a MockBasic object with the 
+        """Convenience method to instantiate a MockBasic object with the
         default library.
         """
         self.mock_basic_integration = self._external_integration(
@@ -180,7 +180,7 @@ class AuthenticatorTest(DatabaseTest):
             self._default_library, self.mock_basic_integration, *args, **kwargs
         )
 
-        
+
 class TestPatronData(AuthenticatorTest):
 
     def setup(self):
@@ -195,8 +195,8 @@ class TestPatronData(AuthenticatorTest):
             fines=Money(6, "USD"),
             block_reason=PatronData.NO_VALUE,
         )
-        
-    
+
+
     def test_apply(self):
         patron = self._patron()
 
@@ -223,7 +223,7 @@ class TestPatronData(AuthenticatorTest):
         patron = self._patron()
         self.data.apply(patron)
         eq_(PatronData.UNKNOWN_BLOCK, patron.block_reason)
-        
+
     def test_apply_multiple_authorization_identifiers(self):
         """If there are multiple authorization identifiers, the first
         one is chosen.
@@ -254,7 +254,7 @@ class TestPatronData(AuthenticatorTest):
         )
         data.apply(patron)
         eq_("3", patron.authorization_identifier)
-        
+
     def test_apply_sets_last_external_sync_if_data_is_complete(self):
         """Patron.last_external_sync is only updated when apply() is called on
         a PatronData object that represents a full set of metadata.
@@ -268,7 +268,7 @@ class TestPatronData(AuthenticatorTest):
         self.data.complete = True
         self.data.apply(patron)
         assert None != patron.last_external_sync
-        
+
     def test_apply_sets_first_valid_authorization_identifier(self):
         """If the ILS has multiple authorization identifiers for a patron, the
         first one is used.
@@ -278,7 +278,7 @@ class TestPatronData(AuthenticatorTest):
         self.data.set_authorization_identifier(["identifier 1", "identifier 2"])
         self.data.apply(patron)
         eq_("identifier 1", patron.authorization_identifier)
-                
+
     def test_apply_leaves_valid_authorization_identifier_alone(self):
         """If the ILS says a patron has a new preferred authorization
         identifier, but our Patron record shows them using an
@@ -311,7 +311,7 @@ class TestPatronData(AuthenticatorTest):
         data already in the database.
         """
         now = datetime.datetime.now()
-        
+
         # If the only thing we know about a patron is that a certain
         # string authenticated them, we set
         # Patron.authorization_identifier to that string but we also
@@ -417,7 +417,7 @@ class TestAuthenticator(ControllerTest):
         self._db.commit()
 
         analytics = MockAnalyticsProvider()
-        
+
         auth = Authenticator(self._db, analytics)
 
         # A LibraryAuthenticator has been created for each Library.
@@ -527,7 +527,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         firstbook.url = "http://url/"
         firstbook.password = "secret"
         library.integrations.append(firstbook)
-        
+
         oauth = self._external_integration(
             "api.clever", ExternalIntegration.PATRON_AUTH_GOAL,
         )
@@ -542,14 +542,14 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         assert isinstance(auth.basic_auth_provider,
                           FirstBookAuthenticationAPI)
         eq_(analytics, auth.basic_auth_provider.analytics)
-            
+
         eq_(1, len(auth.oauth_providers_by_name))
         clever = auth.oauth_providers_by_name[
             CleverAuthenticationAPI.NAME
         ]
         assert isinstance(clever, CleverAuthenticationAPI)
         eq_(analytics, clever.analytics)
-            
+
     def test_with_custom_patron_catalog(self):
         """Instantiation of a LibraryAuthenticator may
         include instantiation of a CustomPatronCatalog.
@@ -607,7 +607,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         # The LibraryAuthenticator exists but has no AuthenticationProviders.
         eq_(None, auth.basic_auth_provider)
         eq_({}, auth.oauth_providers_by_name)
-        
+
         # Both integrations have left their trace in
         # initialization_exceptions.
         not_configured = auth.initialization_exceptions[misconfigured.id]
@@ -617,7 +617,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         not_found = auth.initialization_exceptions[unknown.id]
         assert isinstance(not_found, ImportError)
         eq_('No module named unknown protocol', not_found.message)
-        
+
     def test_register_fails_when_integration_has_wrong_goal(self):
         integration = self._external_integration(
             "protocol", "some other goal"
@@ -651,7 +651,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             CannotLoadConfiguration,
             "Loaded module api.lanes but could not find a class called AuthenticationProvider inside.",
             auth.register_provider, integration
-        )        
+        )
 
     def test_register_provider_fails_but_does_not_explode_on_remote_integration_error(self):
         library = self._default_library
@@ -669,7 +669,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             "Could not instantiate .* authentication provider for library .*, possibly due to a network connection problem.",
             auth.register_provider, integration
         )
-        
+
     def test_register_provider_basic_auth(self):
         firstbook = self._external_integration(
             "api.firstbook", ExternalIntegration.PATRON_AUTH_GOAL,
@@ -682,7 +682,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         assert isinstance(
             auth.basic_auth_provider, FirstBookAuthenticationAPI
         )
-        
+
     def test_register_oauth_provider(self):
         oauth = self._external_integration(
             "api.clever", ExternalIntegration.PATRON_AUTH_GOAL,
@@ -697,7 +697,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             CleverAuthenticationAPI.NAME
         ]
         assert isinstance(clever, CleverAuthenticationAPI)
-            
+
     def test_oauth_provider_requires_secret(self):
         integration = self._external_integration(self._str)
 
@@ -723,7 +723,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             library=self._default_library,
             oauth_providers=[oauth], bearer_token_signing_secret="foo"
         )
-        
+
         # But you can't create an Authenticator that uses OAuth
         # without providing a secret.
         assert_raises_regexp(
@@ -844,7 +844,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             'Two different OAuth providers claim the name "provider1"',
             authenticator.register_oauth_provider, oauth1_dupe
         )
-        
+
     def test_oauth_provider_lookup(self):
 
         # If there are no OAuth providers we cannot look one up.
@@ -860,7 +860,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         problem = authenticator.oauth_provider_lookup("provider1")
         eq_(problem.uri, UNKNOWN_OAUTH_PROVIDER.uri)
         eq_(_("No OAuth providers are configured."), problem.detail)
-        
+
         # We can look up registered providers but not unregistered providers.
         oauth1 = MockOAuthAuthenticationProvider(self._default_library, "provider1")
         oauth2 = MockOAuthAuthenticationProvider(self._default_library, "provider2")
@@ -904,14 +904,14 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             authenticator.authenticated_patron(
                 self._db, dict(username="foo", password="bar")
             )
-        )        
+        )
 
         # OAuth doesn't work.
         problem = authenticator.authenticated_patron(
             self._db, "Bearer abcd"
         )
         eq_(UNSUPPORTED_AUTHENTICATION_MECHANISM, problem)
-        
+
     def test_authenticated_patron_oauth(self):
         patron1 = self._patron()
         patron2 = self._patron()
@@ -928,7 +928,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         token = authenticator.create_bearer_token(
             oauth1.NAME, "some token"
         )
-        
+
         # The authenticator will decode the bearer token into a
         # provider and a provider token. It will look up the oauth1
         # provider (as opposed to oauth2) and ask it to authenticate
@@ -986,7 +986,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             authenticator.get_credential_from_header(credential)
         )
 
-        
+
     def test_create_bearer_token(self):
         oauth1 = MockOAuthAuthenticationProvider(self._default_library, "oauth1")
         oauth2 = MockOAuthAuthenticationProvider(self._default_library, "oauth2")
@@ -1014,13 +1014,13 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             oauth1.NAME, "some other token"
         )
         assert token3 != token1
-        
+
         # Varying the secret used to sign the token varies the bearer
         # token.
         authenticator.bearer_token_signing_secret = "a different secret"
         token4 = authenticator.create_bearer_token(oauth1.NAME, "some token")
         assert token4 != token1
-        
+
     def test_decode_bearer_token(self):
         oauth = MockOAuthAuthenticationProvider(self._default_library, "oauth")
         authenticator = LibraryAuthenticator(
@@ -1081,7 +1081,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         from api.app import app
         self.app = app
         del os.environ['AUTOINITIALIZE']
-        
+
         # Set up configuration settings for links.
         link_config = {
             LibraryAnnotator.TERMS_OF_SERVICE: "http://terms",
@@ -1099,7 +1099,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         ConfigurationSetting.for_library(
             Configuration.LIBRARY_DESCRIPTION, library
         ).value = "Just the best."
-            
+
         # Set the URL to the library's web page.
         ConfigurationSetting.for_library(
             Configuration.WEBSITE_URL, library).value = "http://library/"
@@ -1107,7 +1107,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         # Set the color scheme a client should use.
         ConfigurationSetting.for_library(
             Configuration.COLOR_SCHEME, library).value = "plaid"
-        
+
         # Configure the various ways a patron can get help.
         ConfigurationSetting.for_library(
             Configuration.HELP_EMAIL, library).value = "help@library"
@@ -1119,10 +1119,10 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         # Set up a public key.
         ConfigurationSetting.for_library(
             Configuration.PUBLIC_KEY, library).value = "public key"
-        
+
         base_url = ConfigurationSetting.sitewide(self._db, Configuration.BASE_URL_KEY)
         base_url.value = u'http://circulation-manager/'
-       
+
         with self.app.test_request_context("/"):
             url = authenticator.authentication_document_url(library)
             assert url.endswith(
@@ -1155,7 +1155,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             # focus area and service area.
             eq_("focus area", doc["focus_area"])
             eq_("service area", doc["service_area"])
-            
+
             # We also need to test that the links got pulled in
             # from the configuration.
             (about, alternate, copyright, help_uri, help_web, help_email,
@@ -1170,7 +1170,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             eq_("http://license/", license['href'])
             eq_("image data", logo['href'])
             expect_start = url_for(
-                "index", library_short_name=self._default_library.short_name, 
+                "index", library_short_name=self._default_library.short_name,
                 _external=True
             )
             eq_(expect_start, start['href'])
@@ -1204,7 +1204,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             # The public key is correct.
             eq_("public key", doc['public_key']['value'])
             eq_("RSA", doc['public_key']['type'])
-            
+
 
             # The library's web page shows up as an HTML alternate
             # to the OPDS server.
@@ -1212,7 +1212,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
                 dict(rel="alternate", type="text/html", href="http://library/"),
                 alternate
             )
-            
+
             # Features that are enabled for this library are communicated
             # through the 'features' item.
             features = doc['features']
@@ -1240,7 +1240,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             # document.
             eq_((library, doc, url_for), annotator.called_with)
             eq_('Kilroy was here', doc['modified'])
-            
+
             # While we're in this context, let's also test
             # create_authentication_headers.
 
@@ -1335,14 +1335,14 @@ class TestAuthenticationProvider(AuthenticatorTest):
         provider = self.mock_basic(patrondata=None)
         eq_(self.mock_basic_integration,
             provider.external_integration(self._db))
-    
+
     def test_authenticated_patron_passes_on_none(self):
         provider = self.mock_basic(patrondata=None)
         patron = provider.authenticated_patron(
             self._db, self.credentials
         )
         eq_(None, patron)
-    
+
     def test_authenticated_patron_passes_on_problem_detail(self):
         provider = self.mock_basic(
             patrondata=UNSUPPORTED_AUTHENTICATION_MECHANISM
@@ -1369,7 +1369,7 @@ class TestAuthenticationProvider(AuthenticatorTest):
         )
         eq_("1", patron.external_identifier)
         eq_("2", patron.authorization_identifier)
-        
+
     def test_authenticated_patron_updates_metadata_if_necessary(self):
         patron = self._patron()
         eq_(True, PatronUtility.needs_external_sync(patron))
@@ -1391,7 +1391,7 @@ class TestAuthenticationProvider(AuthenticatorTest):
             authorization_identifier=barcode,
             username=username, complete=True
         )
-        
+
         provider = self.mock_basic(
             patrondata=incomplete_data,
             remote_patron_lookup_patrondata=complete_data
@@ -1406,13 +1406,13 @@ class TestAuthenticationProvider(AuthenticatorTest):
         # We updated their metadata.
         eq_("user", patron.username)
         eq_(barcode, patron.authorization_identifier)
-        
+
         # We did a patron lookup, which means we updated
         # .last_external_sync.
         assert patron.last_external_sync != None
         eq_(barcode, patron.authorization_identifier)
         eq_(username, patron.username)
-        
+
         # Looking up the patron a second time does not cause another
         # metadata refresh, because we just did a refresh and the
         # patron has borrowing privileges.
@@ -1424,7 +1424,7 @@ class TestAuthenticationProvider(AuthenticatorTest):
         eq_(last_sync, patron.last_external_sync)
         eq_(barcode, patron.authorization_identifier)
         eq_(username, patron.username)
-        
+
         # If we somehow authenticate with an identifier other than
         # the ones in the Patron record, we trigger another metadata
         # refresh to see if anything has changed.
@@ -1444,13 +1444,13 @@ class TestAuthenticationProvider(AuthenticatorTest):
         # refresh we get the same data as before.
         eq_(barcode, patron.authorization_identifier)
         eq_(username, patron.username)
-        
+
     def test_update_patron_metadata(self):
         patron = self._patron()
         patron.authorization_identifier="2345"
         eq_(None, patron.last_external_sync)
         eq_(None, patron.username)
-        
+
         patrondata = PatronData(username="user")
         provider = self.mock_basic(remote_patron_lookup_patrondata=patrondata)
         provider.external_type_regular_expression = re.compile("^(.)")
@@ -1458,13 +1458,13 @@ class TestAuthenticationProvider(AuthenticatorTest):
 
         # The patron's username has been changed.
         eq_("user", patron.username)
-        
+
         # last_external_sync has been updated.
         assert patron.last_external_sync != None
 
         # external_type was updated based on the regular expression
         eq_("2", patron.external_type)
-        
+
     def test_update_patron_metadata_noop_if_no_remote_metadata(self):
 
         patron = self._patron()
@@ -1495,7 +1495,7 @@ class TestAuthenticationProvider(AuthenticatorTest):
 
         class MockProvider(AuthenticationProvider):
             NAME = "Just a mock"
-        
+
         setting = ConfigurationSetting.for_library_and_externalintegration(
             self._db, MockProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION,
             library, integration
@@ -1508,11 +1508,11 @@ class TestAuthenticationProvider(AuthenticatorTest):
             patron
         )
         eq_("old value", patron.external_type)
-        
+
         setting.value = "([A-Z])"
         MockProvider(library, integration).update_patron_external_type(patron)
         eq_("A", patron.external_type)
-        
+
         setting.value = "([0-9]$)"
         MockProvider(library, integration).update_patron_external_type(patron)
         eq_("3", patron.external_type)
@@ -1563,7 +1563,7 @@ class TestAuthenticationProvider(AuthenticatorTest):
         eq_(True, m("123", re.compile("^(12|34)"), AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX))
         eq_(True, m("345", re.compile("^(12|34)"), AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX))
         eq_(False, m("abc", re.compile("^bc"), AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX))
-        
+
     def test_enforce_library_identifier_restriction_matches(self):
         """Test the enforce_library_identifier_restriction method."""
         provider = self.mock_basic()
@@ -1613,7 +1613,7 @@ class TestAuthenticationProvider(AuthenticatorTest):
 
         class MockProvider(AuthenticationProvider):
             NAME = "Just a mock"
-        
+
         string_setting = ConfigurationSetting.for_library_and_externalintegration(
             self._db, MockProvider.LIBRARY_IDENTIFIER_RESTRICTION,
             library, integration
@@ -1660,11 +1660,11 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
     def test_constructor(self):
 
         b = BasicAuthenticationProvider
-        
+
         class ConfigAuthenticationProvider(b):
             NAME = "Config loading test"
 
-        
+
         integration = self._external_integration(
             self._str, goal=ExternalIntegration.PATRON_AUTH_GOAL
         )
@@ -1692,8 +1692,8 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         eq_(b.DEFAULT_IDENTIFIER_REGULAR_EXPRESSION,
             provider.identifier_re)
         eq_(None, provider.password_re)
-        
-    
+
+
     def test_testing_patron(self):
         # You don't have to have a testing patron.
         integration = self._external_integration(self._str)
@@ -1802,7 +1802,7 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         integration.setting(b.IDENTIFIER_LABEL).value = "Your Library Card"
         integration.setting(b.PASSWORD_LABEL).value = 'Password'
         integration.setting(b.IDENTIFIER_BARCODE_FORMAT).value = 'some barcode'
-        
+
         provider = b(self._default_library, integration)
 
         eq_(b.EMAIL_ADDRESS_KEYBOARD, provider.identifier_keyboard)
@@ -1810,7 +1810,7 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         eq_("Your Library Card", provider.identifier_label)
         eq_("Password", provider.password_label)
         eq_("some barcode", provider.identifier_barcode_format)
-        
+
     def test_server_side_validation(self):
         b = BasicAuthenticationProvider
         integration = self._external_integration(self._str)
@@ -1818,7 +1818,7 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         integration.setting(b.PASSWORD_REGULAR_EXPRESSION).value = 'bar'
 
         provider = b(self._default_library, integration)
-        
+
         eq_(True, provider.server_side_validation("food", "barbecue"))
         eq_(False, provider.server_side_validation("food", "arbecue"))
         eq_(False, provider.server_side_validation("ood", "barbecue"))
@@ -1861,7 +1861,7 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         integration.setting(b.PASSWORD_MAXIMUM_LENGTH).value = "0"
         provider = b(self._default_library, integration)
         eq_(True, provider.server_side_validation("a", None))
-        
+
     def test_local_patron_lookup(self):
         # This patron of another library looks just like the patron
         # we're about to create, but will never be selected.
@@ -1880,7 +1880,7 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         patron2.authorization_identifier = "patron2_auth_id"
         patron2.username = "patron2"
         self._db.commit()
-        
+
         provider = self.mock_basic()
 
         # If we provide PatronData associated with patron1, we look up
@@ -1918,14 +1918,14 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
             None, provider.local_patron_lookup(
                 self._db, patron1.external_identifier, None
             )
-        )        
+        )
 
     def test_get_credential_from_header(self):
         provider = self.mock_basic()
         eq_(None, provider.get_credential_from_header("Bearer [some token]"))
         eq_(None, provider.get_credential_from_header(dict()))
         eq_("foo", provider.get_credential_from_header(dict(password="foo")))
-        
+
     def test_authentication_flow_document(self):
         """Test the default authentication provider document."""
         provider = self.mock_basic()
@@ -1953,14 +1953,14 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         eq_(provider.password_maximum_length,
             inputs['password']['maximum_length'])
 
-        
+
 class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
     """Test the complex BasicAuthenticationProvider.authenticate method."""
 
     # A dummy set of credentials, for use when the exact details of
     # the credentials passed in are not important.
     credentials = dict(username="user", password="pass")
-    
+
     def test_success(self):
         patron = self._patron()
         patrondata = PatronData(permanent_id=patron.external_identifier)
@@ -1971,7 +1971,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
         # looked up in the database.
         eq_(patron, provider.authenticate(self._db, self.credentials))
 
-        # All the different ways the database lookup might go are covered in 
+        # All the different ways the database lookup might go are covered in
         # test_local_patron_lookup. This test only covers the case where
         # the server sends back the permanent ID of the patron.
 
@@ -1988,7 +1988,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
         provider = self.mock_basic(patrondata=None)
         eq_(None,
             provider.authenticate(self._db, self.credentials))
-        
+
     def test_server_side_validation_runs(self):
         patron = self._patron()
         patrondata = PatronData(permanent_id=patron.external_identifier)
@@ -2011,7 +2011,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
         )
 
     def test_authentication_succeeds_but_patronlookup_fails(self):
-        """This case should never happen--it indicates a malfunctioning 
+        """This case should never happen--it indicates a malfunctioning
         authentication provider. But we handle it.
         """
         patrondata = PatronData(permanent_id=self._str)
@@ -2050,7 +2050,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
         # Information not relevant to the patron's identity was stored
         # in the Patron object after it was created.
         eq_(1, patron.fines)
-    
+
     def test_authentication_updates_outdated_patron_on_permanent_id_match(self):
         # A patron's permanent ID won't change.
         permanent_id = self._str
@@ -2062,7 +2062,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
         patron = self._patron(old_identifier)
         patron.external_identifier = permanent_id
         patron.username = old_username
-        
+
         # The authorization provider has all the new information about
         # this patron.
         new_identifier = "5678"
@@ -2096,7 +2096,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
         patron = self._patron(old_identifier)
         patron.external_identifier = None
         patron.username = username
-        
+
         # The authorization provider has all the new information about
         # this patron.
         patrondata = PatronData(
@@ -2125,7 +2125,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
         patron.external_identifier = None
         patron.authorization_identifier = identifier
         patron.username = old_username
-        
+
         # The authorization provider has all the new information about
         # this patron.
         patrondata = PatronData(
@@ -2172,12 +2172,12 @@ class TestOAuthAuthenticationProvider(AuthenticatorTest):
         eq_(20, provider.token_expiration_days)
 
     def test_get_credential_from_header(self):
-        """There is no way to get a credential from a bearer token that can 
+        """There is no way to get a credential from a bearer token that can
         be passed on to a content provider like Overdrive.
         """
         provider = MockOAuth(self._default_library)
         eq_(None, provider.get_credential_from_header("Bearer abcd"))
-            
+
     def test_create_token(self):
         patron = self._patron()
         provider = MockOAuth(self._default_library)
@@ -2195,7 +2195,7 @@ class TestOAuthAuthenticationProvider(AuthenticatorTest):
         # The token expires in twenty days.
         almost_no_time = abs(token.expires - in_twenty_days)
         assert almost_no_time.seconds < 2
-            
+
     def test_authenticated_patron_success(self):
         patron = self._patron()
         provider = MockOAuth(self._default_library)
@@ -2274,7 +2274,7 @@ class TestOAuthAuthenticationProvider(AuthenticatorTest):
         # library.
         mock_patrondata.set_authorization_identifier("abcd")
         eq_(PATRON_OF_ANOTHER_LIBRARY, oauth.oauth_callback(self._db, "a code"))
-        
+
     def test_authentication_flow_document(self):
         # We're about to call url_for, so we must create an
         # application context.
@@ -2287,7 +2287,7 @@ class TestOAuthAuthenticationProvider(AuthenticatorTest):
             doc = provider.authentication_flow_document(self._db)
             eq_(provider.FLOW_TYPE, doc['type'])
             eq_(provider.NAME, doc['description'])
-            
+
             # To authenticate with this provider, you must follow the
             # 'authenticate' link.
             [link] = [x for x in doc['links'] if x['rel'] == 'authenticate']
@@ -2317,13 +2317,13 @@ class TestOAuthAuthenticationProvider(AuthenticatorTest):
         from api.app import app
         del os.environ['AUTOINITIALIZE']
 
-        with app.test_request_context("/"):        
+        with app.test_request_context("/"):
             params = my_api.external_authenticate_url_parameters("state", self._db)
             eq_("state", params['state'])
             eq_("clientid", params['client_id'])
             expected_url = url_for("oauth_callback", library_short_name=self._default_library.short_name, _external=True)
             eq_(expected_url, params['oauth_callback_url'])
-        
+
 class TestOAuthController(AuthenticatorTest):
 
     def setup(self):
@@ -2339,13 +2339,13 @@ class TestOAuthController(AuthenticatorTest):
                     _db, self.patron, "a token"
                 )
                 self.patrondata = PatronData(personal_name="Abcd")
-                
+
             def external_authenticate_url(self, state, _db):
                 return self.url + "?state=" + state
 
             def oauth_callback(self, _db, params):
                 return self.token, self.patron, self.patrondata
-            
+
         patron = self._patron()
         self.basic = self.mock_basic()
         self.oauth1 = MockOAuthWithExternalAuthenticateURL(
@@ -2366,13 +2366,13 @@ class TestOAuthController(AuthenticatorTest):
         )
 
         self.auth = MockAuthenticator(
-            self._default_library, 
-            { 
+            self._default_library,
+            {
                 self._default_library.short_name : self.library_auth
             }
         )
         self.controller = OAuthController(self.auth)
-    
+
     def test_oauth_authentication_redirect(self):
         """Test the controller method that sends patrons off to the OAuth
         provider, where they're supposed to log in.
@@ -2408,7 +2408,7 @@ class TestOAuthController(AuthenticatorTest):
         """Test the controller method that the OAuth provider is supposed
         to send patrons to once they log in on the remote side.
         """
-        
+
         # Successful callback through OAuth provider 1.
         params = dict(code="foo", state=json.dumps(dict(provider=self.oauth1.NAME)))
         response = self.controller.oauth_authentication_callback(self._db, params)
@@ -2418,7 +2418,7 @@ class TestOAuthController(AuthenticatorTest):
         provider_name, provider_token = self.auth.decode_bearer_token(token)
         eq_(self.oauth1.NAME, provider_name)
         eq_(self.oauth1.token.credential, provider_token)
-        
+
         # Successful callback through OAuth provider 2.
         params = dict(code="foo", state=json.dumps(dict(provider=self.oauth2.NAME)))
         response = self.controller.oauth_authentication_callback(self._db, params)
@@ -2428,7 +2428,7 @@ class TestOAuthController(AuthenticatorTest):
         provider_name, provider_token = self.auth.decode_bearer_token(token)
         eq_(self.oauth2.NAME, provider_name)
         eq_(self.oauth2.token.credential, provider_token)
-            
+
         # State is missing so we never get to check the code.
         params = dict(code="foo")
         response = self.controller.oauth_authentication_callback(self._db, params)

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -2,7 +2,7 @@ import datetime
 from lxml import etree
 from StringIO import StringIO
 from nose.tools import (
-    eq_, 
+    eq_,
     assert_raises,
     assert_raises_regexp,
     set_trace,
@@ -73,7 +73,7 @@ class Axis360Test(DatabaseTest):
     def sample_data(self, filename):
         return sample_data(filename, 'axis')
 
-        
+
 class TestAxis360API(Axis360Test):
 
     def test_external_integration(self):
@@ -369,8 +369,8 @@ class TestCirculationMonitor(Axis360Test):
     BIBLIOGRAPHIC_DATA = Metadata(
         DataSource.AXIS_360,
         publisher=u'Random House Inc',
-        language='eng', 
-        title=u'Faith of My Fathers : A Family Memoir', 
+        language='eng',
+        title=u'Faith of My Fathers : A Family Memoir',
         imprint=u'Random House Inc2',
         published=datetime.datetime(2000, 3, 7, 0, 0),
         primary_identifier=IdentifierData(
@@ -381,10 +381,10 @@ class TestCirculationMonitor(Axis360Test):
             IdentifierData(type=Identifier.ISBN, identifier=u'9780375504587')
         ],
         contributors = [
-            ContributorData(sort_name=u"McCain, John", 
+            ContributorData(sort_name=u"McCain, John",
                             roles=[Contributor.PRIMARY_AUTHOR_ROLE]
                         ),
-            ContributorData(sort_name=u"Salter, Mark", 
+            ContributorData(sort_name=u"Salter, Mark",
                             roles=[Contributor.AUTHOR_ROLE]
                         ),
         ],
@@ -398,7 +398,7 @@ class TestCirculationMonitor(Axis360Test):
 
     AVAILABILITY_DATA = CirculationData(
         data_source=DataSource.AXIS_360,
-        primary_identifier=BIBLIOGRAPHIC_DATA.primary_identifier, 
+        primary_identifier=BIBLIOGRAPHIC_DATA.primary_identifier,
         licenses_owned=9,
         licenses_available=8,
         licenses_reserved=0,
@@ -431,7 +431,7 @@ class TestCirculationMonitor(Axis360Test):
         eq_(Identifier.ISBN, isbn.type)
         eq_(u'9780375504587', isbn.identifier)
 
-        eq_(["McCain, John", "Salter, Mark"], 
+        eq_(["McCain, John", "Salter, Mark"],
             sorted([x.sort_name for x in edition.contributors]),
         )
 
@@ -439,7 +439,7 @@ class TestCirculationMonitor(Axis360Test):
             (x.subject.type, x.subject.identifier)
             for x in edition.primary_identifier.classifications
         )
-        eq_([(Subject.BISAC, u'BIOGRAPHY & AUTOBIOGRAPHY / Political'), 
+        eq_([(Subject.BISAC, u'BIOGRAPHY & AUTOBIOGRAPHY / Political'),
              (Subject.FREEFORM_AUDIENCE, u'Adult')], subs)
 
         eq_(9, license_pool.licenses_owned)
@@ -450,7 +450,7 @@ class TestCirculationMonitor(Axis360Test):
         # Three circulation events were created, backdated to the
         # last_checked date of the license pool.
         events = license_pool.circulation_events
-        eq_([u'distributor_title_add', u'distributor_check_in', u'distributor_license_add'], 
+        eq_([u'distributor_title_add', u'distributor_check_in', u'distributor_license_add'],
             [x.type for x in events])
         for e in events:
             eq_(e.start, license_pool.last_checked)
@@ -516,20 +516,20 @@ class TestResponseParser(object):
     def setup(self):
         # We don't need an actual Collection object to test this
         # class, but we do need to test that whatever object we
-        # _claim_ is a Collection will have its id put into the 
+        # _claim_ is a Collection will have its id put into the
         # right spot of HoldInfo and LoanInfo objects.
         class MockCollection(object):
             pass
         self._default_collection = MockCollection()
         self._default_collection.id = object()
-    
+
 class TestRaiseExceptionOnError(TestResponseParser):
 
     def test_internal_server_error(self):
         data = self.sample_data("internal_server_error.xml")
         parser = HoldReleaseResponseParser(None)
         assert_raises_regexp(
-            RemoteInitiatedServerError, "Internal Server Error", 
+            RemoteInitiatedServerError, "Internal Server Error",
             parser.process_all, data
         )
 
@@ -537,7 +537,7 @@ class TestRaiseExceptionOnError(TestResponseParser):
         data = self.sample_data("invalid_error_code.xml")
         parser = HoldReleaseResponseParser(None)
         assert_raises_regexp(
-            RemoteInitiatedServerError, "Invalid response code from Axis 360: abcd", 
+            RemoteInitiatedServerError, "Invalid response code from Axis 360: abcd",
             parser.process_all, data
         )
 
@@ -545,7 +545,7 @@ class TestRaiseExceptionOnError(TestResponseParser):
         data = self.sample_data("missing_error_code.xml")
         parser = HoldReleaseResponseParser(None)
         assert_raises_regexp(
-            RemoteInitiatedServerError, "No status code!", 
+            RemoteInitiatedServerError, "No status code!",
             parser.process_all, data
         )
 
@@ -560,11 +560,11 @@ class TestCheckoutResponseParser(TestResponseParser):
         eq_(self._default_collection.id, parsed.collection_id)
         eq_(DataSource.AXIS_360, parsed.data_source_name)
         eq_(Identifier.AXIS_360_ID, parsed.identifier_type)
-        eq_(datetime.datetime(2015, 8, 11, 18, 57, 42), 
+        eq_(datetime.datetime(2015, 8, 11, 18, 57, 42),
             parsed.end_date)
 
         assert isinstance(parsed.fulfillment_info, FulfillmentInfo)
-        eq_("http://axis360api.baker-taylor.com/Services/VendorAPI/GetAxisDownload/v2?blahblah", 
+        eq_("http://axis360api.baker-taylor.com/Services/VendorAPI/GetAxisDownload/v2?blahblah",
             parsed.fulfillment_info.content_link)
 
 
@@ -590,7 +590,7 @@ class TestHoldResponseParser(TestResponseParser):
         # The HoldInfo is given the Collection object we passed into
         # the HoldResponseParser.
         eq_(self._default_collection.id, parsed.collection_id)
-        
+
     def test_parse_already_on_hold(self):
         data = self.sample_data("already_on_hold.xml")
         parser = HoldResponseParser(None)

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 from nose.tools import (
-    set_trace, 
+    set_trace,
     eq_,
     assert_raises,
 )
@@ -71,7 +71,7 @@ class BibliothecaAPITest(DatabaseTest):
     def sample_data(self, filename):
         return sample_data(filename, 'bibliotheca')
 
-class TestBibliothecaAPI(BibliothecaAPITest):      
+class TestBibliothecaAPI(BibliothecaAPITest):
 
     def test_external_integration(self):
         eq_(
@@ -285,7 +285,7 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         eq_(0, h2.position)
 
     def test_place_hold(self):
-        patron = self._patron()        
+        patron = self._patron()
         edition, pool = self._edition(with_license_pool=True)
         self.api.queue_response(200, content=self.sample_data("successful_hold.xml"))
         response = self.api.place_hold(patron, 'pin', pool)
@@ -293,7 +293,7 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         eq_(pool.identifier.identifier, response.identifier)
 
     def test_place_hold_fails_if_exceeded_hold_limit(self):
-        patron = self._patron()        
+        patron = self._patron()
         edition, pool = self._edition(with_license_pool=True)
         self.api.queue_response(400, content=self.sample_data("error_exceeded_hold_limit.xml"))
         assert_raises(PatronHoldLimitReached, self.api.place_hold,
@@ -425,7 +425,7 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         eq_(u'1234567890987654321ababa', encrypted[u'findaway:licenseId'])
         eq_(u'3M', encrypted[u'findaway:accountId'])
         eq_(u'123456', encrypted[u'findaway:fulfillmentId'])
-        eq_(u'aaaaaaaa-4444-cccc-dddd-666666666666', 
+        eq_(u'aaaaaaaa-4444-cccc-dddd-666666666666',
             encrypted[u'findaway:sessionKey'])
 
         # Every entry in the license document's 'items' list has
@@ -486,13 +486,13 @@ class TestBibliothecaCirculationSweep(BibliothecaAPITest):
             self._db, self.collection, api_class=self.api
         )
         monitor.process_items([identifier])
-        
+
         # A LicensePool has been created for the previously mysterious
         # identifier.
         [pool] = identifier.licensed_through
         eq_(self.collection, pool.collection)
         eq_(False, pool.open_access)
-        
+
         # Three circulation events were created for this license pool,
         # marking the creation of the license pool, the addition of
         # licenses owned, and the making of those licenses available.
@@ -608,7 +608,7 @@ class TestErrorParser(BibliothecaAPITest):
             u'the patron document status was CAN_WISH and not one of CAN_LOAN,RESERVATION',
             error.message
         )
-        
+
         problem = error.as_problem_detail_document()
         eq_("The library currently has no licenses for this book.",
             problem.detail)
@@ -905,7 +905,7 @@ class TestBibliothecaEventMonitor(BibliothecaAPITest):
         monitor = BibliothecaEventMonitor(
             self._db, self.collection, api_class=api
         )
-        now = datetime.datetime.utcnow() 
+        now = datetime.datetime.utcnow()
         yesterday = now - datetime.timedelta(days=1)
 
         new_timestamp = monitor.run_once(yesterday, now)

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -12,7 +12,7 @@ from api.config import (
 )
 
 from datetime import (
-    datetime, 
+    datetime,
     timedelta,
 )
 
@@ -51,8 +51,8 @@ class TestCirculationAPI(DatabaseTest):
 
     YESTERDAY = datetime.utcnow() - timedelta(days=1)
     TODAY = datetime.utcnow()
-    TOMORROW = datetime.utcnow() + timedelta(days=1) 
-    IN_TWO_WEEKS = datetime.utcnow() + timedelta(days=14) 
+    TOMORROW = datetime.utcnow() + timedelta(days=1)
+    IN_TWO_WEEKS = datetime.utcnow() + timedelta(days=14)
 
     def setup(self):
         super(TestCirculationAPI, self).setup()
@@ -109,7 +109,7 @@ class TestCirculationAPI(DatabaseTest):
         eq_(1, self.analytics.count)
         eq_(CirculationEvent.CM_CHECKOUT,
             self.analytics.event_type)
-            
+
         # Try to 'borrow' the same book again.
         self.remote.queue_checkout(AlreadyCheckedOut())
         loan, hold, is_new = self.borrow()
@@ -119,7 +119,7 @@ class TestCirculationAPI(DatabaseTest):
         # Since the loan already existed, no new analytics event was
         # sent.
         eq_(1, self.analytics.count)
-            
+
         # Now try to renew the book.
         self.remote.queue_checkout(loaninfo)
         loan, hold, is_new = self.borrow()
@@ -135,7 +135,7 @@ class TestCirculationAPI(DatabaseTest):
         self.remote.queue_checkout(loaninfo)
         loan, hold, is_new = self.borrow()
         eq_(3, self.analytics.count)
-            
+
     def test_attempt_borrow_with_existing_remote_loan(self):
         """The patron has a remote loan that the circ manager doesn't know
         about, and they just tried to borrow a book they already have
@@ -194,13 +194,13 @@ class TestCirculationAPI(DatabaseTest):
         assert abs((hold.start-now).seconds) < 2
         eq_(None, hold.end)
         eq_(None, hold.position)
-        
+
     def test_attempt_premature_renew_with_local_loan(self):
         """We have a local loan and a remote loan but the patron tried to
         borrow again -- probably to renew their loan.
         """
         # Local loan.
-        loan, ignore = self.pool.loan_to(self.patron)        
+        loan, ignore = self.pool.loan_to(self.patron)
 
         # Remote loan.
         self.circulation.add_remote_loan(
@@ -219,7 +219,7 @@ class TestCirculationAPI(DatabaseTest):
         borrow again -- probably to renew their loan.
         """
         # Local loan.
-        loan, ignore = self.pool.loan_to(self.patron)        
+        loan, ignore = self.pool.loan_to(self.patron)
 
         # Remote loan.
         self.circulation.add_remote_loan(
@@ -232,11 +232,11 @@ class TestCirculationAPI(DatabaseTest):
         # waiting in line for the book. This case gives a more
         # specific error message.
         #
-        # Contrast with the way NoAvailableCopies is handled in 
+        # Contrast with the way NoAvailableCopies is handled in
         # test_loan_becomes_hold_if_no_available_copies.
         self.remote.queue_checkout(NoAvailableCopies())
         assert_raises_regexp(
-            CannotRenew, 
+            CannotRenew,
             "You cannot renew a loan if other patrons have the work on hold.",
             self.borrow
         )
@@ -299,7 +299,7 @@ class TestCirculationAPI(DatabaseTest):
         eq_(1, self.analytics.count)
         eq_(CirculationEvent.CM_HOLD_PLACE,
             self.analytics.event_type)
-        
+
         # Try to 'borrow' the same book again.
         self.remote.queue_checkout(AlreadyOnHold())
         loan, hold, is_new = self.borrow()
@@ -308,10 +308,10 @@ class TestCirculationAPI(DatabaseTest):
         # Since the hold already existed, no new analytics event was
         # sent.
         eq_(1, self.analytics.count)
-            
+
     def test_loan_becomes_hold_if_no_available_copies_and_preexisting_loan(self):
         # Once upon a time, we had a loan for this book.
-        loan, ignore = self.pool.loan_to(self.patron)        
+        loan, ignore = self.pool.loan_to(self.patron)
         loan.start = self.YESTERDAY
 
         # But no longer! What's more, other patrons have taken all the
@@ -395,7 +395,7 @@ class TestCirculationAPI(DatabaseTest):
         self.patron.block_reason = "some reason"
         assert_raises(AuthorizationBlocked, self.borrow)
         self.patron.block_reason = None
-        
+
     def test_no_licenses_prompts_availability_update(self):
         # Once the library offered licenses for this book, but
         # the licenses just expired.
@@ -510,7 +510,7 @@ class TestCirculationAPI(DatabaseTest):
         self.pool.loan_to(self.patron)
 
         # It has a LicensePoolDeliveryMechanism that is broken (has no
-        # associated Resource).  
+        # associated Resource).
         broken_lpdm = self.delivery_mechanism
         eq_(None, broken_lpdm.resource)
         i_want_an_epub = broken_lpdm.delivery_mechanism
@@ -532,7 +532,7 @@ class TestCirculationAPI(DatabaseTest):
             Hyperlink.OPEN_ACCESS_DOWNLOAD, self._url,
             self.pool.data_source
         )
-        
+
         working_lpdm = self.pool.set_delivery_mechanism(
             i_want_an_epub.content_type,
             i_want_an_epub.drm_scheme,
@@ -545,14 +545,14 @@ class TestCirculationAPI(DatabaseTest):
         eq_(None, link.resource.representation)
         assert_raises(FormatNotAvailable, self.circulation.fulfill_open_access,
                       self.pool, i_want_an_epub)
-        
+
         # Let's add a Representation to the Resource.
         representation, is_new = self._representation(
             link.resource.url, i_want_an_epub.content_type,
             "Dummy content", mirrored=True
         )
         link.resource.representation = representation
-        
+
         # We can finally fulfill a loan.
         result = self.circulation.fulfill_open_access(
             self.pool, broken_lpdm
@@ -570,7 +570,7 @@ class TestCirculationAPI(DatabaseTest):
         assert isinstance(result, FulfillmentInfo)
         eq_(result.content_link, link.resource.representation.public_url)
         eq_(result.content_type, i_want_an_epub.content_type)
-        
+
         # We get the right result even if the code calling
         # fulfill_open_access() is incorrectly written and passes in
         # the broken LicensePoolDeliveryMechanism (as opposed to its
@@ -635,7 +635,7 @@ class TestCirculationAPI(DatabaseTest):
         self.circulation.can_fulfill_without_loan = yes_we_can
         result = try_to_fulfill()
         eq_(fulfillment, result)
-            
+
     def test_revoke_loan_sends_analytics_event(self):
         self.pool.loan_to(self.patron)
         self.remote.queue_checkin(True)
@@ -661,7 +661,7 @@ class TestCirculationAPI(DatabaseTest):
         eq_(1, self.analytics.count)
         eq_(CirculationEvent.CM_HOLD_RELEASE,
             self.analytics.event_type)
-            
+
     def test_sync_bookshelf_ignores_local_loan_with_no_identifier(self):
         loan, ignore = self.pool.loan_to(self.patron)
         loan.start = self.YESTERDAY
@@ -679,7 +679,7 @@ class TestCirculationAPI(DatabaseTest):
 
         # But we can still sync without crashing.
         self.sync_bookshelf()
-        
+
     def test_sync_bookshelf_ignores_local_hold_with_no_identifier(self):
         hold, ignore = self.pool.on_hold_to(self.patron)
         self.pool.identifier = None
@@ -696,7 +696,7 @@ class TestCirculationAPI(DatabaseTest):
 
         # But we can still sync without crashing.
         self.sync_bookshelf()
-        
+
     def test_sync_bookshelf_with_old_local_loan_and_no_remote_loan_deletes_local_loan(self):
         # Local loan that was created yesterday.
         loan, ignore = self.pool.loan_to(self.patron)
@@ -705,13 +705,13 @@ class TestCirculationAPI(DatabaseTest):
         # The loan is in the db.
         loans = self._db.query(Loan).all()
         eq_([loan], loans)
-        
+
         self.sync_bookshelf()
 
         # Now the local loan is gone.
         loans = self._db.query(Loan).all()
         eq_([], loans)
-        
+
     def test_sync_bookshelf_with_new_local_loan_and_no_remote_loan_keeps_local_loan(self):
         # Local loan that was just created.
         loan, ignore = self.pool.loan_to(self.patron)
@@ -720,7 +720,7 @@ class TestCirculationAPI(DatabaseTest):
         # The loan is in the db.
         loans = self._db.query(Loan).all()
         eq_([loan], loans)
-        
+
         self.sync_bookshelf()
 
         # The loan is still in the db, since it was just created.
@@ -762,7 +762,7 @@ class TestCirculationAPI(DatabaseTest):
         # Now the loan is gone.
         loans = self._db.query(Loan).all()
         eq_([], loans)
-        
+
     def test_sync_bookshelf_updates_local_loan_and_hold_with_modified_timestamps(self):
         # We have a local loan that supposedly runs from yesterday
         # until tomorrow.
@@ -788,7 +788,7 @@ class TestCirculationAPI(DatabaseTest):
         hold.start = self.YESTERDAY
         hold.end = self.TOMORROW
         hold.position = 10
-        
+
         self.circulation.add_remote_hold(
             pool2.collection, pool2.data_source, pool2.identifier.type,
             pool2.identifier.identifier, self.TODAY, self.IN_TWO_WEEKS,
@@ -832,7 +832,7 @@ class TestCirculationAPI(DatabaseTest):
         # ... and (once we commit) with the LicensePool.
         self._db.commit()
         assert loan.fulfillment in pool.delivery_mechanisms
-        
+
     def test_patron_activity(self):
         # Get a CirculationAPI that doesn't mock out its API's patron activity.
         circulation = CirculationAPI(
@@ -854,7 +854,7 @@ class TestCirculationAPI(DatabaseTest):
         loans, holds, complete = circulation.patron_activity(self.patron, "1234")
         eq_(0, len(loans))
         eq_(0, len(holds))
-        eq_(False, complete)        
+        eq_(False, complete)
 
     def test_can_fulfill_without_loan(self):
         """Can a title can be fulfilled without an active loan?  It depends on
@@ -912,7 +912,7 @@ class TestDeliveryMechanismInfo(DatabaseTest):
         patron = self._patron()
         loan, ignore = pool.loan_to(patron)
 
-        # When consulting with the source of the loan, we learn that 
+        # When consulting with the source of the loan, we learn that
         # the patron has locked the delivery mechanism to a previously
         # unknown mechanism.
         info = DeliveryMechanismInfo(
@@ -956,7 +956,7 @@ class TestDeliveryMechanismInfo(DatabaseTest):
             if lpdm.delivery_mechanism not in (mechanism, new_mechanism)
         ]
         eq_(oa_lpdm, loan.fulfillment)
-        
+
         # The correct resource and rights status have been associated
         # with the new LicensePoolDeliveryMechanism.
         eq_(RightsStatus.CC0, oa_lpdm.rights_status.uri)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,7 @@ class TestConfiguration(DatabaseTest):
         # holdings.
         large_setting = ConfigurationSetting.for_library(
             C.LARGE_COLLECTION_LANGUAGES, library
-        ) 
+        )
         eq_(["eng"], large_setting.json_value)
         eq_([], ConfigurationSetting.for_library(
             C.SMALL_COLLECTION_LANGUAGES, library).json_value)
@@ -44,7 +44,7 @@ class TestConfiguration(DatabaseTest):
         # We can change these values.
         large_setting.value = json.dumps(["spa", "jpn"])
         eq_(["spa", "jpn"], C.large_collection_languages(library))
-        
+
         # If we enter an invalid value, or a value that's not a list,
         # the estimate is re-calculated the next time we look.
         large_setting.value = "this isn't json"
@@ -52,7 +52,7 @@ class TestConfiguration(DatabaseTest):
 
         large_setting.value = '"this is json but it\'s not a list"'
         eq_(["eng"], C.large_collection_languages(library))
-        
+
     def test_estimate_language_collection_for_library(self):
 
         library = self._default_library
@@ -76,11 +76,11 @@ class TestConfiguration(DatabaseTest):
         eq_(["eng"], ConfigurationSetting.for_library(
             Configuration.LARGE_COLLECTION_LANGUAGES, library
         ).json_value)
-        
+
         eq_([], ConfigurationSetting.for_library(
             Configuration.SMALL_COLLECTION_LANGUAGES, library
         ).json_value)
-            
+
         eq_([], ConfigurationSetting.for_library(
             Configuration.TINY_COLLECTION_LANGUAGES, library
         ).json_value)
@@ -88,7 +88,7 @@ class TestConfiguration(DatabaseTest):
     def test_classify_holdings(self):
 
         m = Configuration.classify_holdings
-        
+
         # If there are no titles in the collection at all, we assume
         # there will eventually be a large English collection.
         eq_([["eng"], [], []], m(Counter()))
@@ -105,4 +105,4 @@ class TestConfiguration(DatabaseTest):
                                   nav=6, ukr=4000, ira=1500)
         eq_([['fre', 'jpn'], ['spa', 'ukr', 'ira'], ['nav']],
             m(different_sizes))
-        
+

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -62,7 +62,7 @@ from api.coverage import (
 
 class TestImporterSubclasses(DatabaseTest):
     """Test the subclasses of OPDSImporter."""
-    
+
     def test_success_status_codes(self):
         """Validate the status codes that different importers
         will treat as successes.
@@ -97,11 +97,11 @@ class TestOPDSImportCoverageProvider(DatabaseTest):
         """
 
         # Unlike other tests in this class, we are using a real
-        # implementation of OPDSImportCoverageProvider.process_batch.        
+        # implementation of OPDSImportCoverageProvider.process_batch.
         class TestProvider(OPDSImportCoverageProvider):
             SERVICE_NAME = "Test provider"
             DATA_SOURCE_NAME = DataSource.OA_CONTENT_SERVER
-            
+
             # Mock the identifier mapping
             def create_identifier_mapping(self, batch):
                 return self.mapping
@@ -159,7 +159,7 @@ class TestOPDSImportCoverageProvider(DatabaseTest):
         # problem: the LicensePool will show up in the results, but
         # the corresponding Edition will not.
         edition2, pool2 = self._edition(with_license_pool=True)
-        
+
         # Here's an identifier that can't be looked up at all,
         # and an identifier that shows up in messages_by_id because
         # its simplified:message was determined to indicate success
@@ -183,17 +183,17 @@ class TestOPDSImportCoverageProvider(DatabaseTest):
 
         # Make the CoverageProvider do its thing.
         fake_batch = [object()]
-        (success_import, failure_mismatched, failure_message, 
+        (success_import, failure_mismatched, failure_message,
          success_message) = provider.process_batch(
             fake_batch
         )
-        
+
         # The fake batch was provided to lookup_and_import_batch.
         eq_([fake_batch], provider.batches)
 
         # The matched Edition/LicensePool pair was returned.
         eq_(success_import, edition.primary_identifier)
-        
+
         # The LicensePool of that pair was passed into finalize_license_pool.
         # The mismatched LicensePool was not.
         eq_([pool], provider.finalized)
@@ -205,7 +205,7 @@ class TestOPDSImportCoverageProvider(DatabaseTest):
             failure_mismatched.exception)
         eq_(pool2.identifier, failure_mismatched.obj)
         eq_(True, failure_mismatched.transient)
-        
+
         # The OPDSMessage with status code 500 was returned as a
         # CoverageFailure object.
         assert isinstance(failure_message, CoverageFailure)
@@ -216,7 +216,7 @@ class TestOPDSImportCoverageProvider(DatabaseTest):
         # The identifier that had a treat-as-success OPDSMessage was returned
         # as-is.
         eq_(not_an_error_identifier, success_message)
-        
+
     def test_process_batch_success_even_if_no_licensepool_exists(self):
         """This shouldn't happen since CollectionCoverageProvider
         only operates on Identifiers that are licensed through a Collection.
@@ -249,7 +249,7 @@ class TestOPDSImportCoverageProvider(DatabaseTest):
         eq_([[item]], provider.batches)
 
     def test_import_feed_response(self):
-        """Verify that import_feed_response instantiates the 
+        """Verify that import_feed_response instantiates the
         OPDS_IMPORTER_CLASS subclass and calls import_from_feed
         on it.
         """
@@ -261,7 +261,7 @@ class TestOPDSImportCoverageProvider(DatabaseTest):
                 right values.
                 """
                 return (
-                    text, self.collection, 
+                    text, self.collection,
                     self.identifier_mapping, self.data_source_name
                 )
 
@@ -275,13 +275,13 @@ class TestOPDSImportCoverageProvider(DatabaseTest):
             200, {'content-type': OPDSFeed.ACQUISITION_FEED_TYPE}, "some data"
         )
         id_mapping = object()
-        (text, collection, mapping, 
+        (text, collection, mapping,
          data_source_name) = provider.import_feed_response(response, id_mapping)
         eq_("some data", text)
         eq_(provider.collection, collection)
         eq_(id_mapping, mapping)
         eq_(provider.data_source.name, data_source_name)
-            
+
 
 class MetadataWranglerCoverageProviderTest(DatabaseTest):
 
@@ -359,7 +359,7 @@ class TestBaseMetadataWranglerCoverageProvider(MetadataWranglerCoverageProviderT
                 Identifier.AXIS_360_ID,
                 Identifier.ONECLICK_ID,
                 Identifier.URI,
-            ]), 
+            ]),
             set(BaseMetadataWranglerCoverageProvider.INPUT_IDENTIFIER_TYPES)
         )
 
@@ -450,7 +450,7 @@ class TestMetadataWranglerCollectionRegistrar(MetadataWranglerCoverageProviderTe
         id1 = self._identifier()
         id2 = self._identifier()
         assert_raises_regexp(
-            BadResponseException, 'Wrong media type', 
+            BadResponseException, 'Wrong media type',
             self.provider.process_batch, [id1, id2]
         )
         eq_([], id1.coverage_records)
@@ -462,7 +462,7 @@ class TestMetadataWranglerCollectionRegistrar(MetadataWranglerCoverageProviderTe
             'Internal Server Error'
         )
         assert_raises_regexp(
-            BadResponseException, "Got status code 500", 
+            BadResponseException, "Got status code 500",
             self.provider.process_batch, [id1, id2]
         )
         eq_([], id1.coverage_records)
@@ -513,11 +513,11 @@ class TestMetadataWranglerCollectionRegistrar(MetadataWranglerCoverageProviderTe
         # This identifier was reaped...
         cr = self._coverage_record(
             pool.identifier, self.provider.data_source,
-            operation=CoverageRecord.REAP_OPERATION, 
+            operation=CoverageRecord.REAP_OPERATION,
             collection=self.collection
         )
         eq_(
-            set(original_coverage_records + [cr]), 
+            set(original_coverage_records + [cr]),
             set(identifier.coverage_records)
         )
 
@@ -545,7 +545,7 @@ class TestMetadataWranglerCollectionRegistrar(MetadataWranglerCoverageProviderTe
         # Adding coverage for an irrelevant collection won't fix that.
         cr = self._coverage_record(
             pool.identifier, self.provider.data_source,
-            operation=self.provider.OPERATION, 
+            operation=self.provider.OPERATION,
             collection=other_collection
         )
         eq_([identifier], qu.all())
@@ -553,7 +553,7 @@ class TestMetadataWranglerCollectionRegistrar(MetadataWranglerCoverageProviderTe
         # Adding coverage for the relevant collection will.
         cr = self._coverage_record(
             pool.identifier, self.provider.data_source,
-            operation=self.provider.OPERATION, 
+            operation=self.provider.OPERATION,
             collection=self.provider.collection
         )
         eq_([], qu.all())
@@ -574,7 +574,7 @@ class TestMetadataWranglerCollectionRegistrar(MetadataWranglerCoverageProviderTe
         # from self.provider.collection.
         cr = self._coverage_record(
             pool.identifier, self.provider.data_source,
-            operation=CoverageRecord.REAP_OPERATION, 
+            operation=CoverageRecord.REAP_OPERATION,
             collection=other_collection
         )
 
@@ -610,7 +610,7 @@ class TestMetadataWranglerCollectionRegistrar(MetadataWranglerCoverageProviderTe
         )
 
         # The book starts showing up in items_that_need_coverage.
-        eq_([pool.identifier], 
+        eq_([pool.identifier],
             provider_with_cutoff.items_that_need_coverage().all())
 
     def test_items_that_need_coverage_respects_count_as_covered(self):
@@ -620,12 +620,12 @@ class TestMetadataWranglerCollectionRegistrar(MetadataWranglerCoverageProviderTe
             identifier_type=Identifier.OVERDRIVE_ID,
         )
         cr = self._coverage_record(
-            pool.identifier, self.provider.data_source, 
+            pool.identifier, self.provider.data_source,
             operation=self.provider.operation,
             status=CoverageRecord.TRANSIENT_FAILURE,
             collection=self.collection
         )
-        
+
         # Ordinarily, a transient failure does not count as coverage.
         [needs_coverage] = self.provider.items_that_need_coverage().all()
         eq_(needs_coverage, pool.identifier)
@@ -842,7 +842,7 @@ class TestMetadataUploadCoverageProvider(DatabaseTest):
         # We don't have a CoverageRecord yet, so the book doesn't show up.
         items = self.provider.items_that_need_coverage().all()
         eq_([], items)
-        
+
         cr = self._coverage_record(
             pool.identifier, self.provider.data_source,
             operation=self.provider.OPERATION, collection=self.collection

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -233,7 +233,7 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
             FeedbooksOPDSImporter.REPLACEMENT_CSS_KEY : "http://css/"
         }
 
-        # The very first request made is going to be to the 
+        # The very first request made is going to be to the
         # REPLACEMENT_CSS_KEY URL.
         self.http.queue_response(
             200, content="Some new CSS", media_type="text/css",

--- a/tests/test_firstbook.py
+++ b/tests/test_firstbook.py
@@ -27,7 +27,7 @@ from core.model import ExternalIntegration
 
 
 class TestFirstBook(DatabaseTest):
-    
+
     def setup(self):
         super(TestFirstBook, self).setup()
         self.integration = self._external_integration(
@@ -40,7 +40,7 @@ class TestFirstBook(DatabaseTest):
             self._default_library, self.integration,
             *args, **kwargs
         )
-        
+
     def test_from_config(self):
         api = None
         integration = self._external_integration(self._str)
@@ -61,7 +61,7 @@ class TestFirstBook(DatabaseTest):
         integration.url = "http://example.com/?foo=bar"
         api = FirstBookAuthenticationAPI(self._default_library, integration)
         eq_('http://example.com/?foo=bar&key=the_key', api.root)
-        
+
     def test_authentication_success(self):
         eq_(True, self.api.remote_pin_test("ABCD", "1234"))
 
@@ -72,7 +72,7 @@ class TestFirstBook(DatabaseTest):
         # credentials are uppercased in remote_authenticate;
         # remote_pin_test just passes on whatever it's sent.
         eq_(False, self.api.remote_pin_test("abcd", "9999"))
-        
+
     def test_remote_authenticate(self):
         patrondata = self.api.remote_authenticate("abcd", "1234")
         eq_("ABCD", patrondata.permanent_id)
@@ -88,19 +88,19 @@ class TestFirstBook(DatabaseTest):
     def test_broken_service_remote_pin_test(self):
         api = self.mock_api(failure_status_code=502)
         assert_raises_regexp(
-            RemoteInitiatedServerError, 
+            RemoteInitiatedServerError,
             "Got unexpected response code 502. Content: Error 502",
             api.remote_pin_test, "key", "pin"
         )
-    
+
     def test_bad_connection_remote_pin_test(self):
         api = self.mock_api(bad_connection=True)
         assert_raises_regexp(
-            RemoteInitiatedServerError, 
+            RemoteInitiatedServerError,
             "Could not connect!",
             api.remote_pin_test, "key", "pin"
         )
-    
+
     def test_authentication_flow_document(self):
         doc = self.api.authentication_flow_document(self._db)
         eq_(self.api.DISPLAY_NAME, doc['description'])

--- a/tests/test_google_analytics_provider.py
+++ b/tests/test_google_analytics_provider.py
@@ -77,7 +77,7 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
 
         work = self._work(
             title=u"pi\u00F1ata", authors=u"chlo\u00E9", fiction=True,
-            audience="audience", language="lang", 
+            audience="audience", language="lang",
             with_license_pool=True, genre="Folklore",
             with_open_access_download=True
         )
@@ -124,7 +124,7 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
         identifier = self._identifier()
         source = DataSource.lookup(self._db, DataSource.GUTENBERG)
         pool, is_new = get_one_or_create(
-            self._db, LicensePool, 
+            self._db, LicensePool,
             identifier=identifier, data_source=source,
             collection=self._default_collection
         )

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -62,7 +62,7 @@ class TestLaneCreation(DatabaseTest):
         # We have five top-level lanes.
         eq_(5, len(lanes))
         eq_(
-            ['Fiction', 'Nonfiction', 'Young Adult Fiction', 
+            ['Fiction', 'Nonfiction', 'Young Adult Fiction',
              'Young Adult Nonfiction', 'Children and Middle Grade'],
             [x.display_name for x in lanes]
         )
@@ -80,7 +80,7 @@ class TestLaneCreation(DatabaseTest):
              'Young Adult Nonfiction', 'Children and Middle Grade'],
             [x.display_name for x in lanes]
         )
-        
+
 
         # The Adult Fiction and Adult Nonfiction lanes reproduce the
         # genre structure found in the genre definitions.
@@ -91,11 +91,11 @@ class TestLaneCreation(DatabaseTest):
         eq_("Science Fiction", sf.display_name)
         assert 'Science Fiction' in [genre.name for genre in sf.genres]
 
-        [nonfiction_humor] = [x for x in nonfiction.sublanes 
+        [nonfiction_humor] = [x for x in nonfiction.sublanes
                               if 'Humor' in x.display_name]
         eq_(False, nonfiction_humor.fiction)
-        
-        [fiction_humor] = [x for x in fiction.sublanes 
+
+        [fiction_humor] = [x for x in fiction.sublanes
                            if 'Humor' in x.display_name]
         eq_(True, fiction_humor.fiction)
 
@@ -125,7 +125,7 @@ class TestLaneCreation(DatabaseTest):
 
         # Now we have six top-level lanes, with best sellers at the beginning.
         eq_(
-            [u'Best Sellers', 'Fiction', 'Nonfiction', 'Young Adult Fiction', 
+            [u'Best Sellers', 'Fiction', 'Nonfiction', 'Young Adult Fiction',
              'Young Adult Nonfiction', 'Children and Middle Grade'],
             [x.display_name for x in lanes]
         )
@@ -202,8 +202,8 @@ class TestLaneCreation(DatabaseTest):
             eq_([Edition.BOOK_MEDIUM], x.media)
 
         eq_(
-            [set(['Adults Only', 'Adult']), 
-             set(['Adults Only', 'Adult']), 
+            [set(['Adults Only', 'Adult']),
+             set(['Adults Only', 'Adult']),
              set(['Young Adult', 'Children'])],
             [set(x.audiences) for x in sublanes]
         )
@@ -441,10 +441,10 @@ class LaneTest(DatabaseTest):
         materialized_expected = []
         if expected:
             materialized_expected = [work.id for work in expected]
-        
+
         query = lane.works(self._db)
         materialized_results = [work.works_id for work in query.all()]
-        
+
         eq_(sorted(materialized_expected), sorted(materialized_results))
 
     def sample_works_for_each_audience(self):
@@ -784,7 +784,7 @@ class TestCrawlableFacets(DatabaseTest):
         eq_([w1.id, w2.id], [mw.works_id for mw in qu])
 
     def test_order_by(self):
-        """Crawlable feeds are always ordered by time updated and then by 
+        """Crawlable feeds are always ordered by time updated and then by
         collection ID and work ID.
         """
         from core.model import MaterializedWorkWithGenre as mw
@@ -845,7 +845,7 @@ class TestCrawlableCustomListBasedLane(DatabaseTest):
         route, kwargs = lane.url_arguments
         eq_(CrawlableCustomListBasedLane.ROUTE, route)
         eq_(list.name, kwargs.get("list_name"))
-        
+
 
 class TestCrawlableCollectionBasedLane(DatabaseTest):
 

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -14,7 +14,7 @@ from core.model import (
 )
 
 class TestMARCExtractor(object):
-    
+
     def sample_data(self, filename):
         return sample_data(filename, "marc")
 

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -28,7 +28,7 @@ class MockAPI(MilleniumPatronAPI):
         super(MockAPI, self).__init__(library_id, integration)
         self.queue = []
         self.requests_made = []
-        
+
     def sample_data(self, filename):
         return sample_data(filename, 'millenium_patron')
 
@@ -66,7 +66,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
             ).value = library_identifier_field
 
         return MockAPI(self._default_library, integration)
-    
+
     def setup(self):
         super(TestMilleniumPatronAPI, self).setup()
         self.api = self.mock_api("http://url/")
@@ -75,7 +75,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         api = self.mock_api("http://example.com/", ["a", "b"])
         eq_("http://example.com/", api.root)
         eq_(["a", "b"], [x.pattern for x in api.blacklist])
-        
+
     def test_remote_patron_lookup_no_such_patron(self):
         self.api.enqueue("dump.no such barcode.html")
         patrondata = PatronData(authorization_identifier="bad barcode")
@@ -131,7 +131,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         patrondata = PatronData(authorization_identifier="good barcode")
         patrondata = api.remote_patron_lookup(patrondata)
         eq_(PatronData.UNKNOWN_BLOCK, patrondata.block_reason)
-        
+
     def test_parse_poorly_behaved_dump(self):
         """The HTML parser is able to handle HTML embedded in
         field values.
@@ -165,7 +165,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         # authorization identifier, because it's likely to be the most
         # recently added one.
         eq_("SECOND-barcode", patrondata.authorization_identifier)
-        
+
     def test_remote_authenticate_no_such_barcode(self):
         self.api.enqueue("pintest.no such barcode.html")
         eq_(False, self.api.remote_authenticate("wrong barcode", "pin"))
@@ -182,7 +182,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         # The return value includes everything we know about the
         # authenticated patron, which isn't much.
         eq_("barcode1234567", patrondata.authorization_identifier)
-        
+
     def test_authentication_updates_patron_authorization_identifier(self):
         """Verify that Patron.authorization_identifier is updated when
         necessary and left alone when not necessary.
@@ -194,7 +194,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         """
         p = self._patron()
         p.external_identifier = "6666666"
-        
+
         # If the patron is new, and logged in with a username, we'll
         # use the last barcode in the list as their authorization
         # identifier.
@@ -354,7 +354,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         p2 = self.api.authenticated_patron(self._db, auth)
         eq_(p2, p)
         eq_(None, p.authorization_expires)
-        
+
     def test_authentication_patron_invalid_fine_amount(self):
         p = self._patron()
         p.authorization_identifier = "44444444444447"
@@ -364,7 +364,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         p2 = self.api.authenticated_patron(self._db, auth)
         eq_(p2, p)
         eq_(0, p.fines)
-        
+
     def test_patron_dump_to_patrondata(self):
         content = self.api.sample_data("dump.success.html")
         patrondata = self.api.patron_dump_to_patrondata('alice', content)
@@ -381,7 +381,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         content = api.sample_data("dump.success.html")
         patrondata = api.patron_dump_to_patrondata('alice', content)
         eq_("10", patrondata.library_identifier)
-        
+
     def test_authorization_identifier_blacklist(self):
         """A patron has two authorization identifiers. Ordinarily the second
         one (which would normally be preferred), but it contains a
@@ -394,7 +394,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         api = self.mock_api(blacklist=["second"])
         patrondata = api.patron_dump_to_patrondata('alice', content)
         eq_("FIRST-barcode", patrondata.authorization_identifier)
-        
+
     def test_blacklist_may_remove_every_authorization_identifier(self):
         """A patron may end up with no authorization identifier whatsoever
         because they're all blacklisted.
@@ -436,15 +436,15 @@ class TestMilleniumPatronAPI(DatabaseTest):
         eq_(unblocked, m(None, None))
         eq_(unblocked, m(None, "-"))
         eq_(unblocked, m(None, " "))
-        
+
         # Behavior with custom block values.
         eq_(blocked, m("abcd", "b"))
         eq_(unblocked, m("abcd", "e"))
         eq_(unblocked, m("", "-"))
-        
+
         # This is unwise but allowed.
         eq_(blocked, m("ab-c", "-"))
-        
+
     def test_family_name_match(self):
         m = MilleniumPatronAPI.family_name_match
         eq_(False, m(None, None))
@@ -499,9 +499,9 @@ class TestMilleniumPatronAPI(DatabaseTest):
         eq_("44444444444447", patrondata.authorization_identifier)
 
         # Since we got a full patron dump, the PatronData we get back
-        # is complete. 
+        # is complete.
         eq_(True, patrondata.complete)
-        
+
     def test_authorization_family_name_failure(self):
         """Test authenticating against the patron's family name, given the
         incorrect name
@@ -511,7 +511,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         eq_(False, self.api.remote_authenticate("44444444444447", "wrong name"))
 
     def test_authorization_family_name_no_such_patron(self):
-        """If no patron is found, authorization based on family name cannot 
+        """If no patron is found, authorization based on family name cannot
         proceed.
         """
         self.api = self.mock_api(auth_mode = "family_name")

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -41,7 +41,7 @@ from api.odl import (
 
 
 class InstrumentedMWCollectionUpdateMonitor(MWCollectionUpdateMonitor):
-    
+
     def __init__(self, *args, **kwargs):
         super(InstrumentedMWCollectionUpdateMonitor, self).__init__(*args, **kwargs)
         self.imports = []
@@ -116,7 +116,7 @@ class TestMWCollectionUpdateMonitor(DatabaseTest):
     def test_run_once(self):
         # Setup authentication and Metadata Wrangler details.
         lp = self._licensepool(
-            None, data_source_name=DataSource.BIBLIOTHECA, 
+            None, data_source_name=DataSource.BIBLIOTHECA,
             collection=self.collection
         )
         lp.identifier.type = Identifier.BIBLIOTHECA_ID
@@ -182,7 +182,7 @@ class TestMWCollectionUpdateMonitor(DatabaseTest):
         )
         new_timestamp = self.monitor.run_once(None, None)
 
-        # run_once() returned the original timestamp, and the 
+        # run_once() returned the original timestamp, and the
         # Timestamp object was not updated.
         eq_(before, new_timestamp)
         eq_(before, self.monitor.timestamp().timestamp)

--- a/tests/test_nyt.py
+++ b/tests/test_nyt.py
@@ -65,13 +65,13 @@ class NYTBestSellerAPITest(DatabaseTest):
         self.metadata_client = DummyMetadataClient()
 
 class TestNYTBestSellerAPI(NYTBestSellerAPITest):
-    
+
     """Test the API calls."""
 
     def test_from_config(self):
         # You have to have an ExternalIntegration for the NYT.
         assert_raises_regexp(
-            CannotLoadConfiguration, 
+            CannotLoadConfiguration,
             "No ExternalIntegration found for the NYT.",
             NYTBestSellerAPI.from_config, self._db
         )
@@ -82,7 +82,7 @@ class TestNYTBestSellerAPI(NYTBestSellerAPITest):
 
         # It has to have the api key in its 'password' setting.
         assert_raises_regexp(
-            CannotLoadConfiguration, 
+            CannotLoadConfiguration,
             "No NYT API key is specified",
             NYTBestSellerAPI.from_config, self._db
         )
@@ -99,7 +99,7 @@ class TestNYTBestSellerAPI(NYTBestSellerAPITest):
         mw = self._external_integration(
             protocol=ExternalIntegration.METADATA_WRANGLER,
             goal=ExternalIntegration.METADATA_GOAL
-        )        
+        )
         mw.url = self._url
 
         api = NYTBestSellerAPI.from_config(self._db)
@@ -190,7 +190,7 @@ class TestNYTBestSellerList(NYTBestSellerAPITest):
         [contributor] = title.metadata.contributors
         eq_("Paula Hawkins", contributor.display_name)
         eq_("Riverhead", title.metadata.publisher)
-        eq_("A psychological thriller set in London is full of complications and betrayals.", 
+        eq_("A psychological thriller set in London is full of complications and betrayals.",
             title.annotation)
         eq_(datetime.datetime(2015, 1, 17), title.first_appearance)
         eq_(datetime.datetime(2015, 2, 1), title.most_recent_appearance)
@@ -216,7 +216,7 @@ class TestNYTBestSellerList(NYTBestSellerAPITest):
         eq_(custom.updated, l.updated)
         eq_(custom.name, l.name)
         eq_(len(l), len(custom.entries))
-        eq_(True, all([isinstance(x, CustomListEntry) 
+        eq_(True, all([isinstance(x, CustomListEntry)
                        for x in custom.entries]))
 
         eq_(20, len(custom.entries))
@@ -242,7 +242,7 @@ class TestNYTBestSellerList(NYTBestSellerAPITest):
         list_name = "espionage"
         l = self.api.best_seller_list(list_name)
         self.api.fill_in_history(l)
-        
+
         # Each 'espionage' best-seller list contains 15 items. Since
         # we picked two, from consecutive months, there's quite a bit
         # of overlap, and we end up with 20.
@@ -288,7 +288,7 @@ class TestNYTBestSellerListTitle(NYTBestSellerAPITest):
         assert edition.permanent_work_id is not None
 
     def test_to_edition_sets_sort_author_name_if_metadata_client_provides_it(self):
-        
+
         # Set the metadata client up for success.
         self.metadata_client.lookups["Paula Hawkins"] = "Hawkins, Paula Z."
 

--- a/tests/test_odilo.py
+++ b/tests/test_odilo.py
@@ -2,8 +2,8 @@
 import json
 
 from nose.tools import (
-    eq_, 
-    ok_, 
+    eq_,
+    ok_,
     assert_raises,
     set_trace,
 )
@@ -216,7 +216,7 @@ class TestOdiloCirculationAPI(OdiloAPITest):
 
         # An absolute URL is not modified.
         for protocol in ('http', 'https'):
-            already_absolute = "%s://example.com/" % protocol 
+            already_absolute = "%s://example.com/" % protocol
             eq_(already_absolute, self.api._make_absolute_url(already_absolute))
 
 

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -592,7 +592,7 @@ class TestODLWithConsolidatedCopiesAPI(DatabaseTest, BaseODLTest):
 
         # When there's a holds queue, the end date is the maximum time it could take for
         # a license to become available.
-        
+
         # One copy, one loan, hold position 1.
         # The hold will be available as soon as the loan expires.
         self.pool.licenses_available = 0
@@ -608,7 +608,7 @@ class TestODLWithConsolidatedCopiesAPI(DatabaseTest, BaseODLTest):
         self.api._update_hold_end_date(hold)
         eq_(tomorrow + datetime.timedelta(days=9), hold.end)
 
-        # Two copies, one loan, one reserved hold, hold position 2. 
+        # Two copies, one loan, one reserved hold, hold position 2.
         # The hold will be available after the loan expires.
         self.pool.licenses_reserved = 1
         self.pool.licenses_owned = 2
@@ -1225,7 +1225,7 @@ class TestODLWithConsolidatedCopiesAPI(DatabaseTest, BaseODLTest):
         eq_(1, self.pool.patrons_in_hold_queue)
         eq_(1, self._db.query(Hold).count())
         eq_(0, other_hold.position)
-        
+
 
 class TestODLBibliographicImporter(DatabaseTest, BaseODLTest):
 
@@ -1839,4 +1839,4 @@ class TestSharedODLImporter(DatabaseTest, BaseODLTest):
         [borrow_link] = [l for l in essex_pool.identifier.links if l.rel == Hyperlink.BORROW]
         eq_('http://localhost:6500/AL/works/URI/http://www.feedbooks.com/item/1946289/borrow', borrow_link.resource.url)
 
-        
+

--- a/tests/test_oneclick.py
+++ b/tests/test_oneclick.py
@@ -3,7 +3,7 @@ import json
 import uuid
 from lxml import etree
 from nose.tools import (
-    eq_, 
+    eq_,
     assert_raises,
     assert_raises_regexp,
     set_trace,
@@ -13,7 +13,7 @@ from StringIO import StringIO
 
 from api.authenticator import BasicAuthenticationProvider
 from api.config import (
-    Configuration, 
+    Configuration,
     temp_config,
 )
 
@@ -44,7 +44,7 @@ from core.metadata_layer import (
 from api.oneclick import (
     AudiobookManifest,
     OneClickAPI,
-    OneClickCirculationMonitor, 
+    OneClickCirculationMonitor,
     MockOneClickAPI,
     RBFulfillmentInfo,
 )
@@ -182,7 +182,7 @@ class TestOneClickAPI(OneClickAPITest):
         """All the OneClickAPI methods that take a Patron object call
         self.patron_remote_identifier() immediately, to find the
         patron's RBdigital ID.
-        
+
         Since the default_patron starts out without a Credential
         containing that ID, this means making a request to the
         RBdigital API to look up an existing ID. If that lookup fails,
@@ -304,7 +304,7 @@ class TestOneClickAPI(OneClickAPITest):
 
         patron = self.default_patron
 
-        # Get the identifier we use when announcing this patron to 
+        # Get the identifier we use when announcing this patron to
         # the remote service.
         patron_identifier = patron.identifier_to_remote_service(
             DataSource.RB_DIGITAL
@@ -333,7 +333,7 @@ class TestOneClickAPI(OneClickAPITest):
         )
         self.api.queue_response(status_code=500, content=datastr)
         assert_raises_regexp(
-            InvalidInputException, "patron_id:", 
+            InvalidInputException, "patron_id:",
             self.api.patron_remote_identifier_lookup, patron
         )
 
@@ -349,14 +349,14 @@ class TestOneClickAPI(OneClickAPITest):
         datastr, datadict = self.api.get_data("response_patron_info_not_found.json")
         self.api.queue_response(status_code=404, content=datastr)
         assert_raises_regexp(
-            NotFoundOnRemote, "patron_info:", 
+            NotFoundOnRemote, "patron_info:",
             self.api.get_patron_information, patron_id='939987'
         )
 
         datastr, datadict = self.api.get_data("response_patron_info_error.json")
         self.api.queue_response(status_code=400, content=datastr)
         assert_raises_regexp(
-            InvalidInputException, "patron_info:", 
+            InvalidInputException, "patron_info:",
             self.api.get_patron_information, patron_id='939981fdsfdsf'
         )
 
@@ -374,7 +374,7 @@ class TestOneClickAPI(OneClickAPITest):
         edition, pool = self._edition(
             identifier_type=Identifier.RB_DIGITAL_ID,
             data_source_name=DataSource.RB_DIGITAL,
-            with_license_pool=True, 
+            with_license_pool=True,
             identifier_id = '9781441260468'
         )
         datastr, datadict = self.api.get_data("response_checkout_success.json")
@@ -402,7 +402,7 @@ class TestOneClickAPI(OneClickAPITest):
         datastr, datadict = self.api.get_data("response_checkout_unavailable.json")
         self.api.queue_response(status_code=409, content=datastr)
         assert_raises_regexp(
-            NoAvailableCopies, "Title is not available for checkout", 
+            NoAvailableCopies, "Title is not available for checkout",
             self.api.circulate_item, oneclick_id, edition.primary_identifier.identifier
         )
         request_url, request_args, request_kwargs = self.api.requests[-1]
@@ -412,7 +412,7 @@ class TestOneClickAPI(OneClickAPITest):
         # book return functionality checks
         self.api.queue_response(status_code=200, content="")
 
-        response_dictionary = self.api.circulate_item(oneclick_id, edition.primary_identifier.identifier, 
+        response_dictionary = self.api.circulate_item(oneclick_id, edition.primary_identifier.identifier,
             return_item=True)
         eq_({}, response_dictionary)
         request_url, request_args, request_kwargs = self.api.requests[-1]
@@ -422,8 +422,8 @@ class TestOneClickAPI(OneClickAPITest):
         datastr, datadict = self.api.get_data("response_return_unavailable.json")
         self.api.queue_response(status_code=409, content=datastr)
         assert_raises_regexp(
-            NotCheckedOut, "checkin:", 
-            self.api.circulate_item, oneclick_id, edition.primary_identifier.identifier, 
+            NotCheckedOut, "checkin:",
+            self.api.circulate_item, oneclick_id, edition.primary_identifier.identifier,
             return_item=True
         )
         request_url, request_args, request_kwargs = self.api.requests[-1]
@@ -453,9 +453,9 @@ class TestOneClickAPI(OneClickAPITest):
         eq_("post", request_kwargs.get("method"))
 
     def test_checkin(self):
-        # Returning a book is, for now, more of a "notify OneClick that we've 
+        # Returning a book is, for now, more of a "notify OneClick that we've
         # returned through Adobe" formality than critical functionality.
-        # There's no information returned from the server on success, so we use a 
+        # There's no information returned from the server on success, so we use a
         # boolean success flag.
 
         patron = self.default_patron
@@ -464,7 +464,7 @@ class TestOneClickAPI(OneClickAPITest):
         edition, pool = self._edition(
             identifier_type=Identifier.RB_DIGITAL_ID,
             data_source_name=DataSource.RB_DIGITAL,
-            with_license_pool=True, 
+            with_license_pool=True,
             identifier_id = '9781441260468'
         )
         work = self._work(presentation_edition=edition)
@@ -498,7 +498,7 @@ class TestOneClickAPI(OneClickAPITest):
         edition, pool = self._edition(
             identifier_type=Identifier.RB_DIGITAL_ID,
             data_source_name=DataSource.RB_DIGITAL,
-            with_license_pool=True, 
+            with_license_pool=True,
             identifier_id = '9781441260468'
         )
         work = self._work(presentation_edition=edition)
@@ -547,7 +547,7 @@ class TestOneClickAPI(OneClickAPITest):
         datastr, datadict = self.api.get_data("response_patron_create_fail_already_exists.json")
         self.api.queue_response(status_code=409, content=datastr)
         assert_raises_regexp(
-            RemotePatronCreationFailedException, 'create_patron: http=409, response={"message":"A patron account with the specified username, email address, or card number already exists for this library."}', 
+            RemotePatronCreationFailedException, 'create_patron: http=409, response={"message":"A patron account with the specified username, email address, or card number already exists for this library."}',
             self.api.create_patron, patron
         )
 
@@ -584,13 +584,13 @@ class TestOneClickAPI(OneClickAPITest):
         self.queue_initial_patron_id_lookup()
 
         identifier = self._identifier(
-            identifier_type=Identifier.RB_DIGITAL_ID, 
+            identifier_type=Identifier.RB_DIGITAL_ID,
             foreign_id='9781426893483')
 
         edition, pool = self._edition(
             identifier_type=Identifier.RB_DIGITAL_ID,
             data_source_name=DataSource.RB_DIGITAL,
-            with_license_pool=True, 
+            with_license_pool=True,
             identifier_id = '9781426893483'
         )
 
@@ -619,7 +619,7 @@ class TestOneClickAPI(OneClickAPITest):
         eq_(download_url, found_fulfillment.content_link)
         eq_(u'application/epub+zip', found_fulfillment.content_type)
         eq_(None, found_fulfillment.content)
-        
+
         # The fulfillment link expires in about 14 minutes -- rather
         # than testing this exactly we estimate it.
         expires = found_fulfillment.content_expires
@@ -633,7 +633,7 @@ class TestOneClickAPI(OneClickAPITest):
         edition2, pool2  = self._edition(
             identifier_type=Identifier.RB_DIGITAL_ID,
             data_source_name=DataSource.RB_DIGITAL,
-            with_license_pool=True, 
+            with_license_pool=True,
             identifier_id = '123456789'
         )
 
@@ -641,8 +641,8 @@ class TestOneClickAPI(OneClickAPITest):
         # RBdigital ID, there will be no initial request looking up their
         # RBdigital ID.
 
-        # Instead we'll go right to the list of active loans, where we'll 
-        # find out that the patron does not have an active loan for the 
+        # Instead we'll go right to the list of active loans, where we'll
+        # find out that the patron does not have an active loan for the
         # requested book.
         datastr, datadict = self.api.get_data("response_patron_checkouts_200_list.json")
         self.api.queue_response(status_code=200, content=datastr)
@@ -672,13 +672,13 @@ class TestOneClickAPI(OneClickAPITest):
 
         audiobook_id = '9781449871789'
         identifier = self._identifier(
-            identifier_type=Identifier.RB_DIGITAL_ID, 
+            identifier_type=Identifier.RB_DIGITAL_ID,
             foreign_id=audiobook_id)
 
         edition, pool = self._edition(
             identifier_type=Identifier.RB_DIGITAL_ID,
             data_source_name=DataSource.RB_DIGITAL,
-            with_license_pool=True, 
+            with_license_pool=True,
             identifier_id = audiobook_id
         )
 
@@ -694,7 +694,7 @@ class TestOneClickAPI(OneClickAPITest):
 
         # Without making any further HTTP requests, we were able to get
         # a Readium Web Publication manifest for the loan.
-        eq_(Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE, 
+        eq_(Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
             found_fulfillment.content_type)
 
         manifest = json.loads(found_fulfillment.content)
@@ -703,19 +703,19 @@ class TestOneClickAPI(OneClickAPITest):
 
     def test_patron_activity(self):
         # Get patron's current checkouts and holds.
-        # Make sure LoanInfo objects were created and filled 
-        # with FulfillmentInfo objects.  Make sure HoldInfo objects 
+        # Make sure LoanInfo objects were created and filled
+        # with FulfillmentInfo objects.  Make sure HoldInfo objects
         # were created.
 
         patron = self.default_patron
         self.queue_initial_patron_id_lookup()
 
         identifier = self._identifier(
-            identifier_type=Identifier.RB_DIGITAL_ID, 
+            identifier_type=Identifier.RB_DIGITAL_ID,
             foreign_id='9781456103859')
 
         identifier = self._identifier(
-            identifier_type=Identifier.RB_DIGITAL_ID, 
+            identifier_type=Identifier.RB_DIGITAL_ID,
             foreign_id='9781426893483')
 
         # queue checkouts list
@@ -732,12 +732,12 @@ class TestOneClickAPI(OneClickAPITest):
         eq_(u'9781456103859', patron_activity[0].identifier)
         eq_(None, patron_activity[0].start_date)
         eq_(datetime.date(2016, 11, 19), patron_activity[0].end_date)
-                 
+
         eq_(Identifier.RB_DIGITAL_ID, patron_activity[1].identifier_type)
         eq_(u'9781426893483', patron_activity[1].identifier)
         eq_(None, patron_activity[1].start_date)
         eq_(datetime.date(2016, 11, 19), patron_activity[1].end_date)
-                 
+
         eq_(Identifier.RB_DIGITAL_ID, patron_activity[2].identifier_type)
         eq_('9781426893483', patron_activity[2].identifier)
         eq_(None, patron_activity[2].start_date)
@@ -753,7 +753,7 @@ class TestOneClickAPI(OneClickAPITest):
         edition, pool = self._edition(
             identifier_type=Identifier.RB_DIGITAL_ID,
             data_source_name=DataSource.RB_DIGITAL,
-            with_license_pool=True, 
+            with_license_pool=True,
             identifier_id = '9781441260468'
         )
 
@@ -763,7 +763,7 @@ class TestOneClickAPI(OneClickAPITest):
         datastr, datadict = self.api.get_data("response_patron_hold_fail_409_already_exists.json")
         self.api.queue_response(status_code=409, content=datastr)
         assert_raises_regexp(
-            CannotHold, ".*Hold or Checkout already exists.", 
+            CannotHold, ".*Hold or Checkout already exists.",
             self.api.place_hold, patron, None, pool, None
         )
 
@@ -772,7 +772,7 @@ class TestOneClickAPI(OneClickAPITest):
         datastr, datadict = self.api.get_data("response_patron_hold_fail_409_reached_limit.json")
         self.api.queue_response(status_code=409, content=datastr)
         assert_raises_regexp(
-            CannotHold, ".*You have reached your checkout limit and therefore are unable to place additional holds.", 
+            CannotHold, ".*You have reached your checkout limit and therefore are unable to place additional holds.",
             self.api.place_hold, patron, None, pool, None
         )
 
@@ -797,7 +797,7 @@ class TestOneClickAPI(OneClickAPITest):
         edition, pool = self._edition(
             identifier_type=Identifier.RB_DIGITAL_ID,
             data_source_name=DataSource.RB_DIGITAL,
-            with_license_pool=True, 
+            with_license_pool=True,
             identifier_id = '9781441260468'
         )
 
@@ -886,7 +886,7 @@ class TestCirculationMonitor(OneClickAPITest):
 
     def test_process_availability(self):
         monitor = OneClickCirculationMonitor(
-            self._db, self.collection, api_class=MockOneClickAPI, 
+            self._db, self.collection, api_class=MockOneClickAPI,
             api_class_kwargs=dict(base_path=self.base_path)
         )
         eq_(ExternalIntegration.RB_DIGITAL, monitor.protocol)
@@ -974,7 +974,7 @@ class TestAudiobookManifest(OneClickAPITest):
 
         # We know it's an audiobook, and that's it.
         eq_(
-            {'@context': 'http://readium.org/webpub/default.jsonld', 
+            {'@context': 'http://readium.org/webpub/default.jsonld',
              'metadata': {'@type': 'http://bib.schema.org/Audiobook'}},
             manifest.as_dict
         )

--- a/tests/test_onix.py
+++ b/tests/test_onix.py
@@ -15,7 +15,7 @@ from core.model import (
 from core.classifier import Classifier
 
 class TestONIXExtractor(object):
-    
+
     def sample_data(self, filename):
         return sample_data(filename, "onix")
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -56,7 +56,7 @@ class OverdriveAPITest(DatabaseTest):
             self._db, library, api_map={ExternalIntegration.OVERDRIVE:MockOverdriveAPI}
         )
         self.api = self.circulation.api_for_collection[self.collection.id]
-        
+
     @classmethod
     def sample_data(self, filename):
         return sample_data(filename, 'overdrive')
@@ -206,7 +206,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         ConfigurationSetting.for_library(
             Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS,
             self._default_library).value = "notifications@example.com"
-        eq_("foo@bar.com", 
+        eq_("foo@bar.com",
             self.api.default_notification_email_address(patron, 'pin'))
 
         # If the patron has never before put an Overdrive book on
@@ -215,13 +215,13 @@ class TestOverdriveAPI(OverdriveAPITest):
         patron_with_no_email = dict(patron_with_email)
         del patron_with_no_email['lastHoldEmail']
         self.api.queue_response(200, content=patron_with_no_email)
-        eq_("notifications@example.com", 
+        eq_("notifications@example.com",
             self.api.default_notification_email_address(patron, 'pin'))
 
         # If there's an error getting the information, use the
         # site default.
         self.api.queue_response(404)
-        eq_("notifications@example.com", 
+        eq_("notifications@example.com",
             self.api.default_notification_email_address(patron, 'pin'))
 
     def test_checkin(self):
@@ -441,7 +441,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         self.api.queue_response(400, content=over_hold_limit)
         assert_raises(
             PatronHoldLimitReached,
-            self.api.place_hold, self._patron(), 'pin', pool, 
+            self.api.place_hold, self._patron(), 'pin', pool,
             notification_email_address='foo@bar.com'
         )
 
@@ -458,7 +458,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         ignore, patron_with_email = self.sample_json(
             "patron_info.json"
         )
-        
+
         # The second request we make will be to put a book on hold,
         # and when we do so we will ask for the notification to be
         # sent to foo@bar.com.
@@ -470,7 +470,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         self.api.queue_response(200, content=successful_hold)
         with temp_config() as config:
             config['default_notification_email_address'] = "notifications@example.com"
-            hold = self.api.place_hold(self._patron(), 'pin', pool, 
+            hold = self.api.place_hold(self._patron(), 'pin', pool,
                                        notification_email_address=None)
 
         # The book was placed on hold.
@@ -505,7 +505,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         # We will get the loan, try to lock in the format, and fail.
         self.api.queue_response(200, content=loan)
         self.api.queue_response(400, content=lock_in_format_not_available)
-        
+
         # Trying to get a fulfillment link raises an exception.
         assert_raises(
             FormatNotAvailable,
@@ -525,7 +525,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         self.api.queue_response(200, content=loan)
         self.api.queue_response(400, content=lock_in_format_not_available)
         self.api.queue_response(200, content=bibliographic)
-        
+
         assert_raises(
             FormatNotAvailable,
             self.api.fulfill,
@@ -646,7 +646,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         eq_(dict(id="an identifier"), book)
         eq_(200, status_code)
         eq_("foo", content)
-        
+
     def test_update_licensepool_error(self):
         # Create an identifier.
         identifier = self._identifier(
@@ -666,7 +666,7 @@ class TestOverdriveAPI(OverdriveAPITest):
             identifier_type=Identifier.OVERDRIVE_ID
         )
 
-        # Prepare bibliographic and availability information 
+        # Prepare bibliographic and availability information
         # for this identifier.
         ignore, availability = self.sample_json(
             "overdrive_availability_information.json"
@@ -689,7 +689,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         # OverdriveBibliographicCoverageProvider, which will
         # create an Edition and a presentation-ready Work.
         pool, was_new, changed = self.api.update_licensepool(identifier.identifier)
-        eq_(True, was_new)        
+        eq_(True, was_new)
         eq_(availability['copiesOwned'], pool.licenses_owned)
 
         edition = pool.presentation_edition
@@ -703,7 +703,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         # The book has been run through the bibliographic coverage
         # provider.
         coverage = [
-            x for x in identifier.coverage_records 
+            x for x in identifier.coverage_records
             if x.operation is None
             and x.data_source.name == DataSource.OVERDRIVE
         ]
@@ -737,11 +737,11 @@ class TestOverdriveAPI(OverdriveAPITest):
         raw['id'] = identifier.identifier
 
         pool, was_new = LicensePool.for_foreign_id(
-            self._db, DataSource.OVERDRIVE, 
+            self._db, DataSource.OVERDRIVE,
             identifier.type, identifier.identifier,
             collection=self.collection
         )
-        
+
         pool, was_new, changed = self.api.update_licensepool_with_book_info(
             raw, pool, was_new
         )
@@ -797,7 +797,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         raw['id'] = identifier.identifier
 
         license_pool, is_new = LicensePool.for_foreign_id(
-            self._db, DataSource.OVERDRIVE, identifier.type, 
+            self._db, DataSource.OVERDRIVE, identifier.type,
             identifier.identifier, collection=self._default_collection
         )
         pool, was_new, changed = self.api.update_licensepool_with_book_info(
@@ -816,7 +816,7 @@ class TestOverdriveAPI(OverdriveAPITest):
 
         data, raw = self.sample_json("patron_token.json")
         self.api.queue_response(200, content=raw)
-        
+
         # Try to refresh the patron access token with a PIN, and
         # then without a PIN.
         self.api.refresh_patron_access_token(credential, patron, "a pin")
@@ -842,7 +842,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         eq_(expect_scope, payload['scope'])
         eq_("false", payload['password_required'])
         eq_("[ignore]", payload['password'])
-        
+
 class TestExtractData(OverdriveAPITest):
 
     def test_get_download_link(self):
@@ -850,9 +850,9 @@ class TestExtractData(OverdriveAPITest):
         url = MockOverdriveAPI.get_download_link(
             json, "ebook-epub-adobe", "http://foo.com/")
         eq_("http://patron.api.overdrive.com/v1/patrons/me/checkouts/76C1B7D0-17F4-4C05-8397-C66C17411584/formats/ebook-epub-adobe/downloadlink?errorpageurl=http://foo.com/", url)
-        
+
         assert_raises(
-            NoAcceptableFormat, 
+            NoAcceptableFormat,
             MockOverdriveAPI.get_download_link,
             json, "no-such-format", "http://foo.com/"
         )
@@ -862,7 +862,7 @@ class TestExtractData(OverdriveAPITest):
         assert_raises(
             FulfilledOnIncompatiblePlatform,
             MockOverdriveAPI.get_download_link,
-            json, "ebook-epub-adobe", "http://foo.com/"            
+            json, "ebook-epub-adobe", "http://foo.com/"
         )
 
     def test_extract_data_from_checkout_resource(self):
@@ -1002,8 +1002,8 @@ class TestSyncBookshelf(OverdriveAPITest):
         [pool] = gutenberg.license_pools
         gutenberg_loan, new = pool.loan_to(patron)
         loans_data, json_loans = self.sample_json("shelf_with_some_checked_out_books.json")
-        holds_data, json_holds = self.sample_json("no_holds.json")     
-   
+        holds_data, json_holds = self.sample_json("no_holds.json")
+
         # Overdrive doesn't know about the Gutenberg loan, but it was
         # not destroyed, because it came from another source.
         self.api.queue_response(200, content=loans_data)
@@ -1014,7 +1014,7 @@ class TestSyncBookshelf(OverdriveAPITest):
         assert gutenberg_loan in patron.loans
 
     def test_sync_bookshelf_creates_local_holds(self):
-        
+
         loans_data, json_loans = self.sample_json("no_loans.json")
         holds_data, json_holds = self.sample_json("holds.json")
 
@@ -1037,7 +1037,7 @@ class TestSyncBookshelf(OverdriveAPITest):
     def test_sync_bookshelf_removes_holds_not_present_on_remote(self):
         loans_data, json_loans = self.sample_json("no_loans.json")
         holds_data, json_holds = self.sample_json("holds.json")
-        
+
         patron = self._patron()
         overdrive_edition, new = self._edition(
             data_source_name=DataSource.OVERDRIVE,
@@ -1073,7 +1073,7 @@ class TestSyncBookshelf(OverdriveAPITest):
         )
         [pool] = overdrive.license_pools
         overdrive_hold, new = pool.on_hold_to(patron)
-   
+
         self.api.queue_response(200, content=loans_data)
         self.api.queue_response(200, content=holds_data)
 

--- a/tests/test_patron_utility.py
+++ b/tests/test_patron_utility.py
@@ -27,7 +27,7 @@ class TestPatronUtility(DatabaseTest):
         yesterday = now - datetime.timedelta(days=1)
 
         patron = self._patron()
-        
+
         # Patron has never been synced.
         patron.last_external_sync = None
         eq_(True, PatronUtility.needs_external_sync(patron))
@@ -93,7 +93,7 @@ class TestPatronUtility(DatabaseTest):
             OutstandingFines,
             PatronUtility.assert_borrowing_privileges, patron
         )
-        
+
         # If your card is blocked for any reason you lose borrowing
         # privileges.
         patron.block_reason = "some reason"

--- a/tests/test_shared_collection.py
+++ b/tests/test_shared_collection.py
@@ -11,7 +11,7 @@ from Crypto.Cipher import PKCS1_OAEP
 
 from api.circulation_exceptions import *
 from api.shared_collection import (
-    SharedCollectionAPI, 
+    SharedCollectionAPI,
     BaseSharedCollectionAPI,
 )
 from core.config import CannotLoadConfiguration
@@ -47,7 +47,7 @@ class MockAPI(BaseSharedCollectionAPI):
     def fulfill_for_external_library(self, client, loan, mechanism):
         self.fulfills.append((client, loan, mechanism))
         return self.fulfillment
-        
+
     def release_hold_from_external_library(self, client, hold):
         self.released_holds.append((client, hold))
 
@@ -154,7 +154,7 @@ class TestSharedCollectionAPI(DatabaseTest):
                                     "links": [{"href": "http://library.org", "rel": "start"}]})
         assert_raises(RemoteInitiatedServerError, self.shared_collection.register,
                       self.collection, "http://library.org/auth", do_get=do_get)
-        
+
 
         # Here's an auth document with a valid key.
         key = RSA.generate(2048)

--- a/tests/test_simple_auth.py
+++ b/tests/test_simple_auth.py
@@ -18,7 +18,7 @@ from api.config import (
 from . import DatabaseTest
 
 class TestSimpleAuth(DatabaseTest):
-    
+
     def test_simple(self):
         p = SimpleAuthenticationProvider
         integration = self._external_integration(self._str)
@@ -84,7 +84,7 @@ class TestSimpleAuth(DatabaseTest):
 
         eq_(None, provider.remote_authenticate("a", None))
         eq_(None, provider.remote_authenticate(None, "pass"))
-        
+
         user = provider.remote_authenticate("a", "pass")
         assert isinstance(user, PatronData)
         eq_("a", user.authorization_identifier)


### PR DESCRIPTION
This will clean up the code generally and put a stop to future branches that include irrelevant whitespace changes.

I made this change with the following script:

`find ./ -type f -name "*.py" -exec sed -ir 's/ \{1,\}$//g' {} \;`