### PR TITLE
Fix casing of NoveList API response

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -1461,9 +1461,8 @@ class NovelistSnapshotScript(LibraryInputScript):
             response = api.put_items_novelist(parsed.libraries[0])
 
             if (response):
-                result = "NoveList Snapshot"
-                result += "\nRecords sent: " + str(response.result["recordsReceived"])
-                result += "\nInvalid Records: " + str(response.result["invalidRecords"]) + "\n"
+                result = "NoveList API Response\n"
+                result += str(response)
 
                 output.write(result)
 

--- a/scripts.py
+++ b/scripts.py
@@ -1462,8 +1462,8 @@ class NovelistSnapshotScript(LibraryInputScript):
 
             if (response):
                 result = "NoveList Snapshot"
-                result += "\nRecords sent: " + str(response["RecordsReceived"])
-                result += "\nInvalid Records: " + str(response["InvalidRecords"]) + "\n"
+                result += "\nRecords sent: " + str(response.result["recordsReceived"])
+                result += "\nInvalid Records: " + str(response.result["invalidRecords"]) + "\n"
 
                 output.write(result)
 


### PR DESCRIPTION
This PR should fix the current issue in the `scripts.py` file which is due to trying to access a non-existent key. 

#### Background 
A few months ago the NoveList team changed the format of the response which is sent back to to callers of the SimplyE API. We made the following quality of life changes:

* Changed to `camelCasing` (C# Web API uses `PascalCase` by default)
* Wrapped all responses in a `` object in order to have a consistent response.
* Created an Open Api Spec and published [Swagger UI](http://www.novelistcollectiondata.com/api/swagger/ui/index)

As the Swagger UI shows, you can expect a **200** status code response data structure to look as follows:

```
{
  "statusCode": 0,
  "requestId": "string",
  "result": {
    "customer": "string",
    "message": "string",
    "recordsReceived": 0,
    "recordsSuccessfullyInserted": 0,
    "invalidRecords": [
      {
        "isbn": "string",
        "author": "string",
        "title": "string",
        "narrator": "string",
        "publicationDate": "string",
        "mediaType": "string"
      }
    ],
    "successfulImport": true
  },
  "error": {
    "code": 0,
    "message": "string"
  }
}
```

FYI:
* If there are no invalid records, the `invalidRecords` object will just be an empty array.
* If there are no errors, the `error` object will not be sent in the response
* The `requestId` is a GUID assigned to each incoming API request. We added this to help with troubleshooting.
* **IMPORTANT**: Please note that the `recordsReceived` prop is now located in the `result` object. My python is pretty rusty, so please correct me if this is the wrong way to access the `result` object:

`str(response.result["recordsReceived"]`

