### PR TITLE
Annotate authentication document with loans and profile links; annotate patron profile with Short Client Token

### DIFF
--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -857,6 +857,7 @@ class AuthdataUtility(object):
 
     @classmethod
     def _adobe_patron_identifier(self, patron):
+        """Take patron object and return identifier for Adobe ID purposes"""
         _db = Session.object_session(patron)
         internal = DataSource.lookup(_db, DataSource.INTERNAL_PROCESSING)
 
@@ -870,6 +871,9 @@ class AuthdataUtility(object):
 
 
     def short_client_token_for_patron(self, patron_information):
+        """Generate short client token for patron, or for a patron's identifier
+         for Adobe ID purposes"""
+
         if isinstance(patron_information, Patron):
             # Find the patron's identifier for Adobe ID purposes.
             patron_identifier = self._adobe_patron_identifier(

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -378,6 +378,7 @@ class PatronData(object):
         self.authorization_identifiers = authorization_identifiers
 
 class CirculationPatronProfileStorage(PatronProfileStorage):
+    """A patron profile storage that can also provide short client tokens"""
     @property
     def profile_document(self):
         doc = super(CirculationPatronProfileStorage, self).profile_document

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -382,11 +382,17 @@ class CirculationPatronProfileStorage(PatronProfileStorage):
     @property
     def profile_document(self):
         doc = super(CirculationPatronProfileStorage, self).profile_document
+        drm = []
         authdata = AuthdataUtility.from_config(self.patron.library)
         if authdata:
             vendor_id, token = authdata.short_client_token_for_patron(self.patron)
-            doc['drm:vendor'] = vendor_id
-            doc['drm:clientToken'] = token
+            adobe_drm = {}
+            adobe_drm['drm:vendor'] = vendor_id
+            adobe_drm['drm:clientToken'] = token
+            adobe_drm['drm:scheme'] = "http://librarysimplified.org/terms/drm/scheme/ACS"
+            drm.append(adobe_drm)
+        if drm:
+            doc['drm'] = drm
         return doc
 
 class Authenticator(object):

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -29,6 +29,7 @@ from core.util.authentication_for_opds import (
     OPDSAuthenticationFlow,
 )
 from core.util.http import RemoteIntegrationException
+from core.user_profile import ProfileController
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql.expression import or_
@@ -36,6 +37,7 @@ from problem_details import *
 from util.patron import PatronUtility
 from api.opds import LibraryAnnotator
 from api.custom_patron_catalog import CustomPatronCatalog
+
 
 import datetime
 import logging
@@ -788,9 +790,22 @@ class LibraryAuthenticator(object):
         # Add a rel="start" link pointing to the root OPDS feed.
         index_url = url_for("index", _external=True,
                             library_short_name=library.short_name)
+        loans_url = url_for("active_loans", _external=True,
+                            library_short_name=library.short_name)
+        profile_url = url_for("patron_profile", _external=True,
+                            library_short_name=library.short_name)
+
         links.append(
             dict(rel="start", href=index_url,
                  type=OPDSFeed.ACQUISITION_FEED_TYPE)
+        )
+        links.append(
+            dict(rel="http://opds-spec.org/shelf", href=loans_url,
+                 type=OPDSFeed.ACQUISITION_FEED_TYPE)
+        )
+        links.append(
+            dict(rel=ProfileController.LINK_RELATION, href=profile_url,
+                 type=ProfileController.MEDIA_TYPE)
         )
 
         # If there is a Designated Agent email address, add it as a

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -18,6 +18,7 @@ from core.model import (
     ExternalIntegration,
     Library,
     Patron,
+    PatronProfileStorage,
     Session,
 )
 from core.util.problem_detail import (
@@ -37,7 +38,7 @@ from problem_details import *
 from util.patron import PatronUtility
 from api.opds import LibraryAnnotator
 from api.custom_patron_catalog import CustomPatronCatalog
-
+from api.adobe_vendor_id import AuthdataUtility
 
 import datetime
 import logging
@@ -375,6 +376,17 @@ class PatronData(object):
             authorization_identifiers = [authorization_identifier]
         self.authorization_identifier = authorization_identifier
         self.authorization_identifiers = authorization_identifiers
+
+class CirculationPatronProfileStorage(PatronProfileStorage):
+    @property
+    def profile_document(self):
+        doc = super(CirculationPatronProfileStorage, self).profile_document
+        authdata = AuthdataUtility.from_config(self.patron.library)
+        if authdata:
+            vendor_id, token = authdata.short_client_token_for_patron(self.patron)
+            doc['drm:vendor'] = vendor_id
+            doc['drm:clientToken'] = token
+        return doc
 
 class Authenticator(object):
     """Route requests to the appropriate LibraryAuthenticator.

--- a/api/controller.py
+++ b/api/controller.py
@@ -70,7 +70,6 @@ from core.model import (
     Loan,
     LicensePoolDeliveryMechanism,
     Patron,
-    PatronProfileStorage,
     Representation,
     Session,
     Work,
@@ -112,6 +111,7 @@ from problem_details import *
 
 from authenticator import (
     Authenticator,
+    CirculationPatronProfileStorage,
     OAuthController,
 )
 from config import (
@@ -1553,7 +1553,6 @@ class WorkController(CirculationManagerController):
         )
         return feed_response(unicode(feed))
 
-
 class ProfileController(CirculationManagerController):
     """Implement the User Profile Management Protocol."""
 
@@ -1562,7 +1561,7 @@ class ProfileController(CirculationManagerController):
         """Instantiate a CoreProfileController that actually does the work.
         """
         patron = self.authenticated_patron_from_request()
-        storage = PatronProfileStorage(patron)
+        storage = CirculationPatronProfileStorage(patron)
         return CoreProfileController(storage)
 
     def protocol(self):

--- a/api/opds.py
+++ b/api/opds.py
@@ -923,19 +923,6 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         link_tag.attrib.update(dict(href=fulfill_url))
         return link_tag
 
-    # @classmethod
-    # def _adobe_patron_identifier(self, patron):
-    #     _db = Session.object_session(patron)
-    #     internal = DataSource.lookup(_db, DataSource.INTERNAL_PROCESSING)
-    #
-    #     def refresh(credential):
-    #         credential.credential = str(uuid.uuid1())
-    #     patron_identifier = Credential.lookup(
-    #         _db, internal, AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER, patron,
-    #         refresher_method=refresh, allow_persistent_token=True
-    #     )
-    #     return patron_identifier.credential
-
     def drm_device_registration_tags(self, license_pool, active_loan,
                                      delivery_mechanism):
         """Construct OPDS Extensions for DRM tags that explain how to

--- a/api/opds.py
+++ b/api/opds.py
@@ -923,18 +923,18 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         link_tag.attrib.update(dict(href=fulfill_url))
         return link_tag
 
-    @classmethod
-    def _adobe_patron_identifier(self, patron):
-        _db = Session.object_session(patron)
-        internal = DataSource.lookup(_db, DataSource.INTERNAL_PROCESSING)
-
-        def refresh(credential):
-            credential.credential = str(uuid.uuid1())
-        patron_identifier = Credential.lookup(
-            _db, internal, AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER, patron,
-            refresher_method=refresh, allow_persistent_token=True
-        )
-        return patron_identifier.credential
+    # @classmethod
+    # def _adobe_patron_identifier(self, patron):
+    #     _db = Session.object_session(patron)
+    #     internal = DataSource.lookup(_db, DataSource.INTERNAL_PROCESSING)
+    #
+    #     def refresh(credential):
+    #         credential.credential = str(uuid.uuid1())
+    #     patron_identifier = Credential.lookup(
+    #         _db, internal, AuthdataUtility.ADOBE_ACCOUNT_ID_PATRON_IDENTIFIER, patron,
+    #         refresher_method=refresh, allow_persistent_token=True
+    #     )
+    #     return patron_identifier.credential
 
     def drm_device_registration_tags(self, license_pool, active_loan,
                                      delivery_mechanism):
@@ -976,27 +976,15 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             cache_key = patron_identifier
         cached = self._adobe_id_tags.get(cache_key)
         if cached is None:
-            if isinstance(patron_identifier, Patron):
-                # Find the patron's identifier for Adobe ID purposes.
-                patron_identifier = self._adobe_patron_identifier(
-                    patron_identifier
-                )
             cached = []
             authdata = AuthdataUtility.from_config(self.library)
             if authdata:
-                # TODO: We would like to call encode() here, and have
-                # the client use a JWT as authdata, but we can't,
-                # because there's no way to use authdata to deactivate
-                # a device. So we've used this alternate technique
-                # that's much smaller than a JWT and can be smuggled
-                # into username/password.
-                vendor_id, jwt = authdata.encode_short_client_token(patron_identifier)
-
+                vendor_id, token = authdata.short_client_token_for_patron(patron_identifier)
                 drm_licensor = OPDSFeed.makeelement("{%s}licensor" % OPDSFeed.DRM_NS)
                 vendor_attr = "{%s}vendor" % OPDSFeed.DRM_NS
                 drm_licensor.attrib[vendor_attr] = vendor_id
                 patron_key = OPDSFeed.makeelement("{%s}clientToken" % OPDSFeed.DRM_NS)
-                patron_key.text = jwt
+                patron_key.text = token
                 drm_licensor.append(patron_key)
 
                 # Add the link to the DRM Device Management Protocol

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -20,6 +20,7 @@ import flask
 from flask import url_for
 
 from core.opds import OPDSFeed
+from core.user_profile import ProfileController
 from core.model import (
     CirculationEvent,
     ConfigurationSetting,
@@ -1159,7 +1160,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             # We also need to test that the links got pulled in
             # from the configuration.
             (about, alternate, copyright, help_uri, help_web, help_email,
-             copyright_agent, license, logo, privacy_policy, register, start,
+             copyright_agent, profile, loans, license, logo, privacy_policy, register, start,
              terms_of_service) = sorted(
                  doc['links'], key=lambda x: (x['rel'], x['href'])
              )
@@ -1169,6 +1170,15 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             eq_("http://about", about['href'])
             eq_("http://license/", license['href'])
             eq_("image data", logo['href'])
+
+            assert ("/loans" in loans['href'])
+            eq_("http://opds-spec.org/shelf", loans['rel'])
+            eq_(OPDSFeed.ACQUISITION_FEED_TYPE, loans['type'])
+
+            assert ("/patrons/me" in profile['href'])
+            eq_(ProfileController.LINK_RELATION, profile['rel'])
+            eq_(ProfileController.MEDIA_TYPE, profile['type'])
+
             expect_start = url_for(
                 "index", library_short_name=self._default_library.short_name,
                 _external=True

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -393,14 +393,17 @@ class TestCirculationPatronProfileStorage(VendorIDTest):
         #Since there's no authdata configured, the DRM fields are not present
         assert 'drm:vendor' not in doc
         assert 'drm:clientToken' not in doc
+        assert 'drm:scheme' not in doc
         #Now there's authdata configured, and the DRM fields are populated with
         #the vendor ID and a short client token
         self.initialize_adobe(patron.library)
         doc = storage.profile_document
-        eq_(doc["drm:vendor"], "vendor id")
-        assert doc["drm:clientToken"].startswith(
+        [adobe] = doc['drm']
+        eq_(adobe["drm:vendor"], "vendor id")
+        assert adobe["drm:clientToken"].startswith(
             patron.library.short_name.upper() + "TOKEN"
         )
+        eq_(adobe["drm:scheme"], "http://librarysimplified.org/terms/drm/scheme/ACS")
 
 class MockAuthenticator(Authenticator):
     """Allows testing Authenticator methods outside of a request context."""

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -37,6 +37,7 @@ from api.controller import (
 from api.lanes import create_default_lanes
 from api.authenticator import (
     BasicAuthenticationProvider,
+    CirculationPatronProfileStorage,
     OAuthController,
     LibraryAuthenticator,
 )
@@ -3545,6 +3546,13 @@ class TestProfileController(ControllerTest):
         self.other_patron = self._patron()
         self.other_patron.synchronize_annotations = False
         self.auth = dict(Authorization=self.valid_auth)
+
+    def test_controller_uses_circulation_patron_profile_storage(self):
+        """Verify that this controller uses circulation manager-specific extensions."""
+        with self.request_context_with_library(
+                "/", method='GET', headers=self.auth
+        ):
+            assert isinstance(self.manager.profiles._controller.storage, CirculationPatronProfileStorage)
 
     def test_get(self):
         """Verify that a patron can see their own profile."""

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -847,7 +847,7 @@ class TestLibraryAnnotator(VendorIDTest):
         parser = OPDSXMLParser()
         licensor = parser._xpath1(tree, "//atom:feed/drm:licensor")
 
-        adobe_patron_identifier = cls._adobe_patron_identifier(patron)
+        adobe_patron_identifier = AuthdataUtility._adobe_patron_identifier(patron)
 
         # The DRM licensing information includes the Adobe vendor ID
         # and the patron's patron identifier for Adobe purposes.


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-1092 and https://jira.nypl.org/browse/SIMPLY-1093.

We've updated https://github.com/NYPL-Simplified/Simplified/wiki/User-Profile-Management-Protocol#profile-registry to reserve the `drm` key and define the semantics of the `drm:` namespace. We use the same keys here as we do in the loans feed -- this is just a faster way to get the same information.