### PR TITLE
Send shared secret with registration request, if available

### DIFF
--- a/api/registry.py
+++ b/api/registry.py
@@ -235,9 +235,8 @@ class Registration(object):
             return payload
 
         headers = self._create_registration_headers()
-
-        if isinstance(payload, ProblemDetail):
-            return payload
+        if isinstance(headers, ProblemDetail):
+            return headers
 
         # Send the document.
         response = self._send_registration_request(

--- a/api/registry.py
+++ b/api/registry.py
@@ -325,6 +325,9 @@ class Registration(object):
         contact = Configuration.configuration_contact_uri(self.library)
         if contact:
             payload['contact'] = contact
+        shared_secret = self.setting(ExternalIntegration.PASSWORD).value
+        if shared_secret:
+            payload['shared_secret'] = shared_secret
         return payload
 
     @classmethod

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -452,6 +452,14 @@ class TestRegistration(DatabaseTest):
         expect_payload['contact'] = contact
         eq_(expect_payload, m(url_for, stage))
 
+        # If a shared secret is configured, it shows up in the payload.
+        setting = ConfigurationSetting.for_library_and_externalintegration(
+            self._db, ExternalIntegration.PASSWORD, self.registration.library,
+            self.registration.registry.integration
+        ).value="a secret"
+        expect_payload['shared_secret'] = 'a secret'
+        eq_(expect_payload, m(url_for, stage))
+
     def test__send_registration_request(self):
         class Mock(object):
             def __init__(self, response):


### PR DESCRIPTION
This is the other part of https://jira.nypl.org/browse/SIMPLY-1031. A circulation manager running this code will transparently re-register itself at a new URL.