### PR TITLE
Library registration type

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -3655,6 +3655,9 @@ class SettingsController(AdminCirculationManagerController):
                     library = registration.library
                     library_info = dict(short_name=library.short_name)
                     status = registration.status_field.value
+                    stage_field = registration.stage_field.value
+                    if stage_field:
+                        library_info["stage"] = stage_field
                     if status:
                         library_info["status"] = status
                         libraries.append(library_info)

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.76"
+    "simplified-circulation-web": "0.0.77"
   }
 }

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.74"
+    "simplified-circulation-web": "0.0.76"
   }
 }

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -6198,12 +6198,18 @@ class TestLibraryRegistration(SettingsControllerTest):
         ConfigurationSetting.for_library_and_externalintegration(
             self._db, "library-registration-status", succeeded, discovery_service,
             ).value = "success"
+        ConfigurationSetting.for_library_and_externalintegration(
+            self._db, "library-registration-stage", succeeded, discovery_service,
+            ).value = "production"
         failed, ignore = create(
             self._db, Library, name="Library 2", short_name="L2",
         )
         ConfigurationSetting.for_library_and_externalintegration(
             self._db, "library-registration-status", failed, discovery_service,
             ).value = "failure"
+        ConfigurationSetting.for_library_and_externalintegration(
+            self._db, "library-registration-stage", failed, discovery_service,
+            ).value = "testing"
         unregistered, ignore = create(
             self._db, Library, name="Library 3", short_name="L3",
         )
@@ -6218,8 +6224,8 @@ class TestLibraryRegistration(SettingsControllerTest):
 
             libraryInfo = serviceInfo[0].get("libraries")
             expected = [
-                dict(short_name=succeeded.short_name, status="success"),
-                dict(short_name=failed.short_name, status="failure"),
+                dict(short_name=succeeded.short_name, status="success", stage="production"),
+                dict(short_name=failed.short_name, status="failure", stage="testing"),
             ]
             eq_(expected, libraryInfo)
 


### PR DESCRIPTION
This helps fix [SIMPLY-1141](https://jira.nypl.org/browse/SIMPLY-1141) along with the UI PR [circ-167](https://github.com/NYPL-Simplified/circulation-web/pull/167). Just exposing the stage variable so that a library's current status can be displayed.