### PR TITLE
If HasSelfTests.prior_test_results raises an exception, act as though there were no test results.

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -2466,10 +2466,10 @@ class SettingsController(AdminCirculationManagerController):
                 # this whole process -- that might prevent an admin from
                 # making the configuration changes necessary to fix
                 # this problem.
-                logging.warn(
-                    "Exception getting self-test results for %r",
-                    collection, exc_info=e
-                )
+                message = _("Exception getting self-test results for collection %s: %s")
+                args = (collection.name, e.message)
+                logging.warn(message, *args, exc_info=e)
+                self_test_results = message % args
 
         return self_test_results
 

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -3428,6 +3428,14 @@ class TestSettingsController(SettingsControllerTest):
         eq_(args[1], OPDSImportMonitor)
         eq_(args[3], OPDSCollection)
 
+        # We don't crash if there's a problem getting the prior test
+        # results -- _get_prior_test_results just returns None.
+        def oops(cls, *args, **kwargs):
+            raise Exception("Test result disaster!")
+        HasSelfTests.prior_test_results = oops
+        self_test_results = controller._get_prior_test_results(OPDSCollection, OPDSImporter)
+        eq_(None, self_test_results)
+
         HasSelfTests.prior_test_results = old_prior_test_results
 
     def test_collection_self_tests_with_no_identifier(self):

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -3028,7 +3028,7 @@ class SettingsControllerTest(AdminControllerTest):
         """Mock HTTP get/post method to replace HTTP.get_with_timeout or post_with_timeout."""
         self.requests.append((url, args, kwargs))
         response = self.responses.pop()
-        return HTTP.process_debuggable_response(response)
+        return HTTP.process_debuggable_response(url, response)
 
 
 class TestSettingsController(SettingsControllerTest):
@@ -3430,11 +3430,19 @@ class TestSettingsController(SettingsControllerTest):
 
         # We don't crash if there's a problem getting the prior test
         # results -- _get_prior_test_results just returns None.
+        @classmethod
         def oops(cls, *args, **kwargs):
             raise Exception("Test result disaster!")
         HasSelfTests.prior_test_results = oops
-        self_test_results = controller._get_prior_test_results(OPDSCollection, OPDSImporter)
-        eq_(None, self_test_results)
+        self_test_results = controller._get_prior_test_results(
+            OPDSCollection, OPDSImporter
+        )
+        eq_(
+            "Exception getting self-test results for collection %s: Test result disaster!" % (
+                OPDSCollection.name
+            ),
+            self_test_results
+        )
 
         HasSelfTests.prior_test_results = old_prior_test_results
 


### PR DESCRIPTION
This fixes a problem I discovered in production. If the Overdrive configuration is incorrect, it's not possible to even instantiate an OverdriveAPI object. This causes `prior_test_results` to raise an unhandled exception. The unhandled exception prevents the admin interface from loading, so there's no way to go in and fix the Overdrive configuration.
