### PR TITLE
Returning the self test exception message in an object for…

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -2469,7 +2469,7 @@ class SettingsController(AdminCirculationManagerController):
                 message = _("Exception getting self-test results for collection %s: %s")
                 args = (collection.name, e.message)
                 logging.warn(message, *args, exc_info=e)
-                self_test_results = message % args
+                self_test_results = dict(exception=message % args)
 
         return self_test_results
 

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.75"
+    "simplified-circulation-web": "0.0.76"
   }
 }

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.77"
+    "simplified-circulation-web": "0.0.78"
   }
 }

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -3441,7 +3441,7 @@ class TestSettingsController(SettingsControllerTest):
             "Exception getting self-test results for collection %s: Test result disaster!" % (
                 OPDSCollection.name
             ),
-            self_test_results
+            self_test_results.exception
         )
 
         HasSelfTests.prior_test_results = old_prior_test_results

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -3441,7 +3441,7 @@ class TestSettingsController(SettingsControllerTest):
             "Exception getting self-test results for collection %s: Test result disaster!" % (
                 OPDSCollection.name
             ),
-            self_test_results.exception
+            self_test_results["exception"]
         )
 
         HasSelfTests.prior_test_results = old_prior_test_results


### PR DESCRIPTION
…consistency instead of as a string.

Bug found by @adriana-alter and later me: The frontend was expecting `self_test_results` to be an object or null. A string is fine but for consistency it may be better to have the error message as a property of `self_test_results`. Part of [circulation-web 170](https://github.com/NYPL-Simplified/circulation-web/pull/170) PR.