### PR TITLE
Generate public/private key pairs as soon as possible, and store them in the database permanently

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -60,9 +60,6 @@ from werkzeug.datastructures import Headers
 from flask_babel import lazy_gettext as _
 import importlib
 
-from Crypto.PublicKey import RSA
-from Crypto.Cipher import PKCS1_OAEP
-
 
 class CannotCreateLocalPatron(Exception):
     """A remote system provided information about a patron, but we could

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -943,7 +943,7 @@ class LibraryAuthenticator(object):
             doc['service_area'] = service_area
 
         # Add the library's public key.
-        doc["public_key"] = dict(type="RSA", value=self.public_key.value)
+        doc["public_key"] = dict(type="RSA", value=self.public_key)
 
         # Add feature flags to signal to clients what features they should
         # offer.

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -582,10 +582,10 @@ class LibraryAuthenticator(object):
         self.bearer_token_signing_secret = bearer_token_signing_secret
         self.initialization_exceptions = dict()
 
-
-        # Make sure there's a public/private key pair for this library.
-        # Store the public key here for convenience; leave the private
-        # key in the database.
+        # Make sure there's a public/private key pair for this
+        # library. This makes it possible to register the library with
+        # discovery services. Store the public key here for
+        # convenience; leave the private key in the database.
         self.public_key, ignore = self.key_pair
 
         if oauth_providers:

--- a/api/config.py
+++ b/api/config.py
@@ -3,7 +3,12 @@ import re
 from nose.tools import set_trace
 import contextlib
 from copy import deepcopy
+
+from Crypto.PublicKey import RSA
+from Crypto.Cipher import PKCS1_OAEP
+
 from flask_babel import lazy_gettext as _
+
 from core.config import (
     Configuration as CoreConfiguration,
     CannotLoadConfiguration,
@@ -507,6 +512,19 @@ class Configuration(CoreConfiguration):
             private_setting.value = key.exportKey()
 
         return public_setting.value, private_setting.value
+
+    @classmethod
+    def cipher(cls, key):
+        """Create a Cipher for a public or private key.
+
+        This just wraps some hard-to-remember Crypto code.
+
+        :param key: A string containing the key.
+
+        :return: A Cipher object which will support either
+        encrypt() (public key) or decrypt() (private key).
+        """
+        return PKCS1_OAEP.new(RSA.import_key(key))
 
 
 @contextlib.contextmanager

--- a/api/config.py
+++ b/api/config.py
@@ -122,6 +122,11 @@ class Configuration(CoreConfiguration):
     # and not editable by admins.
     PUBLIC_KEY = "public-key"
 
+    # Name of the library-wide private key configuration setting for
+    # decrypting a shared secret provided by a library registry. The
+    # setting is automatically generated and not editable by admins.
+    PRIVATE_KEY = "private-key"
+
     SITEWIDE_SETTINGS = CoreConfiguration.SITEWIDE_SETTINGS + [
         {
             "key": BEARER_TOKEN_SIGNING_SECRET,
@@ -468,6 +473,40 @@ class Configuration(CoreConfiguration):
         return cls._email_uri_with_fallback(
             library, Configuration.CONFIGURATION_CONTACT_EMAIL
         )
+
+    @classmethod
+    def key_pair(cls, public_setting, private_setting):
+        """Look up a public-private key pair in two ConfigurationSettings.
+
+        If either setting is unset, a new key pair is created and
+        stored.
+
+        TODO: This could go into ConfigurationSetting or core Configuration.
+
+        :param public_setting: A ConfigurationSetting for the public key.
+        :param private_setting: A ConfigurationSetting for the private key.
+
+        :return: A 2-tuple (public key, private key)
+        """
+        # Prevent bad code where public and private key are mixed up.
+        if 'public' not in public_setting.key.lower():
+            raise ValueError(
+                'Invalid setting "%s" passed in as public key!' %
+                public_setting.key
+            )
+        if 'private' not in private_setting.key.lower()
+            raise ValueError(
+                'Invalid setting "%s" passed in as private key!' %
+                private_setting.key
+            )
+
+        if not public_setting.value or not private_setting.value:
+            key = RSA.generate(2048)
+            encryptor = PKCS1_OAEP.new(key)
+            public_setting.value = key.publickey().exportKey()
+            private_setting.value = key.exportKey()
+
+        return public_setting.value, private_setting.value
 
 
 @contextlib.contextmanager

--- a/api/config.py
+++ b/api/config.py
@@ -499,9 +499,9 @@ class Configuration(CoreConfiguration):
                 'Invalid setting "%s" passed in as public key!' %
                 public_setting.key
             )
-        if 'private' not in private_setting.key.lower()
+        if 'private' not in private_setting.key.lower():
             raise ValueError(
-                'Invalid setting "%s" passed in as private key!' %
+                'Incorrect ConfigurationSetting "%s" passed in as private key!' %
                 private_setting.key
             )
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -203,9 +203,7 @@ class CirculationManager(object):
         new_custom_index_views = {}
 
         # Make sure there's a site-wide public/private key pair.
-        # Store the public key here for convenience; leave the private
-        # key in the database.
-        self.public_key, ignore = self.sitewide_key_pair
+        self.sitewide_key_pair
 
         new_adobe_device_management = None
         for library in self._db.query(Library):
@@ -434,14 +432,12 @@ class CirculationManager(object):
 
     @property
     def public_key_integration_document(self):
-        """Serve a document with the sitewide public key, creating it
-        if necessary.
-        """
+        """Serve a document with the sitewide public key."""
         site_id = ConfigurationSetting.sitewide(self._db, Configuration.BASE_URL_KEY).value
         document = dict(id=site_id)
 
-
-        document['public_key'] = public_key_dict
+        public, private = self.sitewide_key_pair
+        document['public_key'] = dict(type='RSA', value=public)
         return json.dumps(document)
 
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -204,7 +204,6 @@ class CirculationManager(object):
 
         # Make sure there's a site-wide public/private key pair.
         self.sitewide_key_pair
-        set_trace()
 
         new_adobe_device_management = None
         for library in self._db.query(Library):

--- a/api/controller.py
+++ b/api/controller.py
@@ -204,6 +204,7 @@ class CirculationManager(object):
 
         # Make sure there's a site-wide public/private key pair.
         self.sitewide_key_pair
+        set_trace()
 
         new_adobe_device_management = None
         for library in self._db.query(Library):

--- a/api/registry.py
+++ b/api/registry.py
@@ -162,7 +162,7 @@ class Registration(object):
         return setting
 
     def push(self, stage, url_for, catalog_url=None, do_get=HTTP.debuggable_get,
-             do_post=HTTP.debuggable_post, key=None):
+             do_post=HTTP.debuggable_post):
         """Attempt to register a library with a RemoteRegistry.
 
         NOTE: This method is designed to be used in a
@@ -179,8 +179,6 @@ class Registration(object):
             for the application server.
         :param do_get: Mockable method to make a GET request.
         :param do_post: Mockable method to make a POST request.
-        :param key: Pass in an RsaKey object to use a specific public key
-            rather than using the one for this library.
 
         :return: A ProblemDetail if there was a problem; otherwise True.
         """

--- a/api/registry.py
+++ b/api/registry.py
@@ -215,8 +215,8 @@ class Registration(object):
             # session will be committed at the end of this request,
             # so the push attempt would succeed if repeated.
             return SHARED_SECRET_DECRYPTION_ERROR.detailed(
-                "Library %s has no key pair set." %
-                self.library.short_name
+                _("Library %(library)s has no key pair set.",
+                  library=self.library.short_name)
             )
         cipher = Configuration.cipher(private_key)
 
@@ -259,7 +259,7 @@ class Registration(object):
         catalog = json.loads(response.content)
 
         # Process the result.
-        return self._process_registration_result(catalog, self.cipher, stage)
+        return self._process_registration_result(catalog, cipher, stage)
 
     OPDS_1_PREFIX = "application/atom+xml;profile=opds-catalog"
     OPDS_2_TYPE = "application/opds+json"

--- a/api/registry.py
+++ b/api/registry.py
@@ -207,7 +207,7 @@ class Registration(object):
         # needs to be committed to the database _before_ the push
         # attempt starts.
         public_key, private_key = [
-            ConfigurationSetting.for_library(x self.library).value
+            ConfigurationSetting.for_library(x, self.library).value
             for x in (Configuration.PUBLIC_KEY, Configuration.PRIVATE_KEY)
         ]
         if not public_key or not private_key:

--- a/api/registry.py
+++ b/api/registry.py
@@ -197,17 +197,28 @@ class Registration(object):
                 _("%r is not a valid registration stage") % stage
             )
 
-        private_key = ConfigurationSetting.for_library(
-            self.library, Configuration.PRIVATE_KEY
-        )
-        if not private_key.value:
-            # This shouldn't happen because these settings are set on
-            # app server startup.
+        # Verify that a public/private key pair exists for this library.
+        # This key pair is created during initialization of the
+        # LibraryAuthenticator, so this should always be present.
+        #
+        # We can't just create the key pair here because the process
+        # of pushing a registration involves the other site making a
+        # request to the circulation manager. This means the key pair
+        # needs to be committed to the database _before_ the push
+        # attempt starts.
+        public_key, private_key = [
+            ConfigurationSetting.for_library(x self.library).value
+            for x in (Configuration.PUBLIC_KEY, Configuration.PRIVATE_KEY)
+        ]
+        if not public_key or not private_key:
+            # TODO: We could create the key pair _here_. The database
+            # session will be committed at the end of this request,
+            # so the push attempt would succeed if repeated.
             return SHARED_SECRET_DECRYPTION_ERROR.detailed(
-                "Library %s has no private key set." %
+                "Library %s has no key pair set." %
                 self.library.short_name
             )
-        cipher = Configuration.cipher(private_key.value)
+        cipher = Configuration.cipher(private_key)
 
         # Before we can start the registration protocol, we must fetch
         # the remote catalog's URL and extract the link to the

--- a/api/shared_collection.py
+++ b/api/shared_collection.py
@@ -5,9 +5,6 @@ import base64
 import json
 from flask_babel import lazy_gettext as _
 
-from Crypto.PublicKey import RSA
-from Crypto.Cipher import PKCS1_OAEP
-
 from core.model import (
     Collection,
     ConfigurationSetting,
@@ -15,6 +12,7 @@ from core.model import (
     get_one,
 )
 from circulation_exceptions import *
+from config import Configuration
 from core.config import CannotLoadConfiguration
 from core.util.http import HTTP
 
@@ -133,8 +131,7 @@ class SharedCollectionAPI(object):
                 _("Remote authentication document"))
 
         public_key = public_key.get("value")
-        public_key = RSA.importKey(public_key)
-        encryptor = PKCS1_OAEP.new(public_key)
+        public_key = Configuration.cipher(public_key)
 
         normalized_url = IntegrationClient.normalize_url(start_url)
         client = get_one(self._db, IntegrationClient, url=normalized_url)

--- a/api/shared_collection.py
+++ b/api/shared_collection.py
@@ -131,7 +131,7 @@ class SharedCollectionAPI(object):
                 _("Remote authentication document"))
 
         public_key = public_key.get("value")
-        public_key = Configuration.cipher(public_key)
+        encryptor = Configuration.cipher(public_key)
 
         normalized_url = IntegrationClient.normalize_url(start_url)
         client = get_one(self._db, IntegrationClient, url=normalized_url)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1175,11 +1175,6 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         ConfigurationSetting.for_library(
             Configuration.HELP_URI, library).value = "custom:uri"
 
-        # Set up a public key.
-        public_key_setting = ConfigurationSetting.for_library(
-            Configuration.PUBLIC_KEY, library)
-        public_key_setting.value = "public key"
-
         base_url = ConfigurationSetting.sitewide(self._db, Configuration.BASE_URL_KEY)
         base_url.value = u'http://circulation-manager/'
 
@@ -1271,7 +1266,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             eq_("mailto:help@library", copyright_agent['href'])
 
             # The public key is correct.
-            eq_("public key", doc['public_key']['value'])
+            eq_(authenticator.public_key, doc['public_key']['value'])
             eq_("RSA", doc['public_key']['type'])
 
 
@@ -1303,16 +1298,6 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             doc = json.loads(authenticator.create_authentication_document())
             for key in ('focus_area', 'service_area'):
                 assert key not in doc
-
-            # If the library has no public/private key pair, a key
-            # pair is created and stored as a set of per-library settings.
-            public_key_setting.value = None
-            doc = json.loads(authenticator.create_authentication_document())
-            key = doc['public_key']
-            expect = authenticator.public_key
-            assert 'BEGIN PUBLIC KEY' in expect
-            eq_(expect, key['value'])
-            eq_(expect, public_key_setting.value)
 
             # The annotator's annotate_authentication_document method
             # was called and successfully modified the authentication

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,6 @@
+from Crypto.PublicKey import RSA
+from Crypto.Cipher import PKCS1_OAEP
+
 from collections import Counter
 from nose.tools import (
     assert_raises_regexp,
@@ -60,6 +63,25 @@ class TestConfiguration(DatabaseTest):
             Configuration.key_pair, public, irrelevant
         )
 
+    def test_cipher(self):
+        """Test the cipher() helper method."""
+
+        # Generate a public/private key pair.
+        key = RSA.generate(2048)
+        cipher = PKCS1_OAEP.new(key)
+        public = key.publickey().exportKey()
+        private = key.exportKey()
+
+        # Pass the public key into cipher() to get something that can
+        # encrypt.
+        encryptor = Configuration.cipher(public)
+        encrypted = encryptor.encrypt("some text")
+
+        # Pass the private key into cipher() to get something that can
+        # decrypt.
+        decryptor = Configuration.cipher(private)
+        decrypted = decryptor.decrypt(encrypted)
+        eq_("some text", decrypted)
 
     def test_collection_language_method_performs_estimate(self):
         C = Configuration

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,9 @@ from api.config import Configuration
 class TestConfiguration(DatabaseTest):
 
     def test_key_pair(self):
+        # Test the ability to create, replace, or look up a
+        # public/private key pair in a pair of ConfigurationSetting
+        # objects.
         public = ConfigurationSetting.sitewide(
             self._db, Configuration.PUBLIC_KEY
         )
@@ -30,8 +33,8 @@ class TestConfiguration(DatabaseTest):
         )
         irrelevant.value = "blue"
 
-        # If you pass in a public-private key pair, and at least one of the
-        # key pair is missing, a new key pair is created.
+        # If you pass in a pair of ConfigurationSettings, and at least
+        # one of them is missing its value, a new key pair is created.
         public_key, private_key = Configuration.key_pair(public, private)
         assert 'BEGIN PUBLIC KEY' in public_key
         assert 'BEGIN RSA PRIVATE KEY' in private_key

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -244,11 +244,9 @@ class TestRegistration(DatabaseTest):
         url_for = object()
         catalog_url = "http://catalog/"
         do_post = object()
-        key = object()
         def push():
             return registration.push(
-                stage, url_for, catalog_url, registration.mock_do_get, do_post,
-                key
+                stage, url_for, catalog_url, registration.mock_do_get, do_post
             )
 
         result = push()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -266,7 +266,7 @@ class TestRegistration(DatabaseTest):
         ConfigurationSetting.for_library(
             Configuration.PRIVATE_KEY, library).value = key.exportKey()
         result = registration.push(
-            stage, url_for, catalog_url, registration.mock_do_get, do_post, key
+            stage, url_for, catalog_url, registration.mock_do_get, do_post
         )
         eq_("all done!", result)
 
@@ -321,7 +321,7 @@ class TestRegistration(DatabaseTest):
         # If a nonexistent stage is provided a ProblemDetail is the result.
         result = registration.push(
             "no such stage", url_for, catalog_url, registration.mock_do_get,
-            do_post, key
+            do_post
         )
         eq_(INVALID_INPUT.uri, result.uri)
         eq_("'no such stage' is not a valid registration stage",
@@ -331,14 +331,9 @@ class TestRegistration(DatabaseTest):
         # that they return ProblemDetail documents. This tests that if
         # there is a failure at any stage, the ProblemDetail is
         # propagated.
-        def cause_problem():
-            """Try the same method call that worked before; it won't work
-            anymore.
-            """
-            return registration.push(
-                stage, url_for, catalog_url, registration.mock_do_get, do_post,
-                key
-            )
+
+        # The push() function will no longer push anything, so rename it.
+        cause_problem = push
 
         def fail(*args, **kwargs):
             return INVALID_REGISTRATION.detailed(


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1216 by removing the only point in the circulation manager where we do a database commit during a request (rather than at the very end).

Previously we created a public/private key pair, saved the public key to the database, sent an HTTP request to another server, and awaited a response. The other server would make a request to _us_, use the public key in some way, and respond to our original request. We would then use the private key to validate the response to our original request, and delete the public key from the database.

Now we create a public/private key pair for the site when the CirculationManager is initialized -- that is, on the very first request. We create a public/private key pair for a library when its LibraryAuthenticator is created -- again, on the first request.

Unless the very first request made to the circulation manager kicks off this registration process, this ensures that the public key is always available when the callback request is made.

These keys are intended to be transient, and we could just as easily create new ones every single time a CirculationManager or LibraryAuthenticator object is created -- they just need to be in the database _before_ that complicated request begins.