### PR TITLE
Store key pairs in a single Configurationsetting object, and fix call to push()

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -3638,7 +3638,7 @@ class SettingsController(AdminCirculationManagerController):
 
     def discovery_service_library_registrations(
             self, do_get=HTTP.debuggable_get,
-            do_post=HTTP.debuggable_post, key=None,
+            do_post=HTTP.debuggable_post,
             registration_class=None
     ):
         """List the libraries that have been registered with a specific
@@ -3697,7 +3697,7 @@ class SettingsController(AdminCirculationManagerController):
 
             registration = registration_class(registry, library)
             registered = registration.push(
-                stage, self.url_for, do_get=do_get, do_post=do_post, key=key
+                stage, self.url_for, do_get=do_get, do_post=do_post
             )
             if isinstance(registered, ProblemDetail):
                 return registered

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -967,11 +967,10 @@ class LibraryAuthenticator(object):
     def key_pair(self):
         """Look up or create a public/private key pair for use by this library.
         """
-        public, private = [
-            ConfigurationSetting.for_library(x, self.library)
-            for x in Configuration.PUBLIC_KEY, Configuration.PRIVATE_KEY
-        ]
-        return Configuration.key_pair(public, private)
+        setting = ConfigurationSetting.for_library(
+            Configuration.KEY_PAIR, self.library
+        )
+        return Configuration.key_pair(setting)
 
     @classmethod
     def _geographic_areas(cls, library):

--- a/api/controller.py
+++ b/api/controller.py
@@ -424,11 +424,10 @@ class CirculationManager(object):
     @property
     def sitewide_key_pair(self):
         """Look up or create the sitewide public/private key pair."""
-        public, private = [
-            ConfigurationSetting.sitewide(self._db, x)
-            for x in Configuration.PUBLIC_KEY, Configuration.PRIVATE_KEY
-        ]
-        return Configuration.key_pair(public, private)
+        setting = ConfigurationSetting.sitewide(
+            self._db, Configuration.KEY_PAIR
+        )
+        return Configuration.key_pair(setting)
 
     @property
     def public_key_integration_document(self):

--- a/tests/admin/test_controller.py
+++ b/tests/admin/test_controller.py
@@ -6334,12 +6334,11 @@ class TestLibraryRegistration(SettingsControllerTest):
             eq_((Registration.TESTING_STAGE, self.manager.url_for), args)
 
             # We would have made real HTTP requests.
-            eq_(HTTP.debuggable_post, kwargs['do_post'])
-            eq_(HTTP.debuggable_get, kwargs['do_get'])
+            eq_(HTTP.debuggable_post, kwargs.pop('do_post'))
+            eq_(HTTP.debuggable_get, kwargs.pop('do_get'))
 
-            # We would have generated a fresh public key just for this
-            # transaction.
-            eq_(None, kwargs['key'])
+            # No other keyword arguments were passed in.
+            eq_({}, kwargs)
 
 
 class TestCollectionRegistration(SettingsControllerTest):

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1340,13 +1340,12 @@ class TestLibraryAuthenticator(AuthenticatorTest):
 
         library = self._default_library
 
-        # Initially, the PUBLIC_KEY and PRIVATE_KEY settings are not set.
+        # Initially, the KEY_PAIR setting is not set.
         def keys():
-            return [
-                ConfigurationSetting.for_library(v, library).value
-                for v in [Configuration.PUBLIC_KEY, Configuration.PRIVATE_KEY]
-            ]
-        eq_([None, None], keys())
+            return ConfigurationSetting.for_library(
+                Configuration.KEY_PAIR, library
+            ).json_value
+        eq_(None, keys())
 
         # Instantiating a LibraryAuthenticator for a library automatically
         # generates a public/private key pair.


### PR DESCRIPTION
A simple follow-up branch to https://github.com/NYPL-Simplified/circulation/pull/1046. I should have done an end-to-end test on a local circ manager.

Storing the public and private key in the same ConfigurationSetting will avoid the possibility of a race condition. I don't think that explains the problems I've been seeing, but it seems like a good safety measure.