### PR TITLE
Propagate facet information when generating search links.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -680,10 +680,10 @@ class OPDSFeedController(CirculationManagerController):
 
         title = lane.display_name
 
-        annotator = self.manager.annotator(lane)
         facets = load_facets_from_request(worklist=lane)
         if isinstance(facets, ProblemDetail):
             return facets
+        annotator = self.manager.annotator(lane, facets=facets)
         pagination = load_pagination_from_request()
         if isinstance(pagination, ProblemDetail):
             return pagination

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2574,7 +2574,7 @@ class TestFeedController(CirculationControllerTest):
             assert any('order=author' in x['href'] for x in facet_links)
 
             search_link = [x for x in links if x['rel'] == 'search'][0]['href']
-            assert search_link.endswith('/search/%s' % lane_id)
+            assert '/search/%s' % lane_id in search_link
 
             shelf_link = [x for x in links if x['rel'] == 'http://opds-spec.org/shelf'][0]['href']
             assert shelf_link.endswith('/loans/')

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2530,11 +2530,10 @@ class TestFeedController(CirculationControllerTest):
                            ]:
             ConfigurationSetting.for_library(rel, self._default_library).value = value
 
-        with self.request_context_with_library("/"):
+        with self.request_context_with_library("/?entrypoint=Book"):
             response = self.manager.opds_feeds.feed(
                 self.english_adult_fiction.id
             )
-
             assert self.english_1.title in response.data
             assert self.english_2.title not in response.data
             assert self.french_1.title not in response.data
@@ -2549,6 +2548,9 @@ class TestFeedController(CirculationControllerTest):
             eq_("b", by_rel[LibraryAnnotator.PRIVACY_POLICY])
             eq_("c", by_rel[LibraryAnnotator.COPYRIGHT])
             eq_("d", by_rel[LibraryAnnotator.ABOUT])
+
+            search_link = by_rel['search']
+            assert 'entrypoint=Book' in search_link
 
     def test_multipage_feed(self):
         self._work("fiction work", language="eng", fiction=True, with_open_access_download=True)


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-1270 for the `audiobooks` branch.