### PR TITLE
Handle default entry point differently for search controller

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -32,6 +32,7 @@ from core.app_server import (
     HeartbeatController,
     URNLookupController,
 )
+from core.entrypoint import EverythingEntryPoint
 from core.external_search import (
     ExternalSearchIndex,
     MockExternalSearchIndex,
@@ -765,7 +766,8 @@ class OPDSFeedController(CirculationManagerController):
         library_short_name = flask.request.library.short_name
 
         facets = load_facets_from_request(
-            worklist=lane, base_class=SearchFacets
+            worklist=lane, base_class=SearchFacets,
+            default_entrypoint=EverythingEntryPoint,
         )
 
         # Create a function that, when called, generates a URL to the

--- a/api/opds.py
+++ b/api/opds.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import lazyload
 from core.cdn import cdnify
 from core.classifier import Classifier
 from core.entrypoint import (
-    DefaultEntryPoint,
     EverythingEntryPoint,
 )
 from core.opds import (
@@ -733,7 +732,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         if lane and lane.search_target:
             search_facet_kwargs = {}
             if self.facets != None:
-                if isinstance(self.facets.entrypoint, DefaultEntryPoint):
+                if self.facets.entrypoint_is_default:
                     # The currently selected entry point is a default.
                     # Rather than using it, we want the 'default' behavior
                     # for search, which is to search everything.

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -44,7 +44,6 @@ from core.classifier import (
 
 from core.entrypoint import (
     AudiobooksEntryPoint,
-    DefaultEntryPoint,
     EverythingEntryPoint,
 )
 from core.external_search import MockExternalSearchIndex
@@ -1206,9 +1205,7 @@ class TestLibraryAnnotator(VendorIDTest):
 
         # When the selected EntryPoint is a default, it's not used --
         # instead, we search everything.
-        annotator.facets.entrypoint = DefaultEntryPoint(
-            annotator.facets.entrypoint
-        )
+        annotator.facets.entrypoint_is_default = True
         links = annotated_links(lane, annotator)
         [url] = links['search']
         assert 'entrypoint=%s' % EverythingEntryPoint.INTERNAL_NAME in url


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-1262 as well as a related problem.

If the currently selected EntryPoint is selected because it's the default (as opposed to because the user deliberately chose it), then a search from that feed will no longer search the currently selected EntryPoint -- it will search the entire collection.

The related problem: if you hit the search controller directly, without specifying an EntryPoint, you want to search everything, not the library's default entrypoint.