### PR TITLE
A Findaway DRM document is also the manifest file

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -132,7 +132,7 @@ class BibliothecaAPI(BaseCirculationAPI, HasSelfTests):
     delivery_mechanism_to_internal_format = {
         (Representation.EPUB_MEDIA_TYPE, adobe_drm): 'ePub',
         (Representation.PDF_MEDIA_TYPE, adobe_drm): 'PDF',
-        (Representation.MP3_MEDIA_TYPE, findaway_drm) : 'MP3'
+        (None, findaway_drm) : 'MP3'
     }
     internal_format_to_delivery_mechanism = dict(
         [v,k] for k, v in delivery_mechanism_to_internal_format.items()


### PR DESCRIPTION
This builds off of https://github.com/NYPL-Simplified/server_core/pull/965, changing the Bibliotheca client to represent Findaway audiobooks as having no underlying media type separate from the DRM document/manifest file.

This is the only existing delivery mechanism that works this way, although the Axis 360 client will work the same way once it's ready. The migration code in 965 changes this for existing audiobooks.