### PR TITLE
The first entry point is treated as the default only for WorkLists that have no parent.

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -594,6 +594,7 @@ class CacheFacetListsPerLane(CacheRepresentationPerLane):
         )
         chosen_collections = self.collections or [default_collection]
 
+        top_level = (lane.parent is None)
         for entrypoint_name in chosen_entrypoints:
             entrypoint = EntryPoint.BY_INTERNAL_NAME.get(entrypoint_name)
             if not entrypoint:
@@ -620,6 +621,7 @@ class CacheFacetListsPerLane(CacheRepresentationPerLane):
                             availability=availability,
                             entrypoint=entrypoint,
                             entrypoint_is_default=(
+                                top_level and
                                 entrypoint.INTERNAL_NAME == default_entrypoint_name
                             ),
                             order=order, order_ascending=True
@@ -676,6 +678,7 @@ class CacheOPDSGroupFeedPerLane(CacheRepresentationPerLane):
         This is the only way grouped feeds are ever generated, so there is
         no way to override this.
         """
+        top_level = (lane.parent is None)
         library = lane.get_library(self._db)
 
         # If the WorkList has explicitly defined EntryPoints, we want to
@@ -694,7 +697,9 @@ class CacheOPDSGroupFeedPerLane(CacheRepresentationPerLane):
                 minimum_featured_quality=library.minimum_featured_quality,
                 uses_customlists=lane.uses_customlists,
                 entrypoint=entrypoint,
-                entrypoint_is_default=(entrypoint is default_entrypoint)
+                entrypoint_is_default=(
+                    top_level and entrypoint is default_entrypoint
+                )
             )
             yield facets
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -318,6 +318,15 @@ class TestCacheFacetListsPerLane(TestLaneScript):
             eq_(Facets.AVAILABLE_NOW, f.availability)
             eq_(Facets.COLLECTION_FULL, f.collection)
 
+        # The first entry point is treated as the default only for WorkLists
+        # that have no parent. When the WorkList has a parent, the selected
+        # entry point is treated as an explicit choice -- navigating downward
+        # in the lane hierarchy ratifies the default value.
+        sublane = self._lane(parent=lane)
+        f1, f2 = script.facets(sublane)
+        for f in f1, f2:
+            eq_(False, f.entrypoint_is_default)
+
     def test_pagination(self):
         script = CacheFacetListsPerLane(self._db, manager=object(), cmd_args=[])
         script.pages = 3
@@ -475,6 +484,15 @@ class TestCacheOPDSGroupFeedPerLane(TestLaneScript):
             # The FeaturedFacets object knows that custom lists are
             # not in play.
             eq_(False, facets.uses_customlists)
+
+        # The first entry point is treated as the default only for WorkLists
+        # that have no parent. When the WorkList has a parent, the selected
+        # entry point is treated as an explicit choice  -- navigating downward
+        # in the lane hierarchy ratifies the default value.
+        sublane = self._lane(parent=lane)
+        f1, f2 = script.facets(sublane)
+        for f in f1, f2:
+            eq_(False, f.entrypoint_is_default)
 
         # Make it look like the lane uses custom lists.
         lane.list_datasource = DataSource.lookup(self._db, DataSource.OVERDRIVE)


### PR DESCRIPTION
This branch fixes an edge case in https://jira.nypl.org/browse/SIMPLY-1261:

If you search from the top level, then your choice of 'eBooks' is a default choice and you should search everything.

But if you go down into 'Fiction' or 'Best Sellers', then your choice of 'eBooks' is an explicit choice (even though 'eBooks' is the default entry point) and your search should include only ebooks.

I can't reliably duplicate this bug in a real site, but I have seen it once and think it's pretty clearly there based on the code.