### PR TITLE
When only one entry point is enabled, use that entry point as the SearchFacets default

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -757,6 +757,21 @@ class OPDSFeedController(CirculationManagerController):
         )
         return feed_response(feed)
 
+    def _load_search_facets(self, lane):
+        entrypoints = list(flask.request.library.entrypoints)
+        if len(entrypoints) > 1:
+            # There is more than one enabled EntryPoint.
+            # By default, search them all.
+            default_entrypoint = EverythingEntryPoint
+        else:
+            # There is only one enabled EntryPoint,
+            # and no need for a special default.
+            default_entrypoint = None
+        return load_facets_from_request(
+            worklist=lane, base_class=SearchFacets,
+            default_entrypoint=default_entrypoint,
+        )
+
     def search(self, lane_identifier):
 
         lane = self.load_lane(lane_identifier)
@@ -764,11 +779,7 @@ class OPDSFeedController(CirculationManagerController):
             return lane
         query = flask.request.args.get('q')
         library_short_name = flask.request.library.short_name
-
-        facets = load_facets_from_request(
-            worklist=lane, base_class=SearchFacets,
-            default_entrypoint=EverythingEntryPoint,
-        )
+        facets = self._load_search_facets(lane)
 
         # Create a function that, when called, generates a URL to the
         # search controller.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2858,10 +2858,7 @@ class TestFeedController(CirculationControllerTest):
                 # Assert that the given `link` propagates
                 # the query string arguments found in the facets
                 # associated with this request.
-                facets = load_facets_from_request(
-                    self._default_library, lane, base_class=SearchFacets,
-                    default_entrypoint=EverythingEntryPoint,
-                )
+                facets = self.manager.opds_feeds._load_search_facets(lane)
                 for k, v in facets.items():
                     check = '%s=%s' % tuple(map(urllib.quote, (k,v)))
                     assert check in link['href']
@@ -2899,8 +2896,17 @@ class TestFeedController(CirculationControllerTest):
         # Verify that AcquisitionFeed.search() is passed a faceting
         # object with the appropriately selected EntryPoint.
 
-        # By default, the library only has one entry point enabled.
-        # We need to enable more than one so it's a real choice.
+        # By default, the library only has one entry point enabled --
+        # EbooksEntryPoint. In that case, the enabled entry point is
+        # always used.
+        with self.request_context_with_library("/?q=t"):
+            self.manager.opds_feeds.search(None)
+            (s, args) = self.called_with
+            facets = args['facets']
+            assert isinstance(facets, SearchFacets)
+            eq_(EbooksEntryPoint, facets.entrypoint)
+
+        # Enable another entry point so there's a real choice.
         library = self._default_library
         library.setting(EntryPoint.ENABLED_SETTING).value = json.dumps(
             [AudiobooksEntryPoint.INTERNAL_NAME, EbooksEntryPoint.INTERNAL_NAME]


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-1293. The problem was that the EverythingEntryPoint was used as the SearchFacets default, even when there was only one enabled entry point and so the EverythingEntryPoint wasn't even an option. This made AcquisitionFeed.add_entrypoint_links() in core decide to explicitly add a link to the selected entry point (because the selected entry point differed from the default), but the problem wasn't there -- the default was wrong.