### PR TITLE
_remote_patron_lookup returning dict

### DIFF
--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -100,8 +100,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
                 client = SIPClient(
                     target_server=server, target_port=port,
                     login_user_id=login_user_id, login_password=login_password,
-                    location_code=location_code, separator=field_separator,
-                    connect=connect
+                    location_code=location_code, separator=field_separator
                 )
 
         except IOError, e:

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -116,9 +116,10 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             )
 
     def _remote_patron_lookup(self, patron_or_patrondata):
-        return self.patron_information(
+        info = self.patron_information(
             patron_or_patrondata.authorization_identifier, None
         )
+        return self.info_to_patrondata(info, False)
 
     def remote_authenticate(self, username, password):
         """Authenticate a patron with the SIP2 server.
@@ -135,7 +136,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         return self.info_to_patrondata(info)
 
     @classmethod
-    def info_to_patrondata(cls, info):
+    def info_to_patrondata(cls, info, validate_password=True):
 
         """Convert the SIP-specific dictionary obtained from
         SIPClient.patron_information() to an abstract,
@@ -146,7 +147,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             # library. Don't return any data.
             return None
 
-        if info.get('valid_patron_password') == 'N':
+        if info.get('valid_patron_password') == 'N' and validate_password:
             # The patron did not authenticate correctly. Don't
             # return any data.
             return None

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -98,7 +98,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             if self.client:
                 sip = self.client
             else:
-                sip = self.client(
+                sip = SIPClient(
                     target_server=self.server, target_port=self.port,
                     login_user_id=self.login_user_id, login_password=self.login_password,
                     location_code=self.location_code, separator=self.field_separator
@@ -106,7 +106,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             sip.connect()
             sip.login()
             info = sip.patron_information(username, password)
-            sip.end_session()
+            sip.end_session(username, password)
             sip.disconnect()
             return info
 

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -84,33 +84,39 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         super(SIP2AuthenticationProvider, self).__init__(
             library, integration, analytics
         )
+
+        self.server = integration.url
+        self.port = integration.setting(self.PORT).int_value
+        self.login_user_id = integration.username
+        self.login_password = integration.password
+        self.location_code = integration.setting(self.LOCATION_CODE).value
+        self.field_separator = integration.setting(self.FIELD_SEPARATOR).value or '|'
+        self.client = client
+
+    def patron_information(self, username, password):
         try:
-            server = None
-            if client:
-                if callable(client):
-                    client = client()
+            if self.client:
+                sip = self.client
             else:
-                server = integration.url
-                port = integration.setting(self.PORT).int_value
-                login_user_id = integration.username
-                login_password = integration.password
-                location_code = integration.setting(self.LOCATION_CODE).value
-                field_separator = integration.setting(
-                    self.FIELD_SEPARATOR).value or '|'
-                client = SIPClient(
-                    target_server=server, target_port=port,
-                    login_user_id=login_user_id, login_password=login_password,
-                    location_code=location_code, separator=field_separator
+                sip = self.client(
+                    target_server=self.server, target_port=self.port,
+                    login_user_id=self.login_user_id, login_password=self.login_password,
+                    location_code=self.location_code, separator=self.field_separator
                 )
+            sip.connect()
+            sip.login()
+            info = sip.patron_information(username, password)
+            sip.end_session()
+            sip.disconnect()
+            return info
 
         except IOError, e:
             raise RemoteIntegrationException(
-                server or 'unknown server', e.message
+                self.server or 'unknown server', e.message
             )
-        self.client = client
 
     def _remote_patron_lookup(self, patron_or_patrondata):
-        return self.client.patron_information(
+        return self.patron_information(
             patron_or_patrondata.authorization_identifier, None
         )
 
@@ -125,13 +131,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             # Even if we were somehow given a password, we won't be
             # passing it on.
             password = None
-        try:
-            info = self.client.patron_information(username, password)
-        except IOError, e:
-            raise RemoteIntegrationException(
-                self.client.target_server or 'unknown server',
-                e.message
-            )
+        info = self.patron_information(username, password)
         return self.info_to_patrondata(info)
 
     @classmethod

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -288,6 +288,9 @@ class SIPClient(Constants):
     def connect(self):
         """Create a socket connection to a SIP server."""
         try:
+            if self.connection:
+                # If we are still connected then disconnect.
+                self.disconnect()
             self.connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.connection.connect((self.target_server, self.target_port))
         except TypeError:

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -27,12 +27,8 @@ limitations under the License.
 
 import datetime
 import logging
-from nose.tools import set_trace
 import re
 import socket
-import sys
-import threading
-import time
 
 # SIP2 defines a large number of fields which are used in request and
 # response messages. This library focuses on defining the response
@@ -76,6 +72,7 @@ fixed._add('fine_items_count', 4)
 fixed._add('recall_items_count', 4)
 fixed._add('unavailable_holds_count', 4)
 fixed._add('login_ok', 1)
+fixed._add('end_session', 1)
 
 class named(object):
     """A variable-length field in a SIP2 response."""
@@ -234,8 +231,7 @@ class SIPClient(Constants):
     ]
 
     def __init__(self, target_server, target_port, login_user_id=None,
-                 login_password=None, location_code=None, separator=None,
-                 connect=True):
+                 login_password=None, location_code=None, separator=None):
         self.target_server = target_server
         if not target_port:
             target_port = 6001
@@ -252,127 +248,94 @@ class SIPClient(Constants):
             escaped = self.separator
         self.separator_re = re.compile(escaped + "([A-Z][A-Z])")
 
+        self.sequence_number = 0
+
         self.login_user_id = login_user_id
         self.login_password = login_password
         if login_user_id and login_password:
             # We need to log in before using this server.
-            self.logged_in = False
             self.must_log_in = True
         else:
             # We're implicitly logged in.
-            self.logged_in = True
             self.must_log_in = False
 
-        # socket_lock controls access to the socket connection to the
-        # SIP2 server.
-        #
-        # We need to use an RLock here because both connect() and
-        # make_request() require the lock, and make_request() will end
-        # up calling connect() if there's an error.
-        self.socket_lock = threading.RLock()
-
-        # The only reason connect would be false is that we're running
-        # a unit test and don't actually want to use a server.
-        if connect:
-            self.connect()
-
-    def login(self, *args, **kwargs):
-        """Log in to the SIP server."""
-        return self.make_request(
-            self.login_message, self.login_response_parser,
-            *args, **kwargs
-        )
+    def login(self, connection):
+        """Log in to the SIP server if required."""
+        if self.must_log_in:
+            response = self.make_request(
+                connection, self.login_message, self.login_response_parser,
+                self.login_user_id, self.login_password, self.location_code
+            )
+            if response['login_ok'] != '1':
+                raise IOError("Error logging in: %r" % response)
+            return response
 
     def patron_information(self, *args, **kwargs):
         """Get information about a patron, possibly also verifying their
         password.
         """
+        connection = self.connect()
+        self.login(connection)
+        information = self._patron_information(connection, *args, **kwargs)
+        self.end_session(connection, *args, **kwargs)
+        self.disconnect(connection)
+        return information
+
+    def _patron_information(self, connection, *args, **kwargs):
+        """Get information about a patron.
+        """
         return self.make_request(
-            self.patron_information_request, self.patron_information_parser,
+            connection, self.patron_information_request, self.patron_information_parser,
+            *args, **kwargs
+        )
+
+    def end_session(self, connection, *args, **kwargs):
+        """Send end session message."""
+        return self.make_request(
+            connection, self.end_session_message, self.end_session_response_parser,
             *args, **kwargs
         )
 
     def connect(self):
         """Create a socket connection to a SIP server."""
-        with self.socket_lock:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                sock.connect((self.target_server, self.target_port))
-            except TypeError:
-                raise IOError(
-                    "Could not connect to %s:%s" % (
-                        self.target_server, self.target_port
-                    )
+        connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            connection.connect((self.target_server, self.target_port))
+        except TypeError:
+            raise IOError(
+                "Could not connect to %s:%s" % (
+                    self.target_server, self.target_port
                 )
-            sock.settimeout(12)
+            )
+        connection.settimeout(12)
 
-            # Since this is a new socket connection, reset the message count
-            # and, potentially, logged_in.
-            self.reset_connection_state()
-            self.socket = sock
-        return sock
+        # Since this is a new socket connection, reset the message count
+        self.reset_connection_state()
+        return connection
 
     def reset_connection_state(self):
         """Reset connection-specific state.
-
-        Specifically, the sequence number and the flag that tracks
-        whether we're logged in.
+        Specifically, the sequence number.
         """
         self.sequence_number = 0
-        if self.must_log_in:
-            self.logged_in = False
 
-    def make_request(self, message_creator, parser, *args, **kwargs):
+    def disconnect(self, connection):
+        """Close the connection to the SIP server."""
+        connection.close()
+
+    def make_request(self, connection, message_creator, parser, *args, **kwargs):
         """Send a request to a SIP server and parse the response.
 
+        :param connection: Socket to send data over.
         :param message_creator: A function that creates the message to send.
         :param parser: A function that parses the response message.
         """
-        with self.socket_lock:
-            return self._make_request(
-                message_creator, parser, *args, **kwargs
-            )
-
-    def _make_request(self, message_creator, parser, *args, **kwargs):
-        """Send a request to a SIP server and parse the response.
-
-        :param message_creator: A function that creates the message to send.
-        :param parser: A function that parses the response message.
-        """
-        if 'fail_on_network_error' in kwargs:
-            fail_on_network_error = kwargs.pop('fail_on_network_error')
-        else:
-            fail_on_network_error = False
-
-        if (self.must_log_in and not self.logged_in
-            and message_creator != self.login_message):
-            # The first thing we need to do is log in.
-            response = self.login(self.login_user_id, self.login_password,
-                                  self.location_code)
-            if response['login_ok'] != '1':
-                raise IOError("Error logging in: %r" % response)
-            self.logged_in = True
-
         original_message = message_creator(*args, **kwargs)
         message_with_checksum = self.append_checksum(original_message)
         parsed = None
         while not parsed:
-            try:
-                self.send(message_with_checksum)
-                response = self.read_message()
-            except (IOError, socket.error), e:
-                # Most likely there was a problem with the
-                # socket. Create a fresh socket connection and try
-                # again, unless this _is_ the 'try again' phase and
-                # we're still having a problem.
-                if fail_on_network_error:
-                    raise e
-                else:
-                    self.connect()
-                    return self.make_request(
-                        message_creator, parser,
-                        *args, fail_on_network_error=True, **kwargs
-                    )
+            self.send(connection, message_with_checksum)
+            response = self.read_message(connection)
             try:
                 parsed = parser(response)
             except RequestResend, e:
@@ -383,7 +346,6 @@ class SIPClient(Constants):
                     original_message, include_sequence_number=False
                 )
         return parsed
-
 
     def login_message(self, login_user_id, login_password, location_code="",
                       uid_algorithm="0",
@@ -405,10 +367,54 @@ class SIPClient(Constants):
             fixed.login_ok
         )
 
+    def end_session_message(
+            self, patron_identifier, patron_password="", institution_id="",
+            terminal_password="",
+    ):
+        """
+        This message will be sent when a patron has completed all of their
+        transactions. The ACS may, upon receipt of this command, close any
+        open files or deallocate data structures pertaining to that patron.
+        The ACS should respond with an End Session Response message.
+
+        Format of message to send to ILS:
+        35<transaction date><institution id><patron identifier>
+        <terminal password><patron password>
+        transaction date: 18-char, YYYYMMDDZZZZHHMMSS, required
+        institution id: AO, variable length, required
+        patron identifier: AA, variable length, required
+        terminal password: AC, variable length, optional
+        patron password: AD, variable length, optional
+        """
+        code = "35"
+        timestamp = self.now()
+
+        message = (code + timestamp +
+                   "AO" + institution_id + self.separator +
+                   "AA" + patron_identifier + self.separator +
+                   "AC" + terminal_password
+        )
+        if patron_password:
+            message += self.separator + "AD" + patron_password
+        return message
+
+    def end_session_response_parser(self, message):
+        """Parse the response from a end session message."""
+        return self.parse_response(
+            message,
+            36,
+            fixed.end_session,
+            fixed.transaction_date,
+            named.institution_id.required,
+            named.patron_identifier.required,
+            named.screen_message,
+            named.print_line
+        )
+
     def patron_information_request(
             self, patron_identifier, patron_password="", institution_id="",
             terminal_password="",
-            language=None, summary=None, start_item="", end_item=""
+            language=None, summary=None
     ):
         """
         A superset of patron status request.
@@ -545,7 +551,6 @@ class SIPClient(Constants):
         :param return: A dictionary containing the parsed-out information.
         """
         parsed = {}
-        original_message = data
         data = self.consume_status_code(data, str(expect_status_code), parsed)
 
         fields_by_sip_code = dict()
@@ -609,7 +614,6 @@ class SIPClient(Constants):
                     if field.required and field in required_fields_not_seen:
                         required_fields_not_seen.remove(field)
             i += 2
-            field = fields_by_sip_code
 
         # If a named field is required and never showed up, sound the alarm.
         for field in required_fields_not_seen:
@@ -686,28 +690,27 @@ class SIPClient(Constants):
             )
         return summary
 
-    def send(self, data):
+    def send(self, connection, data):
         """Send a message over the socket and update the sequence index."""
         data = data + '\r'
-        return self.do_send(data)
+        return self.do_send(connection, data)
 
-    def do_send(self, data):
+    def do_send(self, connection, data):
         """Actually send data over the socket.
 
         This method exists only to be subclassed by MockSIPClient.
         """
-        self.socket.send(data)
+        connection.send(data)
 
-    def read_message(self, max_size=1024*1024):
+    def read_message(self, connection, max_size=1024*1024):
         """Read a SIP2 message from the socket connection.
 
         A SIP2 message ends with a \r character.
         """
         done = False
         data = ""
-        tmp = ""
         while not done:
-            tmp = self.socket.recv(4096)
+            tmp = connection.recv(4096)
             data = data + tmp
             if not tmp:
                 raise IOError("No data read from socket.")
@@ -715,7 +718,6 @@ class SIPClient(Constants):
                 done = True
             if len(data) > max_size:
                 raise IOError("SIP2 response too large.")
-
         return data
 
     def append_checksum(self, text, include_sequence_number=True):
@@ -782,21 +784,28 @@ class MockSIPClient(SIPClient):
         # connection-specific variables.
         self.status.append("Creating new socket connection.")
         self.reset_connection_state()
+        return None
 
-    def do_send(self, data):
+    def do_send(self, connection, data):
         self.requests.append(data)
 
-    def read_message(self):
+    def read_message(self, connection, max_size=1024*1024):
         """Read a response message off the queue."""
         response = self.responses[0]
         self.responses = self.responses[1:]
         return response
 
+    def end_session(self, connection, *args, **kwargs):
+        pass
+
+    def disconnect(self, connection):
+        pass
+
 
 class CannotSendMockSIPClient(MockSIPClient):
     """A MockSIPClient that can never send data."""
 
-    def do_send(self, data):
+    def do_send(self, connection, data):
         self.status.append("I was unable to send data.")
         raise IOError("I'm doomed.")
 
@@ -804,6 +813,6 @@ class CannotSendMockSIPClient(MockSIPClient):
 class CannotReceiveMockSIPClient(MockSIPClient):
     """A MockSIPClient that can send data but never receives any."""
 
-    def read_message(self):
+    def read_message(self, connection, max_size=1024*1024):
         self.status.append("I was unable to read data.")
         raise socket.timeout()

--- a/tests/mock_authentication_provider.py
+++ b/tests/mock_authentication_provider.py
@@ -1,0 +1,19 @@
+from api.authenticator import BasicAuthenticationProvider
+from core.util.http import RemoteIntegrationException
+
+
+class MockExplodingAuthenticationProvider(BasicAuthenticationProvider):
+    def __init__(self, library, integration, analytics=None, patron=None, patrondata=None, *args, **kwargs):
+        raise RemoteIntegrationException("Mock", "Mock exploded.")
+
+    def authenticate(self, _db, header):
+        pass
+
+    def remote_authenticate(self, username, password):
+        pass
+
+    def remote_patron_lookup(self, patrondata):
+        pass
+
+
+AuthenticationProvider = MockExplodingAuthenticationProvider

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -255,12 +255,18 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
             def patron_information(self, identifier, password):
                 self.patron_information = identifier
                 self.password = password
-                return "Result"
+                return self.patron_information_parser(TestSIP2AuthenticationProvider.polaris_wrong_pin)
 
         client = Mock()
         auth = SIP2AuthenticationProvider(
             self._default_library, integration, client=client
         )
-        eq_(auth._remote_patron_lookup(patron), "Result")
-        eq_(client.patron_information, patron.authorization_identifier)
+        patron = auth._remote_patron_lookup(patron)
+        eq_(patron.__class__, PatronData)
+        eq_("25891000331441", patron.authorization_identifier)
+        eq_("foo@bar.com", patron.email_address)
+        eq_(9.25, patron.fines)
+        eq_("Falk, Jen", patron.personal_name)
+        eq_(datetime(2018, 6, 9, 23, 59, 59), patron.authorization_expires)
+        eq_(client.patron_information, "1234")
         eq_(client.password, None)

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -316,7 +316,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         eq_(None, patron.external_type)
         eq_(PatronData.NO_VALUE, patron.block_reason)
 
-        # Test with invalid login, should return None
+        # Test with invalid login, should return PatronData
         info = client.patron_information_parser(TestSIP2AuthenticationProvider.sierra_invalid_login)
         patron = provider.info_to_patrondata(info, validate_password=False)
         eq_(patron.__class__, PatronData)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -714,12 +714,11 @@ class TestLibraryAuthenticator(AuthenticatorTest):
 
     def test_register_provider_fails_but_does_not_explode_on_remote_integration_error(self):
         library = self._default_library
-        # We're going to instantiate the SIP2 client but since we're not
-        # specifying a server or a port, it will raise an IOError immediately,
-        # which will become a RemoteIntegrationException, which will become
+        # We're going to instantiate the a mock authentication provider that
+        # immediately raises a RemoteIntegrationException, which will become
         # a CannotLoadConfiguration.
         integration = self._external_integration(
-            "api.sip", ExternalIntegration.PATRON_AUTH_GOAL
+            "tests.mock_authentication_provider", ExternalIntegration.PATRON_AUTH_GOAL
         )
         library.integrations.append(integration)
         auth = LibraryAuthenticator(_db=self._db, library=library)


### PR DESCRIPTION
`_remote_patron_lookup` is suposed to return a `PatronData` object but it is returning a dictionary of values from SIPClient.

Call the function to tranform it into a proper `PatronData` object and additionally add some exception handling.

Prevents this error that I was seeing when patrons are logging in: 
```
{"host": "6436e280159d", "name": "root", "level": "ERROR", "timestamp": "2018-10-08T16:50:58.598228", "app": "simplified", "traceback": "Traceback (most recent call last):
  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/flask/app.py\", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/flask/app.py\", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File \"/var/www/circulation/api/routes.py\", line 147, in decorated
    return f(*args, **kwargs)
  File \"/var/www/circulation/api/routes.py\", line 116, in wrapped_function
    resp = make_response(f(*args, **kwargs))
  File \"/var/www/circulation/api/routes.py\", line 89, in decorated
    patron = app.manager.index_controller.authenticated_patron_from_request()
  File \"/var/www/circulation/api/base_controller.py\", line 42, in authenticated_patron_from_request
    patron = self.authenticated_patron(header)
  File \"/var/www/circulation/api/base_controller.py\", line 69, in authenticated_patron
    self._db, authorization_header
  File \"/var/www/circulation/api/authenticator.py\", line 470, in authenticated_patron
    return self.invoke_authenticator_method(\"authenticated_patron\", _db, header)
  File \"/var/www/circulation/api/authenticator.py\", line 467, in invoke_authenticator_method
    return getattr(self.library_authenticators[short_name], method_name)(*args, **kwargs)
  File \"/var/www/circulation/api/authenticator.py\", line 729, in authenticated_patron
    return self.basic_auth_provider.authenticated_patron(_db, header)
  File \"/var/www/circulation/api/authenticator.py\", line 1296, in authenticated_patron
    patron = self.authenticate(_db, header)
  File \"/var/www/circulation/api/authenticator.py\", line 1779, in authenticate
    patrondata = self.remote_patron_lookup(patrondata)
  File \"/var/www/circulation/api/authenticator.py\", line 1664, in remote_patron_lookup
    return self.enforce_library_identifier_restriction(patron_info.authorization_identifier, patron_info)
AttributeError: 'dict' object has no attribute 'authorization_identifier'", "message": "Exception in web app: 'dict' object has no attribute 'authorization_identifier'", "filename": "app_server.py"}
```