### PR TITLE
exception_handler should leave werkzeug exceptions alone.

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -10,6 +10,7 @@ from flask import (
     make_response,
 )
 from flask_cors.core import get_cors_options, set_cors_headers
+from werkzeug.exceptions import HTTPException
 
 from app import app, babel
 
@@ -127,6 +128,11 @@ h = ErrorHandler(app, app.config['DEBUG'])
 @app.errorhandler(Exception)
 @allows_patron_web
 def exception_handler(exception):
+    if isinstance(exception, HTTPException):
+        # This isn't an exception we need to handle, it's werkzeug's way
+        # of interrupting normal control flow with a specific HTTP response.
+        # Return the exception and it will be used as the response.
+        return exception
     return h.handle(exception)
 
 def has_library(f):


### PR DESCRIPTION
Our exception handler deals with exceptions by converting them to problem detail documents if possible, and by generating 500 errors if not. There's a third class of exception we weren't handling: HTTPExceptions generated by werkzeug which handle things like 405 errors and (crucially) redirects generated by the routing code.

Since those exceptions don't get turned into problem detail documents, we were turning them into 500 errors. So redirects were turning into 500 errors. Pretty bad. This branch changes the exception handler to 'handle' HTTPExceptions by returning them -- they'll be converted into the proper HTTP responses.