### PR TITLE
Store a library's web client URL when a registry provides one.

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -27,8 +27,6 @@ class Configuration(CoreConfiguration):
     DEFAULT_OPDS_FORMAT = "simple_opds_entry"
 
     # The name of the sitewide url that points to the patron web catalog.
-    # May be a comma-separated list if there is more than one supported
-    # web client.
     PATRON_WEB_CLIENT_URL = u"Patron Web Client"
 
     # The name of the sitewide secret used to sign cookies for admin login.

--- a/api/config.py
+++ b/api/config.py
@@ -27,6 +27,8 @@ class Configuration(CoreConfiguration):
     DEFAULT_OPDS_FORMAT = "simple_opds_entry"
 
     # The name of the sitewide url that points to the patron web catalog.
+    # May be a comma-separated list if there is more than one supported
+    # web client.
     PATRON_WEB_CLIENT_URL = u"Patron Web Client"
 
     # The name of the sitewide secret used to sign cookies for admin login.

--- a/api/routes.py
+++ b/api/routes.py
@@ -116,7 +116,7 @@ def allows_patron_web(f):
         patron_web_client_url = app.manager.patron_web_client_url
         if patron_web_client_url:
             options = get_cors_options(
-                app, dict(origins=[patron_web_client_url],
+                app, dict(origins=patron_web_client_url.split(","),
                           supports_credentials=True)
             )
             set_cors_headers(resp, options)

--- a/api/routes.py
+++ b/api/routes.py
@@ -113,10 +113,10 @@ def allows_patron_web(f):
         else:
             resp = make_response(f(*args, **kwargs))
 
-        patron_web_client_url = app.manager.patron_web_client_url
-        if patron_web_client_url:
+        patron_web_domains = app.manager.patron_web_domains
+        if patron_web_domains:
             options = get_cors_options(
-                app, dict(origins=patron_web_client_url.split(","),
+                app, dict(origins=patron_web_domains,
                           supports_credentials=True)
             )
             set_cors_headers(resp, options)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -573,12 +573,8 @@ class TestRegistration(DatabaseTest):
         eq_((encryptor, "ciphertext"), reg._decrypt_shared_secret_called_with)
         eq_("cleartext", reg.setting(ExternalIntegration.PASSWORD).value)
 
-        # Web client URL is set, both in a registration setting and in the
-        # sitewide setting for the patron web URL.
+        # Web client URL is set.
         eq_("http://web/library", reg.setting(reg.LIBRARY_REGISTRATION_WEB_CLIENT).value)
-        # The path has been removed for the sitewide setting.
-        eq_("http://web",
-            ConfigurationSetting.sitewide(self._db, Configuration.PATRON_WEB_CLIENT_URL).value)
 
         eq_("another new stage", reg.stage_field.value)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -35,7 +35,7 @@ class MockManager(object):
         self._cache = {}
 
         # This is used by the allows_patron_web annotator.
-        self.patron_web_client_url = "http://patron/web"
+        self.patron_web_domains = set(["http://patron/web"])
 
     def __getattr__(self, controller_name):
         return self._cache.setdefault(


### PR DESCRIPTION
This uses the registry change in https://github.com/NYPL-Simplified/library_registry/pull/79 to get the web client URL for a library when it's successfully registered.

This also changes the sitewide web URL setting to support more than one web-based client.