### PR TITLE
Restore the validation code for web colors and web header links.

### DIFF
--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -5,6 +5,8 @@ from flask_babel import lazy_gettext as _
 import json
 from StringIO import StringIO
 import uuid
+import wcag_contrast_ratio
+
 from . import AdminCirculationManagerController
 from api.config import Configuration
 from api.lanes import create_default_lanes
@@ -104,7 +106,16 @@ class LibrarySettingsController(AdminCirculationManagerController):
 
     def validate_form_fields(self):
         settings = Configuration.LIBRARY_SETTINGS
-        return self.check_for_missing_fields(settings) or self.check_input_type(settings)
+        validations = [
+            self.check_for_missing_fields,
+            self.check_input_type,
+            self.check_web_color_contrast,
+            self.check_header_links
+        ]
+        for validation in validations:
+            result = validation(settings)
+            if result is not None:
+                return result
 
     def check_for_missing_fields(self, settings):
         if not flask.request.form.get("short_name"):
@@ -129,6 +140,29 @@ class LibrarySettingsController(AdminCirculationManagerController):
         for setting in settings:
             if setting.get("type") == "image":
                 return self.check_image_type(setting)
+
+    def check_web_color_contrast(self, settings):
+        """Verify that the web background color and web foreground
+        color go together.
+        """
+        background = flask.request.form.get(Configuration.WEB_BACKGROUND_COLOR, Configuration.DEFAULT_WEB_BACKGROUND_COLOR)
+        foreground = flask.request.form.get(Configuration.WEB_FOREGROUND_COLOR, Configuration.DEFAULT_WEB_FOREGROUND_COLOR)
+        def hex_to_rgb(hex):
+            hex = hex.lstrip("#")
+            return tuple(int(hex[i:i+2], 16)/255.0 for i in (0, 2 ,4))
+        if not wcag_contrast_ratio.passes_AA(wcag_contrast_ratio.rgb(hex_to_rgb(background), hex_to_rgb(foreground))):
+            contrast_check_url = "https://contrast-ratio.com/#%23" + foreground[1:] + "-on-%23" + background[1:]
+            return INVALID_CONFIGURATION_OPTION.detailed(
+                _("The web background and foreground colors don't have enough contrast to pass the WCAG 2.0 AA guidelines and will be difficult for some patrons to read. Check contrast <a href='%(contrast_check_url)s' target='_blank'>here</a>.",
+                  contrast_check_url=contrast_check_url))
+
+    def check_header_links(self, settings):
+        """Verify that header links and labels are the same length."""
+        header_links = flask.request.form.getlist(Configuration.WEB_HEADER_LINKS)
+        header_labels = flask.request.form.getlist(Configuration.WEB_HEADER_LABELS)
+        if len(header_links) != len(header_labels):
+            return INVALID_CONFIGURATION_OPTION.detailed(
+                _("There must be the same number of web header links and web header labels."))
 
     def get_library_from_uuid(self, library_uuid):
         if library_uuid:

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -11,6 +11,7 @@ from werkzeug import ImmutableMultiDict, MultiDict
 from api.admin.exceptions import AdminNotAuthorized
 from api.admin.problem_details import (
     INCOMPLETE_CONFIGURATION,
+    INVALID_CONFIGURATION_OPTION,
     LIBRARY_NOT_FOUND,
     MISSING_LIBRARY_SHORT_NAME,
     LIBRARY_SHORT_NAME_ALREADY_IN_USE,
@@ -149,6 +150,40 @@ class TestLibrarySettings(SettingsControllerTest):
             ])
             response = self.manager.admin_library_settings_controller.process_post()
             eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
+
+        # Test a bad contrast ratio between the web foreground and
+        # web background colors.
+        with self.request_context_with_admin("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("uuid", library.uuid),
+                ("name", "The New York Public Library"),
+                ("short_name", library.short_name),
+                (Configuration.WEBSITE_URL, "https://library.library/"),
+                (Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, "email@example.com"),
+                (Configuration.WEB_BACKGROUND_COLOR, "#000000"),
+                (Configuration.WEB_FOREGROUND_COLOR, "#010101"),
+            ])
+            response = self.manager.admin_library_settings_controller.process_post()
+            eq_(response.uri, INVALID_CONFIGURATION_OPTION.uri)
+            assert "contrast-ratio.com/#%23010101-on-%23000000" in response.detail
+
+        # Test a list of web header links and a list of labels that
+        # aren't the same length.
+        library = self._library()
+        with self.request_context_with_admin("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("uuid", library.uuid),
+                ("name", "The New York Public Library"),
+                ("short_name", library.short_name),
+                (Configuration.WEBSITE_URL, "https://library.library/"),
+                (Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, "email@example.com"),
+                (Configuration.WEB_HEADER_LINKS, "http://library.com/1"),
+                (Configuration.WEB_HEADER_LINKS, "http://library.com/2"),
+                (Configuration.WEB_HEADER_LABELS, "One"),
+            ])
+            response = self.manager.admin_library_settings_controller.process_post()
+            eq_(response.uri, INVALID_CONFIGURATION_OPTION.uri)
+
 
     def test_libraries_post_create(self):
         class TestFileUpload(StringIO):


### PR DESCRIPTION
This branch restores code from https://github.com/NYPL-Simplified/circulation/pull/1059 which was lost when https://github.com/NYPL-Simplified/circulation/pull/1077 was merged in. The code includes special validation for checking _pairs_ of settings: foreground and background colors, and the relative lengths of two lists which have to be the same length.

The affected files were api/admin/controller.py (which was moved to api/admin/controller/__init__.py) and tests/admin/test_controller.py (which was moved to tests/admin/controller/test_controller.py). I did some spot checks and didn't find any other missing code, which makes sense given what happened in 1077.

In the future we'll kick off refactorings like this with a tiny branch that does nothing but move the files around. That way, changes during refactoring will result in merge conflicts instead of silently dropped code.