### PR TITLE
Adding a flag to let the front-end know if the current setting…

### DIFF
--- a/api/admin/controller.py
+++ b/api/admin/controller.py
@@ -2300,6 +2300,9 @@ class SettingsController(AdminCirculationManagerController):
             supports_registration = getattr(api, "SUPPORTS_REGISTRATION", None)
             if supports_registration != None:
                 protocol['supports_registration'] = supports_registration
+            supports_staging = getattr(api, "SUPPORTS_STAGING", None)
+            if supports_staging != None:
+                protocol['supports_staging'] = supports_staging
 
             protocols.append(protocol)
         return protocols
@@ -3600,6 +3603,7 @@ class SettingsController(AdminCirculationManagerController):
                     { "key": ExternalIntegration.URL, "label": _("URL") },
                 ],
                 "supports_registration": True,
+                "supports_staging": True,
             }
         ]
 

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.82"
+    "simplified-circulation-web": "0.0.83"
   }
 }

--- a/api/odl.py
+++ b/api/odl.py
@@ -982,6 +982,7 @@ class SharedODLAPI(BaseCirculationAPI):
     ]
 
     SUPPORTS_REGISTRATION = True
+    SUPPORTS_STAGING = False
 
     TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 


### PR DESCRIPTION
… supports selecting a stage for library registration.

Fixes [SIMPLY-1344](https://jira.nypl.org/browse/SIMPLY-1344).

The shared ODL collection registration for libraries should not have UI controls for selecting what type of staging level the library should be in. There's no big difference between the shared ODL settings and the library registry setting so added a `supports_staging` setting flag for the UI to render or not render the staging registration dropdown.