### PR TITLE
Update circ manager to allow cloudwatch logging

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -60,7 +60,7 @@ from core.model import (
     WorkGenre,
 )
 from core.lane import (Lane, WorkList)
-from core.log import (LogConfiguration, SysLogger, Loggly)
+from core.log import (LogConfiguration, SysLogger, Loggly, CloudwatchLogs)
 from core.util.problem_detail import (
     ProblemDetail,
     JSON_MEDIA_TYPE as PROBLEM_DETAIL_JSON_MEDIA_TYPE,
@@ -2540,7 +2540,7 @@ class SettingsController(AdminCirculationManagerController):
         detail = _("You tried to create a new logging service, but a logging service is already configured.")
         return self._manage_sitewide_service(
             ExternalIntegration.LOGGING_GOAL,
-            [Loggly, SysLogger],
+            [Loggly, SysLogger, CloudwatchLogs],
             'logging_services', detail
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ Flask-Babel
 money
 pymarc
 accept-types
+watchtower # for cloudwatch logging
 
 # Ensure that we support SNI-based SSL
 ndg-httpsclient


### PR DESCRIPTION
Brings the changes from https://github.com/NYPL-Simplified/server_core/pull/982 into the circ manager.