### PR TITLE
Removed remaining incorrect reference to the delivery mechanism of a Bibliotheca audiobook.

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -681,7 +681,7 @@ class ItemListParser(XMLParser):
             Representation.PDF_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM
         ),
         "MP3" : (
-            Representation.MP3_MEDIA_TYPE, DeliveryMechanism.FINDAWAY_DRM
+            None, DeliveryMechanism.FINDAWAY_DRM
         ),
     }
 

--- a/migration/20181113-remove-mp3-findaway-delivery-mechanism.sql
+++ b/migration/20181113-remove-mp3-findaway-delivery-mechanism.sql
@@ -1,0 +1,10 @@
+-- If an audio/mpeg+findaway delivery mechanism was created again after the old
+-- one was removed, change over all rows in licensepooldeliveries that use it.
+update licensepooldeliveries set delivery_mechanism_id=(
+  select id from deliverymechanisms where content_type is null and drm_scheme='application/vnd.librarysimplified.findaway.license+json'
+) where delivery_mechanism_id = (
+  select id from deliverymechanisms where content_type='audio/mpeg' and drm_scheme='application/vnd.librarysimplified.findaway.license+json'
+);
+
+-- Then delete it.
+delete from deliverymechanisms where content_type='audio/mpeg' and drm_scheme='application/vnd.librarysimplified.findaway.license+json';

--- a/migration/20181113-remove-mp3-findaway-delivery-mechanism.sql
+++ b/migration/20181113-remove-mp3-findaway-delivery-mechanism.sql
@@ -8,3 +8,5 @@ update licensepooldeliveries set delivery_mechanism_id=(
 
 -- Then delete it.
 delete from deliverymechanisms where content_type='audio/mpeg' and drm_scheme='application/vnd.librarysimplified.findaway.license+json';
+
+update deliverymechanisms set default_client_can_fulfill='t' where content_type is null and drm_scheme='application/vnd.librarysimplified.findaway.license+json';

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -1254,7 +1254,7 @@ class TestBibliographicCoverageProvider(TestBibliothecaAPI):
         _check_format("EPUB", book, rep.EPUB_MEDIA_TYPE, adobe)
         _check_format("EPUB3", book, rep.EPUB_MEDIA_TYPE, adobe)
         _check_format("PDF", book, rep.PDF_MEDIA_TYPE, adobe)
-        _check_format("MP3", Edition.AUDIO_MEDIUM, rep.MP3_MEDIA_TYPE, findaway)
+        _check_format("MP3", Edition.AUDIO_MEDIUM, None, findaway)
 
         # Now Try a string we don't recognize from Bibliotheca.
         medium, formats = m("Unknown")


### PR DESCRIPTION
It turns out https://jira.nypl.org/browse/SIMPLY-1275 wasn't completely fixed. There were two places we needed to change the Bibliotheca API to represent the fact that the Findaway DRM scheme doesn't have an associated media type, and we only changed one of those places.

This branch changes the other place and adds a migration script that fixes the delivery mechanisms of any books that were incorrectly imported after the old migration script ran.