### PR TITLE
RBdigital library ID is a number, not a URL.

### DIFF
--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -114,7 +114,7 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
 
     SETTINGS = [
         { "key": ExternalIntegration.PASSWORD, "label": _("Basic Token"), "required": True },
-        { "key": Collection.EXTERNAL_ACCOUNT_ID_KEY, "label": _("Library ID"), "required": True, "format": "url" },
+        { "key": Collection.EXTERNAL_ACCOUNT_ID_KEY, "label": _("Library ID"), "required": True, "format": "number"},
         { "key": ExternalIntegration.URL, "label": _("URL"), "default": PRODUCTION_BASE_URL, "required": True, "format": "url" },
     ] + BASE_SETTINGS
 

--- a/tests/admin/controller/test_collections.py
+++ b/tests/admin/controller/test_collections.py
@@ -333,9 +333,10 @@ class TestCollectionSettings(SettingsControllerTest):
         with self.request_context_with_admin("/", method="POST"):
             flask.request.form = MultiDict([
                 ("name", "collection1"),
-                ("protocol", ExternalIntegration.RB_DIGITAL),
+                ("protocol", "Axis 360"),
                 ("password", "password"),
-                ("external_account_id", "bad_url"),
+                ("external_account_id", "account_id"),
+                ("url", "bad_url")
             ])
             response = self.manager.admin_collection_settings_controller.process_collections()
             eq_(response.uri, INVALID_URL.uri)


### PR DESCRIPTION
Fixes https://jira.nypl.org/browse/SIMPLY-1502