### PR TITLE
Handle edge cases in fine enforcement

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -500,7 +500,7 @@ class CirculationAPI(object):
 
         if patron.fines:
             max_fines = Configuration.max_outstanding_fines(patron.library)
-            if max_fines and patron.fines >= max_fines.amount:
+            if max_fines is not None and patron.fines > max_fines.amount:
                 raise OutstandingFines()
 
         # Do we (think we) already have this book out on loan?

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -500,7 +500,7 @@ class CirculationAPI(object):
 
         if patron.fines:
             max_fines = Configuration.max_outstanding_fines(patron.library)
-            if patron.fines >= max_fines.amount:
+            if max_fines and patron.fines >= max_fines.amount:
                 raise OutstandingFines()
 
         # Do we (think we) already have this book out on loan?

--- a/api/config.py
+++ b/api/config.py
@@ -425,8 +425,10 @@ class Configuration(CoreConfiguration):
     def max_outstanding_fines(cls, library):
         max_fines = ConfigurationSetting.for_library(
             cls.MAX_OUTSTANDING_FINES, library
-        ).value
-        return MoneyUtility.parse(max_fines)
+        )
+        if max_fines.value is None:
+            return None
+        return MoneyUtility.parse(max_fines.value)
 
     @classmethod
     def load(cls, _db=None):

--- a/api/util/patron.py
+++ b/api/util/patron.py
@@ -66,7 +66,7 @@ class PatronUtility(object):
 
         if patron.fines:
             max_fines = Configuration.max_outstanding_fines(patron.library)
-            if patron.fines >= max_fines.amount:
+            if max_fines and patron.fines >= max_fines.amount:
                 raise OutstandingFines()
 
         from api.authenticator import PatronData

--- a/api/util/patron.py
+++ b/api/util/patron.py
@@ -66,7 +66,7 @@ class PatronUtility(object):
 
         if patron.fines:
             max_fines = Configuration.max_outstanding_fines(patron.library)
-            if max_fines and patron.fines >= max_fines.amount:
+            if max_fines is not None and patron.fines > max_fines.amount:
                 raise OutstandingFines()
 
         from api.authenticator import PatronData

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -360,7 +360,7 @@ class TestCirculationAPI(DatabaseTest):
         assert_raises(AuthorizationExpired, self.borrow)
         self.patron.authorization_expires = old_expires
 
-    def test_borrow_with_fines_fails(self):
+    def test_borrow_with_outstanding_fines(self):
         # This checkout would succeed...
         now = datetime.now()
         loaninfo = LoanInfo(
@@ -374,17 +374,25 @@ class TestCirculationAPI(DatabaseTest):
         # ...except the patron has too many fines.
         old_fines = self.patron.fines
         self.patron.fines = 1000
-
         setting = ConfigurationSetting.for_library(
             Configuration.MAX_OUTSTANDING_FINES,
             self._default_library
         )
         setting.value = "$0.50"
-        assert_raises(OutstandingFines, self.borrow)
-        self.patron.fines = old_fines
-        setting.value = None
 
-        response = self.borrow()
+        assert_raises(OutstandingFines, self.borrow)
+
+        # Test the case where any amount of fines are too much.
+        setting.value = "$0"
+        assert_raises(OutstandingFines, self.borrow)
+
+
+        # Remove the fine policy, and borrow succeeds.
+        setting.value = None
+        loan, i1, i2 = self.borrow()
+        assert isinstance(loan, Loan)
+
+        self.patron.fines = old_fines
 
     def test_borrow_with_block_fails(self):
         # This checkout would succeed...

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -375,11 +375,16 @@ class TestCirculationAPI(DatabaseTest):
         old_fines = self.patron.fines
         self.patron.fines = 1000
 
-        ConfigurationSetting.for_library(
+        setting = ConfigurationSetting.for_library(
             Configuration.MAX_OUTSTANDING_FINES,
-            self._default_library).value = "$0.50"
+            self._default_library
+        )
+        setting.value = "$0.50"
         assert_raises(OutstandingFines, self.borrow)
         self.patron.fines = old_fines
+        setting.value = None
+
+        response = self.borrow()
 
     def test_borrow_with_block_fails(self):
         # This checkout would succeed...

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,3 +158,25 @@ class TestConfiguration(DatabaseTest):
         eq_([['fre', 'jpn'], ['spa', 'ukr', 'ira'], ['nav']],
             m(different_sizes))
 
+    def test_max_outstanding_fines(self):
+        m = Configuration.max_outstanding_fines
+
+        # By default, fines are not enforced.
+        eq_(None, m(self._default_library))
+
+        # The maximum fine value is determined by this
+        # ConfigurationSetting.
+        setting = ConfigurationSetting.for_library(
+            Configuration.MAX_OUTSTANDING_FINES,
+            self._default_library
+        )
+
+        # Any amount of fines is too much.
+        setting.value = "$0"
+        max_fines = m(self._default_library)
+        eq_(0, max_fines.amount)
+
+        # A more lenient approach.
+        setting.value = "100"
+        max_fines = m(self._default_library)
+        eq_(100, max_fines.amount)


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-1523.

We now distinguish between the case where the maximum fine amount is set to zero (in which case any nonzero amount of fines is too much) and the case where the maximum fine amount is unset (in which case fine limits are not enforced).

Previously we wouldn't have handled either case. If the maximum fine amount was set to zero, any explicitly set amount of fines (even zero) would have caused a problem and only someone with a blank fines field would have gone through. If the maximum fine amount was unset, then anyone _with_ an explicitly set amount of fines would have been denied access.