### PR TITLE
Put the Elasticsearch dependencies in separate files 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
 
 install:
   - pip install -r requirements.txt
+  - pip install -r elasticsearch-requirements-${ELASTICSEARCH_VERSION}.txt
   - python -m textblob.download_corpora
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,7 @@ before_script:
   - psql -c 'grant all privileges on database simplified_circulation_test to simplified_test;' -U postgres
 
 env:
-  - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_circulation_test"
-  - ELASTICSEARCH_VERSION="1"
+  - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_circulation_test" ELASTICSEARCH_VERSION="1"
 
 script:
   - ./verbose-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_script:
 
 env:
   - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_circulation_test"
+  - ELASTICSEARCH_VERSION="1"
 
 script:
   - ./verbose-test

--- a/elasticsearch-requirements-1.txt
+++ b/elasticsearch-requirements-1.txt
@@ -1,0 +1,2 @@
+elasticsearch==2.1.0
+elasticsearch-dsl<2.0.0

--- a/elasticsearch-requirements-6.txt
+++ b/elasticsearch-requirements-6.txt
@@ -1,0 +1,2 @@
+elasticsearch>6.0.0,<7.0.0
+elasticsearch-dsl>6.0.0,<7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 # Core requirements
 boto3
-elasticsearch==2.1.0
-elasticsearch-dsl<2.0.0
-#elasticsearch>6.0.0,<7.0.0
-#elasticsearch-dsl>6.0.0,<7.0.0
+-r elasticsearch-requirements-${ELASTICSEARCH_VERSION}.txt
 pillow
 psycopg2
 requests==2.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # Core requirements
 boto3
--r elasticsearch-requirements-${ELASTICSEARCH_VERSION}.txt
 pillow
 psycopg2
 requests==2.18.4


### PR DESCRIPTION
This makes it easy to switch back and forth by changing an environment variable.

This makes it easier to do https://jira.nypl.org/browse/SIMPLY-1518 -- you just have to specify the variable when deploying -- though I don't know how to do it.