### PR TITLE
Change the Enki self-test to reflect a change in the API.

### DIFF
--- a/api/enki.py
+++ b/api/enki.py
@@ -124,10 +124,13 @@ class EnkiAPI(BaseCirculationAPI, HasSelfTests):
 
     def _run_self_tests(self, _db):
 
+        now = datetime.datetime.utcnow()
+
         def count_loans_and_holds():
             """Count recent circulation events that affected loans or holds.
             """
-            count = len(list(self.recent_activity(minutes=60)))
+            one_hour_ago = now - datetime.timedelta(hours=1)
+            count = len(list(self.recent_activity(since=one_hour_ago)))
             return "%s circulation events in the last hour" % count
 
         yield self.run_test(
@@ -139,8 +142,9 @@ class EnkiAPI(BaseCirculationAPI, HasSelfTests):
             """Count changes to title metadata (usually because of
             new titles).
             """
+            one_day_ago = now - datetime.timedelta(hours=24)
             return "%s titles added/updated in the last day" % (
-                len(list(self.updated_titles(minutes=60*24)))
+                len(list(self.updated_titles(since=one_day_ago)))
             )
 
         yield self.run_test(

--- a/tests/test_enki.py
+++ b/tests/test_enki.py
@@ -102,13 +102,13 @@ class TestEnkiAPI(BaseEnkiTest):
     def test__run_self_tests(self):
         # Mock every method that will be called by the self-test.
         class Mock(MockEnkiAPI):
-            def recent_activity(self, minutes):
-                self.recent_activity_called_with = minutes
+            def recent_activity(self, since):
+                self.recent_activity_called_with = since
                 yield 1
                 yield 2
 
-            def updated_titles(self, minutes):
-                self.updated_titles_called_with = minutes
+            def updated_titles(self, since):
+                self.updated_titles_called_with = since
                 yield 1
                 yield 2
                 yield 3
@@ -144,11 +144,14 @@ class TestEnkiAPI(BaseEnkiTest):
 
         # Verify that each test method was called and returned the
         # expected SelfTestResult object.
-        eq_(60, api.recent_activity_called_with)
+        now = datetime.datetime.utcnow()
+        one_hour_ago = now - datetime.timedelta(hours=1)
+        one_day_ago = now - datetime.timedelta(hours=24)
+        assert (api.recent_activity_called_with - one_hour_ago).total_seconds() < 2
         eq_(True, circulation_changes.success)
         eq_("2 circulation events in the last hour", circulation_changes.result)
 
-        eq_(1440, api.updated_titles_called_with)
+        assert (api.updated_titles_called_with - one_day_ago).total_seconds() < 2
         eq_(True, collection_changes.success)
         eq_("3 titles added/updated in the last day", collection_changes.result)
 


### PR DESCRIPTION
This fixes https://jira.nypl.org/browse/SIMPLY-1561.

Another way of fixing this would mock `request` instead of the methods whose signatures changed. This would prevent this from happening again but the test would get a lot more complex. Let me know if you think it's worth it.