### PR TITLE
Make it possible to connect to an SIP2 server over SSL.

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1,5 +1,6 @@
 from nose.tools import set_trace
 from functools import wraps, update_wrapper
+import logging
 import os
 
 import flask
@@ -40,7 +41,13 @@ def initialize_circulation_manager():
         pass
     else:
         if getattr(app, 'manager', None) is None:
-            app.manager = CirculationManager(app._db)
+            try:
+                app.manager = CirculationManager(app._db)
+            except Exception, e:
+                logging.error(
+                    "Error instantiating circulation manager!", exc_info=e
+                )
+                raise e
             # Make sure that any changes to the database (as might happen
             # on initial setup) are committed before continuing.
             app.manager._db.commit()

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -20,6 +20,9 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
     PORT = "port"
     LOCATION_CODE = "location code"
     FIELD_SEPARATOR = "field separator"
+    USE_SSL = "use_ssl"
+    SSL_CERTIFICATE = "ssl_certificate"
+    SSL_KEY = "ssl_key"
 
     SETTINGS = [
         { "key": ExternalIntegration.URL, "label": _("Server"), "required": True },
@@ -27,6 +30,25 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         { "key": ExternalIntegration.USERNAME, "label": _("Login User ID") },
         { "key": ExternalIntegration.PASSWORD, "label": _("Login Password") },
         { "key": LOCATION_CODE, "label": _("Location Code") },
+        { "key": USE_SSL, "label": _("Connect over SSL?"),
+          "description": _("Some SIP2 servers require or allow clients to connect securely over SSL. Other servers don't support SSL, and require clients to use an ordinary socket connection."),
+          "type": "select",
+          "options": [
+              { "key": "true", "label": _("Connect to the SIP2 server over SSL")},
+              { "key": "false", "label": _("Connect to the SIP2 server over an ordinary socket connection")},
+          ],
+          "default": "false",
+          "required": True,
+        },
+        { "key": SSL_CERTIFICATE, "label": _("SSL Certificate"),
+          "description": _('The SSL certificate used to securely connect to an SSL-enabled SIP2 server. Not all SSL-enabled SIP2 servers require a custom certificate, but some do. This should be a string beginning with <code>-----BEGIN CERTIFICATE-----</code> and ending with <code>-----END CERTIFICATE-----</code>'),
+          "type": "textarea",
+        },
+        {
+            "key": SSL_KEY, "label": _("SSL Key"),
+            "description" : _('The private key, if any, used to sign the SSL certificate above. If present, this should be a string beginning with <code>-----BEGIN PRIVATE KEY-----</code> and ending with <code>-----END PRIVATE KEY-----</code>'),
+          "type": "textarea",
+        },
         { "key": FIELD_SEPARATOR, "label": _("Field Separator"),
           "default": "|", "required": True,
         },
@@ -91,6 +113,9 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         self.login_password = integration.password
         self.location_code = integration.setting(self.LOCATION_CODE).value
         self.field_separator = integration.setting(self.FIELD_SEPARATOR).value or '|'
+        self.use_ssl = integration.setting(self.USE_SSL).json_value
+        self.ssl_cert = integration.setting(self.SSL_CERTIFICATE).value
+        self.ssl_key = integration.setting(self.SSL_KEY).value
         self.client = client
 
     def patron_information(self, username, password):
@@ -101,7 +126,8 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
                 sip = SIPClient(
                     target_server=self.server, target_port=self.port,
                     login_user_id=self.login_user_id, login_password=self.login_password,
-                    location_code=self.location_code, separator=self.field_separator
+                    location_code=self.location_code, separator=self.field_separator,
+                    use_ssl=self.use_ssl, ssl_cert=self.ssl_cert, ssl_key=self.ssl_key
                 )
             sip.connect()
             sip.login()


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1097. 

It's pretty simple to use Python's built-in `ssl` library to wrap a socket connection in SSL. The catch is that the cert file and key file need to be specified as paths to files on disk. This is a limitation of OpenSSL, not something we can get around with clever tricks. To avoid it we need to use a pure-Python SSL implementation, and those are _not_ simple.

So this implementation is really inefficient -- it writes and deletes two temp files every time it establishes a connection. Because of other problems with real SIP2 servers, we make a new connection every time it wants to check someone's credentials. So this isn't great, but it's definitely good enough for a pilot project, which is where we are with the libraries that want to connect to an ILS over SSL with a certificate.