### PR TITLE
Always sync patron data if it's out of date locally

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1772,20 +1772,34 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
 
         # First, try to look up the Patron object in our database.
         patron = self.local_patron_lookup(_db, username, patrondata)
-        if patron:
-            # We found them! Make sure their data is up to date
-            # with whatever we just got from remote.
+        if patron and (
+            patrondata.complete or not PatronUtility.needs_external_sync(patron)
+        ):
+            # We found them! And there is no need to do a separate
+            # lookup for purposes of external sync -- either because
+            # they don't need to be synced or because we got a
+            # complete PatronData as a side effect of the authentication
+            # check.
+            #
+            # Just make sure our local data is up to date with
+            # whatever we just got from remote.
             self.apply_patrondata(patrondata, patron)
             return patron
 
-        # We didn't find them. Now the question is: _why_ didn't the
-        # patron show up locally? Have we never seen them before or
-        # has their authorization identifier changed?
+        # At this point there are two possibilities:
         #
-        # Look up the patron's account remotely to get that
-        # information.  In some providers this step may be a no-op
-        # because we may have gotten patron account information as a
-        # side effect of remote validation.
+        # 1. We didn't find them. Now the question is: _why_ didn't
+        # the patron show up locally? Have we never seen them before
+        # or has their authorization identifier changed?
+        #
+        # 2. We found them, they need an external sync, and we found
+        # them in a way that didn't provide that information.
+        #
+        # In both cases, the next step is to look up the patron's
+        # account details remotely. In some providers this step may
+        # be a no-op. But we have to try it, because if the patron's
+        # account details are out of sync, the rest of the request (the
+        # thing they're actually trying to do) might fail.
         patrondata = self.remote_patron_lookup(patrondata)
         if not patrondata or isinstance(patrondata, ProblemDetail):
             # Either there was a problem looking up the patron data, or
@@ -1800,9 +1814,9 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
             # use that Patron object.
             return patrondata
 
-        # At this point we have an updated PatronData object which
-        # we know represents an existing patron on the remote
-        # side. Try the local lookup again.
+        # At this point we have a _complete_ PatronData object which we
+        # know represents an existing patron on the remote side. Try
+        # the local lookup again.
         patron = self.local_patron_lookup(_db, username, patrondata)
 
         if not patron:
@@ -1814,9 +1828,10 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
 
         # The lookup failed in the first place either because the
         # Patron did not exist on the local side, or because one of
-        # the patron's identifiers changed. Either way, we need to
-        # update the Patron record with the account information we
-        # just got from the source of truth.
+        # the patron's identifiers changed; or, the lookup succeeded
+        # but we needed to do a separate validation step. Either way,
+        # we now need to update the Patron record with the account
+        # information we just got from the source of truth.
         self.apply_patrondata(patrondata, patron)
         return patron
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2178,9 +2178,9 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
 
         # The Authenticator noticed that the patron's account was out
         # of sync, and since the authentication response did not
-        # provide a complete the information necessary, it performed a more
-        # detailed lookup to make sure that the patron's details were
-        # correct going forward.
+        # provide a complete set of patron information, the
+        # Authenticator performed a more detailed lookup to make sure
+        # that the patron's details were correct going forward.
         eq_("new username", patron.username)
         eq_("new authorization identifier", patron.authorization_identifier)
         assert (

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2127,6 +2127,91 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
         # test_local_patron_lookup. This test only covers the case where
         # the server sends back the permanent ID of the patron.
 
+    def _inactive_patron(self):
+        """Simulate a patron who has not logged in for a really long time.
+
+        :return: A 2-tuple (Patron, PatronData). The Patron contains
+        'out-of-date' data and the PatronData containing 'up-to-date'
+        data.
+        """
+        now = datetime.datetime.utcnow()
+        long_ago = now - datetime.timedelta(hours=10000)
+        patron = self._patron()
+        patron.last_external_sync = long_ago
+
+        # All of their authorization information has changed in the
+        # meantime, but -- crucially -- their permanent ID has not.
+        patron.authorization_identifier = "old auth id"
+        patron.username = "old username"
+
+        # Here is the up-to-date information about this patron,
+        # as found in the 'ILS'.
+        patrondata = PatronData(
+            permanent_id=patron.external_identifier,
+            username="new username",
+            authorization_identifier = "new authorization identifier",
+            complete=True
+        )
+
+        return patron, patrondata
+
+    def test_success_but_local_patron_needs_sync(self):
+        # This patron has not logged on in a really long time.
+        patron, complete_patrondata = self._inactive_patron()
+
+        # The 'ILS' will respond to an authentication request with a minimal
+        # set of information.
+        #
+        # It will respond to a patron lookup request with more detailed
+        # information.
+        minimal_patrondata = PatronData(
+            permanent_id=patron.external_identifier,
+            complete=False
+        )
+        provider = self.mock_basic(
+            patrondata=minimal_patrondata,
+            remote_patron_lookup_patrondata=complete_patrondata,
+        )
+
+        # The patron can be authenticated.
+        eq_(patron, provider.authenticate(self._db, self.credentials))
+
+        # The Authenticator noticed that the patron's account was out
+        # of sync, and since the authentication response did not
+        # provide a complete the information necessary, it performed a more
+        # detailed lookup to make sure that the patron's details were
+        # correct going forward.
+        eq_("new username", patron.username)
+        eq_("new authorization identifier", patron.authorization_identifier)
+        assert (
+            datetime.datetime.utcnow()-patron.last_external_sync
+        ).total_seconds() < 10
+
+    def test_success_with_immediate_patron_sync(self):
+        # This patron has not logged on in a really long time.
+        patron, complete_patrondata = self._set_up_inactive_patron()
+
+        # The 'ILS' will respond to an authentication request with a complete
+        # set of information. If a remote patron lookup were to happen,
+        # it would explode.
+        provider = self.mock_basic(
+            patrondata=complete_patrondata,
+            remote_patron_lookup_patrondata=object()
+        )
+
+        # The patron can be authenticated.
+        eq_(patron, provider.authenticate(self._db, self.credentials))
+
+        # Since the authentication response provided a complete
+        # overview of the patron, the Authenticator was able to sync
+        # the account immediately, without doing a separate remote
+        # patron lookup.
+        eq_("new username", patron.username)
+        eq_("new authorization identifier", patron.authorization_identifier)
+        assert (
+            datetime.datetime.utcnow()-patron.last_external_sync
+        ).total_seconds() < 10
+
     def test_failure_when_remote_authentication_returns_problemdetail(self):
         patron = self._patron()
         patrondata = PatronData(permanent_id=patron.external_identifier)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2189,7 +2189,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
 
     def test_success_with_immediate_patron_sync(self):
         # This patron has not logged on in a really long time.
-        patron, complete_patrondata = self._set_up_inactive_patron()
+        patron, complete_patrondata = self._inactive_patron()
 
         # The 'ILS' will respond to an authentication request with a complete
         # set of information. If a remote patron lookup were to happen,


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-1564.

Previously, if patron authorization succeeded, but the patron's authorization identifier had changed since the last time they authorized, the patron's record was not synced with the remote record. Since syncing with the remote record is the only way to update the patron's authorization identifier, this meant their patron record never got synced again. It also meant that they couldn't fulfill Overdrive titles, since we were  sending their old authorization identifier to Overdrive, and Overdrive's ILS cross-check was failing.

We have code in `authenticated_patron` which is supposed to deal with this, but it doesn't work in the case where the patron's authorization identifier has changed, because it does the lookup using the old authorization identifier (which fails). Doing the sync during the login process guarantees that a remote patron lookup will succeed, because we know we have a working authorization identifier -- the one the patron just used to authenticate.

I think the new code will cover every case where a patron record needs to be synced, whether or not their authorization identifier has changed, but I left the `authenticated_patron` code in place just in case I'm wrong.