### PR TITLE
Fixed * setting for patron web client URLs.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -244,6 +244,8 @@ class CirculationManager(object):
         patron_web_domains = set()
 
         def get_domain(url):
+            if url == "*":
+                return url
             scheme, netloc, path, parameters, query, fragment = urlparse.urlparse(url)
             return scheme + "://" + netloc
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -431,6 +431,12 @@ class TestCirculationManager(CirculationControllerTest):
         # have not been reloaded.
         eq_(index_controller, manager.index_controller)
 
+        # The sitewide patron web domain can also be set to *.
+        ConfigurationSetting.sitewide(
+            self._db, Configuration.PATRON_WEB_CLIENT_URL).value = "*"
+        self.manager.load_settings()
+        eq_(set(["*", "http://registration"]), manager.patron_web_domains)
+
         # Restore the CustomIndexView.for_library implementation
         CustomIndexView.for_library = old_for_library
 


### PR DESCRIPTION
Setting the sitewide patron web client URL to `*` wasn't working, I think I broke it when I made it handle both registry URLs and the sitewide setting.