### PR TITLE
Added route for updating lane order.

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1816,12 +1816,10 @@ class LanesController(AdminCirculationManagerController):
         submitted_lanes = json.loads(flask.request.data)
 
         def update_lane_order(lanes):
-            index = 0
-            for lane_data in lanes:
+            for index, lane_data in enumerate(lanes):
                 lane_id = lane_data.get("id")
                 lane = self._db.query(Lane).filter(Lane.id==lane_id).one()
                 lane.priority = index
-                index = index + 1
                 update_lane_order(lane_data.get("sublanes", []))
 
         update_lane_order(submitted_lanes)

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1810,6 +1810,24 @@ class LanesController(AdminCirculationManagerController):
         create_default_lanes(self._db, flask.request.library)
         return Response(unicode(_("Success")), 200)
 
+    def change_order(self):
+        self.require_library_manager(flask.request.library)
+
+        submitted_lanes = json.loads(flask.request.data)
+
+        def update_lane_order(lanes):
+            index = 0
+            for lane_data in lanes:
+                lane_id = lane_data.get("id")
+                lane = self._db.query(Lane).filter(Lane.id==lane_id).one()
+                lane.priority = index
+                index = index + 1
+                update_lane_order(lane_data.get("sublanes", []))
+
+        update_lane_order(submitted_lanes)
+
+        return Response(unicode(_("Success")), 200)
+
 
 class DashboardController(AdminCirculationManagerController):
 

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.96"
+    "simplified-circulation-web": "0.0.97"
   }
 }

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.98"
+    "simplified-circulation-web": "0.0.99"
   }
 }

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.0.97"
+    "simplified-circulation-web": "0.0.98"
   }
 }

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -625,6 +625,14 @@ def lane_hide(lane_identifier):
 def reset_lanes():
     return app.manager.admin_lanes_controller.reset()
 
+@library_route("/admin/lanes/change_order", methods=["POST"])
+@has_library
+@returns_json_or_response_or_problem_detail
+@requires_admin
+@requires_csrf_token
+def change_lane_order():
+    return app.manager.admin_lanes_controller.change_order()
+
 @app.route('/admin/sign_in_again')
 def admin_sign_in_again():
     """Allows an  admin with expired credentials to sign back in


### PR DESCRIPTION
This branch goes with a circulation-web branch that lets you drag and drop lanes on the lanes page of the admin interface.