### PR TITLE
Use DeliveryMechanism.id instead of LicensePoolDeliveryMechanism.id.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1241,8 +1241,8 @@ class LoanController(CirculationManagerController):
         def fulfill_part_url(part):
             return url_for(
                 "fulfill", license_pool_id=requested_license_pool.id,
-                mechanism_id=mechanism.id, part=unicode(part),
-                _external=True
+                mechanism_id=mechanism.delivery_mechanism.id,
+                part=unicode(part), _external=True
             )
 
         try:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1540,7 +1540,7 @@ class TestLoanController(CirculationControllerTest):
             # and make sure it gives the result we expect.
             expect = url_for(
                 "fulfill", license_pool_id=self.pool.id,
-                mechanism_id=mechanism.id, part=part,
+                mechanism_id=mechanism.delivery_mechanism.id, part=part,
                 _external=True
             )
             eq_(expect, fulfill_part_url(part))


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-1659, which was caused by a confusion between LicensePoolDeliveryMechanism and DeliveryMechanism. The `mechanism_id` that needs to go into URL templates like `/works/<work_id>/fulfill/<mechanism_id>/<part>` is the `DeliveryMechanism.id`.