### PR TITLE
Changed update_formats to also update the Overdrive edition with fresh metadata, as long as we have it.

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -833,16 +833,6 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
 
         edition, ignore = self._edition(licensepool)
 
-        # The identifier in the Metadata and CirculationData need to
-        # match the identifier associated with the LicensePool --
-        # otherwise a new LicensePool will be created.
-        #
-        # TODO: It's not clear to me why this code is necessary -- why
-        # would the identifiers not match, given that we looked up
-        # this identifier? -- but removing it without understanding
-        # why it was added seems dangerous.
-        metadata.primary_identifier.identifier = licensepool.identifier.identifier
-        metadata.circulation._primary_identifier.identifier = licensepool.identifier.identifier
         replace = ReplacementPolicy.from_license_source(self._db)
         metadata.apply(edition, self.collection, replace=replace)
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -33,6 +33,7 @@ from core.model import (
     ConfigurationSetting,
     DataSource,
     DeliveryMechanism,
+    Edition,
     ExternalIntegration,
     Identifier,
     LicensePool,
@@ -555,12 +556,14 @@ class TestOverdriveAPI(OverdriveAPITest):
         eq_("text/html", type)
 
     def test_update_formats(self):
-        # Create a LicensePool with an inaccurate delivery mechanism.
+        # Create a LicensePool with an inaccurate delivery mechanism
+        # and the wrong medium.
         edition, pool = self._edition(
             data_source_name=DataSource.OVERDRIVE,
             identifier_type=Identifier.OVERDRIVE_ID,
             with_license_pool=True
         )
+        edition.medium = Edition.PERIODICAL_MEDIUM
 
         # Add the bad delivery mechanism.
         pool.set_delivery_mechanism(Representation.PDF_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM,
@@ -585,6 +588,9 @@ class TestOverdriveAPI(OverdriveAPITest):
             set([lpdm.delivery_mechanism.content_type for lpdm in pool.delivery_mechanisms]))
         eq_(set([DeliveryMechanism.ADOBE_DRM, DeliveryMechanism.KINDLE_DRM, DeliveryMechanism.OVERDRIVE_DRM]),
             set([lpdm.delivery_mechanism.drm_scheme for lpdm in pool.delivery_mechanisms]))
+
+        # The Edition's medium has been corrected.
+        eq_(Edition.BOOK_MEDIUM, edition.medium)
 
     def test_update_availability(self):
         """Test the Overdrive implementation of the update_availability

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -520,6 +520,10 @@ class TestOverdriveAPI(OverdriveAPITest):
             "bibliographic_information.json"
         )
 
+        # To avoid a mismatch, make it look like the information is
+        # for the correct Identifier.
+        bibliographic['id'] = pool.identifier.identifier
+
         # If we have the LicensePool available (as opposed to just the
         # identifier), we will get the loan, try to lock in the
         # format, fail, and then update the bibliographic information.

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -9,6 +9,8 @@ import flask
 from flask import Response
 from werkzeug.exceptions import MethodNotAllowed
 
+from core.app_server import ErrorHandler
+
 from api import app
 from api import routes
 from api.opds import CirculationManagerAnnotator
@@ -713,25 +715,37 @@ class TestExceptionHandler(RouteTest):
     def test_exception_handling(self):
         # The exception handler deals with most exceptions by running them
         # through ErrorHandler.handle()
-        value_error = ValueError()
+        assert isinstance(error_handler_object, ErrorHandler)
+
+        # Temporarily replace the ErrorHandler used by the
+        # exception_handler function -- this is what we imported as
+        # error_handler_object.
+        class MockErrorHandler(object):
+            def handle(self, exception):
+                self.handled = exception
+                return Response("handled it", 500)
+        routes.h = MockErrorHandler()
+
+        # Simulate a request that causes an unhandled exception.
         with self.app.test_request_context():
+            value_error = ValueError()
             result = exception_handler(value_error)
 
-            # This generally turns them into Internal Server Errors.
-            expect = error_handler_object.handle(value_error)
-            eq_(expect.data, result.data)
+            # The exception was passed into MockErrorHandler.handle.
+            eq_(value_error, routes.h.handled)
+
+            # The Response is created was passed along.
+            eq_("handled it", result.data)
             eq_(500, result.status_code)
-            eq_(expect.status_code, result.status_code)
 
-        # At this point the database session has been ruined, so
-        # we can't do any more checks in this test.
-
-    def test_exception_handling_http_exception(self):
         # werkzeug HTTPExceptions are _not_ run through
-        # handle(). werkzeug does the conversion to a Response object
-        # representing a more specific (and possibly even desirable)
-        # HTTP response.
+        # handle(). werkzeug handles the conversion to a Response
+        # object representing a more specific (and possibly even
+        # non-error) HTTP response.
         with self.app.test_request_context():
             exception = MethodNotAllowed()
             response = exception_handler(exception)
             eq_(405, response.status_code)
+
+        # Restore the normal error handler.
+        routes.h = error_handler_object


### PR DESCRIPTION
This fixes https://jira.nypl.org/browse/SIMPLY-1671. It's a low-effort way to make sure that any problems (past or present) with Overdrive metadata are fixed over time.