### PR TITLE
The name of the internal format argument to `fulfill` must always be `internal_format`

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -320,7 +320,7 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasSelfTests):
         response = self.request(url, data=args, method="POST")
         return response
 
-    def fulfill(self, patron, pin, licensepool, internal_format, **kwargs):
+    def fulfill(self, patron, pin, licensepool, **kwargs):
         """Fulfill a patron's request for a specific book.
 
         :param kwargs: A container for arguments to fulfill()

--- a/api/axis.py
+++ b/api/axis.py
@@ -320,7 +320,7 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasSelfTests):
         response = self.request(url, data=args, method="POST")
         return response
 
-    def fulfill(self, patron, pin, licensepool, format_type, **kwargs):
+    def fulfill(self, patron, pin, licensepool, internal_format, **kwargs):
         """Fulfill a patron's request for a specific book.
 
         :param kwargs: A container for arguments to fulfill()

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -414,7 +414,7 @@ class BibliothecaAPI(BaseCirculationAPI, HasSelfTests):
         )
         return loan
 
-    def fulfill(self, patron, password, pool, internal_delivery, **kwargs):
+    def fulfill(self, patron, password, pool, internal_format, **kwargs):
         """Get the actual resource file to the patron.
 
         :param kwargs: A container for standard arguments to fulfill()
@@ -423,7 +423,7 @@ class BibliothecaAPI(BaseCirculationAPI, HasSelfTests):
         :return: a FulfillmentInfo object.
         """
         media_type, drm_scheme = self.internal_format_to_delivery_mechanism.get(
-            internal_delivery, internal_delivery
+            internal_format, internal_format
         )
         if drm_scheme == DeliveryMechanism.FINDAWAY_DRM:
             fulfill_method = self.get_audio_fulfillment_file

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -473,7 +473,9 @@ class TestBibliothecaAPI(BibliothecaAPITest):
             200, headers={"Content-Type": "presumably/an-acsm"},
             content="this is an ACSM"
         )
-        fulfillment = self.api.fulfill(patron, 'password', pool, 'ePub')
+        fulfillment = self.api.fulfill(
+            patron, 'password', pool, internal_format='ePub'
+        )
         assert isinstance(fulfillment, FulfillmentInfo)
         eq_("this is an ACSM", fulfillment.content)
         eq_(pool.identifier.identifier, fulfillment.identifier)
@@ -489,7 +491,9 @@ class TestBibliothecaAPI(BibliothecaAPITest):
             200, headers={"Content-Type": "application/json"},
             content=license
         )
-        fulfillment = self.api.fulfill(patron, 'password', pool, 'MP3')
+        fulfillment = self.api.fulfill(
+            patron, 'password', pool, internal_format='MP3'
+        )
         assert isinstance(fulfillment, FulfillmentInfo)
 
         # Here, the media type reported by the server is not passed
@@ -516,7 +520,9 @@ class TestBibliothecaAPI(BibliothecaAPITest):
             200, headers={"Content-Type": bad_media_type},
             content=bad_content
         )
-        fulfillment = self.api.fulfill(patron, 'password', pool, 'MP3')
+        fulfillment = self.api.fulfill(
+            patron, 'password', pool, internal_format='MP3'
+        )
         assert isinstance(fulfillment, FulfillmentInfo)
 
         # The (apparently) bad document is just passed on to the


### PR DESCRIPTION
This fixes https://jira.nypl.org/browse/SIMPLY-1682, a regression introduced by the partial audiobook fulfillment code.

Automated tests didn't catch this bug because we don't test the through-line from `CirculationAPI` to each specific vendor API. We still don't, but the tests for the two broken vendor APIs now call fulfill() the same way `CirculationAPI` does.

The [code that caused this problem](https://github.com/NYPL-Simplified/circulation/blob/master/api/circulation.py#L784) isn't changed here, because it's actually correct -- the problem was in these two vendor APIs.