### PR TITLE
Allow a library to hide specific content types from OPDS feeds

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -79,6 +79,8 @@ class Configuration(CoreConfiguration):
 
     LANGUAGE_DESCRIPTION = _('Each value must be an <a href="https://www.loc.gov/standards/iso639-2/php/code_list.php" target="_blank">ISO-639-2</a> language code.')
 
+    HIDDEN_CONTENT_TYPES = "hidden_content_types"
+
     # The color scheme for native mobile applications to use for this library.
     COLOR_SCHEME = "color_scheme"
     DEFAULT_COLOR_SCHEME = "blue"
@@ -277,6 +279,13 @@ class Configuration(CoreConfiguration):
             "label": _("Logo image"),
             "type": "image",
             "description": _("The image must be in GIF, PNG, or JPG format, approximately square, no larger than 135x135 pixels, and look good on a white background."),
+            "category": "Client Interface Customization",
+        },
+        {
+            "key": HIDDEN_CONTENT_TYPES,
+            "label": _("Hidden content types"),
+            "type": "text",
+            "description": _('A list of content types to hide from all clients, e.g. <code>["application/pdf"]</code>. This can be left blank except to solve specific problems.'),
             "category": "Client Interface Customization",
         },
         {

--- a/api/opds.py
+++ b/api/opds.py
@@ -60,7 +60,7 @@ class CirculationManagerAnnotator(Annotator):
 
     def __init__(self, lane,
                  active_loans_by_work={}, active_holds_by_work={},
-                 active_fulfillments_by_work={},
+                 active_fulfillments_by_work={}, hidden_content_types=[],
                  test_mode=False):
         if lane:
             logger_name = "Circulation Manager Annotator for %s" % lane.display_name
@@ -71,6 +71,7 @@ class CirculationManagerAnnotator(Annotator):
         self.active_loans_by_work = active_loans_by_work
         self.active_holds_by_work = active_holds_by_work
         self.active_fulfillments_by_work = active_fulfillments_by_work
+        self.hidden_content_types = hidden_content_types
         self.test_mode = test_mode
 
     def _lane_identifier(self, lane):
@@ -158,6 +159,20 @@ class CirculationManagerAnnotator(Annotator):
             return super(
                 CirculationManagerAnnotator, self).active_licensepool_for(work)
 
+    def visible_delivery_mechanisms(self, licensepool):
+        """Filter the given `licensepool`'s LicensePoolDeliveryMechanisms
+        to those with content types that are not hidden.
+        """
+        hidden = self.hidden_content_types
+        for lpdm in licensepool.delivery_mechanisms:
+            mechanism = lpdm.delivery_mechanism
+            if not mechanism:
+                # This shouldn't happen, but just in case.
+                continue
+            if mechanism.content_type in hidden:
+                continue
+            yield lpdm
+
     def annotate_work_entry(self, work, active_license_pool, edition, identifier, feed, entry, updated=None):
         super(CirculationManagerAnnotator, self).annotate_work_entry(
             work, active_license_pool, edition, identifier, feed, entry, updated
@@ -229,7 +244,9 @@ class CirculationManagerAnnotator(Annotator):
                 # The ebook distributor requires that the delivery
                 # mechanism be set at the point of checkout. This means
                 # a separate borrow link for each mechanism.
-                for mechanism in active_license_pool.delivery_mechanisms:
+                for mechanism in self.visible_delivery_mechanisms(
+                        active_license_pool
+                ):
                     borrow_links.append(
                         self.borrow_link(
                             active_license_pool,
@@ -278,7 +295,12 @@ class CirculationManagerAnnotator(Annotator):
                 # set. There is one link for the delivery mechanism
                 # that was locked in, and links for any streaming
                 # delivery mechanisms.
+                #
+                # Since the delivery mechanism has already been locked in,
+                # we choose not to use visible_delivery_mechanisms --
+                # they already chose it and they're stuck with it.
                 for lpdm in active_license_pool.delivery_mechanisms:
+
                     if lpdm is active_loan.fulfillment or lpdm.delivery_mechanism.is_streaming:
                         fulfill_links.append(
                             self.fulfill_link(
@@ -289,9 +311,11 @@ class CirculationManagerAnnotator(Annotator):
                         )
             else:
                 # The delivery mechanism for this loan has not been
-                # set. There is one fulfill link for every delivery
-                # mechanism.
-                for lpdm in active_license_pool.delivery_mechanisms:
+                # set. There is one fulfill link for every visible
+                # delivery mechanism.
+                for lpdm in self.visible_delivery_mechanisms(
+                        active_license_pool
+                ):
                     fulfill_links.append(
                         self.fulfill_link(
                             active_license_pool,
@@ -424,12 +448,15 @@ class LibraryAnnotator(CirculationManagerAnnotator):
           added, for direct acquisition of titles that would normally
           require a loan.
         """
-        super(LibraryAnnotator, self).__init__(lane, active_loans_by_work=active_loans_by_work,
-                                               active_holds_by_work=active_holds_by_work,
-                                               active_fulfillments_by_work=active_fulfillments_by_work,
-                                               test_mode=test_mode)
-        self.circulation = circulation
         self.library = library
+        super(LibraryAnnotator, self).__init__(
+            lane, active_loans_by_work=active_loans_by_work,
+            active_holds_by_work=active_holds_by_work,
+            active_fulfillments_by_work=active_fulfillments_by_work,
+            hidden_content_types=self._hidden_content_types,
+            test_mode=test_mode
+        )
+        self.circulation = circulation
         self.patron = patron
         self.lanes_by_work = defaultdict(list)
         self.facet_view = facet_view
@@ -437,6 +464,28 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         self._top_level_title = top_level_title
         self.identifies_patrons = library_identifies_patrons
         self.facets = facets or None
+
+    @property
+    def _hidden_content_types(self):
+        """Find all content types which this library should not be
+        presenting to patrons.
+
+        This is stored as a per-library setting.
+        """
+        if not self.library:
+            # This shouldn't happen, but we shouldn't crash if it does.
+            return []
+        setting = self.library.setting(Configuration.HIDDEN_CONTENT_TYPES)
+        if not setting or not setting.value:
+            return []
+        try:
+            hidden_types = setting.json_value
+        except ValueError:
+            hidden_types = setting.value
+        hidden_types = hidden_types or []
+        if not isinstance(hidden_types, list):
+            hidden_types = list(hidden_types)
+        return hidden_types
 
     def top_level_title(self):
         return self._top_level_title

--- a/api/opds.py
+++ b/api/opds.py
@@ -448,14 +448,14 @@ class LibraryAnnotator(CirculationManagerAnnotator):
           added, for direct acquisition of titles that would normally
           require a loan.
         """
-        self.library = library
         super(LibraryAnnotator, self).__init__(
             lane, active_loans_by_work=active_loans_by_work,
             active_holds_by_work=active_holds_by_work,
             active_fulfillments_by_work=active_fulfillments_by_work,
-            hidden_content_types=self._hidden_content_types,
+            hidden_content_types=self._hidden_content_types(library),
             test_mode=test_mode
         )
+        self.library = library
         self.circulation = circulation
         self.patron = patron
         self.lanes_by_work = defaultdict(list)
@@ -465,17 +465,17 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         self.identifies_patrons = library_identifies_patrons
         self.facets = facets or None
 
-    @property
-    def _hidden_content_types(self):
+    @classmethod
+    def _hidden_content_types(self, library):
         """Find all content types which this library should not be
         presenting to patrons.
 
         This is stored as a per-library setting.
         """
-        if not self.library:
+        if not library:
             # This shouldn't happen, but we shouldn't crash if it does.
             return []
-        setting = self.library.setting(Configuration.HIDDEN_CONTENT_TYPES)
+        setting = library.setting(Configuration.HIDDEN_CONTENT_TYPES)
         if not setting or not setting.value:
             return []
         try:
@@ -483,7 +483,9 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         except ValueError:
             hidden_types = setting.value
         hidden_types = hidden_types or []
-        if not isinstance(hidden_types, list):
+        if isinstance(hidden_types, basestring):
+            hidden_types = [hidden_types]
+        elif not isinstance(hidden_types, list):
             hidden_types = list(hidden_types)
         return hidden_types
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -230,6 +230,35 @@ class TestLibraryAnnotator(VendorIDTest):
         # A ContributorLane to test code that handles it differently.
         self.contributor_lane = ContributorLane(self._default_library, "Someone", languages=["eng"], audiences=None)
 
+    def test__hidden_content_types(self):
+
+        def f(value):
+            """Set the default library's HIDDEN_CONTENT_TYPES setting
+            to a specific value and see what _hidden_content_types
+            says.
+            """
+            library = self._default_library
+            library.setting(Configuration.HIDDEN_CONTENT_TYPES).value = value
+            return LibraryAnnotator._hidden_content_types(library)
+
+        # When the value is not set at all, no content types are hidden.
+        eq_(
+            [],
+            list(LibraryAnnotator._hidden_content_types(self._default_library))
+        )
+
+        # Now set various values and see what happens.
+        eq_([], f(None))
+        eq_([], f(""))
+        eq_([], f(json.dumps([])))
+        eq_(["text/html"], f("text/html"))
+        eq_(["text/html"], f(json.dumps("text/html")))
+        eq_(["text/html"], f(json.dumps({"text/html" : "some value"})))
+        eq_(
+            ["text/html", "text/plain"],
+            f(json.dumps(["text/html", "text/plain"]))
+        )
+
     def test_add_configuration_links(self):
         mock_feed = []
         link_config = {


### PR DESCRIPTION
This addresses https://jira.nypl.org/browse/SIMPLY-1683. This will let us hide PDF delivery mechanisms on Open eBooks, which will stop the iOS client from trying to download books of this type.