### PR TITLE
Bring circulation up to date with changes to the Timestamp API

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1275,7 +1275,14 @@ class BibliothecaEventMonitor(CollectionMonitor):
 
         The command line date argument should have the format YYYY-MM-DD.
         """
-        initialized = get_one(_db, Timestamp, service=self.service_name)
+
+        # We don't use Monitor.timestamp() because that will create
+        # the timestamp if it doesn't exist -- we want to see whether
+        # or not it exists.
+        initialized = get_one(
+            _db, Timestamp, service=self.service_name,
+            service_type=Timestamp.MONITOR_TYPE
+        )
         default_start_time = datetime.utcnow() - self.DEFAULT_START_TIME
 
         if cli_date:

--- a/api/monitor.py
+++ b/api/monitor.py
@@ -126,9 +126,9 @@ class MWCollectionUpdateMonitor(MetadataWranglerCollectionMonitor):
                     if link not in seen_links:
                         queue.append(link)
             if new_timestamp:
-                self.timestamp().timestamp = new_timestamp
+                self.timestamp().finish = new_timestamp
             self._db.commit()
-        return new_timestamp or self.timestamp().timestamp
+        return new_timestamp or self.timestamp().finish
 
     def import_one_feed(self, timestamp, url):
         response = self.get_response(url=url, timestamp=timestamp)

--- a/scripts.py
+++ b/scripts.py
@@ -952,7 +952,10 @@ class InstanceInitializationScript(TimestampScript):
 
         # Set a timestamp that represents the new database's version.
         db_init_script = DatabaseMigrationInitializationScript(_db=self._db)
-        existing = get_one(self._db, Timestamp, service=db_init_script.name)
+        existing = get_one(
+            self._db, Timestamp, service=db_init_script.name,
+            service_type=Timestamp.SCRIPT_TYPE
+        )
         if existing:
             # No need to run the script. We already have a timestamp.
             return

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -955,7 +955,10 @@ class TestBibliothecaEventMonitor(BibliothecaAPITest):
         # After Bibliotheca has been initialized,
         # create_default_start_time returns None, rather than a date
         # far in the bast, if no cli_date is passed in.
-        Timestamp.stamp(self._db, monitor.service_name, self.collection)
+        Timestamp.stamp(
+            self._db, service=monitor.service_name,
+            service_type=Timestamp.MONITOR_TYPE, collection=self.collection
+        )
         eq_(None, monitor.create_default_start_time(self._db, []))
 
         # Returns a date several years ago if args are formatted

--- a/tests/test_enki.py
+++ b/tests/test_enki.py
@@ -24,7 +24,6 @@ from core.model import (
     Representation,
     Resource,
     Subject,
-    Timestamp,
     Work,
 )
 from . import DatabaseTest

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -111,7 +111,7 @@ class TestMWCollectionUpdateMonitor(DatabaseTest):
 
         # The timestamp was not updated because nothing was in the feed.
         eq_(None, new_timestamp)
-        eq_(None, self.monitor.timestamp().timestamp)
+        eq_(None, self.monitor.timestamp().finish)
 
     def test_run_once(self):
         # Setup authentication and Metadata Wrangler details.
@@ -172,7 +172,7 @@ class TestMWCollectionUpdateMonitor(DatabaseTest):
 
     def test_no_changes_means_no_timestamp_update(self):
         before = datetime.datetime.utcnow()
-        self.monitor.timestamp().timestamp = before
+        self.monitor.timestamp().finish = before
 
         # We're going to ask the metadata wrangler for updates, but
         # there will be none.
@@ -185,7 +185,7 @@ class TestMWCollectionUpdateMonitor(DatabaseTest):
         # run_once() returned the original timestamp, and the
         # Timestamp object was not updated.
         eq_(before, new_timestamp)
-        eq_(before, self.monitor.timestamp().timestamp)
+        eq_(before, self.monitor.timestamp().finish)
 
     def test_no_import_loop(self):
         """We stop processing a feed's 'next' link if it links to a URL we've

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,6 +1,7 @@
 import datetime
 import random
 from nose.tools import (
+    assert_raises_regexp,
     set_trace,
     eq_,
 )
@@ -72,6 +73,15 @@ class TestMWCollectionUpdateMonitor(DatabaseTest):
 
         self.monitor = InstrumentedMWCollectionUpdateMonitor(
             self._db, self.collection, self.lookup
+        )
+
+    def test_monitor_requires_authentication(self):
+        class Mock(object):
+            authenticated = False
+        self.monitor.lookup = Mock()
+        assert_raises_regexp(
+            Exception, "no authentication credentials",
+            self.monitor.run_once, None, None
         )
 
     def test_import_one_feed(self):
@@ -284,6 +294,15 @@ class TestMWAuxiliaryMetadataMonitor(DatabaseTest):
 
         self.monitor = MWAuxiliaryMetadataMonitor(
             self._db, self.collection, lookup=self.lookup, provider=provider
+        )
+
+    def test_monitor_requires_authentication(self):
+        class Mock(object):
+            authenticated = False
+        self.monitor.lookup = Mock()
+        assert_raises_regexp(
+            Exception, "no authentication credentials",
+            self.monitor.run_once, None, None
         )
 
     def prep_feed_identifiers(self):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -148,7 +148,7 @@ class TestMWCollectionUpdateMonitor(DatabaseTest):
         # Normally run_once() doesn't update the monitor's timestamp,
         # but this implementation does, so that work isn't redone if
         # run_once() crashes or the monitor is killed.
-        eq_(new_timestamp, self.monitor.timestamp().timestamp)
+        eq_(new_timestamp, self.monitor.timestamp().finish)
 
         # The original Identifier has information from the
         # mock Metadata Wrangler.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -646,7 +646,10 @@ class TestCacheMARCFiles(TestLaneScript):
 class TestInstanceInitializationScript(DatabaseTest):
 
     def test_run(self):
-        timestamp = get_one(self._db, Timestamp, service=u"Database Migration")
+        timestamp = get_one(
+            self._db, Timestamp, service=u"Database Migration",
+            service_type=Timestamp.SCRIPT_TYPE
+        )
         eq_(None, timestamp)
 
         # Remove all secret keys, should they exist, before running the
@@ -659,7 +662,10 @@ class TestInstanceInitializationScript(DatabaseTest):
         script.do_run(ignore_search=True)
 
         # It initializes the database.
-        timestamp = get_one(self._db, Timestamp, service=u"Database Migration")
+        timestamp = get_one(
+            self._db, Timestamp, service=u"Database Migration",
+            service_type=Timestamp.SCRIPT_TYPE
+        )
         assert timestamp
 
         # It creates a secret key.


### PR DESCRIPTION
This branch changes the circulation manager's use of `Timestamp` to reflect the changes made by https://github.com/NYPL-Simplified/server_core/pull/1013:

* Timestamps are now identified with a `service_type` as well as a `service`.
* The time at which the service completed is now called `finish`, not `timestamp`.
* A `Monitor` that can't complete its task should raise an exception.