### PR TITLE
Changed the Monitor.run_once() implementations that currently return timestamps so that they return TimestampData objects instead.

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -58,6 +58,7 @@ from core.model import (
 from core.monitor import (
     CollectionMonitor,
     IdentifierSweepMonitor,
+    TimelineMonitor,
 )
 
 from core.opds_import import (
@@ -508,7 +509,7 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasSelfTests):
             params=params, **kwargs
         )
 
-class Axis360CirculationMonitor(CollectionMonitor):
+class Axis360CirculationMonitor(CollectionMonitor, TimelineMonitor):
 
     """Maintain LicensePools for Axis 360 titles.
     """
@@ -519,7 +520,6 @@ class Axis360CirculationMonitor(CollectionMonitor):
     PROTOCOL = ExternalIntegration.AXIS_360
 
     DEFAULT_START_TIME = datetime(1970, 1, 1)
-    FIVE_MINUTES = timedelta(minutes=5)
 
     def __init__(self, _db, collection, api_class=Axis360API):
         super(Axis360CirculationMonitor, self).__init__(_db, collection)
@@ -535,28 +535,18 @@ class Axis360CirculationMonitor(CollectionMonitor):
             Axis360BibliographicCoverageProvider(collection, api_class=self.api)
         )
 
-    def run_once(self, progress):
+    def catch_up_from(self, start, cutoff, progress):
         """Find Axis 360 books that changed recently.
 
         :progress: A TimestampData representing the time previously
         covered by this Monitor.
         """
-        # Give us five minutes of overlap with the previous run
-        # because it's very important we don't miss anything.
-        since = progress.finish - self.FIVE_MINUTE
-        cutoff = datetime.datetime.utcnow()
         count = 0
-        for bibliographic, circulation in self.api.recent_activity(since):
+        for bibliographic, circulation in self.api.recent_activity(start):
             self.process_book(bibliographic, circulation)
             count += 1
             if count % self.batch_size == 0:
                 self._db.commit()
-
-        # Update the TimestampData to describe the time span covered
-        # during this run.
-        progress.start = since
-        progress.finish = cutoff
-        return progress
 
     def process_book(self, bibliographic, availability):
 

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -92,6 +92,7 @@ from core.metadata_layer import (
     MeasurementData,
     ReplacementPolicy,
     SubjectData,
+    TimestampData,
 )
 
 from core.testing import DatabaseTest
@@ -1357,7 +1358,8 @@ class BibliothecaEventMonitor(CollectionMonitor):
                     )
                 raise e
         self.log.info("Handled %d events total", i)
-        return most_recent_timestamp
+        return TimestampData(start=most_recent_timestamp,
+                             finish=most_recent_timestamp)
 
     def handle_event(self, bibliotheca_id, isbn, foreign_patron_id,
                      start_time, end_time, internal_event_type):

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1330,14 +1330,14 @@ class BibliothecaEventMonitor(CollectionMonitor):
         start = progress.finish or self.default_start_time
         now = datetime.datetime.utcnow()
 
-        # We use timestamp.start and timestamp.finish to track the 
+        # We use timestamp.start and timestamp.finish to track the
         # first and last events processed during this run.
         #
         # If no events are processed during a run, we preserve the
         # last event processed in the _previous_ run as both the start
         # and end point -- we started there and saw nothing further.
         first_event = None
-        final_event = progress.finish
+        final_event = start
 
         added_books = 0
         i = 0

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -93,7 +93,6 @@ from core.metadata_layer import (
     MeasurementData,
     ReplacementPolicy,
     SubjectData,
-    TimestampData,
 )
 
 from core.testing import DatabaseTest

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1358,7 +1358,7 @@ class BibliothecaEventMonitor(CollectionMonitor):
                     )
                 raise e
         self.log.info("Handled %d events total", i)
-        return TimestampData(start=most_recent_timestamp,
+        return TimestampData(start=start,
                              finish=most_recent_timestamp)
 
     def handle_event(self, bibliotheca_id, isbn, foreign_patron_id,

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1328,7 +1328,7 @@ class BibliothecaEventMonitor(CollectionMonitor):
         # We want to start at the time of the last event successfully
         # processed, and continue up to the current time.
         start = progress.finish or self.default_start_time
-        now = datetime.datetime.utcnow()
+        now = datetime.utcnow()
 
         # We use timestamp.start and timestamp.finish to track the
         # first and last events processed during this run.
@@ -1382,6 +1382,7 @@ class BibliothecaEventMonitor(CollectionMonitor):
             # point to the timestamp of the last event processed on
             # the previous run.
             first_event = progress.finish
+            final_event = first_event
         progress.start = first_event
         progress.finish = final_event
         return progress

--- a/api/enki.py
+++ b/api/enki.py
@@ -693,7 +693,7 @@ class EnkiImport(CollectionMonitor, TimelineMonitor):
     def collection(self):
         return Collection.by_id(self._db, id=self.collection_id)
 
-    def catch_up_from(self, start, *ignore):
+    def catch_up_from(self, start, cutoff, progress):
         """Find Enki books that changed recently.
 
         :param start: Find all books that changed since this date.

--- a/api/enki.py
+++ b/api/enki.py
@@ -58,6 +58,7 @@ from core.monitor import (
     Monitor,
     IdentifierSweepMonitor,
     CollectionMonitor,
+    TimelineMonitor,
 )
 
 from core.analytics import Analytics
@@ -665,7 +666,7 @@ class BibliographicParser(object):
         return circulationdata
 
 
-class EnkiImport(CollectionMonitor):
+class EnkiImport(CollectionMonitor, TimelineMonitor):
     """Make sure our local collection is up-to-date with the remote
     Enki collection.
     """
@@ -692,14 +693,11 @@ class EnkiImport(CollectionMonitor):
     def collection(self):
         return Collection.by_id(self._db, id=self.collection_id)
 
-    def run_once(self, progress):
+    def catch_up_from(self, start, *ignore):
         """Find Enki books that changed recently.
 
-        :progress: A TimestampData representing the time previously
-        covered by this Monitor.
+        :param start: Find all books that changed since this date.
         """
-        start = progress.finish
-        cutoff = datetime.datetime.utcnow()
         if start is None:
             # This is the first time the monitor has run, so it's
             # important that we get the entire collection, even though that
@@ -711,13 +709,7 @@ class EnkiImport(CollectionMonitor):
             #
             # Give us five minutes of overlap because it's very important
             # we don't miss anything.
-            start = last_run-self.FIVE_MINUTES
-
             self.incremental_import(start)
-
-        progress.start = start
-        progress.finish = cutoff
-        return progress
 
     def full_import(self):
         """Import the entire Enki collection, page by page."""

--- a/api/monitor.py
+++ b/api/monitor.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     or_,
 )
 
+from core.metadata_layer import TimestampData
 from core.monitor import (
     CollectionMonitor,
     EditionSweepMonitor,
@@ -136,7 +137,10 @@ class MWCollectionUpdateMonitor(MetadataWranglerCollectionMonitor):
             if new_timestamp:
                 self.timestamp().finish = new_timestamp
             self._db.commit()
-        return new_timestamp or self.timestamp().finish
+        finish = new_timestamp or self.timestamp().finish
+        if finish:
+            return TimestampData(start=start, finish=finish)
+        return None
 
     def import_one_feed(self, timestamp, url):
         response = self.get_response(url=url, timestamp=timestamp)

--- a/api/monitor.py
+++ b/api/monitor.py
@@ -12,7 +12,6 @@ from sqlalchemy import (
     or_,
 )
 
-from core.metadata_layer import TimestampData
 from core.monitor import (
     CollectionMonitor,
     EditionSweepMonitor,

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -917,6 +917,7 @@ class OdiloCirculationMonitor(CollectionMonitor, TimelineMonitor):
         new = 0
         offset = 0
         limit = self.api.PAGE_SIZE_LIMIT
+
         if modification_date and isinstance(modification_date, datetime.date):
             modification_date = modification_date.strftime('%Y-%m-%d')  # Format YYYY-MM-DD
 

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -885,6 +885,7 @@ class OdiloCirculationMonitor(CollectionMonitor, TimelineMonitor):
     SERVICE_NAME = "Odilo Circulation Monitor"
     INTERVAL_SECONDS = 500
     PROTOCOL = ExternalIntegration.ODILO
+    DEFAULT_START_TIME = CollectionMonitor.NEVER
 
     def __init__(self, _db, collection, api_class=OdiloAPI):
         """Constructor."""
@@ -916,7 +917,6 @@ class OdiloCirculationMonitor(CollectionMonitor, TimelineMonitor):
         new = 0
         offset = 0
         limit = self.api.PAGE_SIZE_LIMIT
-
         if modification_date and isinstance(modification_date, datetime.date):
             modification_date = modification_date.strftime('%Y-%m-%d')  # Format YYYY-MM-DD
 

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -890,7 +890,16 @@ class OdiloCirculationMonitor(CollectionMonitor):
         super(OdiloCirculationMonitor, self).__init__(_db, collection)
         self.api = api_class(_db, collection)
 
-    def run_once(self, start, cutoff):
+    def run_once(self, progress):
+        """Find Odilo books that changed recently.
+
+        :progress: A TimestampData representing the time previously
+        covered by this Monitor.
+        """
+
+        # Cover the time period from the last run to now.
+        start = progress.finish
+        cutoff = datetime.datetime.utcnow()
         self.log.info("Starting recently_changed_ids, start: " + str(start) + ", cutoff: " + str(cutoff))
 
         start_time = datetime.datetime.now()
@@ -899,6 +908,10 @@ class OdiloCirculationMonitor(CollectionMonitor):
 
         time_elapsed = finish_time - start_time
         self.log.info("recently_changed_ids finished in: " + str(time_elapsed))
+
+        progress.start = start
+        progress.finish = cutoff
+        return progress
 
     def all_ids(self, modification_date=None):
         """Get IDs for every book in the system, from modification date if any

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -333,8 +333,13 @@ class OPDSForDistributorsReaperMonitor(OPDSForDistributorsImportMonitor):
         identifiers = [entry.get("id") for entry in parsed_feed.get("entries", [])]
         self.seen_identifiers.update(identifiers)
 
-    def run_once(self, start_ignore, cutoff_ignore):
-        super(OPDSForDistributorsReaperMonitor, self).run_once(start_ignore, cutoff_ignore)
+    def run_once(self, progress):
+        """Check to see if any identifiers we know about are no longer
+        present on the remote. If there are any, remove them.
+
+        :param progress: A TimestampData, ignored.
+        """
+        super(OPDSForDistributorsReaperMonitor, self).run_once(progress)
 
         # At this point we've gone through the feed and collected all the identifiers.
         # If there's anything we didn't see, we know it's no longer available.

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -1069,8 +1069,6 @@ class OverdriveCirculationMonitor(CollectionMonitor, TimelineMonitor):
                 consecutive_unchanged_books = 0
             else:
                 consecutive_unchanged_books += 1
-                if consecutive_unchanged_books > 1:
-                    set_trace()
                 if (self.maximum_consecutive_unchanged_books
                     and consecutive_unchanged_books >=
                     self.maximum_consecutive_unchanged_books):

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -1012,7 +1012,6 @@ class OverdriveCirculationMonitor(CollectionMonitor, TimelineMonitor):
     basic Editions for any new LicensePools that show up.
     """
     SERVICE_NAME = "Overdrive Circulation Monitor"
-    INTERVAL_SECONDS = 500
     PROTOCOL = ExternalIntegration.OVERDRIVE
     OVERLAP = datetime.timedelta(minutes=1)
 
@@ -1094,7 +1093,6 @@ class FullOverdriveCollectionMonitor(OverdriveCirculationMonitor):
     are not found in our collection.
     """
     SERVICE_NAME = "Overdrive Collection Overview"
-    INTERVAL_SECONDS = 3600*4
 
     def recently_changed_ids(self, start, cutoff):
         """Ignore the dates and return all IDs."""
@@ -1106,7 +1104,6 @@ class OverdriveCollectionReaper(IdentifierSweepMonitor):
     Overdrive collection.
     """
     SERVICE_NAME = "Overdrive Collection Reaper"
-    INTERVAL_SECONDS = 3600*4
     PROTOCOL = ExternalIntegration.OVERDRIVE
 
     def __init__(self, _db, collection, api_class=OverdriveAPI):
@@ -1121,7 +1118,6 @@ class RecentOverdriveCollectionMonitor(OverdriveCirculationMonitor):
     """Monitor recently changed books in the Overdrive collection."""
 
     SERVICE_NAME = "Reverse Chronological Overdrive Collection Monitor"
-    INTERVAL_SECONDS = 60
     MAXIMUM_CONSECUTIVE_UNCHANGED_BOOKS=100
 
 

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -1013,6 +1013,7 @@ class OverdriveCirculationMonitor(CollectionMonitor):
     SERVICE_NAME = "Overdrive Circulation Monitor"
     INTERVAL_SECONDS = 500
     PROTOCOL = ExternalIntegration.OVERDRIVE
+    OVERLAP = None
 
     # Report successful completion upon finding this number of
     # consecutive books in the Overdrive results whose LicensePools
@@ -1033,7 +1034,7 @@ class OverdriveCirculationMonitor(CollectionMonitor):
     def recently_changed_ids(self, start, cutoff):
         return self.api.recently_changed_ids(start, cutoff)
 
-    def run_once(self, progress):
+    def catch_up_from(self, start, cutoff, progress):
         """Find Overdrive books that changed recently.
 
         :progress: A TimestampData representing the time previously
@@ -1049,9 +1050,6 @@ class OverdriveCirculationMonitor(CollectionMonitor):
 
         # Ask for changes between the last time covered by the Monitor
         # and the current time.
-        start = progress.finish
-        cutoff = datetime.datetime.utcnow()
-
         for i, book in enumerate(self.recently_changed_ids(start, cutoff)):
             total_books += 1
             if not total_books % 100:
@@ -1084,9 +1082,7 @@ class OverdriveCirculationMonitor(CollectionMonitor):
 
         if total_books:
             self.log.info("Processed %d books total.", total_books)
-        progress.start = start
-        progress.finish = cutoff
-        return progress
+
 
 class FullOverdriveCollectionMonitor(OverdriveCirculationMonitor):
     """Monitor every single book in the Overdrive collection.

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -45,6 +45,7 @@ from core.model import (
 from core.monitor import (
     CollectionMonitor,
     IdentifierSweepMonitor,
+    TimelineMonitor,
 )
 from core.util.http import HTTP
 from core.metadata_layer import ReplacementPolicy
@@ -1006,14 +1007,14 @@ class MockOverdriveAPI(BaseMockOverdriveAPI, OverdriveAPI):
         return response
 
 
-class OverdriveCirculationMonitor(CollectionMonitor):
+class OverdriveCirculationMonitor(CollectionMonitor, TimelineMonitor):
     """Maintain LicensePools for recently changed Overdrive titles. Create
     basic Editions for any new LicensePools that show up.
     """
     SERVICE_NAME = "Overdrive Circulation Monitor"
     INTERVAL_SECONDS = 500
     PROTOCOL = ExternalIntegration.OVERDRIVE
-    OVERLAP = None
+    OVERLAP = datetime.timedelta(minutes=1)
 
     # Report successful completion upon finding this number of
     # consecutive books in the Overdrive results whose LicensePools
@@ -1069,6 +1070,8 @@ class OverdriveCirculationMonitor(CollectionMonitor):
                 consecutive_unchanged_books = 0
             else:
                 consecutive_unchanged_books += 1
+                if consecutive_unchanged_books > 1:
+                    set_trace()
                 if (self.maximum_consecutive_unchanged_books
                     and consecutive_unchanged_books >=
                     self.maximum_consecutive_unchanged_books):

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -1940,7 +1940,11 @@ class RBDigitalSyncMonitor(CollectionMonitor):
         super(RBDigitalSyncMonitor, self).__init__(_db, collection)
         self.api = api_class(_db, collection, **api_class_kwargs)
 
-    def run_once(self, start, cutoff):
+    def run_once(self, progress):
+        """Find books in the RBdigital collection that changed recently.
+
+        :param progress: A TimestampData, ignored.
+        """
         items_transmitted, items_created = self.invoke()
         self._db.commit()
         result_string = "%s items transmitted, %s items saved to DB" % (items_transmitted, items_created)
@@ -2032,7 +2036,12 @@ class RBDigitalCirculationMonitor(CollectionMonitor):
     def run(self):
         super(RBDigitalCirculationMonitor, self).run()
 
-    def run_once(self, start, cutoff):
+    def run_once(self, progress):
+        """Update the availability information of all titles in the
+        RBdigital collection.
+
+        :param progress: A TimestampData, ignored.
+        """
         ebook_count = self.process_availability(media_type='eBook')
         eaudio_count = self.process_availability(media_type='eAudio')
 

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -1989,7 +1989,6 @@ class RBDigitalCirculationMonitor(CollectionMonitor):
     """
     SERVICE_NAME = "RBDigital CirculationMonitor"
     DEFAULT_START_TIME = datetime.datetime(1970, 1, 1)
-    INTERVAL_SECONDS = 1200
     DEFAULT_BATCH_SIZE = 50
 
     PROTOCOL = ExternalIntegration.RB_DIGITAL

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -2033,9 +2033,6 @@ class RBDigitalCirculationMonitor(CollectionMonitor):
 
         return item_count
 
-    def run(self):
-        super(RBDigitalCirculationMonitor, self).run()
-
     def run_once(self, progress):
         """Update the availability information of all titles in the
         RBdigital collection.

--- a/tests/files/bibliotheca/empty_event_batch.xml
+++ b/tests/files/bibliotheca/empty_event_batch.xml
@@ -1,0 +1,1 @@
+<LibraryEventBatch xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>

--- a/tests/test_enki.py
+++ b/tests/test_enki.py
@@ -41,6 +41,7 @@ from api.enki import (
 from core.metadata_layer import (
     CirculationData,
     Metadata,
+    TimestampData,
 )
 from core.scripts import RunCollectionCoverageProviderScript
 from core.util.http import (
@@ -541,26 +542,37 @@ class TestEnkiImport(BaseEnkiTest):
 
         importer = Mock(self._db, self.collection, api_class=self.api)
 
-        # If run_once() is called with no start time, as happens the first time
-        # the importer runs, it calls full_import().
-        importer.run_once(None, None)
+        # If the incoming TimestampData makes it look like the process
+        # has never successfully completed, full_import() is called.
+        progress = TimestampData(start=None)
+        importer.run_once(progress)
         eq_(True, importer.full_import_called)
 
         # It doesn't call incremental_import().
         eq_(dummy_value, importer.incremental_import_called_with)
 
-        # If run_once() is called with a start time, a time five
-        # minutes previous is passed into incremental_import()
+        # If run_once() is called with a TimestampData that indicates
+        # an earlier successful run, a time five minutes before the
+        # previous completion time is passed into incremental_import()
         importer.full_import_called = False
-        timestamp = datetime.datetime.utcnow()
-        five_minutes_earlier = timestamp - importer.FIVE_MINUTES
-        importer.run_once(timestamp, None)
+
+        a_while_ago = datetime.datetime(2011, 1, 1)
+        even_earlier = a_while_ago - datetime.timedelta(days=100)
+        timestamp = TimestampData(start=even_earlier, finish=a_while_ago)
+        new_timestamp = importer.run_once(timestamp)
 
         passed_in = importer.incremental_import_called_with
-        assert abs((passed_in-five_minutes_earlier).total_seconds()) < 2
+        expect = a_while_ago - importer.OVERLAP
+        assert abs((passed_in-expect).total_seconds()) < 2
 
         # full_import was not called.
         eq_(False, importer.full_import_called)
+
+        # The proposed new TimestampData covers the entire timespan
+        # from the 'expect' period to now.
+        eq_(expect, new_timestamp.start)
+        now = datetime.datetime.utcnow()
+        assert (now - new_timestamp.finish).total_seconds() < 2
 
     def test_full_import(self):
         """full_import calls get_all_titles over and over again until

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -153,12 +153,12 @@ class TestMWCollectionUpdateMonitor(DatabaseTest):
         # We have a new value to use for the Monitor's timestamp -- the
         # earliest date seen in the last OPDS feed that contained
         # any entries.
-        eq_(datetime.datetime(2016, 9, 20, 19, 37, 2), new_timestamp)
+        eq_(datetime.datetime(2016, 9, 20, 19, 37, 2), new_timestamp.finish)
 
         # Normally run_once() doesn't update the monitor's timestamp,
         # but this implementation does, so that work isn't redone if
         # run_once() crashes or the monitor is killed.
-        eq_(new_timestamp, self.monitor.timestamp().finish)
+        eq_(new_timestamp.finish, self.monitor.timestamp().finish)
 
         # The original Identifier has information from the
         # mock Metadata Wrangler.
@@ -192,9 +192,9 @@ class TestMWCollectionUpdateMonitor(DatabaseTest):
         )
         new_timestamp = self.monitor.run_once(None, None)
 
-        # run_once() returned the original timestamp, and the
-        # Timestamp object was not updated.
-        eq_(before, new_timestamp)
+        # run_once() returned a TimestampData referencing the original
+        # timestamp, and the Timestamp object was not updated.
+        eq_(before, new_timestamp.finish)
         eq_(before, self.monitor.timestamp().finish)
 
     def test_no_import_loop(self):
@@ -226,7 +226,7 @@ class TestMWCollectionUpdateMonitor(DatabaseTest):
         eq_((None, u'http://next-link/'), second)
         eq_((None, u'http://different-link/'), third)
 
-        eq_(datetime.datetime(2016, 9, 20, 19, 37, 2), new_timestamp)
+        eq_(datetime.datetime(2016, 9, 20, 19, 37, 2), new_timestamp.finish)
 
     def test_get_response(self):
 

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -466,7 +466,7 @@ class TestOPDSForDistributorsReaperMonitor(DatabaseTest, BaseOPDSForDistributors
         pool.licenses_owned = 1
         pool.licenses_available = 1
 
-        monitor.run_once(None, None)
+        monitor.run_once(monitor.timestamp().to_data())
 
         eq_(0, pool.licenses_owned)
         eq_(0, pool.licenses_available)

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -12,6 +12,7 @@ from datetime import (
 from api.overdrive import (
     MockOverdriveAPI,
     OverdriveAPI,
+    OverdriveCirculationMonitor,
     OverdriveCollectionReaper,
     OverdriveFormatSweep,
 )
@@ -1092,6 +1093,98 @@ class TestSyncBookshelf(OverdriveAPITest):
         loans, holds = self.circulation.sync_bookshelf(patron, "dummy pin")
         eq_(5, len(patron.holds))
         assert overdrive_hold in patron.holds
+
+class TestOverdriveCircluationMonitor(OverdriveAPITest):
+
+    def test_run(self):
+        # An end-to-end test verifying that this Monitor manages its
+        # state across multiple runs.
+        # 
+        # This tests a lot of code that's technically not in Monitor,
+        # but when the Monitor API changes, it may require changes to
+        # this particular monitor, and it's good to have a test that
+        # will fail if that's true.
+        class Mock(OverdriveCirculationMonitor):
+            def catch_up_from(self, start, cutoff, progress):
+                self.catch_up_from_called_with = (start, cutoff, progress)
+
+        monitor = Mock(self._db, self.collection)
+
+        monitor.run()
+        start, cutoff, progress = monitor.catch_up_from_called_with
+        now = datetime.utcnow()
+
+        # The first time this Monitor is called, its 'start time' is
+        # the current time, and we ask for an overlap of one minute.
+        # This isn't very effective, but we have to start somewhere.
+        #
+        # (This isn't how the Overdrive collection is initially
+        # populated, BTW -- that's FullOverdriveCollectionMonitor.)
+        self.time_eq(start, now-monitor.OVERLAP)
+        self.time_eq(cutoff, now)
+        timestamp = monitor.timestamp()
+        eq_(start, timestamp.start)
+        eq_(cutoff, timestamp.finish)
+
+        # The second time the Monitor is called, its 'start time'
+        # is one minute before the previous cutoff time.
+        monitor.run()
+        new_start, new_cutoff, new_progress = monitor.catch_up_from_called_with
+        now = datetime.utcnow()
+        eq_(new_start, cutoff-monitor.OVERLAP)
+        self.time_eq(new_cutoff, now)
+
+    def test_catch_up_from(self):
+        # catch_up_from() asks Overdrive about recent changes by
+        # calling recently_changed_ids(), and mirrors those changes
+        # locally by calling update_licensepool().
+        class MockAPI(object):
+            def __init__(self, *ignore, **kwignore):
+                self.licensepools = []
+                self.update_licensepool_calls = []
+
+            def update_licensepool(self, book_id):
+                pool, is_new, is_changed = self.licensepools.pop(0)
+                self.update_licensepool_calls.append((book_id, pool))
+                return pool, is_new, is_changed
+
+        class MockMonitor(OverdriveCirculationMonitor):
+
+            recently_changed_ids_called_with = None 
+            def recently_changed_ids(self, start, cutoff):
+                self.recently_changed_ids_called_with = (start, cutoff)
+                return [1, 2, 3, 4]
+
+        monitor = MockMonitor(self._db, self.collection, api_class=MockAPI)
+        monitor.maximum_consecutive_unchanged_books = 2
+        api = monitor.api
+
+        # The 'Overdrive API' is ready to tell us about four books,
+        # but only one of them (the first) represents a change from what
+        # we already know.
+        lp1 = self._licensepool(None)
+        lp2 = self._licensepool(None)
+        lp3 = self._licensepool(None)
+        lp4 = object()
+        api.licensepools.append((lp1, True, True))
+        api.licensepools.append((lp2, False, False))
+        api.licensepools.append((lp3, False, False))
+        api.licensepools.append(lp4)
+
+        monitor.catch_up_from(object(), object(), object())
+
+        # We called update_licensepool on the first three books,
+        # and got the first three LicensePools from the queue.
+        eq_([(1, lp1),(2, lp2),(3, lp3)], api.update_licensepool_calls)
+
+        # At that point we gave up because we'd gotten two consecutive
+        # books from Overdrive that contained no new information.
+
+        # The fourth (bogus) LicensePool is still in api.licensepools
+        eq_([lp4], api.licensepools)
+
+        # TODO: Verify that a DISTRIBUTOR_TITLE_ADD event was gathered
+        # for the newly discovered license pool.
 
 class TestOverdriveFormatSweep(OverdriveAPITest):
 

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -37,6 +37,7 @@ from api.rbdigital import (
     RBDigitalDeltaMonitor,
     RBDigitalImportMonitor,
     RBDigitalRepresentationExtractor,
+    RBDigitalSyncMonitor,
     MockRBDigitalAPI,
     RBFulfillmentInfo,
 )
@@ -1037,6 +1038,24 @@ class TestRBDigitalAPI(RBDigitalAPITest):
 
 class TestCirculationMonitor(RBDigitalAPITest):
 
+    def test_run_once(self):
+        # run_once() calls process_availability twice, once for
+        # ebooks and once for audiobooks.
+
+        class Mock(RBDigitalCirculationMonitor):
+            process_availability_calls = []
+
+            def process_availability(self, media_type):
+                self.process_availability_calls.append(media_type)
+                # Pretend we processed three titles.
+                return 3
+
+        monitor = Mock(
+            self._db, self.collection, api_class=MockRBDigitalAPI,
+        )
+        monitor.run_once(monitor.timestamp().to_data())
+        eq_(['eBook', 'eAudio'], monitor.process_availability_calls)
+
     def test_process_availability(self):
         monitor = RBDigitalCirculationMonitor(
             self._db, self.collection, api_class=MockRBDigitalAPI,
@@ -1438,6 +1457,22 @@ class TestRBDigitalSyncMonitor(DatabaseTest):
         path = os.path.join(self.resource_path, filename)
         data = open(path).read()
         return data, json.loads(data)
+
+    def test_run_once(self):
+        # Calling run_once calls invoke(), and invoke() is
+        # expected to return two numbers.
+        class Mock(RBDigitalSyncMonitor):
+            SERVICE_NAME = "A service"
+
+            def invoke(self):
+                self.invoked = True
+                return 10, 5
+
+        monitor = Mock(
+            self._db, self.collection, api_class=MockRBDigitalAPI,
+        )
+        monitor.run_once(monitor.timestamp().to_data())
+        eq_(True, monitor.invoked)
 
     def test_import(self):
 


### PR DESCRIPTION
This is the circulation portion of https://github.com/NYPL-Simplified/server_core/pull/1021. 

We never override `CoverageProvider.run_once` or have a `Script` whose `run_once` implementation has a return value, so there was no need to change our coverage providers or scripts to reflect the new APIs. However, Monitors use the timestamp differently, so I had to change all the monitor classes.

These monitors became `TimelineMonitor`s. Their `run_once` implementations were converted to `catch_up_from` implementations:

* Axis360CirculationMonitor
* BibliothecaEventMonitor
* EnkiImport
* OdiloCirculationMonitor
* ODLConsolidatedCopiesMonitor
* OverdriveCirculationMonitor

For these monitors I modified `run_once` to change the signature, but didn't make any other changes, because these monitors don't do anything with a timestamp:

* MWAuxiliaryMetadataMonitor
* OPDSForDistributorsReaperMonitor
* RBDigitalSyncMonitor
* RBDigitalCirculationMonitor

I changed this monitor to port its custom behavior (returning a certain meaningful time as a custom value for Timestamp.finish) to the new system:

* MWCollectionUpdateMonitor

`BibliothecaEventMonitor` used to be a "custom behavior" monitor -- it used the timestamp to track the dates of the events it processed. I converted it into a `TimelineMonitor` because doing so dramatically simplified the code, and I don't think we were getting any value from the custom behavior.