### PR TITLE
Implement the new First Book authentication API

### DIFF
--- a/api/admin/controller/patron_auth_services.py
+++ b/api/admin/controller/patron_auth_services.py
@@ -8,7 +8,8 @@ from api.authenticator import AuthenticationProvider
 from api.simple_authentication import SimpleAuthenticationProvider
 from api.millenium_patron import MilleniumPatronAPI
 from api.sip import SIP2AuthenticationProvider
-from api.firstbook import FirstBookAuthenticationAPI
+from api.firstbook import FirstBookAuthenticationAPI as OldFirstBookAuthenticationAPI
+from api.firstbook2 import FirstBookAuthenticationAPI
 from api.clever import CleverAuthenticationAPI
 from core.model import (
     ConfigurationSetting,
@@ -26,6 +27,7 @@ class PatronAuthServicesController(SettingsController):
                          MilleniumPatronAPI,
                          SIP2AuthenticationProvider,
                          FirstBookAuthenticationAPI,
+                         OldFirstBookAuthenticationAPI,
                          CleverAuthenticationAPI,
                         ]
         self.protocols = self._get_integration_protocols(provider_apis)
@@ -34,6 +36,7 @@ class PatronAuthServicesController(SettingsController):
                                 MilleniumPatronAPI.__module__,
                                 SIP2AuthenticationProvider.__module__,
                                 FirstBookAuthenticationAPI.__module__,
+                                OldFirstBookAuthenticationAPI.__module__,
                                ]
 
     def process_patron_auth_services(self):

--- a/tests/admin/controller/test_patron_auth.py
+++ b/tests/admin/controller/test_patron_auth.py
@@ -42,8 +42,10 @@ class TestPatronAuth(SettingsControllerTest):
 
             self.admin.remove_role(AdminRole.SYSTEM_ADMIN)
             self._db.flush()
-            assert_raises(AdminNotAuthorized,
-                          self.manager.admin_patron_auth_services_controller.process_patron_auth_services)
+            assert_raises(
+                AdminNotAuthorized,
+                self.manager.admin_patron_auth_services_controller.process_patron_auth_services
+            )
 
     def test_patron_auth_services_get_with_simple_auth_service(self):
         auth_service, ignore = create(

--- a/tests/admin/controller/test_patron_auth.py
+++ b/tests/admin/controller/test_patron_auth.py
@@ -35,7 +35,7 @@ class TestPatronAuth(SettingsControllerTest):
             response = self.manager.admin_patron_auth_services_controller.process_patron_auth_services()
             eq_(response.get("patron_auth_services"), [])
             protocols = response.get("protocols")
-            eq_(5, len(protocols))
+            eq_(6, len(protocols))
             eq_(SimpleAuthenticationProvider.__module__, protocols[0].get("name"))
             assert "settings" in protocols[0]
             assert "library_settings" in protocols[0]

--- a/tests/test_firstbook2.py
+++ b/tests/test_firstbook2.py
@@ -1,0 +1,142 @@
+from nose.tools import (
+    assert_raises,
+    assert_raises_regexp,
+    eq_,
+    set_trace,
+)
+import jwt
+import os
+import time
+
+from api.authenticator import (
+    PatronData,
+)
+
+from api.config import (
+    Configuration,
+    temp_config,
+)
+
+from api.firstbook2 import (
+    FirstBookAuthenticationAPI,
+    MockFirstBookAuthenticationAPI,
+)
+
+from api.circulation_exceptions import (
+    RemoteInitiatedServerError
+)
+
+from . import DatabaseTest
+from core.model import ExternalIntegration
+
+
+class TestFirstBook(DatabaseTest):
+
+    def setup(self):
+        super(TestFirstBook, self).setup()
+        self.integration = self._external_integration(
+            ExternalIntegration.PATRON_AUTH_GOAL)
+        self.api = self.mock_api(dict(ABCD="1234"))
+
+    def mock_api(self, *args, **kwargs):
+        "Create a MockFirstBookAuthenticationAPI."
+        return MockFirstBookAuthenticationAPI(
+            self._default_library, self.integration,
+            *args, **kwargs
+        )
+
+    def test_from_config(self):
+        api = None
+        integration = self._external_integration(self._str)
+        integration.url = "http://example.com/"
+        integration.password = "the_key"
+        api = FirstBookAuthenticationAPI(self._default_library, integration)
+
+        # Verify that the configuration details were stored properly.
+        eq_('http://example.com/', api.root)
+        eq_('the_key', api.secret)
+
+        # Test the default server-side authentication regular expressions.
+        eq_(False, api.server_side_validation("foo' or 1=1 --;", "1234"))
+        eq_(False, api.server_side_validation("foo", "12 34"))
+        eq_(True, api.server_side_validation("foo", "1234"))
+        eq_(True, api.server_side_validation("foo@bar", "1234"))
+
+    def test_authentication_success(self):
+
+        # The mock API successfully decodes the JWT and verifies that
+        # the given barcode and pin authenticate a specific patron.
+        eq_(True, self.api.remote_pin_test("ABCD", "1234"))
+
+        # Let's see what the mock API had to work with.
+        requested = self.api.request_urls.pop()
+        assert requested.startswith(self.api.root)
+        token = requested[len(self.api.root):]
+
+        # It's a JWT, with the provided barcode and PIN in the
+        # payload.
+        barcode, pin = self.api._decode(token)
+        eq_("ABCD", barcode)
+        eq_("1234", pin)
+
+    def test_authentication_failure(self):
+        eq_(False, self.api.remote_pin_test("ABCD", "9999"))
+        eq_(False, self.api.remote_pin_test("nosuchkey", "9999"))
+
+        # credentials are uppercased in remote_authenticate;
+        # remote_pin_test just passes on whatever it's sent.
+        eq_(False, self.api.remote_pin_test("abcd", "9999"))
+
+    def test_remote_authenticate(self):
+        patrondata = self.api.remote_authenticate("abcd", "1234")
+        eq_("ABCD", patrondata.permanent_id)
+        eq_("ABCD", patrondata.authorization_identifier)
+        eq_(None, patrondata.username)
+
+        patrondata = self.api.remote_authenticate("ABCD", "1234")
+        eq_("ABCD", patrondata.permanent_id)
+        eq_("ABCD", patrondata.authorization_identifier)
+        eq_(None, patrondata.username)
+
+    def test_broken_service_remote_pin_test(self):
+        api = self.mock_api(failure_status_code=502)
+        assert_raises_regexp(
+            RemoteInitiatedServerError,
+            "Got unexpected response code 502. Content: Error 502",
+            api.remote_pin_test, "key", "pin"
+        )
+
+    def test_bad_connection_remote_pin_test(self):
+        api = self.mock_api(bad_connection=True)
+        assert_raises_regexp(
+            RemoteInitiatedServerError,
+            "Could not connect!",
+            api.remote_pin_test, "key", "pin"
+        )
+
+    def test_authentication_flow_document(self):
+        # We're about to call url_for, so we must create an
+        # application context.
+        os.environ['AUTOINITIALIZE'] = "False"
+        from api.app import app
+        self.app = app
+        del os.environ['AUTOINITIALIZE']
+        with self.app.test_request_context("/"):
+            doc = self.api.authentication_flow_document(self._db)
+            eq_(self.api.DISPLAY_NAME, doc['description'])
+            eq_(self.api.FLOW_TYPE, doc['type'])
+
+    def test_jwt(self):
+        # Test the code that generates and signs JWTs.
+        token = self.api.jwt("a barcode", "a pin")
+
+        # The JWT was signed with the shared secret. Decode it (this
+        # validates it as a side effect) and we can see the payload.
+        barcode, pin = self.api._decode(token)
+
+        eq_("a barcode", barcode)
+        eq_("a pin", pin)
+
+        # If the secrets don't match, decoding won't work.
+        self.api.secret = "bad secret"
+        assert_raises(jwt.DecodeError, self.api._decode, token)


### PR DESCRIPTION
This branch implements the new First Book authentication API. It resolves https://jira.nypl.org/browse/SIMPLY-1719.

The new API is located at https://ebooksuat.firstbook.org/api/, but I assume "uat" stands for User Acceptance Testing and the final name will change. Instead of sending barcode and PIN directly in the URL to the API, we create a JWT which includes barcode and PIN in the payload, sign it with a shared secret, and send the JWT over in the URL. So the final URL we use looks like this:

https://ebooksuat.firstbook.org/api/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJiYXJjb2RlIjoiQUJDREVGIiwicGluIjoiMzU3NCIsImlhdCI6IjE1NDk0OTE4MDkifQ.zJ1QXAJbQExrfbP227mNTm_qYri2PKNw_Fpo1qzBZbw

I made a copy of firstbook.py and test_firstbook.py, and modified it as necessary to accommodate the new API. I'll point out the major changes, but I think it's good to go over the whole thing since I don't think you're familiar with the  First Book API.

For now, the circulation manager will support both versions of the API. Once we get Open Ebooks using the new version, we can remove support for the old API.