### PR TITLE
Enki library id for library+collection

### DIFF
--- a/api/enki.py
+++ b/api/enki.py
@@ -70,9 +70,12 @@ class EnkiAPI(BaseCirculationAPI, HasSelfTests):
 
     DESCRIPTION = _("Integrate an Enki collection.")
     SETTINGS = [
-        { "key": Collection.EXTERNAL_ACCOUNT_ID_KEY, "label": _("Library ID"), "required": True },
         { "key": ExternalIntegration.URL, "label": _("URL"), "default": PRODUCTION_BASE_URL, "required": True, "format": "url" },
     ] + BaseCirculationAPI.SETTINGS
+
+    LIBRARY_SETTINGS = [
+        { "key": Collection.EXTERNAL_ACCOUNT_ID_KEY, "label": _("Library ID"), "required": True },
+    ]
 
     list_endpoint = "ListAPI"
     item_endpoint = "ItemAPI"

--- a/api/enki.py
+++ b/api/enki.py
@@ -68,13 +68,14 @@ class EnkiAPI(BaseCirculationAPI, HasSelfTests):
 
     PRODUCTION_BASE_URL = "https://enkilibrary.org/API/"
 
+    ENKI_LIBRARY_ID_KEY = u'enki_library_id'
     DESCRIPTION = _("Integrate an Enki collection.")
     SETTINGS = [
         { "key": ExternalIntegration.URL, "label": _("URL"), "default": PRODUCTION_BASE_URL, "required": True, "format": "url" },
     ] + BaseCirculationAPI.SETTINGS
 
     LIBRARY_SETTINGS = [
-        { "key": Collection.EXTERNAL_ACCOUNT_ID_KEY, "label": _("Library ID"), "required": True },
+        { "key": ENKI_LIBRARY_ID_KEY, "label": _("Library ID"), "required": True },
     ]
 
     list_endpoint = "ListAPI"

--- a/api/enki.py
+++ b/api/enki.py
@@ -111,7 +111,7 @@ class EnkiAPI(BaseCirculationAPI, HasSelfTests):
             )
 
         self.collection_id = collection.id
-        self.library_id = collection.external_account_id
+        self.library_id = collection.external_integration.setting(self.ENKI_LIBRARY_ID_KEY).value
         self.base_url = collection.external_integration.url or self.PRODUCTION_BASE_URL
 
         if not self.library_id or not self.base_url:
@@ -480,7 +480,7 @@ class MockEnkiAPI(EnkiAPI):
                 _db, name="Test Enki Collection", protocol=EnkiAPI.ENKI
             )
             collection.protocol=EnkiAPI.ENKI
-            collection.external_account_id=u'c';
+            collection.external_integration.setting(self.ENKI_LIBRARY_ID_KEY).value = u'c'
         if collection not in library.collections:
             library.collections.append(collection)
         super(MockEnkiAPI, self).__init__(

--- a/migration/20190215-update-enki-collection-integration.sql
+++ b/migration/20190215-update-enki-collection-integration.sql
@@ -5,3 +5,9 @@ select externalintegration_id, library_id, 'enki_library_id', external_account_i
 from collections join externalintegrations_libraries as el
 on collections.external_integration_id=el.externalintegration_id
 join externalintegrations as e on e.id=el.externalintegration_id where e.protocol='Enki';
+
+
+-- Remove external_account_id values for all Enki collections
+update collections
+set external_account_id=null
+where external_integration_id in (select id from externalintegrations where protocol='Enki');

--- a/migration/20190215-update-enki-collection-integration.sql
+++ b/migration/20190215-update-enki-collection-integration.sql
@@ -1,18 +1,7 @@
 -- Moving the "Library ID" Enki integration setting to be associated with each library
 -- and not just the collection.
-update configurationsettings as cs
-set
-    external_integration_id=updatesetting.externalintegration_id,
-    library_id=updatesetting.library_id,
-    key='external_account_id',
-    value=updatesetting.external_account_id
-from (
-    select externalintegration_id, library_id, external_account_id
-    from collections join externalintegrations_libraries as el
-    on collections.external_integration_id=el.externalintegration_id
-    join externalintegrations as e on e.id=el.externalintegration_id where e.protocol='Enki'
-) updatesetting
-where
-    cs.external_integration_id=updatesetting.externalintegration_id
-    and cs.library_id=updatesetting.library_id
-    and key='external_account_id';
+insert into configurationsettings (external_integration_id, library_id, key, value)
+select externalintegration_id, library_id, 'enki_library_id', external_account_id
+from collections join externalintegrations_libraries as el
+on collections.external_integration_id=el.externalintegration_id
+join externalintegrations as e on e.id=el.externalintegration_id where e.protocol='Enki';

--- a/migration/20190215-update-enki-collection-integration.sql
+++ b/migration/20190215-update-enki-collection-integration.sql
@@ -1,0 +1,18 @@
+-- Moving the "Library ID" Enki integration setting to be associated with each library
+-- and not just the collection.
+update configurationsettings as cs
+set
+    external_integration_id=updatesetting.externalintegration_id,
+    library_id=updatesetting.library_id,
+    key='external_account_id',
+    value=updatesetting.external_account_id
+from (
+    select externalintegration_id, library_id, external_account_id
+    from collections join externalintegrations_libraries as el
+    on collections.external_integration_id=el.externalintegration_id
+    join externalintegrations as e on e.id=el.externalintegration_id where e.protocol='Enki'
+) updatesetting
+where
+    cs.external_integration_id=updatesetting.externalintegration_id
+    and cs.library_id=updatesetting.library_id
+    and key='external_account_id';

--- a/tests/test_enki.py
+++ b/tests/test_enki.py
@@ -78,7 +78,7 @@ class TestEnkiAPI(BaseEnkiTest):
             EnkiAPI, self._db, bad_collection
         )
 
-        # Without an external_account_id, an EnkiAPI cannot be instantiated.
+        # Without an external integration library ID value, an EnkiAPI cannot be instantiated.
         bad_collection.protocol = ExternalIntegration.ENKI
         assert_raises_regexp(
             CannotLoadConfiguration,
@@ -88,7 +88,7 @@ class TestEnkiAPI(BaseEnkiTest):
             bad_collection
         )
 
-        bad_collection.external_account_id = "1"
+        bad_collection.external_integration.setting(EnkiAPI.ENKI_LIBRARY_ID_KEY).value = "1"
         EnkiAPI(self._db, bad_collection)
 
     def test_external_integration(self):


### PR DESCRIPTION
Moving the library id setting from the Enki integration setting to be for each associated library in the collection. Adding migration for existing Enki collections.

Fixes [SIMPLY-1220](https://jira.nypl.org/browse/SIMPLY-1220).