### PR TITLE
Update elasticsearch requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,11 @@ before_script:
   - psql -c 'grant all privileges on database simplified_circulation_test to simplified_test;' -U postgres
 
 env:
-  - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_circulation_test"
+  global:
+    - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_circulation_test"
+  matrix:
+    - SIMPLIFIED_ELASTICSEARCH_VERSION=1
+    - SIMPLIFIED_ELASTICSEARCH_VERSION=6
 
 script:
   - ./verbose-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,7 @@ before_script:
 env:
   global:
     - SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:5432/simplified_circulation_test"
-  matrix:
     - SIMPLIFIED_ELASTICSEARCH_VERSION=1
-    - SIMPLIFIED_ELASTICSEARCH_VERSION=6
 
 script:
   - ./verbose-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
   - git submodule update --init --recursive
 
 install:
+  - pip install --upgrade pip
   - pip install -r requirements.txt
   - python -m textblob.download_corpora
 

--- a/elasticsearch-requirements-1.txt
+++ b/elasticsearch-requirements-1.txt
@@ -1,0 +1,2 @@
+elasticsearch==2.1.0
+elasticsearch-dsl<2.0.0

--- a/elasticsearch-requirements-6.txt
+++ b/elasticsearch-requirements-6.txt
@@ -1,0 +1,2 @@
+elasticsearch>6.0.0,<7.0.0
+elasticsearch-dsl>6.0.0,<7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 # Core requirements
 boto3
-elasticsearch==2.1.0
-elasticsearch-dsl<2.0.0
-#elasticsearch>6.0.0,<7.0.0
-#elasticsearch-dsl>6.0.0,<7.0.0
+-r elasticsearch-requirements-${SIMPLIFIED_ELASTICSEARCH_VERSION}.txt
 pillow
 psycopg2
 requests==2.18.4


### PR DESCRIPTION
## Related Tickets / PRs

https://jira.nypl.org/browse/SIMPLY-1518
blocks: https://github.com/NYPL-Simplified/circulation-docker/pull/102

## What does this PR do?

Update `requirements.txt` so that you can install either the libraries for Elastic Search 1 or Elastic Search 6 depending on the `SIMPLIFIED_ELASTICSEARCH_VERSION` environment variable. 

This PR also modifies travis-ci to run the test with both the ES1 and ES6 libraries.

## Changes

When installing requirements you will need to have the `SIMPLIFIED_ELASTICSEARCH_VERSION` environment variable set.