### PR TITLE
Fixed missing presentation editions when a book is in multiple Overdrive collections

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -580,12 +580,12 @@ class Axis360CirculationMonitor(CollectionMonitor):
 
 class MockAxis360API(Axis360API):
     @classmethod
-    def mock_collection(self, _db):
+    def mock_collection(self, _db, name="Test Axis 360 Collection"):
         """Create a mock Axis 360 collection for use in tests."""
         library = DatabaseTest.make_default_library(_db)
         collection, ignore = get_one_or_create(
             _db, Collection,
-            name="Test Axis 360 Collection",
+            name=name,    
             create_method_kwargs=dict(
                 external_account_id=u'c',
             )

--- a/api/odl.py
+++ b/api/odl.py
@@ -1409,11 +1409,17 @@ class SharedODLImporter(OPDSImporter):
                 if copies_tags:
                     copies_tag = copies_tags[0]
                     licenses_available = copies_tag.attrib.get("available")
+                    if licenses_available != None:
+                        licenses_available = int(licenses_available)
                     licenses_owned = copies_tag.attrib.get("total")
+                    if licenses_owned != None:
+                        licenses_owned = int(licenses_owned)
                 holds_tags = parser._xpath(link_tag, 'opds:holds')
                 if holds_tags:
                     holds_tag = holds_tags[0]
                     patrons_in_hold_queue = holds_tag.attrib.get("total")
+                    if patrons_in_hold_queue != None:
+                        patrons_in_hold_queue = int(patrons_in_hold_queue)
 
                 format = FormatData(
                     content_type=content_type,

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -919,15 +919,6 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
 
         edition, is_new_edition = self._edition(license_pool)
 
-        # If the pool does not already have a presentation edition,
-        # then associate pool and edition as presentation_edition.
-        if not license_pool.presentation_edition:
-            edition_changed = license_pool.set_presentation_edition()
-
-        # Make sure the pool also has a work.
-        if not license_pool.work:
-            license_pool.calculate_work()
-
         if is_new_pool:
             license_pool.open_access = False
             self.log.info("New Overdrive book discovered: %r", edition)

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -920,10 +920,13 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
         edition, is_new_edition = self._edition(license_pool)
 
         # If the pool does not already have a presentation edition,
-        # and if this edition is newly made, then associate pool and edition
-        # as presentation_edition
-        if ((not license_pool.presentation_edition) and is_new_edition):
+        # then associate pool and edition as presentation_edition.
+        if not license_pool.presentation_edition:
             edition_changed = license_pool.set_presentation_edition()
+
+        # Make sure the pool also has a work.
+        if not license_pool.work:
+            license_pool.calculate_work()
 
         if is_new_pool:
             license_pool.open_access = False

--- a/migration/20190220-fix-same-book-in-two-collections-from-same-source.sql
+++ b/migration/20190220-fix-same-book-in-two-collections-from-same-source.sql
@@ -1,0 +1,3 @@
+update licensepools as lp set presentation_edition_id = lp2.presentation_edition_id from licensepools as lp2 where lp.identifier_id = lp2.identifier_id and lp.id != lp2.id and lp.data_source_id = lp2.data_source_id and lp.presentation_edition_id is null and lp2.presentation_edition_id is not null;
+
+update licensepools as lp set work_id = lp2.work_id from licensepools as lp2 where lp.identifier_id = lp2.identifier_id and lp.id != lp2.id and lp.data_source_id = lp2.data_source_id and lp.work_id is null and lp2.work_id is not null;

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -660,6 +660,19 @@ class TestCirculationMonitor(Axis360Test):
                    and x.operation is None]
         eq_(1, len(records))
 
+        # Now, another collection with the same book shows up.
+        collection2 = MockAxis360API.mock_collection(self._db, "coll2")
+        monitor = Axis360CirculationMonitor(
+            self._db, collection2, api_class=MockAxis360API,
+        )
+        edition2, license_pool2 = monitor.process_book(
+            self.BIBLIOGRAPHIC_DATA, self.AVAILABILITY_DATA)
+
+        # Both license pools have the same Work and the same presentation
+        # edition.
+        eq_(license_pool.work, license_pool2.work)
+        eq_(license_pool.presentation_edition, license_pool2.presentation_edition)
+
     def test_process_book_updates_old_licensepool(self):
         """If the LicensePool already exists, the circulation monitor
         updates it.

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -779,7 +779,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         # newly created LicensePool.
         raw['id'] = pool.identifier.identifier
 
-        wr.title = "The real title."
+        wr.title = u"The real title."
         eq_(1, pool.licenses_owned)
         eq_(1, pool.licenses_available)
         eq_(0, pool.licenses_reserved)
@@ -793,7 +793,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         eq_(p2, pool)
         # The title didn't change to that title given in the availability
         # information, because we already set a title for that work.
-        eq_("The real title.", wr.title)
+        eq_(u"The real title.", wr.title)
         eq_(raw['copiesOwned'], pool.licenses_owned)
         eq_(raw['copiesAvailable'], pool.licenses_available)
         eq_(0, pool.licenses_reserved)


### PR DESCRIPTION
This hopefully fixes https://jira.nypl.org/browse/SIMPLY-1722.

It uses the same presentation edition and the same work for all the license pools. I think it's better to use the same work but I'm not sure if that will end up having other consequences.