### PR TITLE
Fixed a bug where patrons with holds in another library were being counted in a library's stats.

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1996,8 +1996,11 @@ class DashboardController(AdminCirculationManagerController):
                     join(
                         Hold,
                         Patron,
-                        Patron.id == Hold.patron_id,
-                        Patron.library_id == library.id,
+                        and_(
+                            Patron.id == Hold.patron_id,
+                            Patron.library_id == library.id,
+                            Hold.id != None,
+                        )
                     )
                 )
             ).alias()

--- a/tests/admin/controller/test_controller.py
+++ b/tests/admin/controller/test_controller.py
@@ -2922,15 +2922,26 @@ class TestDashboardController(AdminControllerTest):
                 eq_(1, patron_data.get('loans'))
                 eq_(1, patron_data.get('holds'))
 
-            # This patron is in a different library.
+            # These patrons are in a different library..
             l2 = self._library()
             patron4 = self._patron(library=l2)
+            pool.loan_to(patron4, end=datetime.now() + timedelta(days=5))
+            patron5 = self._patron(library=l2)
+            pool.on_hold_to(patron5)
 
             response = self.manager.admin_dashboard_controller.stats()
             library_data = response.get(self._default_library.short_name)
             total_data = response.get("total")
             eq_(4, library_data.get('patrons').get('total'))
-            eq_(5, total_data.get('patrons').get('total'))
+            eq_(1, library_data.get('patrons').get('with_active_loans'))
+            eq_(2, library_data.get('patrons').get('with_active_loans_or_holds'))
+            eq_(1, library_data.get('patrons').get('loans'))
+            eq_(1, library_data.get('patrons').get('holds'))
+            eq_(6, total_data.get('patrons').get('total'))
+            eq_(2, total_data.get('patrons').get('with_active_loans'))
+            eq_(4, total_data.get('patrons').get('with_active_loans_or_holds'))
+            eq_(2, total_data.get('patrons').get('loans'))
+            eq_(2, total_data.get('patrons').get('holds'))
 
             # If the admin only has access to some libraries, only those will be counted
             # in the total stats.
@@ -2941,7 +2952,15 @@ class TestDashboardController(AdminControllerTest):
             library_data = response.get(self._default_library.short_name)
             total_data = response.get("total")
             eq_(4, library_data.get('patrons').get('total'))
+            eq_(1, library_data.get('patrons').get('with_active_loans'))
+            eq_(2, library_data.get('patrons').get('with_active_loans_or_holds'))
+            eq_(1, library_data.get('patrons').get('loans'))
+            eq_(1, library_data.get('patrons').get('holds'))
             eq_(4, total_data.get('patrons').get('total'))
+            eq_(1, total_data.get('patrons').get('with_active_loans'))
+            eq_(2, total_data.get('patrons').get('with_active_loans_or_holds'))
+            eq_(1, total_data.get('patrons').get('loans'))
+            eq_(1, total_data.get('patrons').get('holds'))
 
     def test_stats_inventory(self):
         with self.request_context_with_admin("/"):


### PR DESCRIPTION
Carissa reported this - sometimes the "Patrons with active loans or holds" count could be larger that total patrons, because it was incorrectly including some patrons from other libraries.