### PR TITLE
Fix NoveList library list bug where a non-NoveList library terminates update process

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1615,7 +1615,7 @@ class WorkController(CirculationManagerController):
             lane = RecommendationLane(
                 library, work, lane_name, novelist_api=novelist_api
             )
-        except ValueError, e:
+        except CannotLoadConfiguration, e:
             # NoveList isn't configured.
             return NO_SUCH_LANE.detailed(_("Recommendations not available"))
 

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -11,7 +11,10 @@ import elasticsearch
 import logging
 
 import core.classifier as genres
-from config import Configuration
+from config import (
+    CannotLoadConfiguration,
+    Configuration,
+)
 from core.classifier import (
     Classifier,
     fiction_genres,
@@ -886,7 +889,7 @@ class RelatedBooksLane(WorkBasedLane):
             )
             if recommendation_lane.recommendations:
                 yield recommendation_lane
-        except ValueError, e:
+        except CannotLoadConfiguration, e:
             # NoveList isn't configured.
             pass
 

--- a/api/novelist.py
+++ b/api/novelist.py
@@ -5,7 +5,10 @@ from collections import Counter
 from nose.tools import set_trace
 from flask_babel import lazy_gettext as _
 
-from core.config import Configuration
+from core.config import (
+    CannotLoadConfiguration,
+    Configuration,
+)
 from core.coverage import (
     CoverageFailure,
     IdentifierCoverageProvider,
@@ -94,7 +97,9 @@ class NoveListAPI(object):
     def from_config(cls, library):
         profile, password = cls.values(library)
         if not (profile and password):
-            raise ValueError("No NoveList client configured.")
+            raise CannotLoadConfiguration(
+                "No NoveList integration configured for library (%s)." % library.short_name
+            )
 
         _db = Session.object_session(library)
         return cls(_db, profile, password)

--- a/scripts.py
+++ b/scripts.py
@@ -1679,15 +1679,20 @@ class NovelistSnapshotScript(TimestampScript, LibraryInputScript):
 
     def do_run(self, output=sys.stdout, *args, **kwargs):
         parsed = self.parse_command_line(self._db, *args, **kwargs)
-        api = NoveListAPI.from_config(parsed.libraries[0])
-        if (api):
-            response = api.put_items_novelist(parsed.libraries[0])
+        for library in parsed.libraries:
+            try:
+                api = NoveListAPI.from_config(library)
+            except CannotLoadConfiguration as e:
+                self.log.info(e.message)
+                continue
+            if (api):
+                response = api.put_items_novelist(library)
 
-            if (response):
-                result = "NoveList API Response\n"
-                result += str(response)
+                if (response):
+                    result = "NoveList API Response\n"
+                    result += str(response)
 
-                output.write(result)
+                    output.write(result)
 
 class ODLBibliographicImportScript(OPDSImportScript):
     """Import bibliographic information from the feed associated

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -342,7 +342,7 @@ class TestRelatedBooksLane(DatabaseTest):
         self._db.commit()
 
         assert_raises(
-            CannotLoadConfiguration, RelatedBooksLane, self._default_library, self.work, ""
+            ValueError, RelatedBooksLane, self._default_library, self.work, ""
         )
 
         # A book with a contributor initializes a RelatedBooksLane.

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -29,6 +29,7 @@ from core.model import (
 
 from api.config import (
     Configuration,
+    CannotLoadConfiguration,
     temp_config,
 )
 from api.lanes import (
@@ -341,7 +342,7 @@ class TestRelatedBooksLane(DatabaseTest):
         self._db.commit()
 
         assert_raises(
-            ValueError, RelatedBooksLane, self._default_library, self.work, ""
+            CannotLoadConfiguration, RelatedBooksLane, self._default_library, self.work, ""
         )
 
         # A book with a contributor initializes a RelatedBooksLane.

--- a/tests/test_novelist.py
+++ b/tests/test_novelist.py
@@ -18,6 +18,7 @@ from core.model import (
     Identifier,
     Representation,
 )
+from api.config import CannotLoadConfiguration
 from api.novelist import (
     MockNoveListAPI,
     NoveListAPI,
@@ -63,11 +64,11 @@ class TestNoveListAPI(DatabaseTest):
 
         # Without either configuration value, an error is raised.
         self.integration.password = None
-        assert_raises(ValueError, NoveListAPI.from_config, self._default_library)
+        assert_raises(CannotLoadConfiguration, NoveListAPI.from_config, self._default_library)
 
         self.integration.password = u'yep'
         self.integration.username = None
-        assert_raises(ValueError, NoveListAPI.from_config, self._default_library)
+        assert_raises(CannotLoadConfiguration, NoveListAPI.from_config, self._default_library)
 
     def test_is_configured(self):
         # If an ExternalIntegration exists, the API is_configured


### PR DESCRIPTION
This fixes the NoveList library list issue as discussed. I did have to add an import for the CannotLoadConfiguration class to the novelist.py file. Otherwise, I've tested the change in v.2.2.14 on our live CM, scheduling a separate novelist_update job with a non-NoveList library and our new NoveList library as parameters. The log indicates an 'info' entry for the non-novelist library and follows with a good connection/update entry for the NoveList library.