### PR TITLE
Monitors track their achievements across runs

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -547,9 +547,7 @@ class Axis360CirculationMonitor(CollectionMonitor, TimelineMonitor):
             count += 1
             if count % self.batch_size == 0:
                 self._db.commit()
-        progress.achievements = progress.format_achievements(
-            "Caught up with %(number)s %(thing)s.", count, "modified title"
-        )
+        progress.achievements = "Modified titles: %d." % count
 
     def process_book(self, bibliographic, availability):
 

--- a/api/axis.py
+++ b/api/axis.py
@@ -547,6 +547,9 @@ class Axis360CirculationMonitor(CollectionMonitor, TimelineMonitor):
             count += 1
             if count % self.batch_size == 0:
                 self._db.commit()
+        progress.achievements = progress.format_achievements(
+            "Caught up with %(number)s %(thing)s.", count, "modified title"
+        )
 
     def process_book(self, bibliographic, availability):
 

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1345,10 +1345,7 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
                 if not i % 1000:
                     self._db.commit()
             self._db.commit()
-        progress.achievements = progress.format_achievements(
-            "Handled %(number)s %(thing)s total.", i, "event"
-        )
-        self.log.info(progress.achievements)
+        progress.achievements = "Events handled: %d." % i
 
     def handle_event(self, bibliotheca_id, isbn, foreign_patron_id,
                      start_time, end_time, internal_event_type):

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1345,7 +1345,10 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
                 if not i % 1000:
                     self._db.commit()
             self._db.commit()
-        self.log.info("Handled %d events total", i)
+        progress.achievements = progress.format_achievements(
+            "Handled %(number)s %(thing)s total.", i, "event"
+        )
+        self.log.info(progress.achievements)
 
     def handle_event(self, bibliotheca_id, isbn, foreign_patron_id,
                      start_time, end_time, internal_event_type):

--- a/api/enki.py
+++ b/api/enki.py
@@ -716,13 +716,11 @@ class EnkiImport(CollectionMonitor, TimelineMonitor):
             # we don't miss anything.
             new_titles, circulation_updates = self.incremental_import(start)
 
-        new = progress.format_achievements(
-            None, new_titles, "new or modified title"
+        progress.achievements = (
+            "New or modified titles: %d. Titles with circulation changes: %d." % (
+                new_titles, circulation_updates
+            )
         )
-        modified = progress.format_achievements(
-            None, circulation_updates, "circulation update"
-        )
-        progress.achievements = "%s, %s." % (new, modified)
 
     def full_import(self):
         """Import the entire Enki collection, page by page."""

--- a/api/enki.py
+++ b/api/enki.py
@@ -760,7 +760,7 @@ class EnkiImport(CollectionMonitor, TimelineMonitor):
         circulation_changes = 0
         for circulation in self.api.recent_activity(since):
             circulation_changes += 1
-            license_pool, made_changes = circulation.apply(
+            license_pool, is_new = circulation.license_pool(
                 self._db, self.collection
             )
             if not license_pool.work:
@@ -771,6 +771,11 @@ class EnkiImport(CollectionMonitor, TimelineMonitor):
                 metadata = self.api.get_item(license_pool.identifier.identifier)
                 if metadata:
                     self.process_book(metadata)
+            else:
+                license_pool, made_changes = circulation.apply(
+                    self._db, self.collection
+                )
+
         return circulation_changes
 
     def process_book(self, bibliographic):

--- a/api/monitor.py
+++ b/api/monitor.py
@@ -113,6 +113,7 @@ class MWCollectionUpdateMonitor(MetadataWranglerCollectionMonitor):
         self.assert_authenticated()
         queue = [None]
         seen_links = set()
+        total_editions = 0
 
         new_timestamp = None
         while queue:
@@ -122,6 +123,8 @@ class MWCollectionUpdateMonitor(MetadataWranglerCollectionMonitor):
             next_links, editions, possible_new_timestamp = self.import_one_feed(
                 start, url
             )
+            total_editions += len(editions)
+            achievements = "Editions processed: %s" % total_editions
             if not new_timestamp or (
                     possible_new_timestamp
                     and possible_new_timestamp > new_timestamp
@@ -146,7 +149,9 @@ class MWCollectionUpdateMonitor(MetadataWranglerCollectionMonitor):
             # Immediately update the timestamps table so that a later
             # crash doesn't mean we have to redo this work.
             if new_timestamp:
-                self.timestamp().finish = new_timestamp
+                timestamp_obj = self.timestamp()
+                timestamp_obj.finish = new_timestamp
+                timestamp_obj.achievements = achievements
             self._db.commit()
 
         # The TimestampData we return is going to be written to the database.
@@ -164,6 +169,7 @@ class MWCollectionUpdateMonitor(MetadataWranglerCollectionMonitor):
 
         progress.start = start
         progress.finish = finish
+        progress.achievements = achievements
         return progress
 
     def import_one_feed(self, timestamp, url):
@@ -228,6 +234,7 @@ class MWAuxiliaryMetadataMonitor(MetadataWranglerCollectionMonitor):
         queue = [None]
         seen_links = set()
 
+        total_identifiers_processed = 0
         while queue:
             url = queue.pop(0)
             if url in seen_links:
@@ -241,6 +248,7 @@ class MWAuxiliaryMetadataMonitor(MetadataWranglerCollectionMonitor):
             # to send.)
             identifiers = [i for i in identifiers
                            if i.work and i.work.simple_opds_entry]
+            total_identifiers_processed += len(identifiers)
             self.provider.bulk_register(identifiers)
             self.provider.run_on_specific_identifiers(identifiers)
 
@@ -249,6 +257,8 @@ class MWAuxiliaryMetadataMonitor(MetadataWranglerCollectionMonitor):
                 for link in next_links:
                     if link not in seen_links:
                         queue.append(link)
+        achievements = "Identifiers processed: %d" % total_identifiers_processed
+        return TimestampData(achievements=achievements)
 
     def get_identifiers(self, url=None):
         """Pulls mapped identifiers from a feed of SimplifiedOPDSMessages."""

--- a/api/monitor.py
+++ b/api/monitor.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     or_,
 )
 
+from core.metadata_layer import TimestampData
 from core.monitor import (
     CollectionMonitor,
     EditionSweepMonitor,

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -902,11 +902,14 @@ class OdiloCirculationMonitor(CollectionMonitor, TimelineMonitor):
         self.log.info("Starting recently_changed_ids, start: " + str(start) + ", cutoff: " + str(cutoff))
 
         start_time = datetime.datetime.now()
-        self.all_ids(start)
+        updated, new = self.all_ids(start)
         finish_time = datetime.datetime.now()
 
         time_elapsed = finish_time - start_time
         self.log.info("recently_changed_ids finished in: " + str(time_elapsed))
+        progress.achievements = (
+            "Updated records: %d. New records: %d." % (updated, new)
+        )
 
     def all_ids(self, modification_date=None):
         """Get IDs for every book in the system, from modification date if any
@@ -959,6 +962,7 @@ class OdiloCirculationMonitor(CollectionMonitor, TimelineMonitor):
                 self.log.error('ERROR response content: ' + str(content))
         else:
             self.log.info('Retrieving all ids finished ok. Retrieved %i records. New records: %i!!' % (retrieved, new))
+        return retrieved, new
 
     def get_url(self, limit, modification_date, offset):
         url = "%s?limit=%i&offset=%i" % (self.api.ALL_PRODUCTS_ENDPOINT, limit, offset)

--- a/api/odl.py
+++ b/api/odl.py
@@ -20,6 +20,7 @@ from core.opds_import import (
     OPDSImporter,
     OPDSImportMonitor,
 )
+from core.metadata_layer import TimestampData
 from core.monitor import (
     CollectionMonitor,
     TimelineMonitor,

--- a/api/odl.py
+++ b/api/odl.py
@@ -884,10 +884,7 @@ class ODLConsolidatedCopiesMonitor(CollectionMonitor, TimelineMonitor):
                 url = urlparse.urljoin(url, next_url)
             else:
                 url = None
-        progress.achievements = progress.format_achievements(
-            "Updated %(number)s %(thing)s total.",
-            total_updates, "license"
-        )
+        progress.achievements = "Licenses updated: %d." % total_updates
 
     def process_one_page(self, response):
         content = json.loads(response.content)

--- a/api/odl.py
+++ b/api/odl.py
@@ -940,12 +940,12 @@ class ODLHoldReaper(CollectionMonitor):
 
         for pool in changed_pools:
             self.api.update_hold_queue(pool)
-        progress.achievements = (
-            "Holds deleted: %d. License pools updated: %d" % (
-                total_deleted_holds,
-                len(changed_pools)
-            )
+
+        message = "Holds deleted: %d. License pools updated: %d" % (
+            total_deleted_holds,
+            len(changed_pools)
         )
+        progress = TimestampData(achievements=message)
         return progress
 
 class MockODLWithConsolidatedCopiesAPI(ODLWithConsolidatedCopiesAPI):

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -25,7 +25,10 @@ from core.model import (
     get_one,
     get_one_or_create,
 )
-from core.metadata_layer import FormatData
+from core.metadata_layer import (
+    FormatData,
+    TimestampData,
+)
 from core.selftest import HasSelfTests
 from circulation import (
     BaseCirculationAPI,
@@ -355,14 +358,17 @@ class OPDSForDistributorsReaperMonitor(OPDSForDistributorsImportMonitor):
             LicensePool.licenses_available > 0
         )
 
+        pools_reaped = qu.count()
         self.log.info(
-            "Reaping %s license pools for collection %s." % (qu.count(), self.collection.name)
+            "Reaping %s license pools for collection %s." % (pools_reaped, self.collection.name)
         )
 
         for pool in qu:
             pool.licenses_available = 0
             pool.licenses_owned = 0
         self._db.commit()
+        achievements = "License pools removed: %d." % pools_reaped
+        return TimestampData(achievements=achievements)
 
 class MockOPDSForDistributorsAPI(OPDSForDistributorsAPI):
 

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -335,6 +335,7 @@ class OPDSForDistributorsReaperMonitor(OPDSForDistributorsImportMonitor):
         parsed_feed = feedparser.parse(feed)
         identifiers = [entry.get("id") for entry in parsed_feed.get("entries", [])]
         self.seen_identifiers.update(identifiers)
+        return [], {}
 
     def run_once(self, progress):
         """Check to see if any identifiers we know about are no longer

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -1080,8 +1080,11 @@ class OverdriveCirculationMonitor(CollectionMonitor, TimelineMonitor):
                                   consecutive_unchanged_books)
                     break
 
-        if total_books:
-            self.log.info("Processed %d books total.", total_books)
+        progress.achievements = progress.format_achievements(
+            "Processed %(number)s %(thing)s total.",
+            total_books, "book"
+        )
+        self.log.info(progress.achievements)
 
 
 class FullOverdriveCollectionMonitor(OverdriveCirculationMonitor):

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -1080,11 +1080,7 @@ class OverdriveCirculationMonitor(CollectionMonitor, TimelineMonitor):
                                   consecutive_unchanged_books)
                     break
 
-        progress.achievements = progress.format_achievements(
-            "Processed %(number)s %(thing)s total.",
-            total_books, "book"
-        )
-        self.log.info(progress.achievements)
+        progress.achievements = "Books processed: %d" % total_books
 
 
 class FullOverdriveCollectionMonitor(OverdriveCirculationMonitor):

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -1074,7 +1074,7 @@ class OverdriveCirculationMonitor(CollectionMonitor, TimelineMonitor):
                                   consecutive_unchanged_books)
                     break
 
-        progress.achievements = "Books processed: %d" % total_books
+        progress.achievements = "Books processed: %d." % total_books
 
 
 class FullOverdriveCollectionMonitor(OverdriveCirculationMonitor):

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -1952,7 +1952,6 @@ class RBDigitalSyncMonitor(CollectionMonitor):
                 items_transmited, items_created
             )
         )
-        self.log.info(achievements)
         return TimestampData(achievements=achievements)
 
     def invoke(self):

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -1947,15 +1947,13 @@ class RBDigitalSyncMonitor(CollectionMonitor):
         """
         items_transmitted, items_created = self.invoke()
         self._db.commit()
-
-        transmitted = progress.format_achievements(None, items_transmitted, "item")
-        written = progress.format_achievements(None, items_created, "item")
-
-        result_string = "Got %s from vendor, wrote %s to DB" % (
-            transmitted, written
+        achievements = (
+            "Records received from vendor: %d. Records written to database: %d" % (
+                items_transmited, items_created
+            )
         )
-        progress.achievements = result_string
-        self.log.info(result_string)
+        self.log.info(achievements)
+        return TimestampData(achievements=achievements)
 
     def invoke(self):
         raise NotImplementedError()

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -42,6 +42,7 @@ from core.metadata_layer import (
     Metadata,
     ReplacementPolicy,
     SubjectData,
+    TimestampData,
 )
 
 from core.model import (
@@ -1944,12 +1945,13 @@ class RBDigitalSyncMonitor(CollectionMonitor):
         """Find books in the RBdigital collection that changed recently.
 
         :param progress: A TimestampData, ignored.
+        :return: A TimestampData describing what was accomplished.
         """
         items_transmitted, items_created = self.invoke()
         self._db.commit()
         achievements = (
             "Records received from vendor: %d. Records written to database: %d" % (
-                items_transmited, items_created
+                items_transmitted, items_created
             )
         )
         return TimestampData(achievements=achievements)
@@ -2041,11 +2043,15 @@ class RBDigitalCirculationMonitor(CollectionMonitor):
         RBdigital collection.
 
         :param progress: A TimestampData, ignored.
+        :return: A TimestampData describing what was accomplished.
         """
         ebook_count = self.process_availability(media_type='eBook')
         eaudio_count = self.process_availability(media_type='eAudio')
 
-        self.log.info("Processed %d ebooks and %d audiobooks.", ebook_count, eaudio_count)
+        message = "Ebooks processed: %d. Audiobooks processed: %d." % (
+            ebook_count, eaudio_count
+        )
+        return TimestampData(achievements=message)
 
 class AudiobookManifest(CoreAudiobookManifest):
     """A standard AudiobookManifest derived from an RBdigital audiobook

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -1947,7 +1947,14 @@ class RBDigitalSyncMonitor(CollectionMonitor):
         """
         items_transmitted, items_created = self.invoke()
         self._db.commit()
-        result_string = "%s items transmitted, %s items saved to DB" % (items_transmitted, items_created)
+
+        transmitted = progress.format_achievements(None, items_transmitted, "item")
+        written = progress.format_achievements(None, items_created, "item")
+
+        result_string = "Got %s from vendor, wrote %s to DB" % (
+            transmitted, written
+        )
+        progress.achievements = result_string
         self.log.info(result_string)
 
     def invoke(self):

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -647,7 +647,7 @@ class TestCirculationMonitor(Axis360Test):
 
         # The number of books processed was stored in
         # TimestampData.achievements.
-        eq_("Caught up with 2 modified titles.", progress.achievements)
+        eq_("Modified titles: 2.", progress.achievements)
 
     def test_process_book(self):
         integration, ignore = create(

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -1042,6 +1042,9 @@ class TestBibliothecaEventMonitor(BibliothecaAPITest):
         eq_(two_days_ago-monitor.OVERLAP, after_timestamp.start)
         self.time_eq(after_timestamp.finish, now)
 
+        # The timestamp's achivements have been updated.
+        eq_("Handled 1 event total.", after_timestamp.achievements)
+
         # If we tell run_once() to work through an amount of time
         # where the are no events, it does nothing but update the
         # timestamp.

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -1043,7 +1043,7 @@ class TestBibliothecaEventMonitor(BibliothecaAPITest):
         self.time_eq(after_timestamp.finish, now)
 
         # The timestamp's achivements have been updated.
-        eq_("Handled 1 event total.", after_timestamp.achievements)
+        eq_("Events handled: 1.", after_timestamp.achievements)
 
         # If we tell run_once() to work through an amount of time
         # where the are no events, it does nothing but update the

--- a/tests/test_enki.py
+++ b/tests/test_enki.py
@@ -549,7 +549,7 @@ class TestEnkiImport(BaseEnkiTest):
         progress = TimestampData(start=None)
         importer.run_once(progress)
         eq_(True, importer.full_import_called)
-        eq_("10 new or modified titles, 0 circulation updates.",
+        eq_("New or modified titles: 10. Titles with circulation changes: 0.",
             progress.achievements)
 
         # It doesn't call incremental_import().

--- a/tests/test_enki.py
+++ b/tests/test_enki.py
@@ -577,7 +577,7 @@ class TestEnkiImport(BaseEnkiTest):
         eq_(expect, new_timestamp.start)
         now = datetime.datetime.utcnow()
         assert (now - new_timestamp.finish).total_seconds() < 2
-        eq_("4 new or modified titles, 7 circulation updates.",
+        eq_("New or modified titles: 4. Titles with circulation changes: 7.",
             new_timestamp.achievements)
 
     def test_full_import(self):

--- a/tests/test_enki.py
+++ b/tests/test_enki.py
@@ -536,9 +536,11 @@ class TestEnkiImport(BaseEnkiTest):
             incremental_import_called_with = dummy_value
             def full_import(self):
                 self.full_import_called = True
+                return 10
 
             def incremental_import(self, since):
                 self.incremental_import_called_with = since
+                return 4, 7
 
         importer = Mock(self._db, self.collection, api_class=self.api)
 
@@ -547,6 +549,8 @@ class TestEnkiImport(BaseEnkiTest):
         progress = TimestampData(start=None)
         importer.run_once(progress)
         eq_(True, importer.full_import_called)
+        eq_("10 new or modified titles, 0 circulation updates.",
+            progress.achievements)
 
         # It doesn't call incremental_import().
         eq_(dummy_value, importer.incremental_import_called_with)
@@ -573,6 +577,8 @@ class TestEnkiImport(BaseEnkiTest):
         eq_(expect, new_timestamp.start)
         now = datetime.datetime.utcnow()
         assert (now - new_timestamp.finish).total_seconds() < 2
+        eq_("4 new or modified titles, 7 circulation updates.",
+            new_timestamp.achievements)
 
     def test_full_import(self):
         """full_import calls get_all_titles over and over again until

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -11,6 +11,7 @@ from . import (
     sample_data,
 )
 
+from core.metadata_layer import TimestampData
 from core.model import (
     Annotation,
     Collection,

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -391,6 +391,11 @@ class TestMWAuxiliaryMetadataMonitor(MonitorTest):
         # Only the identifier with a work has been given coverage.
         eq_("Identifiers processed: 1", progress.achievements)
 
+        # The TimestampData returned by run_once() does not include
+        # any timing information -- that will be applied by run().
+        eq_(TimestampData.NO_VALUE, progress.start)
+        eq_(TimestampData.NO_VALUE, progress.finish)
+
         record = CoverageRecord.lookup(
             overdrive, self.monitor.provider.data_source,
             operation=self.monitor.provider.operation

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -159,12 +159,14 @@ class TestMWCollectionUpdateMonitor(MonitorTest):
                 200, {'content-type' : OPDSFeed.ACQUISITION_FEED_TYPE}, data
             )
 
-        new_timestamp = self.monitor.run_once(self.ts)
+        timestamp = self.ts
+        new_timestamp = self.monitor.run_once(timestamp)
 
         # We have a new value to use for the Monitor's timestamp -- the
         # earliest date seen in the last OPDS feed that contained
         # any entries.
         eq_(datetime.datetime(2016, 9, 20, 19, 37, 2), new_timestamp.finish)
+        eq_("Editions processed: 1", new_timestamp.achievements)
 
         # Normally run_once() doesn't update the monitor's timestamp,
         # but this implementation does, so that work isn't redone if
@@ -384,9 +386,11 @@ class TestMWAuxiliaryMetadataMonitor(MonitorTest):
                 200, {'content-type' : OPDSFeed.ACQUISITION_FEED_TYPE}, feed
             )
 
-        self.monitor.run_once(self.ts)
+        progress = self.monitor.run_once(self.ts)
 
         # Only the identifier with a work has been given coverage.
+        eq_("Identifiers processed: 1", progress.achievements)
+
         record = CoverageRecord.lookup(
             overdrive, self.monitor.provider.data_source,
             operation=self.monitor.provider.operation

--- a/tests/test_odilo.py
+++ b/tests/test_odilo.py
@@ -583,13 +583,19 @@ class TestOdiloDiscoveryAPI(OdiloAPITest):
         class Mock(OdiloCirculationMonitor):
             def all_ids(self, modification_date=None):
                 self.called_with = modification_date
+                return 30, 15
 
         # The first time run() is called, all_ids is called with
         # a modification_date of None.
         monitor = Mock(self._db, self.collection, api_class=MockOdiloAPI)
         monitor.run()
         eq_(None, monitor.called_with)
-        completed = monitor.timestamp().finish
+        progress = monitor.timestamp()
+        completed = progress.finish
+
+        # The return value of all_ids() is used to populate the
+        # achievements field.
+        eq_("Updated records: 30. New records: 15.", progress.achievements)
 
         # The second time run() is called, all_ids() is called with a
         # modification date five minutes earlier than the completion
@@ -600,8 +606,8 @@ class TestOdiloDiscoveryAPI(OdiloAPITest):
 
     def test_all_ids_with_date(self):
         # TODO: This tests that all_ids doesn't crash when you pass in
-        # a date. It doesn't test that all_ids does anything in
-        # particular.
+        # a date. It doesn't test anything about all_ids except the
+        # return value.
         monitor = OdiloCirculationMonitor(self._db, self.collection, api_class=MockOdiloAPI)
         ok_(monitor, 'Monitor null !!')
         eq_(ExternalIntegration.ODILO, monitor.protocol, 'Wat??')
@@ -616,14 +622,16 @@ class TestOdiloDiscoveryAPI(OdiloAPITest):
         monitor.api.queue_response(200, content='[]')  # No more resources retrieved
 
         timestamp = TimestampData(start=datetime.datetime(2017, 9, 1))
-        monitor.all_ids(None)
+        updated, new = monitor.all_ids(None)
+        eq_(10, updated)
+        eq_(10, new)
 
         self.api.log.info('Odilo circulation monitor with date finished ok!!')
 
     def test_all_ids_without_date(self):
         # TODO: This tests that all_ids doesn't crash when you pass in
-        # an empty date. It doesn't test that all_ids does anything in
-        # particular.
+        # an empty date. It doesn't test anything about all_ids except the
+        # return value.
 
         monitor = OdiloCirculationMonitor(self._db, self.collection, api_class=MockOdiloAPI)
         ok_(monitor, 'Monitor null !!')
@@ -638,7 +646,9 @@ class TestOdiloDiscoveryAPI(OdiloAPITest):
 
         monitor.api.queue_response(200, content='[]')  # No more resources retrieved
 
-        monitor.all_ids(datetime.datetime(2017, 9, 1))
+        updated, new = monitor.all_ids(datetime.datetime(2017, 9, 1))
+        eq_(10, updated)
+        eq_(10, new)
 
         self.api.log.info('Odilo circulation monitor without date finished ok!!')
 

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -1399,7 +1399,7 @@ class TestODLConsolidatedCopiesMonitor(DatabaseTest, BaseODLTest):
 
         # The TimestampData was updated with the total number of
         # licenses we heard about.
-        eq_("Updated 3 licenses total.", progress.achievements)
+        eq_("Licenses updated: 3.", progress.achievements)
 
         # If the monitor is run in order to catch up to a specific
         # time, it will subtract 5 minutes from that time and add a

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -1453,9 +1453,15 @@ class TestODLHoldReaper(DatabaseTest, BaseODLTest):
         eq_(1, pool.licenses_available)
         eq_(2, pool.licenses_reserved)
 
-        # The TimestampData has been updated to reflect what
-        # work was done.
+        # The TimestampData returned reflects what work was done.
         eq_('Holds deleted: 3. License pools updated: 1', progress.achievements)
+
+        # The TimestampData does not include any timing information --
+        # that will be applied by run().
+        eq_(TimestampData.NO_VALUE, progress.start)
+        eq_(TimestampData.NO_VALUE, progress.finish)
+
+
 
 class TestSharedODLAPI(DatabaseTest, BaseODLTest):
 

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -470,4 +470,12 @@ class TestOPDSForDistributorsReaperMonitor(DatabaseTest, BaseOPDSForDistributors
 
         eq_(0, pool.licenses_owned)
         eq_(0, pool.licenses_available)
+
+        # The TimestampData returned by run_once() describes its
+        # achievements.
         eq_("License pools removed: 1.", result.achievements)
+
+        # The TimestampData does not include any timing information --
+        # that will be applied by run().
+        eq_(TimestampData.NO_VALUE, progress.start)
+        eq_(TimestampData.NO_VALUE, progress.finish)

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -467,14 +467,14 @@ class TestOPDSForDistributorsReaperMonitor(DatabaseTest, BaseOPDSForDistributors
         pool.licenses_owned = 1
         pool.licenses_available = 1
 
-        result = monitor.run_once(monitor.timestamp().to_data())
+        progress = monitor.run_once(monitor.timestamp().to_data())
 
         eq_(0, pool.licenses_owned)
         eq_(0, pool.licenses_available)
 
         # The TimestampData returned by run_once() describes its
         # achievements.
-        eq_("License pools removed: 1.", result.achievements)
+        eq_("License pools removed: 1.", progress.achievements)
 
         # The TimestampData does not include any timing information --
         # that will be applied by run().

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -466,7 +466,8 @@ class TestOPDSForDistributorsReaperMonitor(DatabaseTest, BaseOPDSForDistributors
         pool.licenses_owned = 1
         pool.licenses_available = 1
 
-        monitor.run_once(monitor.timestamp().to_data())
+        result = monitor.run_once(monitor.timestamp().to_data())
 
         eq_(0, pool.licenses_owned)
         eq_(0, pool.licenses_available)
+        eq_("License pools removed: 1.", result.achievements)

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -16,6 +16,7 @@ from api.opds_for_distributors import (
 )
 from api.circulation_exceptions import *
 from . import DatabaseTest
+from core.metadata_layer import TimestampData
 from core.model import (
     Collection,
     Credential,

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -1190,7 +1190,7 @@ class TestOverdriveCirculationMonitor(OverdriveAPITest):
 
         # The incoming TimestampData object was updated with
         # a summary of what happened.
-        eq_("Processed 3 books total.", progress.achievements)
+        eq_("Books processed: %d.", progress.achievements)
 
 
 class TestOverdriveFormatSweep(OverdriveAPITest):

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -1223,7 +1223,7 @@ class TestOverdriveCirculationMonitor(OverdriveAPITest):
 
         # The incoming TimestampData object was updated with
         # a summary of what happened.
-        eq_("Books processed: %d.", progress.achievements)
+        eq_("Books processed: 3.", progress.achievements)
 
 
 class TestOverdriveFormatSweep(OverdriveAPITest):

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -29,6 +29,7 @@ from . import (
     sample_data
 )
 
+from core.metadata_layer import TimestampData
 from core.model import (
     Collection,
     ConfigurationSetting,
@@ -1094,7 +1095,7 @@ class TestSyncBookshelf(OverdriveAPITest):
         eq_(5, len(patron.holds))
         assert overdrive_hold in patron.holds
 
-class TestOverdriveCircluationMonitor(OverdriveAPITest):
+class TestOverdriveCirculationMonitor(OverdriveAPITest):
 
     def test_run(self):
         # An end-to-end test verifying that this Monitor manages its
@@ -1171,7 +1172,8 @@ class TestOverdriveCircluationMonitor(OverdriveAPITest):
         api.licensepools.append((lp3, False, False))
         api.licensepools.append(lp4)
 
-        monitor.catch_up_from(object(), object(), object())
+        progress = TimestampData()
+        monitor.catch_up_from(object(), object(), progress)
 
         # We called update_licensepool on the first three books,
         # and got the first three LicensePools from the queue.
@@ -1185,6 +1187,11 @@ class TestOverdriveCircluationMonitor(OverdriveAPITest):
 
         # TODO: Verify that a DISTRIBUTOR_TITLE_ADD event was gathered
         # for the newly discovered license pool.
+
+        # The incoming TimestampData object was updated with
+        # a summary of what happened.
+        eq_("Processed 3 books total.", progress.achievements)
+
 
 class TestOverdriveFormatSweep(OverdriveAPITest):
 

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -1054,9 +1054,18 @@ class TestCirculationMonitor(RBDigitalAPITest):
             self._db, self.collection, api_class=MockRBDigitalAPI,
         )
         timestamp = monitor.timestamp().to_data()
-        monitor.run_once(timestamp)
+        progress = monitor.run_once(timestamp)
         eq_(['eBook', 'eAudio'], monitor.process_availability_calls)
-        set_trace()
+
+        # The TimestampData returned by run_once() describes its
+        # achievements.
+        eq_("Ebooks processed: 3. Audiobooks processed: 3.",
+            progress.achievements)
+
+        # The TimestampData does not include any timing information
+        # -- that will be applied by run().
+        eq_(TimestampData.NO_VALUE, progress.start)
+        eq_(TimestampData.NO_VALUE, progress.finish)
 
     def test_process_availability(self):
         monitor = RBDigitalCirculationMonitor(
@@ -1473,8 +1482,22 @@ class TestRBDigitalSyncMonitor(DatabaseTest):
         monitor = Mock(
             self._db, self.collection, api_class=MockRBDigitalAPI,
         )
-        monitor.run_once(monitor.timestamp().to_data())
+        progress = monitor.run_once(monitor.timestamp().to_data())
+
+        # invoke() was called.
         eq_(True, monitor.invoked)
+
+        # The TimestampData returned by run_once() describes its
+        # achievements.
+        eq_(
+            "Records received from vendor: 10. Records written to database: 5",
+            progress.achievements
+        )
+
+        # The TimestampData does not include any timing information --
+        # that will be applied by run().
+        eq_(TimestampData.NO_VALUE, progress.start)
+        eq_(TimestampData.NO_VALUE, progress.finish)
 
     def test_import(self):
 

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -1053,8 +1053,10 @@ class TestCirculationMonitor(RBDigitalAPITest):
         monitor = Mock(
             self._db, self.collection, api_class=MockRBDigitalAPI,
         )
-        monitor.run_once(monitor.timestamp().to_data())
+        timestamp = monitor.timestamp().to_data()
+        monitor.run_once(timestamp)
         eq_(['eBook', 'eAudio'], monitor.process_availability_calls)
+        set_trace()
 
     def test_process_availability(self):
         monitor = RBDigitalCirculationMonitor(

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -51,6 +51,7 @@ from core.metadata_layer import (
     IdentifierData,
     Metadata,
     SubjectData,
+    TimestampData,
 )
 
 from core.model import (


### PR DESCRIPTION
This branch completes the work for https://jira.nypl.org/browse/SIMPLY-1699.

This branch modifies all circulation manager Monitors so that they report their progress when they run. "Progress" is calculated differently for each monitor, but it's generally the number of database records or books processed according to guidance from some external API.

All monitors gathered this data in their own way to send to the logs. Now the data is recorded to the `timestamps` table as well. In some cases the numbers were calculated by a method called by `run_once` or `catch_up_from`, so I had to change the return value of that method to propagate those numbers, so that `run_once` or `catch_up_from` could record them.

These Monitors are TimelineMonitors so I changed their `catch_up_from` implementations to set `progress.achievements`, which is the simple solution:

* Axis360CirculationMonitor
* BibliothecaEventMonitor
* EnkiImport
* OdiloCirculationMonitor
* ODLConsolidatedCopiesMonitor
* OverdriveCirculationMonitor


These monitors override `Monitor.run_once`, so to add achievement support I needed to make sure they return a brand new `TimestampData` that doesn't have values for `start` or `end`.

* MWAuxiliaryMetadataMonitor
* ODLHoldReaper
* OPDSForDistributorsReaperMonitor
* RBDigitalCirculationMonitor
* RBDigitalSyncMonitor

`MWCollectionUpdateMonitor` overrides `run_once` but it also manages its own timestamp, so it's okay that that one modifies `progress.achievements` -- it's also setting its own values for `start` and `finish`.