### PR TITLE
Change the process by which RBdigital accounts are looked up/created for circulation manager patrons

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1252,6 +1252,8 @@ class BaseCirculationAPI(object):
         """
         # LibraryAuthenticator knows about all authentication techniques
         # used to identify patrons of this library.
+        from authenticator import LibraryAuthenticator
+        _db = Session.object_session(patron)
         library_authenticator = LibraryAuthenticator.from_config(
             _db, patron.library
         )

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1224,13 +1224,49 @@ class BaseCirculationAPI(object):
             )
         return internal_format
 
-    def default_notification_email_address(self, patron, pin):
-        """What email address should be used to notify this patron
-        of changes?
+    def default_notification_email_address(self, library_or_patron, pin):
+        """What email address should be used to notify this library's
+        patrons of changes?
+
+        :param library_or_patron: A Library or a Patron.
         """
+        if isinstance(library_or_patron, Patron):
+            library_or_patron = patron.library
         return ConfigurationSetting.for_library(
-            Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, patron.library
+            Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS,
+            library_or_patron
         ).value
+
+    def patron_email_address(self, patron):
+        """Look up the email address that the given Patron shared
+        with their library.
+
+        We do not store this information, but some API integrations
+        need it, so we give the ability to look it up as needed.
+
+        :param patron: A Patron.
+        :return: The patron's email address. None if the patron never
+            shared their email address with their library, or if the
+            authentication technique will not share that information
+            with us.
+        """
+        # LibraryAuthenticator knows about all authentication techniques
+        # used to identify patrons of this library.
+        library_authenticator = LibraryAuthenticator.from_config(
+            _db, patron.library
+        )
+        authorization_identifier = patron.authorization_identifier
+
+        # remote_patron_lookup will try to get information about the
+        # patron through each authentication technique in turn.
+        # As soon as one of these techniques gives us an email
+        # address, we're done.
+        email_address = None
+        for authenticator in library_authenticator.providers:
+            patrondata = authenticator.remote_patron_lookup(patron)
+            if patrondata and patrondata.email_address:
+                email_address = patrondata.email_address
+        return email_address
 
     def checkin(self, patron, pin, licensepool):
         """  Return a book early.

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -26,6 +26,7 @@ from core.model import (
     LicensePool,
     Loan,
     Hold,
+    Patron,
     RightsStatus,
     Session,
 )
@@ -1224,6 +1225,7 @@ class BaseCirculationAPI(object):
             )
         return internal_format
 
+    @classmethod
     def default_notification_email_address(self, library_or_patron, pin):
         """What email address should be used to notify this library's
         patrons of changes?
@@ -1231,7 +1233,7 @@ class BaseCirculationAPI(object):
         :param library_or_patron: A Library or a Patron.
         """
         if isinstance(library_or_patron, Patron):
-            library_or_patron = patron.library
+            library_or_patron = library_or_patron.library
         return ConfigurationSetting.for_library(
             Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS,
             library_or_patron

--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -180,7 +180,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
             'Authorization': 'Bearer %s' % token
         }
         result = self._get(self.CLEVER_API_BASE_URL + '/me', bearer_headers)
-        data = result.get('data', {})
+        data = result.get('data', {}) or {}
 
         identifier = data.get('id', None)
 

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -714,7 +714,7 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
         credential = Credential.lookup(
             _db, DataSource.RB_DIGITAL,
             Credential.IDENTIFIER_FROM_REMOTE_SERVICE,
-            patron, _refresh_credential, allow_persistent_token=True
+            patron, refresh_credential, allow_persistent_token=True
         )
         return credential.credential
 
@@ -766,7 +766,7 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
         post_args = self._create_patron_body(
             library, authorization_identifier, email_address
         )
-        
+
         resp_dict = {}
         message = None
         response = self.request(
@@ -894,7 +894,7 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
         """
         action="patron_id"
         url = "%s/rpc/libraries/%s/patrons/%s" % (
-            self.base_url, self.library_id, patron_identifier
+            self.base_url, self.library_id, remote_identifier
         )
 
         response = self.request(url)
@@ -1125,7 +1125,7 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
         if response.status_code not in [200, 201]:
             if not message:
                 message = response.text
-            self.log.warning("%s call failed: %s ", action, message)
+            self.log.info("%s call failed: %s ", action, message)
 
             if response.status_code == 500:
                 # yes, it could be a server error, but it can also be a malformed value in the request

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -1057,31 +1057,6 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
 
         return holds
 
-    def get_patron_information(self, patron_id):
-        """
-        Retrieves patron's name, email, library card number from RBDigital.
-
-        :param patron_id RBDigital's internal id for the patron.
-        """
-        if not patron_id:
-            raise InvalidInputException("Need patron RBDigital id.")
-
-        url = "%s/libraries/%s/patrons/%s" % (self.base_url, str(self.library_id), patron_id)
-        action="patron_info"
-
-        try:
-            response = self.request(url)
-        except Exception, e:
-            self.log.error("Patron info call failed: %r", e, exc_info=e)
-            raise RemoteInitiatedServerError(e.message, action)
-
-        resp_dict = response.json()
-        message = resp_dict.get('message', None)
-        self.validate_response(response, message, action=action)
-
-        # If needed, will put info into PatronData subclass.  For now, OK to return a dictionary.
-        return resp_dict
-
     def patron_activity(self, patron, pin):
         """ Get a patron's current checkouts and holds.
 

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -669,29 +669,29 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
 
         The identifier is cached in a persistent Credential object.
 
-        I. If an already-cached identifier is present, we use
-           it.
+        The logic is complicated and spread out over multiple methods,
+        so here it is all in one place:
 
-        II. Otherwise, we look up the patron's barcode on RBdigital to try
-           to find an existing RBdigital account for them.
+        If an already-cached identifier is present, we use it.
 
-        II.1. If we find an existing RBdigital account, we set the
-              patron's barcode as their RBdigital identifier.
+        Otherwise, we look up the patron's barcode on RBdigital to try
+        to find their existing RBdigital account.
 
-        II.2. If we find no existing RBdigital account, we need to create
-              one.
+        If we find an existing RBdigital account, we cache the
+        identifier associated with that account.
 
-        II.2.a. If the ILS provides access to the patron's email
-                address, we create an account using the patron's actual
-                barcode and email address -- this will let them use the
-                'recover password' feature if they want to use the
-                RBdigital web site.
+        Otherwise, we need to create an RBdigital account for this patron:
 
-        II.2.b. If the ILS does not provide access to the patron's email
-                address, we create an account using the patron's actual
-                barcode with six random characters appended. This will let
-                the patron create a new RBdigital account using their
-                actual barcode, if they want to use the web site.
+        If the ILS provides access to the patron's email address, we
+        create an account using the patron's actual barcode and email
+        address. This will let them use the 'recover password' feature
+        if they want to use the RBdigital web site.
+
+        If the ILS does not provide access to the patron's email
+        address, we create an account using the patron's actual
+        barcode but with six random characters appended. This will let
+        the patron create a new RBdigital account using their actual
+        barcode, if they want to use the web site.
 
         :param patron: A Patron.
         :return: The identifier associated with the patron's (possibly

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -7,9 +7,11 @@ import json
 import logging
 from nose.tools import set_trace
 import os
+import random
 import re
 import requests
 from sqlalchemy.orm.session import Session
+import string
 import uuid
 
 from circulation import (

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -918,6 +918,19 @@ class TestCirculationAPI(DatabaseTest):
 
 class TestBaseCirculationAPI(DatabaseTest):
 
+    def test_default_notification_email_address(self):
+        # Test the ability to get the default notification email address
+        # for a patron or a library.
+        self._default_library.setting(
+            Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS).value = (
+                "help@library"
+            )
+        m = BaseCirculationAPI.default_notification_email_address
+        eq_("help@library", m(self._default_library, None))
+        eq_("help@library", m(self._patron(), None))
+        other_library = self._library()
+        eq_(None, m(other_library, None))
+
     def test_can_fulfill_without_loan(self):
         """By default, there is a blanket prohibition on fulfilling a title
         when there is no active loan.

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -16,6 +16,10 @@ from datetime import (
     timedelta,
 )
 
+from api.authenticator import (
+    LibraryAuthenticator,
+    PatronData,
+)
 from api.circulation_exceptions import *
 from api.circulation import (
     APIAwareFulfillmentInfo,
@@ -912,7 +916,7 @@ class TestCirculationAPI(DatabaseTest):
         pool.open_access = True
         eq_(True, circulation.can_fulfill_without_loan(None, pool, object()))
 
-class TestBaseCirculationAPI(object):
+class TestBaseCirculationAPI(DatabaseTest):
 
     def test_can_fulfill_without_loan(self):
         """By default, there is a blanket prohibition on fulfilling a title
@@ -920,6 +924,93 @@ class TestBaseCirculationAPI(object):
         """
         api = BaseCirculationAPI()
         eq_(False, api.can_fulfill_without_loan(object(), object(), object()))
+
+    def test_patron_email_address(self):
+        # Test the method that looks up a patron's actual email address
+        # (the one they shared with the library) on demand.
+        class Mock(BaseCirculationAPI):
+            @classmethod
+            def _library_authenticator(self, library):
+                self._library_authenticator_called_with = library
+                value = BaseCirculationAPI._library_authenticator(library)
+                self._library_authenticator_returned = value
+                return value
+
+        api = Mock()
+        patron = self._patron()
+        library = patron.library
+
+        # In a non-test scenario, a real LibraryAuthenticator is
+        # created and used as a source of knowledge about a patron's
+        # email address.
+        #
+        # However, the default library has no authentication providers
+        # set up, so the patron has no email address -- there's no one
+        # capable of providing an address.
+        eq_(None, api.patron_email_address(patron))
+        eq_(patron.library, api._library_authenticator_called_with)
+        assert isinstance(
+            api._library_authenticator_returned, LibraryAuthenticator
+        )
+
+        # Now we're going to pass in our own LibraryAuthenticator,
+        # which we've populated with mock authentication providers,
+        # into a real BaseCirculationAPI.
+        api = BaseCirculationAPI()
+        authenticator = LibraryAuthenticator(_db=self._db, library=library)
+
+        # This OAuth authentication provider doesn't implement
+        # remote_patron_lookup (it raises NotImplementedError),
+        # so it's no help.
+        class MockOAuth(object):
+            NAME = "mock oauth"
+            def remote_patron_lookup(self, patron):
+                self.called_with = patron
+                raise NotImplementedError()
+        mock_oauth = MockOAuth()
+        authenticator.register_oauth_provider(mock_oauth)
+        eq_(
+            None,
+            api.patron_email_address(
+                patron, library_authenticator=authenticator
+            )
+        )
+        # But we can verify that remote_patron_lookup was in fact
+        # called.
+        eq_(patron, mock_oauth.called_with)
+
+        # This basic authentication provider _does_ implement
+        # remote_patron_lookup, but doesn't provide the crucial
+        # information, so still no help.
+        class MockBasic(object):
+            def remote_patron_lookup(self, patron):
+                self.called_with = patron
+                return PatronData(authorization_identifier="patron")
+        basic = MockBasic()
+        authenticator.register_basic_auth_provider(basic)
+        eq_(
+            None,
+            api.patron_email_address(
+                patron, library_authenticator=authenticator
+            )
+        )
+        eq_(patron, basic.called_with)
+
+        # This basic authentication provider gives us the information
+        # we're after.
+        class MockBasic(object):
+            def remote_patron_lookup(self, patron):
+                self.called_with = patron
+                return PatronData(email_address="me@email")
+        basic = MockBasic()
+        authenticator.basic_auth_provider = basic
+        eq_(
+            "me@email",
+            api.patron_email_address(
+                patron, library_authenticator=authenticator
+            )
+        )
+        eq_(patron, basic.called_with)
 
 
 class TestDeliveryMechanismInfo(DatabaseTest):

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -338,7 +338,7 @@ class TestRBDigitalAPI(RBDigitalAPITest):
 
         # If it turns out the API has never heard of a given patron, a
         # second call is made to create_patron().
-        eq_("generic id", api.patron_remote_identifier(patron))
+        eq_("rbdigital internal id", api.patron_remote_identifier(patron))
 
         library, authorization_identifier, email_address = api.called_with
 

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -438,30 +438,6 @@ class TestRBDigitalAPI(RBDigitalAPITest):
             m, identifier
         )
 
-    def test_get_patron_information(self):
-        datastr, datadict = self.api.get_data("response_patron_info_not_found.json")
-        self.api.queue_response(status_code=404, content=datastr)
-        assert_raises_regexp(
-            NotFoundOnRemote, "patron_info:",
-            self.api.get_patron_information, patron_id='939987'
-        )
-
-        datastr, datadict = self.api.get_data("response_patron_info_error.json")
-        self.api.queue_response(status_code=400, content=datastr)
-        assert_raises_regexp(
-            InvalidInputException, "patron_info:",
-            self.api.get_patron_information, patron_id='939981fdsfdsf'
-        )
-
-        datastr, datadict = self.api.get_data("response_patron_info_found.json")
-        self.api.queue_response(status_code=200, content=datastr)
-        patron = self.api.get_patron_information(patron_id='939981')
-        eq_(u'1305722621', patron['libraryCardNumber'])
-        eq_(u'Mic', patron['firstName'])
-        eq_(u'Mouse', patron['lastName'])
-        eq_(u'mickeymouse1', patron['userName'])
-        eq_(u'mickey1@mouse.com', patron['email'])
-
     def test_get_ebook_availability_info(self):
         datastr, datadict = self.api.get_data("response_availability_ebook_1.json")
         self.api.queue_response(status_code=200, content=datastr)

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -330,7 +330,7 @@ class TestRBDigitalAPI(RBDigitalAPITest):
 
             def create_patron(self, *args):
                 self.called_with = args
-                return "generic id"
+                return "rbdigital internal id"
 
         api = NeverHeardOfYouAPI(self._db, self.collection)
 
@@ -340,12 +340,12 @@ class TestRBDigitalAPI(RBDigitalAPITest):
         # second call is made to create_patron().
         eq_("generic id", api.patron_remote_identifier(patron))
 
-        library, authorization_identifer, email_address = self.called_with
+        library, authorization_identifier, email_address = api.called_with
 
         # A permanent Credential has been created for the remote
         # identifier.
         self._assert_patron_has_remote_identifier_credential(
-            patron, "generic id"
+            patron, "rbdigital internal id"
         )
 
         # The patron's library and authorization identifier were passed
@@ -359,6 +359,8 @@ class TestRBDigitalAPI(RBDigitalAPITest):
         eq_(None, email_address)
 
     def test_patron_remote_identifier_existing_patron(self):
+        # End-to-end test of patron_remote_identifier, in the case
+        # where we already know the patron's internal RBdigital ID.
 
         class IKnowYouAPI(RBDigitalAPI):
             """A mock RBDigitalAPI that has heard of any given
@@ -385,6 +387,221 @@ class TestRBDigitalAPI(RBDigitalAPITest):
             patron, "i know you"
         )
 
+    def test_patron_remote_identifier(self):
+        # Mocked-up test of patron_remote_identifier, as opposed to
+        # the tests above, which mock only the methods that would
+        # access the RBdigital API.
+        class Mock(MockRBDigitalAPI):
+            called_with = None
+            def _find_or_create_remote_account(self, patron):
+                if self.called_with:
+                    raise Exception("I was already called!")
+                self.called_with = patron
+                return "rbdigital internal id"
+
+        # The first time we call patron_remote_identifier,
+        # _find_or_create_remote_account is called, and the result is
+        # associated with a Credential for the patron.
+        api = Mock(self._db, self.collection, base_path=self.base_path)
+        patron = self._patron()
+        eq_("rbdigital internal id", api.patron_remote_identifier(patron))
+        self._assert_patron_has_remote_identifier_credential(
+            patron, "rbdigital internal id"
+        )
+        eq_(patron, api.called_with)
+
+        # The second time, _find_or_create_remove_account is _not_
+        # called -- calling the mock method again would raise an
+        # exception. Instead, the cached Credential is returned.
+        eq_("rbdigital internal id", api.patron_remote_identifier(patron))
+
+    def test__find_or_create_remote_account(self):
+        # If the remote lookup succeeds (because the patron already
+        # made an account using their barcode), create_patron() is not
+        # called.
+        class RemoteLookupSucceeds(MockRBDigitalAPI):
+
+            def patron_remote_identifier_lookup(self, identifier):
+                self.patron_remote_identifier_lookup_called_with = identifier
+                return "an internal ID"
+
+            def create_patron(self):
+                raise Exception("I'll never be called.")
+
+        api = RemoteLookupSucceeds(
+            self._db, self.collection, base_path=self.base_path
+        )
+        patron = self._patron("a barcode")
+        patron.authorization_identifier = "a barcode"
+        eq_("an internal ID", api._find_or_create_remote_account(patron))
+        eq_("a barcode", api.patron_remote_identifier_lookup_called_with)
+
+        # If the remote lookup fails, create_patron() is called
+        # with the patron's library, authorization identifier, and
+        # email address.
+        class RemoteLookupFails(MockRBDigitalAPI):
+            def patron_remote_identifier_lookup(self, identifier):
+                self.patron_remote_identifier_lookup_called_with = identifier
+                return None
+
+            def create_patron(self, *args):
+                self.create_patron_called_with = args
+                return "an internal ID"
+
+            def patron_email_address(self, patron):
+                self.patron_email_address_called_with = patron
+                return "mock email address"
+
+        api = RemoteLookupFails(
+            self._db, self.collection, base_path=self.base_path
+        )
+        eq_("an internal ID", api._find_or_create_remote_account(patron))
+        eq_("a barcode", api.patron_remote_identifier_lookup_called_with)
+        eq_(patron, api.patron_email_address_called_with)
+        eq_((patron.library, patron.authorization_identifier,
+             "mock email address"), api.create_patron_called_with)
+
+    def test_create_patron(self):
+        # Test the method that creates an RBdigital account for a
+        # library patron.
+
+        class Mock(MockRBDigitalAPI):
+            def _create_patron_body(
+                    self, library, authorization_identifier, email_address
+            ):
+                self.called_with = (
+                    library, authorization_identifier, email_address
+                )
+        api = Mock(self._db, self.collection, base_path=self.base_path)
+
+        # Test the case where the patron can be created.
+        datastr, datadict = api.get_data(
+            "response_patron_create_success.json"
+        )
+        api.queue_response(status_code=201, content=datastr)
+        args = "library", "auth", "email"
+        patron_rbdigital_id = api.create_patron(*args)
+
+        # The arguments we passed in were propagated to _create_patron_body.
+        eq_(args, api.called_with)
+
+        # The return value is the internal ID RBdigital established for this
+        # patron.
+        eq_(940000, patron_rbdigital_id)
+
+        # Test the case where the patron already exists.
+        datastr, datadict = api.get_data("response_patron_create_fail_already_exists.json")
+        api.queue_response(status_code=409, content=datastr)
+        assert_raises_regexp(
+            RemotePatronCreationFailedException, 'create_patron: http=409, response={"message":"A patron account with the specified username, email address, or card number already exists for this library."}',
+            api.create_patron, *args
+        )
+
+    def test__create_patron_body(self):
+        # Test the method that builds the data (possibly fake, possibly not)
+        # for an RBdigital patron creation call.
+
+        class Mock(MockRBDigitalAPI):
+            dummy_patron_identifier_called_with = None
+            dummy_email_address_called_with = None
+
+            def dummy_patron_identifier(self, authorization_identifier):
+                self.dummy_patron_identifier_called_with = (
+                    authorization_identifier
+                )
+                return "dummyid"
+
+            def dummy_email_address(self, library, authorization_identifier):
+                self.dummy_email_address_called_with = (
+                    library, authorization_identifier
+                )
+                return "dummy@email"
+
+        api = Mock(self._db, self.collection, base_path=self.base_path)
+
+        # Test the case where a 'real' email address is provided.
+        library = object()
+        identifier = "auth_identifier"
+        email = "me@email"
+        body = api._create_patron_body(library, identifier, email)
+
+        # We can't test the password, even by seeding the random
+        # number generator, because it's generated with os.urandom(),
+        # but we can verify that it's the right length.
+        password = body.pop("password")
+        eq_(16, len(password))
+
+        # And we can directly check every other value.
+        expect = {
+            'userName': identifier,
+            'firstName': 'Library',
+            'libraryCardNumber': identifier,
+            'lastName': 'Simplified',
+            'postalCode': '11111',
+            'libraryId': api.library_id,
+            'email': email
+        }
+        eq_(expect, body)
+
+        # dummy_patron_identifier and dummy_email_address were not called,
+        # since we're able to create an RBdigital account that the patron
+        # can use through other means.
+        eq_(None, api.dummy_patron_identifier_called_with)
+        eq_(None, api.dummy_email_address_called_with)
+
+        # Test the case where no 'real' email address is provided.
+        body = api._create_patron_body(library, identifier, None)
+        body.pop("password")
+        expect = {
+            'userName': 'dummyid',
+            'firstName': 'Library',
+            'libraryCardNumber': 'dummyid',
+            'lastName': 'Simplified',
+            'postalCode': '11111',
+            'libraryId': api.library_id,
+            'email': 'dummy@email'
+        }
+        eq_(expect, body)
+
+        # dummy_patron_identifier and dummy_email_address were called.
+        eq_(identifier, api.dummy_patron_identifier_called_with)
+        eq_((library, identifier), api.dummy_email_address_called_with)
+
+    def test_dummy_patron_identifier(self):
+        random.seed(42)
+        patron = self.default_patron
+        auth = patron.authorization_identifier
+        remote_auth = self.api.dummy_patron_identifier(auth)
+
+        # The dummy identifier is the input identifier plus
+        # 6 random characters.
+        eq_(auth + "N098QO", remote_auth)
+
+        # It's different every time.
+        remote_auth = self.api.dummy_patron_identifier(auth)
+        eq_(auth + "W3F17I", remote_auth)
+
+    def test_dummy_email_address(self):
+
+        patron = self.default_patron
+        library = patron.library
+        auth = patron.authorization_identifier
+        m = self.api.dummy_email_address
+
+        # Without a setting for DEFAULT_NOTIFICATION_EMAIL_ADDRESS, we
+        # can't calculate the email address to send RBdigital for a
+        # patron.
+        assert_raises_regexp(
+            RemotePatronCreationFailedException,
+            "Cannot create remote account for patron because library's default notification address is not set.",
+            m, patron, auth
+        )
+
+        self._set_notification_address(patron.library)
+        address = m(patron, auth)
+        eq_("genericemail+rbdigital-%s@library.org" % auth,
+            address)
+
     def test_patron_remote_identifier_lookup(self):
         # Test the method that tries to convert a patron identifier
         # (e.g. the one the patron uses to authenticate with their
@@ -400,7 +617,7 @@ class TestRBDigitalAPI(RBDigitalAPITest):
         self.api.queue_response(status_code=200, content=datastr)
         rbdigital_patron_id = m(identifier)
         eq_(None, rbdigital_patron_id)
-        
+
         # Test the case where RBdigital recognizes the identifier
         # we're using.
         self.queue_initial_patron_id_lookup()
@@ -611,147 +828,6 @@ class TestRBDigitalAPI(RBDigitalAPITest):
         checkout_url = self.api.requests[-1][0]
         assert "days=%s" % audio_period in checkout_url
         assert (loan_info.end_date - today).days <= audio_period
-
-    def test_create_patron(self):        
-        # Test the method that creates an RBdigital account for a
-        # library patron.
-
-        class Mock(MockRBDigitalAPI):
-            def _create_patron_body(
-                    self, library, authorization_identifier, email_address
-            ):
-                self.called_with = (
-                    library, authorization_identifier, email_address
-                )
-        api = Mock(self._db, self.collection, base_path=self.base_path)
-
-        # Test the case where the patron can be created.
-        datastr, datadict = api.get_data(
-            "response_patron_create_success.json"
-        )
-        api.queue_response(status_code=201, content=datastr)
-        args = "library", "auth", "email"
-        patron_rbdigital_id = api.create_patron(*args)
-
-        # The arguments we passed in were propagated to _create_patron_body.
-        eq_(args, api.called_with)
-
-        # The return value is the internal ID RBdigital established for this
-        # patron.
-        eq_(940000, patron_rbdigital_id)
-        
-        # Test the case where the patron already exists.
-        datastr, datadict = api.get_data("response_patron_create_fail_already_exists.json")
-        api.queue_response(status_code=409, content=datastr)
-        assert_raises_regexp(
-            RemotePatronCreationFailedException, 'create_patron: http=409, response={"message":"A patron account with the specified username, email address, or card number already exists for this library."}',
-            api.create_patron, *args
-        )
-
-    def test__create_patron_body(self):
-        # Test the method that builds the data (possibly fake, possibly not)
-        # for an RBdigital patron creation call.
-
-        class Mock(MockRBDigitalAPI):
-            dummy_patron_identifier_called_with = None
-            dummy_email_address_called_with = None
-
-            def dummy_patron_identifier(self, authorization_identifier):
-                self.dummy_patron_identifier_called_with = (
-                    authorization_identifier
-                )
-                return "dummyid"
-
-            def dummy_email_address(self, library, authorization_identifier):
-                self.dummy_email_address_called_with = (
-                    library, authorization_identifier
-                )
-                return "dummy@email"
-
-        api = Mock(self._db, self.collection, base_path=self.base_path)
-
-        # Test the case where a 'real' email address is provided.
-        library = object()
-        identifier = "auth_identifier"
-        email = "me@email"
-        body = api._create_patron_body(library, identifier, email)
-
-        # We can't test the password, even by seeding the random
-        # number generator, because it's generated with os.urandom(),
-        # but we can verify that it's the right length.
-        password = body.pop("password")
-        eq_(16, len(password))
-
-        # And we can directly check every other value.
-        expect = {
-            'userName': identifier,
-            'firstName': 'Library',
-            'libraryCardNumber': identifier,
-            'lastName': 'Simplified',
-            'postalCode': '11111',
-            'libraryId': api.library_id,
-            'email': email
-        }
-        eq_(expect, body)
-
-        # dummy_patron_identifier and dummy_email_address were not called,
-        # since we're able to create an RBdigital account that the patron
-        # can use through other means.
-        eq_(None, api.dummy_patron_identifier_called_with)
-        eq_(None, api.dummy_email_address_called_with)
-
-        # Test the case where no 'real' email address is provided.
-        body = api._create_patron_body(library, identifier, None)
-        body.pop("password")
-        expect = {
-            'userName': 'dummyid',
-            'firstName': 'Library',
-            'libraryCardNumber': 'dummyid',
-            'lastName': 'Simplified',
-            'postalCode': '11111',
-            'libraryId': api.library_id,
-            'email': 'dummy@email'
-        }
-        eq_(expect, body)
-
-        # dummy_patron_identifier and dummy_email_address were called.
-        eq_(identifier, api.dummy_patron_identifier_called_with)
-        eq_((library, identifier), api.dummy_email_address_called_with)
-
-    def test_dummy_patron_identifier(self):
-        random.seed(42)
-        patron = self.default_patron
-        auth = patron.authorization_identifier
-        remote_auth = self.api.dummy_patron_identifier(auth)
-
-        # The dummy identifier is the input identifier plus
-        # 6 random characters.
-        eq_(auth + "N098QO", remote_auth)
-
-        # It's different every time.
-        remote_auth = self.api.dummy_patron_identifier(auth)
-        eq_(auth + "W3F17I", remote_auth)
-
-    def test_dummy_email_address(self):
-
-        patron = self.default_patron
-        library = patron.library
-        auth = patron.authorization_identifier
-        m = self.api.dummy_email_address
-
-        # Without a setting for DEFAULT_NOTIFICATION_EMAIL_ADDRESS, we
-        # can't calculate the email address to send RBdigital for a
-        # patron.
-        assert_raises_regexp(
-            RemotePatronCreationFailedException,
-            "Cannot create remote account for patron because library's default notification address is not set.",
-            m, patron, auth
-        )
-
-        self._set_notification_address(patron.library)
-        address = m(patron, auth)
-        eq_("genericemail+rbdigital-%s@library.org" % auth,
-            address)
 
     def test_fulfill(self):
         patron = self.default_patron


### PR DESCRIPTION
This branch implements our side of the changes laid out in https://jira.nypl.org/browse/SIMPLY-1723.

The functional changes are these:

* We will look up an existing RBdigital account for a patron's actual barcode before trying to create a new account for them.
* If the ILS provides us with access to the patron's email address, we will use it, plus their real barcode, to create an RBdigital account that can be used in other contexts, e.g. through the RBdigital web site.
* If we need to create a dummy account for a patron, we will use a patron identifier based on their barcode, rather than one that's totally random. This will get us past library-specific data validation.
* A dummy value for `postalCode` is now provided when creating a patron account.

To implement these changes I refactored the account creation code and added a lot of mocked-up tests.