### PR TITLE
The NoveList API call might take a very long time to process, so disable the timeout.

### DIFF
--- a/api/novelist.py
+++ b/api/novelist.py
@@ -615,8 +615,12 @@ class NoveListAPI(object):
         data = kwargs.get('data')
         if 'data' in kwargs:
             del kwargs['data']
-
-        response = HTTP.put_with_timeout(url, data, headers=headers, **kwargs)
+        # This might take a very long time -- disable the normal
+        # timeout.
+        kwargs['timeout'] = None
+        response = HTTP.put_with_timeout(
+            url, data, headers=headers, **kwargs
+        )
         return response
 
 


### PR DESCRIPTION
It seems a little silly to call a method called `request_with_timeout` and pass in `timeout=None`, but `request_with_timeout` is our generic 'HTTP request' method.