### PR TITLE
Don't consider a title problematic for having no delivery mechanisms if it also has no owned licenses.

### DIFF
--- a/api/selftest.py
+++ b/api/selftest.py
@@ -11,6 +11,7 @@ from feedbooks import (
 from core.config import IntegrationException
 from core.model import (
     ExternalIntegration,
+    LicensePool,
 )
 from core.opds_import import (
     OPDSImporter,
@@ -152,7 +153,9 @@ class HasCollectionSelfTests(HasSelfTests):
         # mechanisms.
         titles = []
 
-        for lp in self.collection.pools_with_no_delivery_mechanisms:
+        qu = self.collection.pools_with_no_delivery_mechanisms
+        qu = qu.filter(LicensePool.licenses_owned > 0)
+        for lp in qu:
             edition = lp.presentation_edition
             if edition:
                 title = edition.title

--- a/tests/test_selftest.py
+++ b/tests/test_selftest.py
@@ -242,8 +242,8 @@ class TestHasCollectionSelfTests(DatabaseTest):
             collection = self._default_collection
         hastests = Mock()
         result = hastests._no_delivery_mechanisms_test()
-        eq_("All titles in this collection have delivery mechanisms.",
-            result)
+        success = "All titles in this collection have delivery mechanisms."
+        eq_(success, result)
 
         # Destroy the delivery mechanism.
         [self._db.delete(x) for x in pool.delivery_mechanisms]
@@ -253,3 +253,10 @@ class TestHasCollectionSelfTests(DatabaseTest):
         [result] = hastests._no_delivery_mechanisms_test()
         eq_("[title unknown] (ID: %s)" % pool.identifier.identifier,
             result)
+
+        # Change the LicensePool so it has no owned licenses.
+        # Now the book is no longer considered problematic,
+        # since it's not actually in the collection.
+        pool.licenses_owned = 0
+        result = hastests._no_delivery_mechanisms_test()
+        eq_(success, result)


### PR DESCRIPTION
This solves the mystery I mentioned here: https://jira.nypl.org/browse/SIMPLY-1711?focusedCommentId=31334&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-31334

The reaper didn't make the problematic books disappear from the list because _they'd already been reaped_. They're no longer in our collection at all, so it doesn't matter that there were no EPUBs for them. This branch changes the query that finds problematic LicensePools so that a pool isn't counted if it has no licenses owned.