### PR TITLE
If there's an exception initializing the search index, the search controller will return a problem detail document rather than faking it with an empty list of search results.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -122,6 +122,7 @@ from authenticator import (
 from config import (
     Configuration,
     CannotLoadConfiguration,
+    IntegrationException,
 )
 
 from lanes import (
@@ -868,13 +869,17 @@ class OPDSFeedController(CirculationManagerController):
 
         annotator = self.manager.annotator(lane, facets)
         info = OpenSearchDocument.search_info(lane)
+        search_engine = self.manager.external_search
+        if not search_engine:
+            return REMOTE_INTEGRATION_FAILED.detailed(
+                _("The search index for this site is not properly configured.")
+            )
         opds_feed = AcquisitionFeed.search(
             _db=self._db, title=info['name'],
-            url=this_url, lane=lane, search_engine=self.manager.external_search,
+            url=this_url, lane=lane, search_engine=search_engine,
             query=query, annotator=annotator, pagination=pagination,
             facets=facets,
         )
-
         return feed_response(opds_feed)
 
 class MARCRecordController(CirculationManagerController):

--- a/api/controller.py
+++ b/api/controller.py
@@ -122,7 +122,6 @@ from authenticator import (
 from config import (
     Configuration,
     CannotLoadConfiguration,
-    IntegrationException,
 )
 
 from lanes import (


### PR DESCRIPTION
This is a very simple way of addressing https://jira.nypl.org/browse/SIMPLY-1214 -- simpler than the solution proposed in the issue.