### PR TITLE
Writing self tests for SIP2 connection and test patron testing.

### DIFF
--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -26,7 +26,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
 
     SETTINGS = [
         { "key": ExternalIntegration.URL, "label": _("Server"), "required": True },
-        { "key": PORT, "label": _("Port"), "required": True },
+        { "key": PORT, "label": _("Port"), "required": True , "type": "number" },
         { "key": ExternalIntegration.USERNAME, "label": _("Login User ID") },
         { "key": ExternalIntegration.PASSWORD, "label": _("Login Password") },
         { "key": LOCATION_CODE, "label": _("Location Code") },
@@ -160,6 +160,44 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             password = None
         info = self.patron_information(username, password)
         return self.info_to_patrondata(info)
+
+    def _run_self_tests(self, _db):
+        def makeConnection(sip):
+            sip.connect()
+            return sip.connection
+
+        if self.client:
+            sip = self.client
+        else:
+            sip = SIPClient(
+                target_server=self.server, target_port=self.port,
+                login_user_id=self.login_user_id, login_password=self.login_password,
+                location_code=self.location_code, separator=self.field_separator,
+                use_ssl=self.use_ssl, ssl_cert=self.ssl_cert, ssl_key=self.ssl_key
+            )
+        
+        connection = self.run_test(
+            ("Test Connection"),
+            makeConnection,
+            sip
+        )
+        yield connection
+
+        if not connection.success:
+            return
+
+        login = self.run_test(
+            ("Test Login with username '%s' and password '%s'" % (self.login_user_id, self.login_password)),
+            sip.login
+        )
+        yield login
+
+        # Log in was successful so test patron's test credentials
+        if login.success:
+            results = super(SIP2AuthenticationProvider, self)._run_self_tests(_db)
+            for x in results:
+                yield x
+        
 
     @classmethod
     def info_to_patrondata(cls, info, validate_password=True):

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -205,6 +205,13 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
                     return json.dumps(info, indent=1)
 
                 yield self.run_test(
+                    "Patron information request",
+                    sip.patron_information_request,
+                    self.test_username,
+                    patron_password=self.test_password
+                )
+
+                yield self.run_test(
                     ("Raw test patron information"),
                     raw_patron_information
                 )

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -9,6 +9,7 @@ from api.sip.client import SIPClient
 from core.util.http import RemoteIntegrationException
 from core.util import MoneyUtility
 from core.model import ExternalIntegration
+import json
 
 class SIP2AuthenticationProvider(BasicAuthenticationProvider):
 
@@ -194,9 +195,19 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
 
         # Log in was successful so test patron's test credentials
         if login.success:
-            results = super(SIP2AuthenticationProvider, self)._run_self_tests(_db)
-            for x in results:
-                yield x
+            results = [r for r in super(SIP2AuthenticationProvider, self)._run_self_tests(_db)]
+            for result in results:
+                yield result
+
+            if results[0].success:
+                def raw_patron_information():
+                    info = sip.patron_information(self.test_username, self.test_password)
+                    return json.dumps(info, indent=1)
+
+                yield self.run_test(
+                    ("Raw test patron information"),
+                    raw_patron_information
+                )
         
 
     @classmethod

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -844,10 +844,6 @@ class MockSIPClient(SIPClient):
         self.status.append("Creating new socket connection.")
         self.reset_connection_state()
         return None
-    
-    def login(self):
-        if not self.login_user_id and not self.login_password:
-            raise IOError("Error logging in")
 
     def do_send(self, data):
         self.requests.append(data)

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -32,6 +32,7 @@ import re
 import socket
 import ssl
 import tempfile
+from nose.tools import set_trace
 
 # SIP2 defines a large number of fields which are used in request and
 # response messages. This library focuses on defining the response
@@ -315,14 +316,16 @@ class SIPClient(Constants):
                 self.connection = self.make_secure_connection()
             else:
                 self.connection = self.make_insecure_connection()
+            
+            self.connection.settimeout(12)
             self.connection.connect((self.target_server, self.target_port))
-        except TypeError:
+        except socket.error as message:
             raise IOError(
-                "Could not connect to %s:%s" % (
-                    self.target_server, self.target_port
+                "Could not connect to %s:%s - %s" % (
+                    self.target_server, self.target_port, message
                 )
             )
-        self.connection.settimeout(12)
+        
         # Since this is a new socket connection, reset the message count
         self.reset_connection_state()
 
@@ -841,6 +844,10 @@ class MockSIPClient(SIPClient):
         self.status.append("Creating new socket connection.")
         self.reset_connection_state()
         return None
+    
+    def login(self):
+        if not self.login_user_id and not self.login_password:
+            raise IOError("Error logging in")
 
     def do_send(self, data):
         self.requests.append(data)

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -339,6 +339,11 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
                 # probably a timeout if the server or port values are not valid
                 raise IOError("Could not connect")
 
+        class MockSIPLogin(MockSIPClient):
+            def login(self):
+                if not self.login_user_id and not self.login_password:
+                    raise IOError("Error logging in")
+
         client = MockBadConnection()
         auth = SIP2AuthenticationProvider(
             self._default_library, integration, client=client
@@ -351,7 +356,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         eq_(results[0].success, False)
         assert(results[0].exception, IOError("Could not connect"))
 
-        client = MockSIPClient()
+        client = MockSIPLogin()
         auth = SIP2AuthenticationProvider(
             self._default_library, integration, client=client
         )
@@ -368,7 +373,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         # Set the log in username and password
         integration.username = "user1"
         integration.password = "pass1"
-        client = MockSIPClient(login_user_id="user1", login_password="pass1")
+        client = MockSIPLogin(login_user_id="user1", login_password="pass1")
         auth = SIP2AuthenticationProvider(
             self._default_library, integration, client=client
         )

--- a/tests/sip/test_client.py
+++ b/tests/sip/test_client.py
@@ -103,7 +103,7 @@ class TestSIPClient(object):
                 assert tmpfile.startswith("/tmp")
                 # By the time the SSL socket has been wrapped, the
                 # temporary file has already been removed.  Because of
-                # that we can't verify from within a unit testthat the
+                # that we can't verify from within a unit test that the
                 # correct contents were written to the file.
                 assert not os.path.exists(tmpfile)
         finally:


### PR DESCRIPTION
Fixes [SIMPLY-1756](https://jira.nypl.org/browse/SIMPLY-1756).

Writing self tests for testing the SIP2 connection as well as logging in with a username and password. Once those pass, the test patron's self tests also run.

Samples of failing tests:
![Screen Shot 2019-03-12 at 5 12 07 PM](https://user-images.githubusercontent.com/1280564/54236586-460ffe00-44ea-11e9-95da-78ee9b7e7bf4.png)
![Screen Shot 2019-03-12 at 5 12 33 PM](https://user-images.githubusercontent.com/1280564/54236590-47412b00-44ea-11e9-8d4f-65f8bbbb1e47.png)
