### PR TITLE
Novelist script - handle publication dates older than 1900.

### DIFF
--- a/api/novelist.py
+++ b/api/novelist.py
@@ -609,7 +609,7 @@ class NoveListAPI(object):
 
             publicationDate = object[5]
             if publicationDate:
-                publicationDateString = publicationDate.strftime("%Y%m%d").replace("-", "")
+                publicationDateString = publicationDate.isoformat().replace("-", "")
                 newItem["publicationDate"] = publicationDateString
 
             # If we are processing a new item and there is an existing item,

--- a/tests/test_novelist.py
+++ b/tests/test_novelist.py
@@ -411,7 +411,7 @@ class TestNoveListAPI(DatabaseTest):
             "Gutenberg")
         book2_from_query = (
             "34567", "Axis 360 ID", "56789",
-            "Title 2", "Book", datetime.date(2013, 1, 1),
+            "Title 2", "Book", datetime.date(1414, 1, 1),
             "Author", "Author 3",
             "Gutenberg")
 
@@ -502,7 +502,7 @@ class TestNoveListAPI(DatabaseTest):
             "role": "Author",
             "author": "Author 3",
             "distributor": "Gutenberg",
-            "publicationDate": "20130101"
+            "publicationDate": "14140101"
             })
         eq_(addItem, True)
 


### PR DESCRIPTION
This helps fix an issue where real dataset publication dates older than 1900 failed with `strftime()`. Using `isoformat()` instead.

Related ticket: [SIMPLY-1749](https://jira.nypl.org/browse/SIMPLY-1749)