### PR TITLE
Fix missing import

### DIFF
--- a/api/monitor.py
+++ b/api/monitor.py
@@ -28,6 +28,7 @@ from core.model import (
     Identifier,
     LicensePool,
     Loan,
+    Timestamp,
 )
 from core.opds_import import (
     MetadataWranglerOPDSLookup,
@@ -149,7 +150,7 @@ class MWCollectionUpdateMonitor(MetadataWranglerCollectionMonitor):
 
             # Immediately update the timestamps table so that a later
             # crash doesn't mean we have to redo this work.
-            if new_timestamp:
+            if new_timestamp not in (None, Timestamp.CLEAR_VALUE):
                 timestamp_obj = self.timestamp()
                 timestamp_obj.finish = new_timestamp
                 timestamp_obj.achievements = achievements
@@ -164,10 +165,9 @@ class MWCollectionUpdateMonitor(MetadataWranglerCollectionMonitor):
         #
         # Otherwise, the existing timestamp.finish should be used. If
         # that value happens to be None, we need to set
-        # TimestampData.finish to NO_VALUE to make sure it ends up
+        # TimestampData.finish to CLEAR_VALUE to make sure it ends up
         # as None (rather than the current time).
-        finish = new_timestamp or self.timestamp().finish or Timestamp.NO_VALUE
-
+        finish = new_timestamp or self.timestamp().finish or Timestamp.CLEAR_VALUE
         progress.start = start
         progress.finish = finish
         progress.achievements = achievements

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -1458,8 +1458,8 @@ class TestODLHoldReaper(DatabaseTest, BaseODLTest):
 
         # The TimestampData does not include any timing information --
         # that will be applied by run().
-        eq_(TimestampData.NO_VALUE, progress.start)
-        eq_(TimestampData.NO_VALUE, progress.finish)
+        eq_(None, progress.start)
+        eq_(None, progress.finish)
 
 
 

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -478,5 +478,5 @@ class TestOPDSForDistributorsReaperMonitor(DatabaseTest, BaseOPDSForDistributors
 
         # The TimestampData does not include any timing information --
         # that will be applied by run().
-        eq_(TimestampData.NO_VALUE, progress.start)
-        eq_(TimestampData.NO_VALUE, progress.finish)
+        eq_(None, progress.start)
+        eq_(None, progress.finish)

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -1722,8 +1722,8 @@ class TestRBDigitalSyncMonitor(RBDigitalAPITest):
 
         # The TimestampData does not include any timing information --
         # that will be applied by run().
-        eq_(TimestampData.NO_VALUE, progress.start)
-        eq_(TimestampData.NO_VALUE, progress.finish)
+        eq_(None, progress.start)
+        eq_(None, progress.finish)
 
 
 class TestRBDigitalImportMonitor(RBDigitalAPITest):

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -1305,8 +1305,8 @@ class TestCirculationMonitor(RBDigitalAPITest):
 
         # The TimestampData does not include any timing information
         # -- that will be applied by run().
-        eq_(TimestampData.NO_VALUE, progress.start)
-        eq_(TimestampData.NO_VALUE, progress.finish)
+        eq_(None, progress.start)
+        eq_(None, progress.finish)
 
     def test_process_availability(self):
         monitor = RBDigitalCirculationMonitor(


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-1796 by adding a missing import. It also adds a test against the code path that wasn't previously being triggered (which is why we didn't notice the import was missing).

This was a useful exercise because it exposed some problemn in core, which are fixed by https://github.com/NYPL-Simplified/server_core/pull/1044