### PR TITLE
Updated test to work with newest Flask.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ urllib3<1.24 # Travis problem introduced 20181016 - check to see when we can rem
 sqlalchemy==1.2.0
 flask-sqlalchemy-session
 lxml
-flask
+flask>1.0.1
 isbnlib
 nose
 python-dateutil

--- a/tests/admin/controller/test_controller.py
+++ b/tests/admin/controller/test_controller.py
@@ -172,8 +172,8 @@ class TestViewController(AdminControllerTest):
             location = response.headers.get("Location")
             assert "sign_in" in location
             assert "admin%2Fweb" in location
-            assert "collection%2Fa%2F%28b%29" in location
-            assert "book%2Fc%2F%28d%29" in location
+            assert "collection%2Fa%252F%2528b%2529" in location
+            assert "book%2Fc%252F%2528d%2529" in location
 
     def test_redirect_to_library(self):
         # If the admin doesn't have access to any libraries, they get a message


### PR DESCRIPTION
There was apparently a change to the behavior of url_for in Flask so that it now URL encodes the redirect_url parameter. This is correct - our redirecting didn't work for some URLs before. The change was released last May, but for some reason Travis seems to have only started using it yesterday.

I updated one of our tests and changed requirements.txt so we can reinstall it to update flask.