### PR TITLE
Pin Werkzeug to a version compatible with our pinned Flask version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ sqlalchemy==1.2.0
 flask-sqlalchemy-session
 lxml
 flask>1.0.1
+werkzeug>=0.14
 isbnlib
 nose
 python-dateutil


### PR DESCRIPTION
I ran into [this problem](https://stackoverflow.com/questions/52174600/error-in-flask-while-using-flash-typeerror) on a site upgraded from the previous version. Flask was upgraded during the upgrade but Werkzeug was not.