### PR TITLE
Delete collections

### DIFF
--- a/api/admin/controller/collection_settings.py
+++ b/api/admin/controller/collection_settings.py
@@ -57,6 +57,8 @@ class CollectionSettingsController(SettingsController):
                 protocolClass = self.find_protocol_class(collection_object)
 
             collection_dict["self_test_results"] = self._get_prior_test_results(collection_object, protocolClass)
+            collection_dict["marked_for_deletion"] = collection_object.marked_for_deletion
+
             collections.append(collection_dict)
 
         return dict(
@@ -298,5 +300,7 @@ class CollectionSettingsController(SettingsController):
             return MISSING_COLLECTION
         if len(collection.children) > 0:
             return CANNOT_DELETE_COLLECTION_WITH_CHILDREN
-        self._db.delete(collection)
+        
+        # Flag the collection to be deleted by script in the background.
+        collection.marked_for_deletion = True
         return Response(unicode(_("Deleted")), 200)

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.1.9"
+    "simplified-circulation-web": "0.1.10"
   }
 }


### PR DESCRIPTION
Helps fix [SIMPLY-1846](https://jira.nypl.org/browse/SIMPLY-1846). This add the `marked_for_deletion` flag to the collection object that is sent to the UI. It also marks a collection for deletion instead of outright deleting it.