### PR TITLE
Fix syncing patron activity for shared ODL collection

### DIFF
--- a/api/odl.py
+++ b/api/odl.py
@@ -1442,6 +1442,7 @@ class MockSharedODLAPI(SharedODLAPI):
     def __init__(self, _db, collection, *args, **kwargs):
         self.responses = []
         self.requests = []
+        self.request_args = []
         super(MockSharedODLAPI, self).__init__(
             _db, collection, *args, **kwargs
         )
@@ -1454,5 +1455,6 @@ class MockSharedODLAPI(SharedODLAPI):
     def _get(self, url, patron=None, headers=None, allowed_response_codes=None):
         allowed_response_codes = allowed_response_codes or ["2xx", "3xx"]
         self.requests.append(url)
+        self.request_args.append((patron, headers, allowed_response_codes))
         response = self.responses.pop()
         return HTTP._process_response(url, response, allowed_response_codes=allowed_response_codes)

--- a/api/odl.py
+++ b/api/odl.py
@@ -1264,7 +1264,7 @@ class SharedODLAPI(BaseCirculationAPI):
         activity = []
         for loan in loans:
             info_url = loan.external_identifier
-            response = self._get(info_url, allowed_response_codes=["2xx", "3xx", "404"])
+            response = self._get(info_url, patron=patron, allowed_response_codes=["2xx", "3xx", "404"])
             if response.status_code == 404:
                 # 404 is returned when the loan has been deleted. Leave this loan out of the result.
                 continue
@@ -1293,7 +1293,7 @@ class SharedODLAPI(BaseCirculationAPI):
             )
         for hold in holds:
             info_url = hold.external_identifier
-            response = self._get(info_url, allowed_response_codes=["2xx", "3xx", "404"])
+            response = self._get(info_url, patron=patron, allowed_response_codes=["2xx", "3xx", "404"])
             if response.status_code == 404:
                 # 404 is returned when the hold has been deleted. Leave this hold out of the result.
                 continue
@@ -1451,7 +1451,7 @@ class MockSharedODLAPI(SharedODLAPI):
             0, MockRequestsResponse(status_code, headers, content)
         )
 
-    def _get(self, url, headers=None, allowed_response_codes=None):
+    def _get(self, url, patron=None, headers=None, allowed_response_codes=None):
         allowed_response_codes = allowed_response_codes or ["2xx", "3xx"]
         self.requests.append(url)
         response = self.responses.pop()

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -1692,6 +1692,11 @@ class TestSharedODLAPI(DatabaseTest, BaseODLTest):
         eq_(datetime.datetime(2018, 3, 29, 17, 44, 11), loan_info.end_date)
         eq_([loan.external_identifier], self.api.requests)
 
+        # The _get method was passed a patron - this is necessary because
+        # the patron_activity method may be called from a thread without
+        # access to the flask request.
+        eq_(self.patron, self.api.request_args[0][0])
+
         # The patron's loan has been deleted on the remote.
         self.api.queue_response(404, content="No loan here")
         activity = self.api.patron_activity(self.patron, "pin")


### PR DESCRIPTION
Tests didn't catch this since the `_get` method is mocked. Using `flask.request.patron` was failing from the method for syncing the patron activity, probably because it is called from a thread with no request context.