### PR TITLE
Login error styling

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -452,10 +452,12 @@ class SignInController(AdminController):
     ERROR_RESPONSE_TEMPLATE = """<!DOCTYPE HTML>
 <html lang="en">
 <head><meta charset="utf8"></head>
-<body>
+<body style="{error}">
 <p><strong>%(status_code)d ERROR:</strong> %(message)s</p>
+<hr style="{hr}">
+<a href="/admin/sign_in" style="{link}">Try again</a>
 </body>
-</html>"""
+</html>""".format(error=error_style, hr=hr_style, link=small_link_style)
 
     SIGN_IN_TEMPLATE = """<!DOCTYPE HTML>
 <html lang="en">
@@ -540,6 +542,7 @@ class SignInController(AdminController):
 
     def error_response(self, problem_detail):
         """Returns a problem detail as an HTML response"""
+        # set_trace()
         html = self.ERROR_RESPONSE_TEMPLATE % dict(
             status_code=problem_detail.status_code,
             message=problem_detail.detail

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -542,7 +542,6 @@ class SignInController(AdminController):
 
     def error_response(self, problem_detail):
         """Returns a problem detail as an HTML response"""
-        # set_trace()
         html = self.ERROR_RESPONSE_TEMPLATE % dict(
             status_code=problem_detail.status_code,
             message=problem_detail.detail

--- a/api/admin/template_styles.py
+++ b/api/admin/template_styles.py
@@ -15,6 +15,10 @@ body_style = """
 label_style = """
     font-weight: 700;
 """
+
+error_style = body_style + """
+    border-color: #D0343A;
+"""
 input_style = """
     display: block;
     padding: 10px;
@@ -56,6 +60,11 @@ link_style = """
     display: block;
     width: 25vw;
     margin: 2vh auto;
+"""
+
+small_link_style = link_style + """
+    width: 5vw;
+    margin-bottom: 0;
 """
 
 hr_style = """


### PR DESCRIPTION
A (very minor) UX improvement: add CSS styling to the message that admins see when they try to log in with invalid credentials, and add a "try again" link so they can more easily go back to the login form.  (Modeled on the code from when we previously added styling to the login form.)

Existing version:
<img width="386" alt="Screen Shot 2019-04-22 at 12 56 12 PM" src="https://user-images.githubusercontent.com/42178216/56513191-a89fe500-64ff-11e9-997b-bfd15554c07f.png">

Proposed improvement:
<img width="701" alt="Screen Shot 2019-04-22 at 11 58 20 AM" src="https://user-images.githubusercontent.com/42178216/56513202-b190b680-64ff-11e9-966b-3ea9ada33bba.png">

[JIRA ticket](https://jira.nypl.org/browse/SIMPLY-1880)