### PR TITLE
Run validations on patron auth service form fields

### DIFF
--- a/api/admin/controller/patron_auth_services.py
+++ b/api/admin/controller/patron_auth_services.py
@@ -81,9 +81,11 @@ class PatronAuthServicesController(SettingsController):
             )
             if isinstance(auth_service, ProblemDetail):
                 return auth_service
-            format_error = self.validate_formats()
-            if format_error:
-                return format_error
+
+        format_error = self.validate_formats()
+        if format_error:
+            self._db.rollback()
+            return format_error
 
         name = self.get_name(auth_service)
         if isinstance(name, ProblemDetail):

--- a/api/admin/controller/patron_auth_services.py
+++ b/api/admin/controller/patron_auth_services.py
@@ -62,9 +62,9 @@ class PatronAuthServicesController(SettingsController):
     def process_post(self):
         protocol = flask.request.form.get("protocol")
         is_new = False
-        error = self.validate_form_fields(protocol)
-        if error:
-            return error
+        protocol_error = self.validate_form_fields(protocol)
+        if protocol_error:
+            return protocol_error
 
         id = flask.request.form.get("id")
         if id:
@@ -81,6 +81,9 @@ class PatronAuthServicesController(SettingsController):
             )
             if isinstance(auth_service, ProblemDetail):
                 return auth_service
+            format_error = self.validate_formats()
+            if format_error:
+                return format_error
 
         name = self.get_name(auth_service)
         if isinstance(name, ProblemDetail):

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2072,7 +2072,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider):
     DEFAULT_TOKEN_EXPIRATION_DAYS = 42
 
     SETTINGS = [
-        { "key": OAUTH_TOKEN_EXPIRATION_DAYS, "label": _("Days until OAuth token expires") },
+        { "key": OAUTH_TOKEN_EXPIRATION_DAYS, "type": "number", "label": _("Days until OAuth token expires") },
     ] + AuthenticationProvider.SETTINGS
 
     # Name of the site-wide ConfigurationSetting containing the secret

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -42,7 +42,7 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
     DEFAULT_PASSWORD_REGULAR_EXPRESSION = '^[0-9]+$'
 
     SETTINGS = [
-        { "key": ExternalIntegration.URL, "label": _("URL"), "required": True },
+        { "key": ExternalIntegration.URL, "format": "url", "label": _("URL"), "required": True },
         { "key": ExternalIntegration.PASSWORD, "label": _("Key"), "required": True },
     ] + BasicAuthenticationProvider.SETTINGS
 

--- a/api/firstbook2.py
+++ b/api/firstbook2.py
@@ -50,7 +50,7 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
 
     SETTINGS = [
         {
-            "key": ExternalIntegration.URL, "label": _("URL"),
+            "key": ExternalIntegration.URL, "format": "url", "label": _("URL"),
             "default": "https://ebooksprod.firstbook.org/api/",
             "required": True
         },

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -71,7 +71,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
     ]
 
     SETTINGS = [
-        { "key": ExternalIntegration.URL, "label": _("URL"), "required": True },
+        { "key": ExternalIntegration.URL, "format": "url", "label": _("URL"), "required": True },
         { "key": VERIFY_CERTIFICATE, "label": _("Certificate Verification"),
           "type": "select", "options": [
               { "key": "true", "label": _("Verify Certificate Normally (Required for production)") },

--- a/tests/admin/controller/test_patron_auth.py
+++ b/tests/admin/controller/test_patron_auth.py
@@ -7,6 +7,7 @@ import flask
 from flask_babel import lazy_gettext as _
 import json
 from werkzeug import MultiDict
+from api.admin.controller.patron_auth_services import PatronAuthServicesController
 from api.admin.exceptions import *
 from api.authenticator import (
     AuthenticationProvider,
@@ -354,7 +355,22 @@ class TestPatronAuth(SettingsControllerTest):
             assert_raises(AdminNotAuthorized,
                           self.manager.admin_patron_auth_services_controller.process_patron_auth_services)
 
+    def _get_mock(self):
+        manager = self.manager
+        class Mock(PatronAuthServicesController):
+            def __init__(self, manager):
+                self.validate_formats_call_count = 0
+                super(Mock, self).__init__(manager)
+            def validate_formats(self):
+                self.validate_formats_call_count += 1
+                super(Mock, self).validate_formats()
+
+        self.manager.admin_patron_auth_services_controller = Mock(manager)
+        return self.manager.admin_patron_auth_services_controller
+
     def test_patron_auth_services_post_create(self):
+        mock_controller = self._get_mock()
+
         library, ignore = create(
             self._db, Library, name="Library", short_name="L",
         )
@@ -370,8 +386,10 @@ class TestPatronAuth(SettingsControllerTest):
                     AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION: "^1234",
                 }])),
             ] + self._common_basic_auth_arguments())
-            response = self.manager.admin_patron_auth_services_controller.process_patron_auth_services()
+
+            response = mock_controller.process_patron_auth_services()
             eq_(response.status_code, 201)
+            eq_(mock_controller.validate_formats_call_count, 1)
 
         auth_service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.PATRON_AUTH_GOAL)
         eq_(auth_service.id, int(response.response[0]))
@@ -390,8 +408,9 @@ class TestPatronAuth(SettingsControllerTest):
                 (MilleniumPatronAPI.VERIFY_CERTIFICATE, "true"),
                 (MilleniumPatronAPI.AUTHENTICATION_MODE, MilleniumPatronAPI.PIN_AUTHENTICATION_MODE),
             ] + common_args)
-            response = self.manager.admin_patron_auth_services_controller.process_patron_auth_services()
+            response = mock_controller.process_patron_auth_services()
             eq_(response.status_code, 201)
+            eq_(mock_controller.validate_formats_call_count, 2)
 
         auth_service2 = get_one(self._db, ExternalIntegration,
                                goal=ExternalIntegration.PATRON_AUTH_GOAL,
@@ -409,6 +428,8 @@ class TestPatronAuth(SettingsControllerTest):
         eq_([], auth_service2.libraries)
 
     def test_patron_auth_services_post_edit(self):
+        mock_controller = self._get_mock()
+
         l1, ignore = create(
             self._db, Library, name="Library 1", short_name="L1",
         )
@@ -438,6 +459,7 @@ class TestPatronAuth(SettingsControllerTest):
             ] + self._common_basic_auth_arguments())
             response = self.manager.admin_patron_auth_services_controller.process_patron_auth_services()
             eq_(response.status_code, 200)
+            eq_(mock_controller.validate_formats_call_count, 1)
 
         eq_(auth_service.id, int(response.response[0]))
         eq_(SimpleAuthenticationProvider.__module__, auth_service.protocol)

--- a/tests/admin/controller/test_patron_auth.py
+++ b/tests/admin/controller/test_patron_auth.py
@@ -273,7 +273,7 @@ class TestPatronAuth(SettingsControllerTest):
                 ("name", "some auth name"),
                 ("id", auth_service.id),
                 ("protocol", MilleniumPatronAPI.__module__),
-                (ExternalIntegration.URL, "url"),
+                (ExternalIntegration.URL, "http://url"),
                 (M.AUTHENTICATION_MODE, "Invalid mode"),
                 (M.VERIFY_CERTIFICATE, "true"),
             ] + common_args)


### PR DESCRIPTION
Validations weren't being run on the forms for creating/editing patron auth service; 1) the patron auth services controller wasn't calling the `validate_formats` method, and 2) the relevant settings weren't specifying what format the input should be in.  [JIRA ticket](https://jira.nypl.org/browse/SIMPLY-1885)