### PR TITLE
Look up zip codes when library form loads

### DIFF
--- a/api/admin/geographic_validator.py
+++ b/api/admin/geographic_validator.py
@@ -22,7 +22,21 @@ class GeographicValidator(Validator):
 
         us_search = uszipcode.SearchEngine(simple_zipcode=True)
         ca_search = PostalCodeDatabase()
-        CA_PROVINCES = ["AB", "BC", "MB", "NB", "NL", "NT", "NS", "NU", "ON", "PE", "QC", "SK", "YT"]
+        CA_PROVINCES = {
+            "AB": "Alberta",
+            "BC": "British Columbia",
+            "MB": "Manitoba",
+            "NB": "New Brunswick",
+            "NL": "Newfoundland and Labrador",
+            "NT": "Northwest Territories",
+            "NS": "Nova Scotia",
+            "NU": "Nunavut",
+            "ON": "Ontario",
+            "PE": "Prince Edward Island",
+            "QC": "Quebec",
+            "SK": "Saskatchewan",
+            "YT": "Yukon Territories"
+        }
 
         locations = {"US": [], "CA": []}
 
@@ -34,17 +48,25 @@ class GeographicValidator(Validator):
                 if len(value) == 2:
                     # Is it a US state or Canadian province abbreviation?
                     if value in CA_PROVINCES:
-                        locations["CA"].append(value)
+                        locations["CA"].append(CA_PROVINCES[value])
                     elif len(us_search.query(state=value)):
                         locations["US"].append(value)
                     else:
                         return UNKNOWN_LOCATION.detailed(_('"%(value)s" is not a valid U.S. state or Canadian province abbreviation.', value=value))
-                # elif len(value) == 3 and re.search("^[A-Za-z]\\d[A-Za-z]", value):
+                elif value in CA_PROVINCES.values():
+                    locations["CA"].append(value)
                 elif self.is_zip(value, "CA"):
                     # Is it a Canadian zipcode?
                     try:
-                        self.look_up_zip(value, "CA")
-                        locations["CA"].append(value);
+                        info = self.look_up_zip(value, "CA")
+                        formatted = "%s, %s" % (info.city, info.province)
+                        # In some cases--mainly involving very small towns--even if the zip code is valid,
+                        # the registry won't recognize the name of the place to which it corresponds.
+                        registry_response = self.find_location_through_registry(formatted, db)
+                        if registry_response:
+                            locations["CA"].append(formatted);
+                        else:
+                            return UNKNOWN_LOCATION.detailed(_('Unable to locate "%(value)s" (%(formatted)s).  Try entering the name of a larger area.', value=value, formatted=formatted))
                     except:
                         return UNKNOWN_LOCATION.detailed(_('"%(value)s" is not a valid Canadian zipcode.', value=value))
                 elif len(value.split(", ")) == 2:

--- a/api/admin/geographic_validator.py
+++ b/api/admin/geographic_validator.py
@@ -80,7 +80,7 @@ class GeographicValidator(Validator):
         if country == "US":
             return len(value) == 5 and value.isdigit()
         elif country == "CA":
-            return len(value) == 3 and re.search("^[A-Za-z]\\d[A-Za-z]", value)
+            return len(value) == 3 and bool(re.search("^[A-Za-z]\\d[A-Za-z]", value))
 
     def look_up_zip(self, zip, country, formatted=False):
         if country == "US":

--- a/api/admin/geographic_validator.py
+++ b/api/admin/geographic_validator.py
@@ -39,11 +39,12 @@ class GeographicValidator(Validator):
                         locations["US"].append(value)
                     else:
                         return UNKNOWN_LOCATION.detailed(_('"%(value)s" is not a valid U.S. state or Canadian province abbreviation.', value=value))
-                elif len(value) == 3 and re.search("^[A-Za-z]\\d[A-Za-z]", value):
+                # elif len(value) == 3 and re.search("^[A-Za-z]\\d[A-Za-z]", value):
+                elif self.is_zip(value, "CA"):
                     # Is it a Canadian zipcode?
                     try:
-                        info = ca_search[value]
-                        locations["CA"].append(self.format_place(value, info.city, info.province));
+                        self.look_up_zip(value, "CA")
+                        locations["CA"].append(value);
                     except:
                         return UNKNOWN_LOCATION.detailed(_('"%(value)s" is not a valid Canadian zipcode.', value=value))
                 elif len(value.split(", ")) == 2:
@@ -56,12 +57,12 @@ class GeographicValidator(Validator):
                     else:
                         # Flag this as needing to be checked with the registry
                         flagged = True
-                elif value.isdigit():
+                elif self.is_zip(value, "US"):
                     # Is it a US zipcode?
-                    info = us_search.by_zipcode(value)
+                    info = self.look_up_zip(value, "US")
                     if not info:
                         return UNKNOWN_LOCATION.detailed(_('"%(value)s" is not a valid U.S. zipcode.', value=value))
-                    locations["US"].append(self.format_place(value, info.major_city, info.state));
+                    locations["US"].append(value);
                 else:
                     flagged = True
 
@@ -73,12 +74,28 @@ class GeographicValidator(Validator):
                         locations[registry_response].append(value)
                     else:
                         return UNKNOWN_LOCATION.detailed(_('Unable to locate "%(value)s".', value=value))
-
         return json.dumps(locations)
 
+    def is_zip(self, value, country):
+        if country == "US":
+            return len(value) == 5 and value.isdigit()
+        elif country == "CA":
+            return len(value) == 3 and re.search("^[A-Za-z]\\d[A-Za-z]", value)
+
+    def look_up_zip(self, zip, country, formatted=False):
+        if country == "US":
+            info = uszipcode.SearchEngine(simple_zipcode=True).by_zipcode(zip)
+            if formatted:
+                info = self.format_place(zip, info.major_city, info.state)
+        elif country == "CA":
+            info = PostalCodeDatabase()[zip]
+            if formatted:
+                info = self.format_place(zip, info.city, info.province)
+        return info
+
     def format_place(self, zip, city, state_or_province):
-        info = "%s, %s" % (city, state_or_province)
-        return { zip: info }
+        details = "%s, %s" % (city, state_or_province)
+        return { zip: details }
 
     def find_location_through_registry(self, value, db):
         for nation in ["US", "CA"]:
@@ -109,4 +126,3 @@ class GeographicValidator(Validator):
                     return True
 
         return result
-    

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -9,6 +9,6 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-circulation-web": "0.2.0"
+    "simplified-circulation-web": "0.2.1"
   }
 }

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -240,7 +240,7 @@ class TestLibrarySettings(SettingsControllerTest):
                 (Configuration.WEBSITE_URL, "https://library.library/"),
                 (Configuration.TINY_COLLECTION_LANGUAGES, ['ger']),
                 (Configuration.LIBRARY_SERVICE_AREA, ['06759', 'everywhere', 'MD', 'Boston, MA']),
-                (Configuration.LIBRARY_FOCUS_AREA, ['V5K', 'Broward County, FL', 'QC']),
+                (Configuration.LIBRARY_FOCUS_AREA, ['Manitoba', 'Broward County, FL', 'QC']),
                 (Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, "email@example.com"),
                 (Configuration.HELP_EMAIL, "help@example.com"),
                 (Configuration.FEATURED_LANE_SIZE, "5"),
@@ -256,7 +256,6 @@ class TestLibrarySettings(SettingsControllerTest):
             ])
             validator = MockValidator()
             response = self.manager.admin_library_settings_controller.process_post(validator)
-
             eq_(response.status_code, 201)
 
         library = get_one(self._db, Library, short_name="nypl")
@@ -277,7 +276,7 @@ class TestLibrarySettings(SettingsControllerTest):
         eq_(validator.was_called, True)
         eq_('{"CA": [], "US": ["06759", "everywhere", "MD", "Boston, MA"]}',
             ConfigurationSetting.for_library(Configuration.LIBRARY_SERVICE_AREA, library).value)
-        eq_('{"CA": ["V5K", "QC"], "US": ["Broward County, FL"]}',
+        eq_('{"CA": ["Manitoba", "Quebec"], "US": ["Broward County, FL"]}',
             ConfigurationSetting.for_library(Configuration.LIBRARY_FOCUS_AREA, library).value)
 
         # When the library was created, default lanes were also created


### PR DESCRIPTION
Good news: we've gone back to storing geographical input in the right format, without sacrificing the hover functionality in the interface.

Bad news: apparently that wasn't the only problem.  Trying to update the library's registration is still throwing an error.  I will continue to investigate (possibly in a different branch). 
<img width="680" alt="Screen Shot 2019-05-02 at 4 35 43 PM" src="https://user-images.githubusercontent.com/42178216/57105290-6729e980-6cf8-11e9-8873-7e36e775b41c.png">
