### PR TITLE
Don't show a refresh metadata button if no metadata wrangler is configured.

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -901,10 +901,10 @@ class WorkController(AdminCirculationManagerController):
             return work
 
         if not provider and work.license_pools:
-            provider = MetadataWranglerCollectionRegistrar(work.license_pools[0].collection)
-
-        if not provider:
-            return METADATA_REFRESH_FAILURE
+            try:
+                provider = MetadataWranglerCollectionRegistrar(work.license_pools[0].collection)
+            except CannotLoadConfiguration:
+                return METADATA_REFRESH_FAILURE
 
         identifier = work.presentation_edition.primary_identifier
         try:

--- a/tests/admin/controller/test_controller.py
+++ b/tests/admin/controller/test_controller.py
@@ -969,6 +969,14 @@ class TestWorkController(AdminControllerTest):
             eq_(METADATA_REFRESH_FAILURE.status_code, response.status_code)
             eq_(METADATA_REFRESH_FAILURE.detail, response.detail)
 
+            # If we don't pass in a provider, it will also fail because there
+            # isn't one connfigured.
+            response = self.manager.admin_work_controller.refresh_metadata(
+                lp.identifier.type, lp.identifier.identifier
+            )
+            eq_(METADATA_REFRESH_FAILURE.status_code, response.status_code)
+            eq_(METADATA_REFRESH_FAILURE.detail, response.detail)
+
         self.admin.remove_role(AdminRole.LIBRARIAN, self._default_library)
         with self.request_context_with_library_and_admin("/"):
             assert_raises(AdminNotAuthorized,

--- a/tests/admin/test_opds.py
+++ b/tests/admin/test_opds.py
@@ -44,6 +44,30 @@ class TestOPDS(DatabaseTest):
         eq_(3, float(rating['schema:ratingvalue']))
         eq_(Measurement.RATING, rating['additionaltype'])
 
+    def test_feed_includes_refresh_link(self):
+        work = self._work(with_open_access_download=True)
+        lp = work.license_pools[0]
+        lp.suppressed = False
+        self._db.commit()
+
+        # If the metadata wrangler isn't configured, the link is left out.
+        feed = AcquisitionFeed(self._db, "test", "url", [work], AdminAnnotator(None, self._default_library, test_mode=True))
+        [entry] = feedparser.parse(unicode(feed))['entries']
+        eq_([],
+            [x for x in entry['links'] if x['rel'] == "http://librarysimplified.org/terms/rel/refresh"])
+
+        # If we configure a metadata wrangler integration, the link appears.
+        integration = self._external_integration(
+            ExternalIntegration.METADATA_WRANGLER,
+            goal=ExternalIntegration.METADATA_GOAL,
+            settings={ ExternalIntegration.URL: "http://metadata" },
+            password="pw")
+        integration.collections += [self._default_collection]
+        feed = AcquisitionFeed(self._db, "test", "url", [work], AdminAnnotator(None, self._default_library, test_mode=True))
+        [entry] = feedparser.parse(unicode(feed))['entries']
+        [refresh_link] = [x for x in entry['links'] if x['rel'] == "http://librarysimplified.org/terms/rel/refresh"]
+        assert lp.identifier.identifier in refresh_link["href"]
+
     def test_feed_includes_suppress_link(self):
         work = self._work(with_open_access_download=True)
         lp = work.license_pools[0]


### PR DESCRIPTION
This removes the "Refresh Metadata" button in the admin interface if the metadata wrangler is not configured, since it would just give an error anyway. That button is a bit misleading since librarians using it may not be aware of the metadata wrangler - it's not clear that it uses an external source. But that's a separate issue. I also added some test coverage.