### PR TITLE
Update RBDigital to store credentials based on collection.

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -32,6 +32,7 @@ from core.model import (
 )
 from util.patron import PatronUtility
 from config import Configuration
+import sys
 
 class CirculationInfo(object):
 
@@ -939,6 +940,7 @@ class CirculationAPI(object):
                 self.pin = pin
                 self.activity = None
                 self.exception = None
+                self.trace = None
                 super(PatronActivityThread, self).__init__()
 
             def run(self):
@@ -948,6 +950,7 @@ class CirculationAPI(object):
                         self.patron, self.pin)
                 except Exception, e:
                     self.exception = e
+                    self.trace = sys.exc_info()
                 after = time.time()
                 log.debug(
                     "Synced %s in %.2f sec", self.api.__class__.__name__,
@@ -974,7 +977,7 @@ class CirculationAPI(object):
                 self.log.error(
                     "%s errored out: %s", thread.api.__class__.__name__,
                     thread.exception,
-                    exc_info=thread.exception
+                    exc_info=thread.trace
                 )
             if thread.activity:
                 for i in thread.activity:

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -713,11 +713,12 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
 
         # Find or create the credential.
         _db = Session.object_session(patron)
+        collection = Collection.by_id(_db, id=self.collection_id)
         credential = Credential.lookup(
             _db, DataSource.RB_DIGITAL,
             Credential.IDENTIFIER_FROM_REMOTE_SERVICE,
             patron, refresh_credential,
-            collection=self.collection, allow_persistent_token=True
+            collection=collection, allow_persistent_token=True
         )
         return credential.credential
 

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -715,6 +715,11 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
             return credential
 
         # Find or create the credential.
+        # We use the DB session from the passed in patron object here
+        # because in the case we are in a thread the self._db session may be
+        # different from the session used for patron. By using the session
+        # from patron we make sure all the DB objects interacting with each
+        # other are from the same session.
         _db = Session.object_session(patron)
         collection = Collection.by_id(_db, id=self.collection_id)
         credential = Credential.lookup(

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -716,7 +716,8 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
         credential = Credential.lookup(
             _db, DataSource.RB_DIGITAL,
             Credential.IDENTIFIER_FROM_REMOTE_SERVICE,
-            patron, refresh_credential, allow_persistent_token=True
+            patron, refresh_credential,
+            collection=self.collection, allow_persistent_token=True
         )
         return credential.credential
 

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -711,7 +711,7 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
                 credential.credential = remote_identifier
                 credential.expires = None
             except CirculationException:
-                self.log.exception("Failed to create RBDigital User.")
+                self.log.exception("Failed to create RBDigital User. Collection: %s", self.collection.name)
             return credential
 
         # Find or create the credential.

--- a/migration/20190522-2-add-collection-to-rb-credentials.py
+++ b/migration/20190522-2-add-collection-to-rb-credentials.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.model import (
+    Credential,
+    Collection,
+    ExternalIntegration,
+    DataSource,
+    production_session
+)
+from api.rbdigital import RBDigitalAPI
+from sqlalchemy import update
+
+_db = production_session()
+
+def check_patron_id(api, patron):
+    url = "%s/libraries/%s/patrons/%s" % (api.base_url, api.library_id, patron)
+    response = api.request(url)
+    return response.status_code == 200
+
+# See if we have multiple RB Digital collections
+rb_digital_collections = _db.query(Collection.id)\
+    .select_from(ExternalIntegration)\
+    .join(ExternalIntegration.collections)\
+    .filter(ExternalIntegration.protocol == ExternalIntegration.RB_DIGITAL)\
+    .all()
+
+# We don't have to do any validation just update the credentials table
+if len(rb_digital_collections) == 1:
+    rb_collection_id = rb_digital_collections[0][0]
+    source = DataSource.lookup(_db, DataSource.RB_DIGITAL)
+    update(Credential)\
+        .where(
+            Credential.data_source_id == source.id,
+            Credential.type == Credential.IDENTIFIER_FROM_REMOTE_SERVICE
+        )\
+        .values(collection_id=rb_collection_id)
+
+# We have multiple RBDigital integration and we don't know which credential
+# belongs to each one. Have to check each credential against RBDigital API.
+else:
+    rb_api = []
+    for collection_id in rb_digital_collections:
+        collection = Collection.by_id(_db, collection_id[0])
+        rb_api.append(RBDigitalAPI(_db, collection))
+    source = DataSource.lookup(_db, DataSource.RB_DIGITAL)
+    credentials = _db.query(Credential)\
+        .filter(
+            Credential.data_source_id == source.id,
+            Credential.type == Credential.IDENTIFIER_FROM_REMOTE_SERVICE,
+            Credential.credential != None
+        )
+    for credential in credentials:
+        for api in rb_api:
+            if check_patron_id(api, credential.credential):
+                credential.collection = api.collection
+                break
+
+# Remove credentials stored with none as the credential
+source = DataSource.lookup(_db, DataSource.RB_DIGITAL)
+credential = _db.query(Credential)\
+    .filter(
+        Credential.data_source_id == source.id,
+        Credential.type == Credential.IDENTIFIER_FROM_REMOTE_SERVICE,
+        Credential.credential == None
+    ).first()
+_db.delete(credential)
+
+_db.commit()
+_db.close()


### PR DESCRIPTION
## JIRA Ticket
https://jira.nypl.org/browse/SIMPLY-1998

Depends on: 
https://github.com/NYPL-Simplified/server_core/pull/1063

## What does this Pull Request do?

In order to allow a single circulation manager to have multiple RBDigital collections we need to be able to store the credentials returned from RBDigital with the collection they belong to. This PR makes the RBDigital API store the credentials with the collection they came from.

## Problem Detail

Prior to this change library with access to two RBDigital collections were seeing errors like this in the logs when trying to log in: 
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 861, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/var/www/circulation/core/log.py", line 30, in format
    message = record.msg % record.args
  File "/var/www/circulation/core/model/datasource.py", line 92, in __repr__
    return '<DataSource: name="%s">' % (self.name)
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/attributes.py", line 242, in __get__
    return self.impl.get(instance_state(instance), dict_)
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/attributes.py", line 598, in get
    value = state._load_expired(state, passive)
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/state.py", line 608, in _load_expired
    self.manager.deferred_scalar_loader(self, toload)
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/loading.py", line 847, in load_scalar_attributes
    only_load_props=attribute_names)
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/loading.py", line 231, in load_on_ident
    return q.one()
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2837, in one
    ret = self.one_or_none()
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2807, in one_or_none
    ret = list(self)
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2878, in __iter__
    return self._execute_and_instances(context)
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2899, in _execute_and_instances
    close_with_result=True)
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2908, in _get_bind_args
    **kw
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2890, in _connection_from_session
    conn = self.session.connection(**kw)
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 1029, in connection
    execution_options=execution_options)
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 1034, in _connection_for_bind
    engine, execution_options)
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 382, in _connection_for_bind
    self._assert_active()
  File "/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 276, in _assert_active
    % self._rollback_exception
InvalidRequestError: This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "credentials_data_source_id_patron_id_type_key"
DETAIL:  Key (data_source_id, patron_id, type)=(2, 44, Identifier Received From Remote Service) already exists.
 [SQL: 'INSERT INTO credentials (data_source_id, patron_id, type, credential, expires) VALUES (%(data_source_id)s, %(patron_id)s, %(type)s, %(credential)s, %(expires)s) RETURNING credentials.id'] [parameters: {'patron_id': 44, 'expires': None, 'type': 'Identifier Received From Remote Service', 'data_source_id': 2, 'credential': None}] (Background on this error at: http://sqlalche.me/e/gkpj)
Logged from file __init__.py, line 124
{"host": "f419b5b3f56b", "name": "RBDigital Patron API", "level": "INFO", "timestamp": "2019-05-21T13:11:53.508931", "app": "simplified", "message": "patron_id call failed: Patron not found. ", "filename": "rbdigital.py"}
{"host": "f419b5b3f56b", "name": "root", "level": "ERROR", "timestamp": "2019-05-21T13:11:54.251197", "app": "simplified", "traceback": "Traceback (most recent call last):\n  File \"/var/www/circulation/core/app_server.py\", line 183, in handle\n    LogConfiguration.from_configuration(_db)\n  File \"/var/www/circulation/core/log.py\", line 465, in from_configuration\n    ConfigurationSetting.sitewide(_db, Configuration.LOG_LEVEL).value\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/ext/hybrid.py\", line 869, in __get__\n    return self.fget(instance)\n  File \"/var/www/circulation/core/model/configuration.py\", line 542, in value\n    if self._value:\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/attributes.py\", line 242, in __get__\n    return self.impl.get(instance_state(instance), dict_)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/attributes.py\", line 598, in get\n    value = state._load_expired(state, passive)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/state.py\", line 608, in _load_expired\n    self.manager.deferred_scalar_loader(self, toload)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/loading.py\", line 847, in load_scalar_attributes\n    only_load_props=attribute_names)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/loading.py\", line 231, in load_on_ident\n    return q.one()\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py\", line 2837, in one\n    ret = self.one_or_none()\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py\", line 2807, in one_or_none\n    ret = list(self)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py\", line 2878, in __iter__\n    return self._execute_and_instances(context)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py\", line 2899, in _execute_and_instances\n    close_with_result=True)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py\", line 2908, in _get_bind_args\n    **kw\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py\", line 2890, in _connection_from_session\n    conn = self.session.connection(**kw)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py\", line 1029, in connection\n    execution_options=execution_options)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py\", line 1034, in _connection_for_bind\n    engine, execution_options)\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py\", line 382, in _connection_for_bind\n    self._assert_active()\n  File \"/var/www/circulation/env/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py\", line 276, in _assert_active\n    % self._rollback_exception\nInvalidRequestError: This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint \"credentials_data_source_id_patron_id_type_key\"\nDETAIL:  Key (data_source_id, patron_id, type)=(2, 44, Identifier Received From Remote Service) already exists.\n [SQL: 'INSERT INTO credentials (data_source_id, patron_id, type, credential, expires) VALUES (%(data_source_id)s, %(patron_id)s, %(type)s, %(credential)s, %(expires)s) RETURNING credentials.id'] [parameters: {'patron_id': 44, 'expires': None, 'type': 'Identifier Received From Remote Service', 'data_source_id': 2, 'credential': None}] (Background on this error at: http://sqlalche.me/e/gkpj)", "message": "Exception in web app: This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint \"credentials_data_source_id_patron_id_type_key\"\nDETAIL:  Key (data_source_id, patron_id, type)=(2, 44, Identifier Received From Remote Service) already exists.\n [SQL: 'INSERT INTO credentials (data_source_id, patron_id, type, credential, expires) VALUES (%(data_source_id)s, %(patron_id)s, %(type)s, %(credential)s, %(expires)s) RETURNING credentials.id'] [parameters: {'patron_id': 44, 'expires': None, 'type': 'Identifier Received From Remote Service', 'data_source_id': 2, 'credential': None}] (Background on this error at: http://sqlalche.me/e/gkpj)", "filename": "app_server.py"}
```

## Interested parties
@leonardr