### PR TITLE
Deleting a custom lane whenever all its lists are deleted.

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1740,11 +1740,16 @@ class CustomListsController(AdminCirculationManagerController):
             # Build the list of affected lanes before modifying the
             # CustomList.
             affected_lanes = Lane.affected_by_customlist(list)
+            for lane in affected_lanes:
+                lane.update_size(self._db)
+                # There's only one custom list in the lane and it's going
+                # to be deleted.
+                if lane.size == 0 and len(lane._customlist_ids) == 1:
+                    self._db.delete(lane)
             for entry in list.entries:
                 self._db.delete(entry)
             self._db.delete(list)
-            for lane in affected_lanes:
-                lane.update_size(self._db)
+
             return Response(unicode(_("Deleted")), 200)
 
 

--- a/tests/admin/controller/test_controller.py
+++ b/tests/admin/controller/test_controller.py
@@ -2395,8 +2395,11 @@ class TestCustomListsController(AdminControllerTest):
 
         # This lane depends heavily on lists from this data source.
         lane = self._lane()
+        lane.display_name = "to be automatically removed"
         lane.list_datasource = list.data_source
+        lane.customlists.append(list)
         lane.size = 100
+        eq_(1, self._db.query(Lane).filter(Lane.display_name=="to be automatically removed").count())
 
         with self.request_context_with_library_and_admin("/", method="DELETE"):
             response = self.manager.admin_custom_lists_controller.custom_list(list.id)
@@ -2404,6 +2407,7 @@ class TestCustomListsController(AdminControllerTest):
 
             eq_(0, self._db.query(CustomList).count())
             eq_(0, self._db.query(CustomListEntry).count())
+            eq_(0, self._db.query(Lane).filter(Lane.display_name=="to be automatically removed").count())
 
         # The lane's estimate has been updated to reflect the removal
         # of a list from its data source.


### PR DESCRIPTION
Server-side fix for [SIMPLY-579](https://jira.nypl.org/browse/SIMPLY-579). Deleting a lane once all of its custom lists have been deleted.