### PR TITLE
Postgres 9.3 no longer works -- remove all references to it to start using 11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 sudo: required
 
-addons:
-  postgresql: "9.3"
-  apt:
-    packages:
-      - postgresql-contrib-9.3
-
 services:
   - postgresql
 


### PR DESCRIPTION
This branch removes code to install the 'contrib' APT package for Postgres 9.3. Version 9.3 is no longer supported by Travis, and removing this stanza seems to get us to version 11 instead with no problems.