### PR TITLE
Upgrade Travis postgres from 9.3 to 9.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: required
 
 addons:
-  postgresql: "9.3"
+  postgresql: "9.6"
   apt:
     packages:
-      - postgresql-contrib-9.3
+      - postgresql-contrib-9.6
 
 services:
   - postgresql


### PR DESCRIPTION
9.3 is no longer supported; this bumps Travis up to a version closer to what's used in production.