### PR TITLE
Remove materialized view from contributor lane generation

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1552,8 +1552,8 @@ class WorkController(CirculationManagerController):
         if not contributor_name:
             return NO_SUCH_LANE.detailed(_("No contributor provided"))
 
-        # contributor_name is probably a sort_name, but it could be a
-        # display_name. Pass it in for both fields and
+        # contributor_name is probably a display_name, but it could be a
+        # sort_name. Pass it in for both fields and
         # ContributorData.lookup() will do its best to figure it out.
         contributor = ContributorData.lookup(
             self._db, sort_name=contributor_name, display_name=contributor_name

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1053,70 +1053,63 @@ class SeriesLane(DynamicLane):
             kwargs['audiences'] = self.audience_key
         return self.ROUTE, kwargs
 
+class ContributorFacets(Facets):
 
-class ContributorLane(WorksFromDatabase):
+    def from_request(cls, library, config, get_argument, get_header, worklist,
+                     *args, **kwargs):
+        """Instantiate a Contributor from request information plus
+        the contributor associated with the given WorkList.
+        """
+        facets = super(ContributorFacets, cls).from_request(
+            library, config, get_argument, get_header, worklist, *args,
+            **kwargs
+        )
+        facets.contributor = worklist.contributor
+        return facets
+
+    def navigate(self, *args, **kwargs):
+        """Propagate the selected contributor to a new Facets object."""
+        facets = super(ContributorFacets, self).navigate(*args, **kwargs)
+        facets.contributor = self.contributor
+        return facets
+
+    def modify_search_filter(self, filter):
+        super(ContributorFacets, self).modify_search_filter(filter)
+        filter.author = self.contributor
+
+
+class ContributorLane(DynamicLane):
     """A lane of Works written by a particular contributor"""
 
     ROUTE = 'contributor'
     MAX_CACHE_AGE = 48*60*60    # 48 hours
 
-    def __init__(self, library, contributor_name,
+    def __init__(self, library, contributor,
                  parent=None, languages=None, audiences=None):
-        if not contributor_name:
-            raise ValueError("ContributorLane can't be created without contributor")
+        if not contributor:
+            raise ValueError(
+                "ContributorLane can't be created without contributor"
+            )
 
-        self.contributor_name = contributor_name
-        display_name = contributor_name
+        self.contributor = contributor
+        display_name = (
+            self.contributor.display_name or self.contributor.sort_name
+        )
         super(ContributorLane, self).initialize(
             library, display_name=display_name,
             audiences=audiences, languages=languages,
         )
         if parent:
             parent.append_child(self)
-        _db = Session.object_session(library)
-        self.contributors = _db.query(Contributor)\
-                .filter(or_(*self.contributor_name_clauses)).all()
 
     @property
     def url_arguments(self):
         kwargs = dict(
-            contributor_name=self.contributor_name,
+            contributor_id=self.contributor_id,
             languages=self.language_key,
             audiences=self.audience_key
         )
         return self.ROUTE, kwargs
-
-    @property
-    def contributor_name_clauses(self):
-        return [
-            Contributor.display_name==self.contributor_name,
-            Contributor.sort_name==self.contributor_name
-        ]
-
-    def apply_filters(self, _db, qu, facets, pagination, featured=False):
-        if not self.contributor_name:
-            return None
-
-        work_edition = aliased(Edition)
-        qu = qu.join(work_edition).join(work_edition.contributions)
-        qu = qu.join(Contribution.contributor)
-
-        # Run a number of queries against the Edition table based on the
-        # available contributor information: name, display name, id, viaf.
-        clauses = self.contributor_name_clauses
-
-        if self.contributors:
-            viafs = list(set([c.viaf for c in self.contributors if c.viaf]))
-            if len(viafs) == 1:
-                # If there's only one VIAF here, look for other
-                # Contributors that share it. This helps catch authors
-                # with pseudonyms.
-                clauses.append(Contributor.viaf==viafs[0])
-        or_clause = or_(*clauses)
-        qu = qu.filter(or_clause)
-
-        return super(ContributorLane, self).apply_filters(
-            _db, qu, facets, pagination, featured=featured)
 
 
 class CrawlableFacets(Facets):

--- a/api/opds.py
+++ b/api/opds.py
@@ -682,33 +682,6 @@ class LibraryAnnotator(CirculationManagerAnnotator):
                 )
             )
 
-    def contributor_tag(cls, work, edition, contribution, state):
-        """Create an <author> or <contributor> tag, then
-        add a link to a feed of books by that person.
-        """
-        tag = super(LibraryAnnotator, super).contributor_tag(
-            contribution, state
-        )
-        if tag is None:
-            return tag
-
-        contributor = contribution.contributor
-        languages, audiences = self.language_and_audience_key_from_work(work)
-        feed.add_link_to_entry(
-            tag,
-            rel='contributor',
-            type=OPDSFeed.ACQUISITION_FEED_TYPE,
-            title=contributor_name,
-            href=self.url_for(
-                'contributor',
-                contributor_id=contributor.id,
-                languages=languages,
-                audiences=audiences,
-                library_short_name=self.library.short_name,
-                _external=True
-            )
-        )
-
     @classmethod
     def related_books_available(cls, work, library):
         """:return: bool asserting whether related books might exist for
@@ -782,7 +755,6 @@ class LibraryAnnotator(CirculationManagerAnnotator):
                     _external=True
                 )
             )
-
 
     def add_series_link(self, work, feed, entry):
         series_tag = OPDSFeed.schema_('Series')

--- a/api/routes.py
+++ b/api/routes.py
@@ -374,14 +374,14 @@ def loan_or_hold_detail(identifier_type, identifier):
 def work():
     return app.manager.urn_lookup.work_lookup('work')
 
-@library_dir_route('/works/contributor/<contributor_id>', defaults=dict(languages=None, audiences=None))
-@library_dir_route('/works/contributor/<contributor_id>/<languages>', defaults=dict(audiences=None))
-@library_route('/works/contributor/<contributor_id>/<languages>/<audiences>')
+@library_dir_route('/works/contributor/<contributor_name>', defaults=dict(languages=None, audiences=None))
+@library_dir_route('/works/contributor/<contributor_name>/<languages>', defaults=dict(audiences=None))
+@library_route('/works/contributor/<contributor_name>/<languages>/<audiences>')
 @has_library
 @allows_patron_web
 @returns_problem_detail
-def contributor(contributor_id, languages, audiences):
-    return app.manager.work_controller.contributor(contributor_id, languages, audiences)
+def contributor(contributor_name, languages, audiences):
+    return app.manager.work_controller.contributor(contributor_name, languages, audiences)
 
 @library_dir_route('/works/series/<series_name>', defaults=dict(languages=None, audiences=None))
 @library_dir_route('/works/series/<series_name>/<languages>', defaults=dict(audiences=None))

--- a/api/routes.py
+++ b/api/routes.py
@@ -374,14 +374,14 @@ def loan_or_hold_detail(identifier_type, identifier):
 def work():
     return app.manager.urn_lookup.work_lookup('work')
 
-@library_dir_route('/works/contributor/<contributor_name>', defaults=dict(languages=None, audiences=None))
-@library_dir_route('/works/contributor/<contributor_name>/<languages>', defaults=dict(audiences=None))
-@library_route('/works/contributor/<contributor_name>/<languages>/<audiences>')
+@library_dir_route('/works/contributor/<contributor_id>', defaults=dict(languages=None, audiences=None))
+@library_dir_route('/works/contributor/<contributor_id>/<languages>', defaults=dict(audiences=None))
+@library_route('/works/contributor/<contributor_id>/<languages>/<audiences>')
 @has_library
 @allows_patron_web
 @returns_problem_detail
-def contributor(contributor_name, languages, audiences):
-    return app.manager.work_controller.contributor(contributor_name, languages, audiences)
+def contributor(contributor_id, languages, audiences):
+    return app.manager.work_controller.contributor(contributor_id, languages, audiences)
 
 @library_dir_route('/works/series/<series_name>', defaults=dict(languages=None, audiences=None))
 @library_dir_route('/works/series/<series_name>/<languages>', defaults=dict(audiences=None))

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -37,6 +37,8 @@ from api.controller import (
 )
 from api.lanes import (
     create_default_lanes,
+    ContributorFacets,
+    ContributorLane,
     SeriesFacets,
     SeriesLane,
 )
@@ -57,7 +59,10 @@ from core.external_search import (
     MockExternalSearchIndex,
     mock_search_index,
 )
-from core.metadata_layer import Metadata
+from core.metadata_layer import (
+    ContributorData,
+    Metadata,
+)
 from core import model
 from core.entrypoint import (
     EbooksEntryPoint,
@@ -2098,86 +2103,177 @@ class TestWorkController(CirculationControllerTest):
         self.identifier = self.lp.identifier
 
     def test_contributor(self):
-        # Give the Contributor a display_name.
+        m = self.manager.work_controller.contributor
+
+        # Find a real Contributor put in the system through the setup
+        # process.
         [contribution] = self.english_1.presentation_edition.contributions
-        contribution.contributor.display_name = u"John Bull"
+        contributor = contribution.contributor
 
-        # For works without a contributor name, a ProblemDetail is returned.
+        # No contributor name -> ProblemDetail
         with self.request_context_with_library('/'):
-            response = self.manager.work_controller.contributor('', None, None)
+            response = m('', None, None)
         eq_(404, response.status_code)
-        eq_("http://librarysimplified.org/terms/problem/unknown-lane", response.uri)
+        eq_(NO_SUCH_LANE.uri, response.uri)
+        eq_("No contributor provided", response.detail)
 
-        contributor = self.edition.contributions[0].contributor
-        contributor.display_name = name = 'John Bull'
-
-        # Similarly if the pagination data is bad.
-        with self.request_context_with_library('/?size=abc'):
-            response = self.manager.work_controller.contributor(name, None, None)
-            eq_(400, response.status_code)
-
-        # Or if the facet data is bad.
-        with self.request_context_with_library('/?order=nosuchorder'):
-            response = self.manager.work_controller.contributor(name, None, None)
-            eq_(400, response.status_code)
-
-        # If the work has a contributor, a feed is returned.
-        SessionManager.refresh_materialized_views(self._db)
+        # Unable to load ContributorData from contributor name ->
+        # ProblemDetail
         with self.request_context_with_library('/'):
-            response = self.manager.work_controller.contributor(name, None, None)
+            response = m('Unknown Author', None, None)
+        eq_(404, response.status_code)
+        eq_(NO_SUCH_LANE.uri, response.uri)
+        eq_("Unknown contributor: Unknown Author", response.detail)
 
+        contributor = contributor.sort_name
+
+        # Search index misconfiguration -> Problem detail
+        self.assert_bad_search_index_gives_problem_detail(
+            lambda: self.manager.work_controller.series(
+                contributor, None, None
+            )
+        )
+
+        # Bad facet data -> ProblemDetail
+        with self.request_context_with_library('/?order=nosuchorder'):
+            response = m(contributor, None, None)
+            eq_(400, response.status_code)
+            eq_(INVALID_INPUT.uri, response.uri)
+
+        # Bad pagination data -> ProblemDetail
+        with self.request_context_with_library('/?size=abc'):
+            response = m(contributor, None, None)
+            eq_(400, response.status_code)
+            eq_(INVALID_INPUT.uri, response.uri)
+
+        # Test an end-to-end success (not including a test that the
+        # search engine can actually find books by a given person --
+        # that's tested in core/tests/test_external_search.py).
+        with self.request_context_with_library('/'):
+            response = m(contributor, 'eng,spa', 'Children,Young Adult')
         eq_(200, response.status_code)
+        eq_(OPDSFeed.ACQUISITION_FEED_TYPE, response.headers['Content-Type'])
         feed = feedparser.parse(response.data)
-        eq_(name, feed['feed']['title'])
+
+        # The feed is named after the person we looked up.
+        eq_(contributor, feed['feed']['title'])
+
+        # It's got one entry -- the book added to the search engine
+        # during test setup.
         [entry] = feed['entries']
         eq_(self.english_1.title, entry['title'])
 
         # The feed has facet links.
         links = feed['feed']['links']
-        facet_links = [link for link in links if link['rel'] == 'http://opds-spec.org/facet']
+        facet_links = [link for link in links
+                       if link['rel'] == 'http://opds-spec.org/facet']
         eq_(9, len(facet_links))
 
-        another_work = self._work("Not open access", name, with_license_pool=True)
-        another_work.license_pools[0].open_access = False
-        duplicate_contributor = another_work.presentation_edition.contributions[0].contributor
-        duplicate_contributor.display_name = name
+        # The feed was cached.
+        cached = self._db.query(CachedFeed).one()
+        eq_(CachedFeed.CONTRIBUTOR_TYPE, cached.type)
+        eq_(
+            'Bull, John-eng,spa-Children,Young+Adult',
+            cached.unique_key
+        )
 
-        # Facets work.
-        SessionManager.refresh_materialized_views(self._db)
-        with self.request_context_with_library("/?order=title"):
-            response = self.manager.work_controller.contributor(name, None, None)
+        # At this point we don't want to generate real feeds anymore.
+        # We can't do a real end-to-end test without setting up a real
+        # search index, which is obnoxiously slow.
+        #
+        # Instead, we will mock AcquisitionFeed.page, and examine the objects
+        # passed into it under different mock requests.
+        #
+        # Those objects, such as ContributorLane and
+        # ContributorFacets, are tested elsewhere, in terms of their
+        # effects on search objects such as Filter. Those search
+        # objects are the things that are tested against a real search
+        # index (in core).
+        #
+        # We know from the previous test that any results returned
+        # from the search engine are converted into an OPDS feed. Now
+        # we verify that an incoming request results in the objects
+        # we'd expect to use to generate the feed for that request.
+        class Mock(object):
+            @classmethod
+            def page(cls, **kwargs):
+                self.called_with = kwargs
+                return "An OPDS feed"
 
+        # Test a basic request with custom faceting, pagination, and a
+        # language and audience restriction. This will exercise nearly
+        # all the functionality we need to check.
+        languages = "some languages"
+        audiences = "some audiences"
+        with self.request_context_with_library(
+            "/?order=title&size=100&after=20&entrypoint=Audio"
+        ):
+            response = m(contributor, languages, audiences, feed_class=Mock)
+
+        # We got a 200 response, where the data returned by the mock
+        # method is served as an OPDS feed.
         eq_(200, response.status_code)
-        feed = feedparser.parse(response.data)
-        eq_(2, len(feed['entries']))
+        eq_(OPDSFeed.ACQUISITION_FEED_TYPE, response.headers['content-type'])
+        eq_("An OPDS feed", response.data)
 
-        with self.request_context_with_library("/?available=always"):
-            response = self.manager.work_controller.contributor(name, None, None)
+        # Now check all the keyword arguments that were passed into
+        # page().
+        kwargs = self.called_with
 
-        eq_(200, response.status_code)
-        feed = feedparser.parse(response.data)
-        eq_(1, len(feed['entries']))
-        [entry] = feed['entries']
-        eq_(self.english_1.title, entry['title'])
+        eq_(self._db, kwargs.pop('_db'))
+        eq_(self.manager._external_search, kwargs.pop('search_engine'))
+        eq_(CachedFeed.CONTRIBUTOR_TYPE, kwargs.pop('cache_type'))
 
-        # Pagination works.
-        with self.request_context_with_library("/?size=1"):
-            response = self.manager.work_controller.contributor(name, None, None)
+        # The feed is named after the contributor the request asked
+        # about.
+        eq_(contributor, kwargs.pop('title'))
 
-        eq_(200, response.status_code)
-        feed = feedparser.parse(response.data)
-        eq_(1, len(feed['entries']))
-        [entry] = feed['entries']
-        eq_(another_work.title, entry['title'])
+        # Query string arguments were taken into account when
+        # creating the Facets and Pagination objects.
+        facets = kwargs.pop('facets')
+        assert isinstance(facets, ContributorFacets)
+        eq_(AudiobooksEntryPoint, facets.entrypoint)
+        eq_('title', facets.order)
+        pagination = kwargs.pop('pagination')
+        eq_(100, pagination.size)
+        eq_(20, pagination.offset)
 
-        with self.request_context_with_library("/?after=1"):
-            response = self.manager.work_controller.contributor(name, None, None)
+        lane = kwargs.pop('lane')
+        assert isinstance(lane, ContributorLane)
+        assert isinstance(lane.contributor, ContributorData)
 
-        eq_(200, response.status_code)
-        feed = feedparser.parse(response.data)
-        eq_(1, len(feed['entries']))
-        [entry] = feed['entries']
-        eq_(self.english_1.title, entry['title'])
+        # We don't know whether the incoming name is a sort name
+        # or a display name, so we ask ContributorData.lookup to
+        # try it both ways.
+        eq_(contributor, lane.contributor.sort_name)
+        eq_(contributor, lane.contributor.display_name)
+        eq_([languages], lane.languages)
+        eq_([audiences], lane.audiences)
+
+        # Checking the URL is difficult because it requires a request
+        # context, _plus_ the ContributorFacets, Pagination and Lane
+        # created during the original request.
+        library = self._default_library
+        route, url_kwargs = lane.url_arguments
+        url_kwargs.update(dict(facets.items()))
+        url_kwargs.update(dict(pagination.items()))
+        with self.request_context_with_library(""):
+            expect_url = self.manager.opds_feeds.url_for(
+                route, lane_identifier=None,
+                library_short_name=library.short_name,
+                **url_kwargs
+            )
+        eq_(kwargs.pop('url'), expect_url)
+
+        # The Annotator object was instantiated with the proper lane
+        # and the newly created Facets object.
+        annotator = kwargs.pop('annotator')
+        eq_(lane, annotator.lane)
+        eq_(facets, annotator.facets)
+
+        # No other arguments were passed into page().
+        eq_({}, kwargs)
+
 
     def test_permalink(self):
         with self.request_context_with_library("/"):
@@ -2591,8 +2687,8 @@ class TestWorkController(CirculationControllerTest):
         # We can't do a real end-to-end test without setting up a real
         # search index, which is obnoxiously slow.
         #
-        # Instead, we will mock OPDSFeed.page, and examine the objects
-        # passed into it under different mock requests.
+        # Instead, we will mock AcquisitionFeed.page, and examine the
+        # objects passed into it under different mock requests.
         #
         # Those objects, such as SeriesLane and SeriesFacets, are
         # tested elsewhere, in terms of their effects on search

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -1,6 +1,11 @@
 # encoding: utf-8
 from collections import Counter
-from nose.tools import set_trace, eq_, assert_raises
+from nose.tools import (
+    set_trace,
+    eq_,
+    assert_raises,
+    assert_raises_regexp,
+)
 import json
 import datetime
 
@@ -722,78 +727,55 @@ class TestContributorLane(LaneTest):
         )
 
     def test_initialization(self):
-        # An error is raised if ContributorLane is created without
-        # at least a name.
-        assert_raises(ValueError, ContributorLane, self._default_library, '')
-
-    def test_works_query(self):
-        # A work by someone else.
-        w1 = self._work(with_license_pool=True)
-
-        # A work by the contributor with the same name, without VIAF info.
-        w2 = self._work(title="X is for Xylophone", with_license_pool=True)
-        same_name = w2.presentation_edition.contributions[0].contributor
-        same_name.display_name = 'Lois Lane'
-        self._db.commit()
-        SessionManager.refresh_materialized_views(self._db)
-
-        # The work with a matching name is found in the contributor lane.
-        lane = ContributorLane(self._default_library, 'Lois Lane')
-        self.assert_works_queries(lane, [w2])
-
-        # And when we add some additional works, like:
-        # A work by the contributor.
-        w3 = self._work(title="A is for Apple", with_license_pool=True)
-        w3.presentation_edition.add_contributor(self.contributor, [Contributor.PRIMARY_AUTHOR_ROLE])
-
-        # A work by the contributor with VIAF info, writing with a pseudonym.
-        w4 = self._work(title="D is for Dinosaur", with_license_pool=True)
-        same_viaf, i = self._contributor('Lane, L', **dict(viaf='7'))
-        w4.presentation_edition.add_contributor(same_viaf, [Contributor.EDITOR_ROLE])
-        self._db.commit()
-        SessionManager.refresh_materialized_views(self._db)
-
-        # Those works are also included in the lane, in alphabetical order.
-        self.assert_works_queries(lane, [w3, w4, w2])
-
-        # If the lane is created with languages, works in other languages
-        # aren't included.
-        fre = self._work(with_license_pool=True, language='fre')
-        spa = self._work(with_license_pool=True, language='spa')
-        for work in [fre, spa]:
-            main_contribution = work.presentation_edition.contributions[0]
-            main_contribution.contributor = self.contributor
-        self._db.commit()
-        SessionManager.refresh_materialized_views(self._db)
-
-        lane = ContributorLane(self._default_library, 'Lois Lane', languages=['eng'])
-        self.assert_works_queries(lane, [w3, w4, w2])
-
-        lane.languages = ['fre', 'spa']
-        self.assert_works_queries(lane, [fre, spa])
-
-    def test_works_query_accounts_for_source_audience(self):
-        works = self.sample_works_for_each_audience()
-        [children, ya] = works[:2]
-
-        # Give them all the same contributor.
-        for work in works:
-            work.presentation_edition.contributions[0].contributor = self.contributor
-        self._db.commit()
-        SessionManager.refresh_materialized_views(self._db)
-
-        # Only childrens works are available in a ContributorLane with a
-        # Children audience source
-        children_lane = ContributorLane(
-            self._default_library, 'Lois Lane', audiences=[Classifier.AUDIENCE_CHILDREN]
+        assert_raises_regexp(
+            ValueError, 
+            "ContributorLane can't be created without contributor",
+            ContributorLane,
+            self._default_library,
+            None
         )
-        self.assert_works_queries(children_lane, [children])
 
-        # When more than one audience is requested, all are included.
-        ya_lane = ContributorLane(
-            self._default_library, 'Lois Lane', audiences=list(Classifier.AUDIENCES_JUVENILE)
+        parent = WorkList()
+        parent.initialize(self._default_library)
+
+        lane = ContributorLane(
+            self._default_library, self.contributor, parent,
+            languages=['a'], audiences=['b'],
         )
-        self.assert_works_queries(ya_lane, [children, ya])
+        eq_(self.contributor, lane.contributor)
+        eq_(['a'], lane.languages)
+        eq_(['b'], lane.audiences)
+        eq_([lane], parent.children)
+
+        # The contributor_key will be used in links to other pages
+        # of this Lane and so on.
+        eq_("Lois Lane", lane.contributor_key)
+
+        # If the contributor used to create a ContributorLane has no
+        # display name, their sort name is used as the
+        # contributor_key.
+        contributor = ContributorData(sort_name="Lane, Lois")
+        lane = ContributorLane(self._default_library, contributor)
+        eq_(contributor, lane.contributor)
+        eq_("Lane, Lois", lane.contributor_key)
+
+    def test_url_arguments(self):
+        lane = ContributorLane(
+            self._default_library, self.contributor,
+            languages=['eng', 'spa'], audiences=['Adult', 'Children'],
+        )
+        route, kwargs = lane.url_arguments
+        eq_(lane.ROUTE, route)
+
+        eq_(
+            dict(
+                contributor_name=lane.contributor_key,
+                languages='eng,spa',
+                audiences='Adult,Children'
+            ),
+            kwargs
+        )
+
 
 class TestCrawlableFacets(DatabaseTest):
 

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -379,9 +379,8 @@ class TestRelatedBooksLane(DatabaseTest):
         self.edition = self.work.presentation_edition
 
     def test_initialization(self):
-        """Asserts that a RelatedBooksLane won't be initialized for a work
-        without related books
-        """
+        # Asserts that a RelatedBooksLane won't be initialized for a work
+        # without related books
 
         # A book without a series or a contributor on a circ manager without
         # NoveList recommendations raises an error.
@@ -400,7 +399,7 @@ class TestRelatedBooksLane(DatabaseTest):
         eq_(self.work, result.work)
         [sublane] = result.children
         eq_(True, isinstance(sublane, ContributorLane))
-        eq_(sublane.contributors, [luthor])
+        eq_(sublane.contributor, luthor)
 
         # As does a book in a series.
         self.edition.series = "All By Myself"
@@ -449,7 +448,7 @@ class TestRelatedBooksLane(DatabaseTest):
         result = RelatedBooksLane(self._default_library, self.work, '')
         eq_(1, len(result.children))
         [sublane] = result.children
-        eq_([original], sublane.contributors)
+        eq_(original, sublane.contributor)
 
         # A book with multiple contributors results in multiple
         # ContributorLane sublanes.
@@ -458,7 +457,7 @@ class TestRelatedBooksLane(DatabaseTest):
         result = RelatedBooksLane(self._default_library, self.work, '')
         eq_(2, len(result.children))
         sublane_contributors = list()
-        [sublane_contributors.extend(c.contributors) for c in result.children]
+        [sublane_contributors.append(c.contributor) for c in result.children]
         eq_(set([lane, original]), set(sublane_contributors))
 
         # When there are no AUTHOR_ROLES present, contributors in
@@ -471,7 +470,7 @@ class TestRelatedBooksLane(DatabaseTest):
         result = RelatedBooksLane(self._default_library, self.work, '')
         eq_(1, len(result.children))
         [sublane] = result.children
-        eq_([luthor], sublane.contributors)
+        eq_(luthor, sublane.contributor)
 
     def test_works_query(self):
         """RelatedBooksLane is an invisible, groups lane without works."""

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -228,7 +228,11 @@ class TestLibraryAnnotator(VendorIDTest):
         self._default_library.library_registry_shared_secret = "s3cr3t5"
 
         # A ContributorLane to test code that handles it differently.
-        self.contributor_lane = ContributorLane(self._default_library, "Someone", languages=["eng"], audiences=None)
+        self.contributor, ignore = self._contributor("Someone")
+        self.contributor_lane = ContributorLane(
+            self._default_library, self.contributor, languages=["eng"],
+            audiences=None
+        )
 
     def test__hidden_content_types(self):
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -530,7 +530,7 @@ class TestLibraryAnnotator(VendorIDTest):
         self.annotator.lane = self.contributor_lane
         feed_url_contributor = self.annotator.feed_url(self.contributor_lane, dict(), dict())
         assert self.contributor_lane.ROUTE in feed_url_contributor
-        assert self.contributor_lane.contributor_name in feed_url_contributor
+        assert self.contributor_lane.contributor_key in feed_url_contributor
         assert self._default_library.name in feed_url_contributor
 
     def test_search_url(self):
@@ -555,7 +555,7 @@ class TestLibraryAnnotator(VendorIDTest):
         facet_url_contributor = self.annotator.facet_url(facets)
         assert "collection=main" in facet_url_contributor
         assert self.contributor_lane.ROUTE in facet_url_contributor
-        assert self.contributor_lane.contributor_name in facet_url_contributor
+        assert self.contributor_lane.contributor_key in facet_url_contributor
 
     def test_alternate_link_is_permalink(self):
         work = self._work(with_open_access_download=True)


### PR DESCRIPTION
Once I got the Elasticsearch part of this working and moved the "do your best to find this person" code [into core](https://github.com/NYPL-Simplified/server_core/pull/1076), this was basically the same as my SeriesLane code. There's a ContributorFacets which changes the search filter (this is clumsy and I'd like to refactor it if possible), a ContributorLane which manages the Lane configuration, and a controller method that ties everything together.