### PR TITLE
Bug fixes and minor improvements for ElasticSearch

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -803,9 +803,7 @@ class OPDSFeedController(CirculationManagerController):
         title = library.name
         lane = CrawlableCollectionBasedLane()
         lane.initialize(library)
-        return self._crawlable_feed(
-            library=library, title=title, url=url, lane=lane
-        )
+        return self._crawlable_feed(title=title, url=url, lane=lane)
 
     def crawlable_collection_feed(self, collection_name):
         """Build or retrieve a crawlable acquisition feed for the

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -971,13 +971,21 @@ class RecommendationLane(WorkBasedLane, DatabaseExclusiveWorkList):
         suitable for showing an overview of this WorkList in a grouped
         feed.
         """
-        # The faceting object doesn't matter much here, but it
-        # does need to be a DatabaseBackedFacets.
+        # We're looking up specific works in the database, so this
+        # must be a DatabaseBackedFacets.
+        #
+        # For most other WorkLists that implement overview_facets, the
+        # overview is a place to show a full picture of the library's
+        # holdings; those WorkLists set availability=AVAILABLE_ALL. But
+        # the purpose of the recommendation feed is to suggest books
+        # that can be borrowed immediately, so we set
+        # availability=AVAILABLE_NOW.
         #
         # TODO: It would be better to order works in the same order
         # they come from the recommendation engine.
         return DatabaseBackedFacets.default(
-            self.get_library(_db), entrypoint=facets.entrypoint,
+            self.get_library(_db), collection=facets.COLLECTION_FULL,
+            availability=facets.AVAILABLE_NOW, entrypoint=facets.entrypoint,
         )
 
     def modify_database_query_hook(self, _db, qu):
@@ -1047,7 +1055,8 @@ class SeriesLane(DynamicLane):
         be ordered by series position.
         """
         return SeriesFacets.default(
-            self.get_library(_db), entrypoint=facets.entrypoint
+            self.get_library(_db), collection=facets.COLLECTION_FULL,
+            availability=facets.AVAILABLE_ALL, entrypoint=facets.entrypoint,
         )
 
     def modify_search_filter_hook(self, filter):
@@ -1109,7 +1118,8 @@ class ContributorLane(DynamicLane):
         use in a grouped feed.
         """
         return ContributorFacets.default(
-            self.get_library(_db), entrypoint=facets.entrypoint
+            self.get_library(_db), collection=facets.COLLECTION_FULL,
+            availability=facets.AVAILABLE_ALL, entrypoint=facets.entrypoint,
         )
 
     def modify_search_filter_hook(self, filter):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -894,7 +894,7 @@ class RecommendationLane(WorkBasedLane, DatabaseExclusiveWorkList):
         # recommendations that were unavailable when the feed was
         # generated became available.
         #
-        # For now, it's better to look up all books and let people put
+        # For now, it's better to show all books and let people put
         # the unavailable ones on hold if they want.
         #
         # TODO: It would be better to order works in the same order

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -849,7 +849,10 @@ class RecommendationLane(WorkBasedLane, DatabaseExclusiveWorkList):
 
     DISPLAY_NAME = "Recommended Books"
     ROUTE = "recommendations"
-    MAX_CACHE_AGE = 7*24*60*60      # one week
+
+    # Cache for 24 hours -- would ideally be much longer but availability
+    # information goes stale.
+    MAX_CACHE_AGE = 24*60*60
     CACHED_FEED_TYPE = CachedFeed.RECOMMENDATIONS_TYPE
 
     def __init__(self, library, work, display_name=None,
@@ -934,7 +937,9 @@ class SeriesLane(DynamicLane):
     """A lane of Works in a particular series."""
 
     ROUTE = 'series'
-    MAX_CACHE_AGE = 96*60*60    # 96 hours
+    # Cache for 24 hours -- would ideally be longer but availability
+    # information goes stale.
+    MAX_CACHE_AGE = 24*60*60
     CACHED_FEED_TYPE = CachedFeed.SERIES_TYPE
 
     def __init__(self, library, series_name, parent=None, **kwargs):
@@ -992,7 +997,9 @@ class ContributorLane(DynamicLane):
     """A lane of Works written by a particular contributor"""
 
     ROUTE = 'contributor'
-    MAX_CACHE_AGE = 96*60*60    # 96 hours
+    # Cache for 24 hours -- would ideally be longer but availability
+    # information goes stale.
+    MAX_CACHE_AGE = 24*60*60
     CACHED_FEED_TYPE = CachedFeed.CONTRIBUTOR_TYPE
 
     def __init__(self, library, contributor,

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -884,18 +884,25 @@ class RecommendationLane(WorkBasedLane, DatabaseExclusiveWorkList):
         # We're looking up specific works in the database, so this
         # must be a DatabaseBackedFacets.
         #
-        # For most other WorkLists that implement overview_facets, the
-        # overview is a place to show a full picture of the library's
-        # holdings; those WorkLists set availability=AVAILABLE_ALL. But
-        # the purpose of the recommendation feed is to suggest books
-        # that can be borrowed immediately, so we set
-        # availability=AVAILABLE_NOW.
+        # TODO: Since the purpose of the recommendation feed is to
+        # suggest books that can be borrowed immediately, it would be
+        # better to set availability=AVAILABLE_NOW. However, this feed
+        # is cached for so long that we can't rely on the availability
+        # information staying accurate. It would be especially bad if
+        # people borrowed all of the recommendations that were
+        # available at the time this feed was generated, and then
+        # recommendations that were unavailable when the feed was
+        # generated became available.
+        #
+        # For now, it's better to look up all books and let people put
+        # the unavailable ones on hold if they want.
         #
         # TODO: It would be better to order works in the same order
-        # they come from the recommendation engine.
+        # they come from the recommendation engine, since presumably
+        # the best recommendations are in the front.
         return DatabaseBackedFacets.default(
             self.get_library(_db), collection=facets.COLLECTION_FULL,
-            availability=facets.AVAILABLE_NOW, entrypoint=facets.entrypoint,
+            availability=facets.AVAILABLE_ALL, entrypoint=facets.entrypoint,
         )
 
     def modify_database_query_hook(self, _db, qu):

--- a/api/opds.py
+++ b/api/opds.py
@@ -176,9 +176,28 @@ class CirculationManagerAnnotator(Annotator):
             yield lpdm
 
     def annotate_work_entry(self, work, active_license_pool, edition, identifier, feed, entry, updated=None):
+        # If ElasticSearch included a more accurate last_update_time,
+        # use it instead of Work.last_update_time
+        updated = work.last_update_time
+        if isinstance(work, WorkSearchResult):
+            # Elasticsearch puts this field in a list, but we've set it up
+            # so there will be at most one value.
+            last_updates = getattr(work._hit, 'last_update', [])
+            if last_updates:
+                # last_update is seconds-since epoch; convert to UTC datetime.
+                updated = datetime.datetime.utcfromtimestamp(last_updates[0])
+
+                # There's a chance that work.last_updated has been
+                # modified but the change hasn't made it to the search
+                # engine yet. Even then, we stick with the search
+                # engine value, because a sorted list is more
+                # important to the import process than an up-to-date
+                # 'last update' value.
+
         super(CirculationManagerAnnotator, self).annotate_work_entry(
             work, active_license_pool, edition, identifier, feed, entry, updated
         )
+
         active_loan = self.active_loans_by_work.get(work)
         active_hold = self.active_holds_by_work.get(work)
         active_fulfillment = self.active_fulfillments_by_work.get(work)
@@ -596,22 +615,6 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         return url
 
     def annotate_work_entry(self, work, active_license_pool, edition, identifier, feed, entry):
-        updated = work.last_update_time
-        if isinstance(work, WorkSearchResult):
-            # Elasticsearch puts this field in a list, but we've set it up
-            # so there will be at most one value.
-            last_updates = getattr(work._hit, 'last_update', [])
-            if last_updates:
-                # last_update is seconds-since epoch; convert to UTC datetime.
-                updated = datetime.datetime.utcfromtimestamp(last_updates[0])
-
-                # There's a chance that work.last_updated has been
-                # modified but the change hasn't made it to the search
-                # engine yet. Even then, we stick with the search
-                # engine value, because a sorted list is more
-                # important to the import process than an up-to-date
-                # 'last update' value.
-
         # Add a link for reporting problems.
         feed.add_link_to_entry(
             entry,

--- a/api/opds.py
+++ b/api/opds.py
@@ -197,7 +197,6 @@ class CirculationManagerAnnotator(Annotator):
         super(CirculationManagerAnnotator, self).annotate_work_entry(
             work, active_license_pool, edition, identifier, feed, entry, updated
         )
-
         active_loan = self.active_loans_by_work.get(work)
         active_hold = self.active_holds_by_work.get(work)
         active_fulfillment = self.active_fulfillments_by_work.get(work)

--- a/api/opds.py
+++ b/api/opds.py
@@ -629,7 +629,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         )
 
         super(LibraryAnnotator, self).annotate_work_entry(
-            work, active_license_pool, edition, identifier, feed, entry, updated
+            work, active_license_pool, edition, identifier, feed, entry
         )
 
         # Add a link to each author tag.

--- a/tests/admin/controller/test_sitewide_settings.py
+++ b/tests/admin/controller/test_sitewide_settings.py
@@ -24,11 +24,11 @@ class TestSitewideSettings(SettingsControllerTest):
 
             eq_([], settings)
             keys = [s.get("key") for s in all_settings]
-            assert AcquisitionFeed.GROUPED_MAX_AGE_POLICY in keys
-            assert AcquisitionFeed.NONGROUPED_MAX_AGE_POLICY in keys
+            assert Configuration.LOG_LEVEL in keys
+            assert Configuration.DATABASE_LOG_LEVEL in keys
             assert Configuration.SECRET_KEY in keys
 
-        ConfigurationSetting.sitewide(self._db, AcquisitionFeed.GROUPED_MAX_AGE_POLICY).value = 0
+        ConfigurationSetting.sitewide(self._db, Configuration.DATABASE_LOG_LEVEL).value = 'INFO'
         ConfigurationSetting.sitewide(self._db, Configuration.SECRET_KEY).value = "secret"
         self._db.flush()
 
@@ -39,11 +39,11 @@ class TestSitewideSettings(SettingsControllerTest):
 
             eq_(2, len(settings))
             settings_by_key = { s.get("key") : s.get("value") for s in settings }
-            eq_("0", settings_by_key.get(AcquisitionFeed.GROUPED_MAX_AGE_POLICY))
+            eq_("INFO", settings_by_key.get(Configuration.DATABASE_LOG_LEVEL))
             eq_("secret", settings_by_key.get(Configuration.SECRET_KEY))
             keys = [s.get("key") for s in all_settings]
-            assert AcquisitionFeed.GROUPED_MAX_AGE_POLICY in keys
-            assert AcquisitionFeed.NONGROUPED_MAX_AGE_POLICY in keys
+            assert Configuration.LOG_LEVEL in keys
+            assert Configuration.DATABASE_LOG_LEVEL in keys
             assert Configuration.SECRET_KEY in keys
 
             self.admin.remove_role(AdminRole.SYSTEM_ADMIN)
@@ -77,36 +77,36 @@ class TestSitewideSettings(SettingsControllerTest):
     def test_sitewide_settings_post_create(self):
         with self.request_context_with_admin("/", method="POST"):
             flask.request.form = MultiDict([
-                ("key", AcquisitionFeed.GROUPED_MAX_AGE_POLICY),
+                ("key", Configuration.DATABASE_LOG_LEVEL),
                 ("value", "10"),
             ])
             response = self.manager.admin_sitewide_configuration_settings_controller.process_post()
             eq_(response.status_code, 200)
 
         # The setting was created.
-        setting = ConfigurationSetting.sitewide(self._db, AcquisitionFeed.GROUPED_MAX_AGE_POLICY)
+        setting = ConfigurationSetting.sitewide(self._db, Configuration.DATABASE_LOG_LEVEL)
         eq_(setting.key, response.response[0])
         eq_("10", setting.value)
 
     def test_sitewide_settings_post_edit(self):
-        setting = ConfigurationSetting.sitewide(self._db, AcquisitionFeed.GROUPED_MAX_AGE_POLICY)
-        setting.value = "10"
+        setting = ConfigurationSetting.sitewide(self._db, Configuration.DATABASE_LOG_LEVEL)
+        setting.value = "WARN"
 
         with self.request_context_with_admin("/", method="POST"):
             flask.request.form = MultiDict([
-                ("key", AcquisitionFeed.GROUPED_MAX_AGE_POLICY),
-                ("value", "20"),
+                ("key", Configuration.DATABASE_LOG_LEVEL),
+                ("value", "ERROR"),
             ])
             response = self.manager.admin_sitewide_configuration_settings_controller.process_post()
             eq_(response.status_code, 200)
 
         # The setting was changed.
         eq_(setting.key, response.response[0])
-        eq_("20", setting.value)
+        eq_("ERROR", setting.value)
 
     def test_sitewide_setting_delete(self):
-        setting = ConfigurationSetting.sitewide(self._db, AcquisitionFeed.GROUPED_MAX_AGE_POLICY)
-        setting.value = "10"
+        setting = ConfigurationSetting.sitewide(self._db, Configuration.DATABASE_LOG_LEVEL)
+        setting.value = "WARN"
 
         with self.request_context_with_admin("/", method="DELETE"):
             self.admin.remove_role(AdminRole.SYSTEM_ADMIN)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3372,8 +3372,12 @@ class TestCrawlableFeed(CirculationControllerTest):
         """
         controller = self.manager.opds_feeds
         original = controller._crawlable_feed
-        def mock(**kwargs):
-            self._crawlable_feed_called_with = kwargs
+        def mock(title, url, lane, annotator=None,
+                 feed_class=AcquisitionFeed):
+            self._crawlable_feed_called_with = dict(
+                title=title, url=url, lane=lane, annotator=annotator,
+                feed_class=feed_class
+            )
             return "An OPDS feed."
         controller._crawlable_feed = mock
         yield
@@ -3400,8 +3404,9 @@ class TestCrawlableFeed(CirculationControllerTest):
         # Verify that _crawlable_feed was called with the right arguments.
         kwargs = self._crawlable_feed_called_with
         eq_(expect_url, kwargs.pop('url'))
-        eq_(library, kwargs.pop('library'))
         eq_(library.name, kwargs.pop('title'))
+        eq_(None, kwargs.pop('annotator'))
+        eq_(AcquisitionFeed, kwargs.pop('feed_class'))
 
         # A CrawlableCollectionBasedLane has been set up to show
         # everything in any of the requested library's collections.
@@ -3410,6 +3415,7 @@ class TestCrawlableFeed(CirculationControllerTest):
         eq_(library.id, lane.library_id)
         eq_([x.id for x in library.collections], lane.collection_ids)
         eq_({}, kwargs)
+
 
     def test_crawlable_collection_feed(self):
         # Test the creation of a crawlable feed for everything in
@@ -3512,6 +3518,8 @@ class TestCrawlableFeed(CirculationControllerTest):
         kwargs = self._crawlable_feed_called_with
         eq_(expect_url, kwargs.pop('url'))
         eq_(customlist.name, kwargs.pop('title'))
+        eq_(None, kwargs.pop('annotator'))
+        eq_(AcquisitionFeed, kwargs.pop('feed_class'))
 
         # A CrawlableCustomListBasedLane was created to fetch only
         # the works in the custom list.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3416,7 +3416,6 @@ class TestCrawlableFeed(CirculationControllerTest):
         eq_([x.id for x in library.collections], lane.collection_ids)
         eq_({}, kwargs)
 
-
     def test_crawlable_collection_feed(self):
         # Test the creation of a crawlable feed for everything in
         # a collection.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3078,8 +3078,6 @@ class TestFeedController(CirculationControllerTest):
         # full end-to-end test would require setting up a real search
         # index, so we're just going to test that groups() is called
         # properly.
-        ConfigurationSetting.sitewide(
-            self._db, AcquisitionFeed.GROUPED_MAX_AGE_POLICY).value = 10
         library = self._default_library
         library.setting(library.MINIMUM_FEATURED_QUALITY).value = 0.15
         library.setting(library.FEATURED_LANE_SIZE).value = 2

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -599,6 +599,8 @@ class TestRecommendationLane(LaneTest):
         )
         overview = lane.overview_facets(self._db, featured)
         assert isinstance(overview, DatabaseBackedFacets)
+        eq_(Facets.COLLECTION_FULL, overview.collection)
+        eq_(Facets.AVAILABLE_ALL, overview.availability)
         eq_(Facets.ORDER_AUTHOR, overview.order)
 
         # Entry point was preserved.
@@ -659,6 +661,8 @@ class TestSeriesLane(LaneTest):
         lane = SeriesLane(self._default_library, "Alrighty Then")
         overview = lane.overview_facets(self._db, featured)
         assert isinstance(overview, SeriesFacets)
+        eq_(Facets.COLLECTION_FULL, overview.collection)
+        eq_(Facets.AVAILABLE_ALL, overview.availability)
         eq_(Facets.ORDER_SERIES_POSITION, overview.order)
 
         # Entry point was preserved.
@@ -746,6 +750,8 @@ class TestContributorLane(LaneTest):
         lane = ContributorLane(self._default_library, self.contributor)
         overview = lane.overview_facets(self._db, featured)
         assert isinstance(overview, ContributorFacets)
+        eq_(Facets.COLLECTION_FULL, overview.collection)
+        eq_(Facets.AVAILABLE_ALL, overview.availability)
         eq_(Facets.ORDER_TITLE, overview.order)
 
         # Entry point was preserved.

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -234,9 +234,9 @@ class TestCirculationManagerAnnotator(DatabaseTest):
 
         # If the work passed in is a WorkSearchResult that indicates
         # the search index found a later 'update time', then the later
-        # time is used. This value isn't always present -- it's only calculated when the
-        # list is being _ordered_ by 'update time' -- otherwise it's
-        # too slow to bother.
+        # time is used. This value isn't always present -- it's only
+        # calculated when the list is being _ordered_ by 'update time'.
+        # Otherwise it's too slow to bother.
         class MockHit(object):
             def __init__(self, last_update):
                 # Store the time the way we get it from ElasticSearch --


### PR DESCRIPTION
I wrote a script that requested various special (non-Lane) OPDS feeds from a circ manager, parsed out the pagination and faceting links, and displayed that information along with the works in the feed and the information used to sort the work lists.

I ran this script against NYPL's QA circulation manager using the current (materialized view) code and using the new (ElasticSearch) code. Then I manually compared the outputs. While doing this I found some bugs and inconsistencies, most of which are resolved in this branch. (The main bug not yet resolved is https://jira.nypl.org/browse/SIMPLY-2087.)

Here are the inconsistencies that remain -- these are all situations where either the new code is better than the old code, or there's no way to get the functionality of the old code.

* All crawlable feeds are properly sorted by update time. (But because of this, generating those feeds is much slower.)

* Pages of crawlable feeds are twice as large as they used to be. (I bumped up the size to compensate for the slowness.)

* The portion of a contributor feed that shows up in the "related books" feed is now sorted by title. I can't tell how those books were sorted previously.

* The various "books like this one" feeds (contributor, series, recommendations, and "related books") now include books from the full collection and books that have a holds queue. I don't think it worked this way before. It's debatable whether we want to show books with a holds queue, but I think this makes sense -- especially given how long we cache these feeds -- and it's now very clear how to change this if we want.

* Recommendation feeds are no longer sortable by 'recently added', since that's only available for feeds that go through ElasticSearch.

* Series feeds now propagate entry point, like author and recommendation feeds; previously they didn't.

* On a series feed, 'series position' is the first facet in the facet group. Previously it was selected but not the first one in the group.

* Previously generic series feeds had an extra slash ("{controller}//{faceting info}") in their pagination/faceting URLs. That extra slash is still there for generic contributor feeds, and I can't figure out what the difference is, but it's not hurting anybody. By "generic feeds", I mean feeds for a series or contributor that don't also have a language or audience restriction. That makes me think it has something to do with the routing.
