### PR TITLE
Added missing shebang and made Python migration script executable.

### DIFF
--- a/bin/informational/overdrive-advantage-list
+++ b/bin/informational/overdrive-advantage-list
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+from nose.tools import set_trace
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from api.overdrive import OverdriveAdvantageAccountListScript
+OverdriveAdvantageAccountListScript().run()

--- a/migration/20190515-reformat-existing-geographic-data.py
+++ b/migration/20190515-reformat-existing-geographic-data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from nose.tools import set_trace
 from sqlalchemy.sql import *
 import json


### PR DESCRIPTION
This branch fixes a problem I found while migrating a real server to 2.3.5. The Python script isn't executable, which causes the migration script to fail.

I verified the fix by migrating a different server using this branch. The migration script ran without a problem.

I also added a script in bin/informational that was missing -- the script class was written but there was no file in `bin` to invoke it, so it was impossible to run.