### PR TITLE
Lane size is now calculated through search engine

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -951,7 +951,7 @@ class LanesController(AdminCirculationManagerController):
             for list in lane.customlists:
                 if list.id not in custom_list_ids:
                     lane.customlists.remove(list)
-            lane.update_size(self._db)
+            lane.update_size(self._db, self.search_engine)
 
             if is_new:
                 return Response(unicode(lane.id), 201)

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -774,7 +774,7 @@ class CustomListsController(AdminCirculationManagerController):
             # If this list was used to populate any lanes, those
             # lanes need to have their counts updated.
             for lane in Lane.affected_by_customlist(list):
-                lane.update_size(self._db)
+                lane.update_size(self._db, self.search_engine)
 
         new_collections = []
         for collection_id in collections:
@@ -863,7 +863,7 @@ class CustomListsController(AdminCirculationManagerController):
             # Update the size for any lanes affected by this
             # CustomList which _weren't_ deleted.
             for lane in surviving_lanes:
-                lane.update_size(self._db)
+                lane.update_size(self._db, self.search_engine)
             return Response(unicode(_("Deleted")), 200)
 
 

--- a/api/admin/controller/work_editor.py
+++ b/api/admin/controller/work_editor.py
@@ -961,7 +961,9 @@ class WorkController(AdminCirculationManagerController):
                         affected_lanes.add(lane)
 
             # If any list changes affected lanes, update their sizes.
+            # NOTE: This may not make a difference until the
+            # works are actually re-indexed.
             for lane in affected_lanes:
-                lane.update_size(self._db)
+                lane.update_size(self._db, self.search_engine)
 
             return Response(unicode(_("Success")), 200)

--- a/tests/admin/controller/test_work_editor.py
+++ b/tests/admin/controller/test_work_editor.py
@@ -1150,10 +1150,14 @@ class TestWorkController(AdminControllerTest):
         self.add_to_materialized_view([work])
         identifier = work.presentation_edition.primary_identifier
 
+        # Whenever the mocked search engine is asked how many
+        # works are in a Lane, it will say there are two.
+        self.controller.search_engine.docs = dict(id1="doc1", id2="doc2")
+
         # Create a Lane that depends on this CustomList for its membership.
         lane = self._lane()
         lane.customlists.append(list)
-        eq_(0, lane.size)
+        lane.size = 300
 
         # Add the list to the work.
         with self.request_context_with_library_and_admin("/", method="POST"):
@@ -1170,9 +1174,10 @@ class TestWorkController(AdminControllerTest):
             # Lane.size will not be updated until the work is
             # reindexed with its new list memebership and lane sizes
             # are recalculated.
-            eq_(0, lane.size)
+            eq_(2, lane.size)
 
-        # Now remove the list.
+        # Now remove the work from the list.
+        self.controller.search_engine.docs = dict(id1="doc1")
         with self.request_context_with_library_and_admin("/", method="POST"):
             flask.request.form = MultiDict([
                 ("lists", json.dumps([])),
@@ -1181,7 +1186,9 @@ class TestWorkController(AdminControllerTest):
         eq_(200, response.status_code)
         eq_(0, len(work.custom_list_entries))
         eq_(0, len(list.entries))
-        eq_(0, lane.size)
+
+        # The lane size was recalculated once again.
+        eq_(1, lane.size)
 
         # Add a list that didn't exist before.
         with self.request_context_with_library_and_admin("/", method="POST"):

--- a/tests/admin/controller/test_work_editor.py
+++ b/tests/admin/controller/test_work_editor.py
@@ -1167,10 +1167,10 @@ class TestWorkController(AdminControllerTest):
             eq_(list, work.custom_list_entries[0].customlist)
             eq_(True, work.custom_list_entries[0].featured)
 
-            # The lane's size will be updated once the materialized
-            # views are refreshed.
-            SessionManager.refresh_materialized_views(self._db)
-            eq_(1, lane.size)
+            # Lane.size will not be updated until the work is
+            # reindexed with its new list memebership and lane sizes
+            # are recalculated.
+            eq_(0, lane.size)
 
         # Now remove the list.
         with self.request_context_with_library_and_admin("/", method="POST"):


### PR DESCRIPTION
Dealing with fallout from the core branch that fixed https://jira.nypl.org/browse/SIMPLY-2088.

This branch changes the way controller code tells a lane to update its `.size`. Since this now happens through the search engine, the controller's `.search_engine` is passed in to `Lane.update_size`. As a side effect, this makes it easy to set up mocks to ensure that the size is updated.