### PR TITLE
Use update_availability instead of setting .licenses_owned directly.

### DIFF
--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -274,8 +274,10 @@ class OPDSForDistributorsImporter(OPDSImporter):
             OPDSForDistributorsImporter, self).update_work_for_edition(
                 *args, **kwargs
         )
-        pool.licenses_owned = 1
-        pool.licenses_available = 1
+        pool.update_availability(
+            new_licenses_owned=1, new_licenses_available=1,
+            new_licenses_reserved=0, new_patrons_in_hold_queue=0
+        )
         return pool, work
 
     @classmethod

--- a/tests/test_opds_for_distributors.py
+++ b/tests/test_opds_for_distributors.py
@@ -410,6 +410,7 @@ class TestOPDSForDistributorsImporter(DatabaseTest, BaseOPDSForDistributorsTest)
         # Each work has a license pool.
         [camelot_pool] = camelot.license_pools
         [southern_pool] = southern.license_pools
+        now = datetime.datetime.utcnow()
 
         for pool in [camelot_pool, southern_pool]:
             eq_(False, pool.open_access)
@@ -418,6 +419,7 @@ class TestOPDSForDistributorsImporter(DatabaseTest, BaseOPDSForDistributorsTest)
             eq_(DeliveryMechanism.BEARER_TOKEN, pool.delivery_mechanisms[0].delivery_mechanism.drm_scheme)
             eq_(1, pool.licenses_owned)
             eq_(1, pool.licenses_available)
+            assert (pool.work.last_update_time - now).total_seconds() <= 2
 
         [camelot_acquisition_link] = [l for l in camelot_pool.identifier.links
                                       if l.rel == Hyperlink.GENERIC_OPDS_ACQUISITION


### PR DESCRIPTION
This should complete https://jira.nypl.org/browse/SIMPLY-2122. It's the only place I could find where switching out the listeners in https://github.com/NYPL-Simplified/server_core/pull/1093 might make works stop being reindexed when their circulation data changes.