### PR TITLE
Update the search integration test now that we only support Elasticsearch 6

### DIFF
--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -22,8 +22,7 @@
 # unnecessarily. (e.g. the search for "dirtbike" checks for books
 # filed under certain subjects, not specific titles).
 #
-# To run the tests, put the URL to your Elasticsearch index in the
-# ES1_ELASTICSEARCH environment variable and run this command:
+# Run the tests with this command:
 #
 # $ nosetests integration_tests/test_search.py
 
@@ -45,6 +44,7 @@ from core.external_search import (
     ExternalSearchIndex,
     Filter
 )
+
 
 # A problem from the unit tests that we couldn't turn into a
 # real integration test.
@@ -69,7 +69,7 @@ class Searcher(object):
     def query(self, query, pagination):
         return self.index.query_works(
             query, filter=self.filter, pagination=pagination,
-            debug=True, return_raw_results=True
+            debug=True
         )
 
 
@@ -2310,17 +2310,8 @@ class TestAgeRangeRestriction(SearchTest):
         )
 
 
-ES6 = ('es6' in os.environ['VIRTUAL_ENV'])
-if ES6:
-    url = os.environ['ES6_ELASTICSEARCH']
-    index = "es6-test-v3"
-else:
-    url = os.environ['ES1_ELASTICSEARCH']
-    index = None
-
 _db = production_session()
 library = None
 
-index = ExternalSearchIndex(_db, url=url, works_index=index)
-index.works_alias = index
+index = ExternalSearchIndex(_db)
 SearchTest.searcher = Searcher(library, index)


### PR DESCRIPTION
This branch makes the changes necessary to make the integration_tests/test_search.py script run in the new system. Since all the ES servers I might test this script against are on ES6, there's no longer any need to accommodate an ES1 server, and no reason to go against any server than the one used by the site configuration.

I ran the tests and got 150 successes. That's slightly down from 155 when I ran this code against an ES6 index in October, before all of the ES6-specific work. We're now in a position to work on https://jira.nypl.org/browse/SIMPLY-569, which should bring those numbers up.