### PR TITLE
Improve instrumentation on search integration tests, update them, and add new ones

### DIFF
--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -2251,7 +2251,8 @@ class TestSeriesMatch(SearchTest):
         self.search("the hunger games", Common(series="The Hunger Games"))
 
     def test_hunger_games_misspelled(self):
-        self.search("The hinger games", Common(series="The Hunger Games"))
+        self.search("The hinger games",
+                    Common(series=re.compile("Hunger Games", re.I)))
 
     def test_mockingjay(self):
         self.search(
@@ -2635,6 +2636,7 @@ class TestAgeRangeRestriction(SearchTest):
             "chapter books", Common(target_age=(6, 10))
         )
 
+    @known_to_fail
     def test_chapter_books_misspelled_1(self):
         # NOTE: We don't do fuzzy matching on things that would become
         # filter terms. When this works, it's because of fuzzy title

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -563,12 +563,18 @@ class TestTitleMatch(SearchTest):
             ]
         )
 
-    def test_elision_filter(self):
-        # This tests the elision filter.
+    def test_possessives(self):
+        # Verify that possessives are stemmed.
         self.search(
-            "washington's war",
-            FirstMatch(title="George Washington's War")
+            "washington war",
+            AtLeastOne(title="George Washington's War")
         )
+
+        self.search(
+            "washingtons war",
+            AtLeastOne(title="George Washington's War")
+        )
+
 
     def test_it(self):
         # The book "It" is correctly prioritized over books whose titles contain

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -67,7 +67,7 @@ def known_to_fail(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         try:
-            return f(*args, **kwargs)
+            ignore = f(*args, **kwargs)
         except Exception, e:
             logging.debug("Expected this test to fail, and it did: %r" % e)
             return
@@ -699,65 +699,62 @@ class TestUnownedTitle(SearchTest):
 class TestMisspelledTitleSearch(SearchTest):
     # Test title searches where the title is misspelled.
 
-    def test_allegiant_misspelled(self):
+    @known_to_fail
+    def test_allegiant(self):
         # A very bad misspelling.
         self.search(
             "alliagent",
             FirstMatch(title="Allegiant")
         )
 
-    def test_misspelled_title_match_marriage(self):
-        # NOTE: fails on both versions.  The first result is "The Marriage Contract,"
-        # and "The Marriage Lie" (which is presumably what the user wanted, and
-        # which is in the collection) isn't even in the top ten.
+    @known_to_fail
+    def test_marriage_lie(self):
+        # NOTE: "The Marriage Lie" (which is presumably what the user
+        # wanted, and which is in the collection) isn't on the first
+        # page of results.
         self.search(
             "Marriage liez",
             FirstMatch(title="The Marriage Lie")
         )
 
-    def test_misspelled_title_match_emmie(self):
-        # NOTE: this currently fails in both versions of ES.
-        # The target title does appear in the top search results,
-        # but it's not first.
-
-        # One word in the title is slightly misspelled.
+    @known_to_fail
+    def test_invisible_emmie(self):
+        # One word in the title is slightly misspelled. This makes
+        # "Emmy & Oliver" show up before the correct title match, which
+        # isn't too bad.
         self.search(
-            "Ivisible emmie",
-            FirstMatch(title="Invisible Emmie")
+            "Ivisible emmie", FirstMatch(title="Invisible Emmie")
         )
 
-    def test_misspelled_title_match_karamazov(self):
-        # NOTE: this works on ES1 but fails on ES6; not only is the target title
-        # not the first result in ES6, it's not any of the top results.  Fixing
-        # the typo makes it work.
-
+    @known_to_fail
+    def test_karamazov(self):
         # Extremely uncommon proper noun, slightly misspelled
+        #
+        # The desired book does not show up in the first page --
+        # it's all books called "Brothers".
         self.search(
             "Brothers karamzov",
             FirstMatch(title="The Brothers Karamazov")
         )
 
-    def test_misspelled_title_match_wave(self):
-        # NOTE: this currently fails in both versions of ES; the target book is
-        # result #4.  Fixing the typo fixes the search results.
-
+    def test_restless_wave(self):
         # One common word in the title is slightly misspelled.
         self.search(
             "He restless wave",
             FirstMatch(title="The Restless Wave")
         )
 
-    def test_misspelled_title_match_kingdom(self):
-        # NOTE: this works in ES1, but not in ES6!  In ES6, the target title is not
-        # in the top search results.
-
+    @known_to_fail
+    def test_kingdom_of_the_blind(self):
         # The first word, which is a fairly common word, is slightly misspelled.
+        #
+        # The desired book is not on the first page.
         self.search(
             "Kngdom of the blind",
             FirstMatch(title="The Kingdom of the Blind")
         )
 
-    def test_misspelled_title_match_husbands(self):
+    def test_seven_husbands(self):
         # Two words--1) a common word which is spelled as a different word
         # ("if" instead of "of"), and 2) a proper noun--are misspelled.
         self.search(
@@ -765,10 +762,10 @@ class TestMisspelledTitleSearch(SearchTest):
             FirstMatch(title="The Seven Husbands of Evelyn Hugo")
         )
 
-    def test_misspelled_title_match_nightingale(self):
-        # NOTE: this fails in both versions of ES, but the top ES1 results are reasonable
-        # (titles containing "nightfall"), whereas the top ES6 result is entitled
-        # "Modern Warfare, Intelligence, and Deterrence."
+    @known_to_fail
+    def test_nightingale(self):
+        # The top results are works like "Modern Warfare, Intelligence,
+        # and Deterrence."
 
         # Unusual word, misspelled
         self.search(
@@ -776,68 +773,62 @@ class TestMisspelledTitleSearch(SearchTest):
             FirstMatch(title="The Nightingale")
         )
 
-    def test_misspelled_title_match_geisha(self):
-        # NOTE: this currently fails in both versions of ES.
+    @known_to_fail
+    def test_memoirs_geisha(self):
+        # The desired work shows up on the first page, but it should
+        # be first.
         self.search(
             "Memoire of a ghesia",
             FirstMatch(title="Memoirs of a Geisha")
         )
 
-    def test_misspelled_title_match_healthyish(self):
-        # The title is not a real word, and is misspelled.
+    def test_healthyish(self):
+        # Misspelling of the title, which is a neologism.
         self.search(
-            "healtylish",
-            FirstMatch(title="Healthyish")
+            "healtylish", FirstMatch(title="Healthyish")
         )
 
-    def test_misspelled_title_match_zodiac(self):
+    def test_zodiac(self):
         # Uncommon word, slightly misspelled.
         self.search(
-            "Zodiaf",
-            FirstMatch(title="Zodiac")
+            "Zodiaf", FirstMatch(title="Zodiac")
         )
 
-    def test_misspelled_title_match_bell(self):
-        # One word, which is a relatively common word, is spelled as a different word.
+    def test_for_whom_the_bell_tolls(self):
+        # A relatively common word is spelled as a different, more common word.
         self.search(
             "For whom the bell tools",
             FirstMatch(title="For Whom the Bell Tolls")
         )
 
-    def test_misspelled_title_match_baghdad(self):
-        # One word, which is an extremely common word, is spelled as a different word.
+    @known_to_fail
+    def test_came_to_baghdad(self):
+        # An extremely common word is spelled as a different word.
         self.search(
             "They cane to baghdad",
             FirstMatch(title="They Came To Baghdad")
         )
 
-    def test_misspelled_title_match_genghis(self):
-        # NOTE: this doesn't work.  The collection definitely contains books with
-        # "Genghis Khan" in the title, but all of the top search results are books
-        # by authors with the last name "Khan."
-
+    def test_genghis_khan(self):
         self.search(
             "Ghangiz Khan",
-            AtLeastOne(title=re.compile("Genghis Khan"))
+            AtLeastOne(title=re.compile("Genghis Khan", re.I))
         )
 
-    def test_misspelled_title_match_guernsey(self):
-        # NOTE: this works in ES6 but not in ES1.  ES1 fixes the typo, but
-        # doesn't seem able to handle converting the "and" into an ampersand.
-
+    def test_guernsey(self):
         # One word, which is a place name, is misspelled.
         self.search(
             "The gurnsey literary and potato peel society",
             FirstMatch(title="The Guernsey Literary & Potato Peel Society")
         )
 
+    @known_to_fail
     def test_british_spelling_color_of_our_sky(self):
-        # NOTE: fails on both.  In ES1, the target book is the 3rd result; in
-        # ES6, it's nowhere in the top results.
+        # The book we're looking for is on the first page, but
+        # below "The Weight of Our Sky"
         #
         # Note to pedants: the title of the book as published is
         # "The Color of Our Sky".
-
         self.search(
             "The colour of our sky",
             FirstMatch(title="The Color of Our Sky")

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -838,6 +838,7 @@ class TestMisspelledTitleSearch(SearchTest):
 class TestPartialTitleSearch(SearchTest):
     # Test title searches where only part of the title is provided.
 
+    @known_to_fail
     def test_i_funnyest(self):
         # An important word from the middle of the title is omitted.
         self.search(
@@ -845,36 +846,39 @@ class TestPartialTitleSearch(SearchTest):
             AtLeastOne(title="I Totally Funniest"),
         )
 
-    def test_partial_title_match_home(self):
+    def test_future_home(self):
         # The search query only contains half of the title.
         self.search(
             "Future home of",
             FirstMatch(title="Future Home Of the Living God")
         )
 
-    def test_partial_title_match_supervision(self):
-        # NOTE: works on ES1, fails on ES6; it's the second title rather than
-        # the first in ES6.
-
+    def test_fundamentals_of_supervision(self):
         # A word from the middle of the title is missing.
-
-        # I think they might be searching for a different book
-        # we don't have. - LR
         self.search(
             "fundamentals of supervision",
             FirstMatch(title="Fundamentals of Library Supervision")
         )
 
-    def test_partial_title_match_hurin(self):
-        # Successfully searches "Húrin" (even though that's not a real word, and
-        # the query didn't have the accent mark) before trying to correct it.
-        self.search(
-            "Hurin",
-            FirstMatch(author=re.compile("tolkien"))
-        )
+    def test_hurin(self):
+        # A single word is so unusual that it can identify the book
+        # we're looking for.
+        for query in (
+            "Hurin", u"Húrin"
+        ):
+            self.search(
+                query,
+                FirstMatch(
+                    title=u"The Children of Húrin", author=re.compile("tolkien")
+                )
+            )
 
-    def test_partial_title_match_open_wide(self):
+    @known_to_fail
+    def test_open_wide(self):
         # Search query cuts off midway through the second word of the subtitle.
+        #
+        # The book we're looking for is on the first page, but underneath two
+        # other books called "open wide" or "wide open".
         self.search(
             "Open wide a radical",
             FirstMatch(
@@ -883,39 +887,36 @@ class TestPartialTitleSearch(SearchTest):
             )
         )
 
-    def test_partial_title_match_friends(self):
+    def test_how_to_win_friends(self):
         # The search query only contains half of the title.
         self.search(
             "How to win friends",
             FirstMatch(title="How to Win Friends and Influence People")
         )
 
-    def test_partial_title_match_face_1(self):
+    def test_wash_your_face_1(self):
         # The search query is missing the last word of the title.
         self.search(
             "Girl wash your",
             FirstMatch(title="Girl, Wash Your Face")
         )
 
-    def test_partial_title_match_face_2(self):
+    def test_wash_your_face_2(self):
         # The search query is missing the first word of the title.
         self.search(
             "Wash your face",
             FirstMatch(title="Girl, Wash Your Face")
         )
 
-    def test_partial_title_match_theresa(self):
+    def test_theresa(self):
         # The search results correctly prioritize books with titles containing
         # "Theresa" over books by authors with the first name "Theresa."
         self.search(
             "Theresa",
-            FirstMatch(title="Theresa Raquin")
+            FirstMatch(title=re.compile("Theresa"))
         )
 
-    def test_misspelled_partial_title_match_brodie(self):
-      # NOTE: this works in ES1, but not in ES6!  In ES6, the target title is in
-      # the top search results, but is not first.
-
+    def test_prime_of_miss_jean_brodie(self):
       # The search query only has the first and last words from the title, and
       # the last word is misspelled.
       self.search(

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -1180,7 +1180,9 @@ class TestMixedTitleAuthorMatch(SearchTest):
 class TestTheHateUGive(VariantSearchTest):
     """Test various ways of searching for "The Hate U Give"."""
 
-    EVALUATOR = FirstMatch(title="The Hate U Give")
+    # We check the start of the title because for some reason we have
+    # a copy of the book that includes the author's name in the title.
+    EVALUATOR = FirstMatch(title=re.compile("^The Hate U Give", re.I))
 
     def test_correct_spelling(self):
         self.search("the hate u give")
@@ -1194,6 +1196,7 @@ class TestTheHateUGive(VariantSearchTest):
     def test_with_you(self):
         self.search("hate you give")
 
+    @known_to_fail
     def test_with_you_misspelled(self):
         self.search("hate you gove")
 
@@ -1206,14 +1209,24 @@ class TestCharlottesWeb(VariantSearchTest):
     def test_with_apostrophe(self):
         self.search("charlotte's web")
 
+    def test_without_possessive(self):
+        self.search("charlotte web")
+
     def test_without_apostrophe(self):
         self.search("charlottes web")
 
+    @known_to_fail
     def test_misspelled_no_apostrophe(self):
         self.search("charlettes web")
 
     def test_no_apostrophe_with_author(self):
         self.search("charlottes web eb white")
+
+    @known_to_fail
+    def test_no_apostrophe_with_author_space(self):
+        # NOTE: This promotes several other E. B. White titles
+        # over "Charlotte's Web".
+        self.search("charlottes web e b white")
 
 
 class TestChristopherMouse(VariantSearchTest):
@@ -1247,8 +1260,7 @@ class TestSubtitleMatch(SearchTest):
 
     def test_shame_stereotypes(self):
         # "Sister Citizen" has both search terms in its
-        # subtitle. "Posess" has 'shamed' in its subtitle but does not
-        # match 'stereotype' at all.
+        # subtitle.
         self.search(
             "shame stereotypes", FirstMatch(title="Sister Citizen")
         )

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -663,9 +663,7 @@ class TestUnownedTitle(SearchTest):
         # should still be reasonably relevant.
         self.search(
             "Patterns of fashion", [
-                AtLeastOne(subject=re.compile("crafts")),
-                Common(title=re.compile("(pattern|fashion)"),
-                       first_must_match=False)
+                Common(subject=re.compile("crafts"), first_must_match=False),
             ]
         )
 
@@ -1724,13 +1722,13 @@ class TestGenreMatch(SearchTest):
         )
 
     def test_spy(self):
-        # NOTE: Results are dominated by title matches, which is
-        # probably fine, since people don't really think of "Spy" as a
-        # genre, and people who do type in "spy" looking for spy books
-        # will find them.
+        # Results are dominated by title matches, which is probably
+        # fine, since people don't really think of "Spy" as a genre,
+        # and people who do type in "spy" looking for spy books will
+        # find them.
         self.search(
             "Spy",
-            Common(genre=re.compile("(espionage|history|crime|thriller)"))
+            Common(title=re.compile("(spy|spies)", re.I))
         )
 
     def test_espionage(self):

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -811,8 +811,6 @@ class TestMisspelledTitleSearch(SearchTest):
 
     def test_kingdom_of_the_blind(self):
         # The first word, which is a fairly common word, is slightly misspelled.
-        #
-        # The desired book is not on the first page.
         self.search(
             "Kngdom of the blind",
             FirstMatch(title="Kingdom of the Blind")
@@ -1189,7 +1187,7 @@ class TestMixedTitleAuthorMatch(SearchTest):
         )
 
     def test_grisham(self):
-        # Full title, author's first name only
+        # Full title, author name misspelled
         self.search(
             "The reckoning john grisham",
             FirstMatch(title="The Reckoning", author="John Grisham")
@@ -1477,9 +1475,6 @@ class TestAuthorMatch(SearchTest):
 
     def test_griffiths(self):
         # The search query gives the author's sort name.
-        #
-        # The first two matches are for "Doom of the Griffiths" by
-        # Elizabeth Gaskell and "Ellis Island" by Kate Kerrigan.
         self.search(
             "Griffiths elly", SpecificAuthor("Elly Griffiths")
         )
@@ -1503,7 +1498,9 @@ class TestAuthorMatch(SearchTest):
         )
 
     def test_steve_berry(self):
-        # This search has been difficult in the past.
+        # This search looks like nothing special but it has been
+        # difficult in the past, possibly because "berry" is an
+        # English word.
         self.search("steve berry", Common(author="Steve Berry"))
 
     @known_to_fail
@@ -2370,7 +2367,6 @@ class TestSeriesMatch(SearchTest):
         )
 
     def test_goosebumps_misspelled(self):
-        # NOTE: This gets no results at all.
         self.search(
             "goosebump", 
             SpecificSeries(
@@ -2414,9 +2410,6 @@ class TestSeriesMatch(SearchTest):
         )
 
     def test_i_funny(self):
-        # Although we get good results, we need to use an author match
-        # to verify them. Many of the results don't have .series set
-        # and match due to a partial title match.
         self.search(
             "i funny",
             SpecificSeries(series="I, Funny", author="Chris Grabenstein"),
@@ -2463,8 +2456,8 @@ class TestSeriesMatch(SearchTest):
         # These children's biographies don't have .series set but
         # are clearly part of a series.
         #
-        # Because those books don't have .series set, the matches are
-        # done solely through title, so unrelated books like "Who Is
+        # Because those books don't have .series set, the matches
+        # happen solely through title, so unrelated books like "Who Is
         # Rich?" appear to be part of the series.
         self.search("who is", SpecificSeries(series="Who Is"))
 
@@ -2510,7 +2503,7 @@ class TestSeriesTitleMatch(SearchTest):
         # The first result is the requested title. Other results
         # are from the same series.
         #
-        # NOTE: The title match is too powerful -- "Wimpy Kid Movie Diary"
+        # NOTE: The title match is too powerful -- "Wimpy Kid"
         # overrides "Dog Days"
         self.search(
             "dairy of the wimpy kid dog days",
@@ -2746,10 +2739,11 @@ class TestAwardSearch(SearchTest):
         self.search(
             "staff picks",
             [
-                Uncommon(author=re.compile("staff|picks")),
-                Uncommon(title=re.compile("staff|picks"))
+                Uncommon(author=re.compile("(staff|picks)")),
+                Uncommon(title=re.compile("(staff|picks)"))
             ]
         )
+
 
 class TestCharacterMatch(SearchTest):
     # These searches are best understood as an attempt to find books

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -687,6 +687,19 @@ class TestUnownedTitle(SearchTest):
             ]
         )
 
+    def test_title_match_with_genre_name(self):
+        # This book is unowned and its title includes a genre name.
+        # We're going to get a lot of books with "life" or "spy" in
+        # the title.
+        #
+        # The first result is a book that fills the intent of the
+        # search query but doesn't say "spy" anywhere.
+        self.search(
+            "My life as a spy",
+            Common(title=re.compile("life|spy"), first_must_match=False,
+                   threshold=0.9)
+        )
+
     @known_to_fail
     def test_nonexistent_title_tower(self):
         # NOTE: there is no book with this title.  The most likely
@@ -929,9 +942,14 @@ class TestTitleGenreConflict(SearchTest):
     # These tests address a longstanding problem of books whose titles
     # contain the names of genres.
 
+    @known_to_fail
     def test_drama(self):
         # The title of the book is the name of a genre, and another
         # genre has been added to the search term to clarify it.
+        #
+        # NOTE: This probably fails because "Drama" is parsed as a
+        # genre name but "comic" is not parsed as "Comics & Graphic
+        # Novels"
         self.search(
             "drama comic",
             FirstMatch(title="Drama", author="Raina Telgemeier")
@@ -943,7 +961,6 @@ class TestTitleGenreConflict(SearchTest):
         self.search(
             "modern romance", FirstMatch(title="Modern Romance")
         )
-
 
     def test_modern_romance_with_author(self):
         self.search(
@@ -957,8 +974,12 @@ class TestTitleGenreConflict(SearchTest):
             FirstMatch(title="Law of the Mountain Man")
         )
 
-
+    @known_to_fail
     def test_law_of_the_mountain_man_with_author(self):
+        # "Law of the Mountain Man" is the second result, but it
+        # really should be first. Maybe the first result here has
+        # William Johnstone as the primary author instead of a regular
+        # author.
         self.search(
             "law of the mountain man william johnstone",
             [
@@ -967,20 +988,13 @@ class TestTitleGenreConflict(SearchTest):
             ]
         )
 
-    def test_title_match_with_genre_name_spy_unowned(self):
-        # NOTE: this book is not in the system.
-        self.search(
-            "My life as a spy",
-            Common(title=re.compile("(life|spy)"), threshold=.9)
-        )
-
-    def test_title_match_with_genre_name_spy(self):
+    def test_spy(self):
         self.search(
             "spying on whales",
             FirstMatch(title="Spying on Whales")
         )
 
-    def test_title_match_with_genre_name_dance(self):
+    def test_dance(self):
         self.search(
             "dance with dragons",
             FirstMatch(title="A Dance With Dragons")

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -1558,19 +1558,20 @@ class TestMJRose(VariantSearchTest):
         # This proves that we do have the books and can find them.
         self.search("m. j. rose")
 
+    def test_with_spaces(self):
+        # This is how the author's name is indexed internally.
+        self.search("m j rose")
+
     @known_to_fail
     def test_with_periods(self):
         # This only gets three books by this author.
+        # Maybe 'm.j.' is parsed as a single token or something.
         self.search("m.j. rose")
 
     @known_to_fail
     def test_with_one_period(self):
-        # This only three books by this author.
+        # This only gets three books by this author.
         self.search("m.j rose")
-
-    def test_with_spaces(self):
-        # This only gets four books by this author.
-        self.search("m j rose")
 
     @known_to_fail
     def test_with_no_periods_or_spaces(self):
@@ -1908,17 +1909,12 @@ class TestSubjectMatch(SearchTest):
         )
 
     def test_greek_romance(self):
-        # NOTE: this fails.  All of the top results are romance novels with
-        # "Greek" in the summary.  Not necessarily problematic...but the
-        # user is probably more likely to be looking for something like "Essays
-        # on the Greek Romances."  If you search "Greek romances" rather than
-        # "Greek romance," then "Essays on the Greek Romances" becomes the first
-        # result on ES1, but is still nowhere to be found on ES6.
-        #
-        # I think this person might be searching for romance novels... -LR
+        # This person might be searching for romance novels or for
+        # something like "Essays on the Greek Romances."
         self.search(
             "Greek romance",
-            AtLeastOne(title=re.compile("greek romance"))
+            [Common(genre="Romance", first_must_match=False),
+             AtLeastOne(title=re.compile("greek romance"))]
         )
 
     def test_ice_cream(self):

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -2718,6 +2718,20 @@ class TestAwardSearch(SearchTest):
             ]
         )
 
+    @known_to_fail
+    def test_staff_picks(self):
+        # We're looking for books that are this library's staff picks,
+        # not books attributed to some company's "staff".
+        #
+        # We don't know which books are staff picks, but we can check
+        # that the obvious wrong answers don't show up.
+        self.search(
+            "staff picks",
+            [
+                Uncommon(author=re.compile("staff|picks")),
+                Uncommon(title=re.compile("staff|picks"))
+            ]
+        )
 
 class TestCharacterMatch(SearchTest):
     # These searches are best understood as an attempt to find books

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -1638,6 +1638,39 @@ class TestMJRose(VariantSearchTest):
         self.search("mj rose")
 
 
+class TestPublisherMatch(SearchTest):
+    # Test the ability to find books by a specific publisher or
+    # imprint.
+
+    def test_harlequin_romance(self):
+        self.search(
+            "harlequin romance", Common(publisher="harlequin", genre="Romance")
+        )
+
+    def test_harlequin_historical(self):
+        self.search(
+            "harlequin historical",
+            Common(imprint="harlequin historical", genre="Romance")
+        )
+
+    def test_princeton_review(self):
+        self.search(
+            "princeton review",
+            Common(imprint="princeton review")
+        )
+
+    def test_scholastic(self):
+        self.search(
+            "scholastic", Common(publisher="scholastic inc.")
+        )
+
+    @known_to_fail
+    def test_wizards(self):
+        self.search(
+            "wizards coast", Common(publisher="wizards of the coast")
+        )
+
+
 class TestGenreMatch(SearchTest):
     # A genre search is a search for books in a certain 'section'
     # of the library.

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -2690,6 +2690,16 @@ class TestAwardSearch(SearchTest):
         )
 
     @known_to_fail
+    def test_tiptree_award(self):
+        # This award is named after an author. We don't want their
+        # books -- we want the award winners.
+        self.search(
+            "tiptree award",
+            [Common(summary=re.compile("tiptree award")),
+             Uncommon(author=re.compile("james tiptree"))],
+        )
+
+    @known_to_fail
     def test_newberry(self):
         # Tends to get author matches.
         self.search(

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -172,7 +172,7 @@ class Evaluator(object):
                 )
             )
             for hit in hits:
-                logging.info(hit)
+                logging.info(repr(hit))
         assert actual >= threshold
 
     def _match_scalar(self, value, expect, inclusive=False, case_sensitive=False):
@@ -2656,6 +2656,66 @@ class TestLanguageRestriction(SearchTest):
         self.search(
             "gatos",
             Common(language="spa", threshold=0.7)
+        )
+
+
+class TestAwardSearch(SearchTest):
+    # Attempts to find books that won particular awards.
+
+    @known_to_fail
+    def test_hugo(self):
+        # This has big problems because the name of the award is also
+        # a very common personal name.
+        self.search(
+            "hugo award",
+            [
+                Common(summary=re.compile("hugo award")),
+                Uncommon(author="Victor Hugo"),
+                Uncommon(series=re.compile("hugo")),
+            ]
+        )
+
+    def test_nebula(self):
+        self.search(
+            "nebula award",
+            Common(summary=re.compile("nebula award"))
+        )
+
+    def test_nebula_no_award(self):
+        # This one does great -- the award is the most common
+        # use of the word "nebula".
+        self.search(
+            "nebula",
+            Common(summary=re.compile("nebula award"))
+        )
+
+    @known_to_fail
+    def test_newberry(self):
+        # Tends to get author matches.
+        self.search(
+            "newbery",
+            Common(summary=re.compile("newbery medal"))
+        )
+
+    @known_to_fail
+    def test_man_booker(self):
+        # This gets author and title matches.
+        self.search(
+            "man booker prize",
+            Common(summary=re.compile("man booker prize"),
+                   first_must_match=False)
+        )
+
+    def test_award_winning(self):
+        # NOTE: It's unclear how to validate these results, but it's
+        # more likely an award-winning book will mention "award" in
+        # its summary than in its title.
+        self.search(
+            "award-winning",
+            [
+                Common(summary=re.compile("award"), threshold=0.5),
+                Uncommon(title=re.compile("award"), threshold=0.5),
+            ]
         )
 
 

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -1040,16 +1040,21 @@ class TestTitleAuthorConflict(SearchTest):
     def test_disney(self):
         # The majority of the search results will be about Walt Disney and/or the
         # Disney Company, but there should also be some published by the Disney Book Group
+
+        # NOTE: The first result is a book whose .series is the literal
+        # string "Disney". This triggers a keyword series match which
+        # bumps it to the top.
         self.search(
             "disney",
-                [ Common(title=re.compile("disney")),
+                [ Common(title=re.compile("disney"), first_must_match=False),
                   AtLeastOne(title=re.compile("walt disney")),
                   AtLeastOne(author="Disney Book Group") ]
         )
 
     def test_bridge(self):
-        # The search results correctly prioritize the book with this title over books
-        # by authors whose names contain "Luis" or "Rey."
+        # The search results correctly prioritize the book with this
+        # title over books by authors whose names contain "Luis" or
+        # "Rey."
         self.search(
             "the bridge of san luis rey",
             FirstMatch(title="The Bridge of San Luis Rey")

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -2359,35 +2359,45 @@ class TestSeriesTitleMatch(SearchTest):
     """Test a search that tries to match a specific book in a series."""
 
     def test_39_clues_specific_title(self):
-        # The first result is the requested title. Other results
-        # are from the same series.
+        # The first result is a compilation containing this title. The
+        # title shows up on its own elsewhere on the list, and other
+        # results are from the same series.
+        #
+        # NOTE: it would be better if the standalone title showed up
+        # as the first result.
         self.search(
             "39 clues maze of bones",
             [
-                FirstMatch(title="The Maze of Bones"),
+                AtLeastOne(title="The Maze of Bones"),
                 Common(series="the 39 clues", threshold=0.9)
             ]
         )
 
     def test_harry_potter_specific_title(self):
-        # The first result is the requested title. TODO: other results
-        # should be from the same series, but this doesn't happen much
-        # compared to other, similar tests.
+        # The first result is the requested title.
+        #
+        # NOTE: It would be good if other results came be from the
+        # same series, but this doesn't happen much compared to other,
+        # similar tests. We get more partial title matches.
         self.search(
             "chamber of secrets", [
                 FirstMatch(title="Harry Potter and the Chamber of Secrets"),
-                Common(series="Harry Potter", threshold=0.3)
+                Common(series="Harry Potter", threshold=0.2)
             ]
         )
 
+    @known_to_fail
     def test_wimpy_kid_specific_title(self):
         # The first result is the requested title. Other results
         # are from the same series.
+        #
+        # NOTE: The title match is too powerful -- "Diary of a Wimpy Kid"
+        # overrides "Dog Days"
         self.search(
             "dairy of the wimpy kid dog days",
             [
-                FirstMatch(title="Dog Days", author="Jeff Kinney"),
                 Common(series="Diary of a Wimpy Kid"),
+                FirstMatch(title="Dog Days", author="Jeff Kinney"),
             ]
         )
 

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -415,6 +415,8 @@ class SpecificAuthor(FirstMatch):
             return True
 
         # We have failed.
+        if hasattr(expect, 'match'):
+            expect = expect.pattern
         eq_(expect, first.contributors)
 
     def evaluate_hits(self, hits):
@@ -2369,7 +2371,8 @@ class TestSeriesTitleMatch(SearchTest):
             "39 clues maze of bones",
             [
                 AtLeastOne(title="The Maze of Bones"),
-                Common(series="the 39 clues", threshold=0.9)
+                Common(series="the 39 clues", threshold=0.5,
+                       first_must_match=False)
             ]
         )
 
@@ -2401,15 +2404,20 @@ class TestSeriesTitleMatch(SearchTest):
             ]
         )
 
+    @known_to_fail
     def test_foundation_specific_title_by_number(self):
-        # NOTE: this works on ES1 but not on ES6!
-        # Series, full author, and book number
+        # NOTE: we don't have series position information for this series,
+        # and we don't search it, so there's no way to make this work.
         self.search(
             "Isaac Asimov foundation book 1",
-            FirstMatch(series="Foundation", title="Prelude to Foundation")
+            FirstMatch(series="Foundation", title="Foundation")
         )
 
+    @known_to_fail
     def test_survivors_specific_title(self):
+        # NOTE: This gives a lot of title matches for "Survivor"
+        # or "Survivors". Theoretically we could use "book 1"
+        # as a signal that we only want a series match.
         self.search(
             "survivors book 1",
             [
@@ -2430,19 +2438,22 @@ class TestISurvived(VariantSearchTest):
     def test_correct_spelling(self):
         self.search("i survived")
 
+    @known_to_fail
     def test_incorrect_1(self):
         self.search("i survied")
 
+    @known_to_fail
     def test_incorrect_2(self):
         self.search("i survive")
 
+    @known_to_fail
     def test_incorrect_3(self):
         self.search("i survided")
 
 
 class TestDorkDiaries(VariantSearchTest):
     # Test different ways of spelling "Dork Diaries"
-    EVALUATOR = Common(series="Dork Diaries")
+    EVALUATOR = SpecificAuthor(re.compile(u"Rachel .* Russell", re.I))
 
     def test_correct_spelling(self):
         self.search('dork diaries')
@@ -2450,6 +2461,7 @@ class TestDorkDiaries(VariantSearchTest):
     def test_misspelling_and_number(self):
         self.search("dork diarys #11")
 
+    @known_to_fail
     def test_misspelling_with_punctuation(self):
         self.search('doke diaries.')
 
@@ -2459,15 +2471,19 @@ class TestDorkDiaries(VariantSearchTest):
     def test_misspelling_1(self):
         self.search('dork diarys')
 
+    @known_to_fail
     def test_misspelling_2(self):
         self.search('doke dirares')
 
+    @known_to_fail
     def test_misspelling_3(self):
         self.search('doke dares')
 
+    @known_to_fail
     def test_misspelling_4(self):
         self.search('doke dires')
 
+    @known_to_fail
     def test_misspelling_5(self):
         self.search('dork diareis')
 

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -2689,6 +2689,14 @@ class TestAwardSearch(SearchTest):
             Common(summary=re.compile("nebula award"))
         )
 
+    def test_world_fantasy(self):
+        # This award contains the name of a genre.
+        self.search(
+            "world fantasy award",
+            Common(summary=re.compile("world fantasy award"),
+                   first_must_match=False)
+        )
+
     @known_to_fail
     def test_tiptree_award(self):
         # This award is named after an author. We don't want their

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -137,7 +137,7 @@ class Evaluator(object):
             series=result.series,
             summary=result.summary,
             genres=result.genres,
-            imlogging.info=result.imlogging.info,
+            imprint=result.imprint,
             publisher=result.publisher,
         )
         return dict(
@@ -1623,7 +1623,7 @@ class TestMJRose(VariantSearchTest):
 
 class TestPublisherMatch(SearchTest):
     # Test the ability to find books by a specific publisher or
-    # imlogging.info.
+    # imprint.
 
     def test_harlequin_romance(self):
         self.search(
@@ -1633,13 +1633,13 @@ class TestPublisherMatch(SearchTest):
     def test_harlequin_historical(self):
         self.search(
             "harlequin historical",
-            Common(imlogging.info="harlequin historical", genre="Romance")
+            Common(imprint="harlequin historical", genre="Romance")
         )
 
     def test_princeton_review(self):
         self.search(
             "princeton review",
-            Common(imlogging.info="princeton review")
+            Common(imprint="princeton review")
         )
 
     def test_scholastic(self):

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -768,12 +768,11 @@ class TestMisspelledTitleSearch(SearchTest):
             FirstMatch(title="The Seven Husbands of Evelyn Hugo")
         )
 
-    @known_to_fail
     def test_nightingale(self):
         # Unusual word misspelled.
         #
-        # This isn't so bad -- the book we're looking for is the second result,
-        # with the first being a title by Florence Nightingale.
+        # This might fail because a book by Florence Nightingale is
+        # seen as a better match.
         self.search(
             "The nightenale",
             FirstMatch(title="The Nightingale")
@@ -1425,12 +1424,12 @@ class TestAuthorMatch(SearchTest):
             SpecificAuthor("Vladimir Nabokov", accept_title="Nabokov")
         )
 
-    @known_to_fail
     def test_ba_paris(self):
         # Author's last name could also be a subject keyword.
         #
-        # These results are very good, but the first result is a title
-        # match with stopword removed, "Escalier B, Paris 12".
+        # These results are always very good, but sometimes the first
+        # result is a title match with stopword removed, "Escalier B,
+        # Paris 12".
         self.search(
             "b a paris", SpecificAuthor("B. A. Paris")
         )
@@ -1869,11 +1868,13 @@ class TestSubjectMatch(SearchTest):
             )
         )
 
+    @known_to_fail
     def test_da_vinci(self):
         # Someone who searches for "da vinci" is almost certainly
         # looking entirely for books _about_ Da Vinci.
         #
-        # TODO: "The Da Vinci Code" dominates these results.
+        # TODO: The first few results are good but then we go into
+        # "Da Vinci Code" territory. Maybe that's fine, though.
         self.search(
             "Da Vinci",
             Common(genre=re.compile("(biography|art)"), first_must_match=False)

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -1043,7 +1043,7 @@ class TestTitleAuthorConflict(SearchTest):
 
         # NOTE: The first result is a book whose .series is the literal
         # string "Disney". This triggers a keyword series match which
-        # bumps it to the top.
+        # bumps it to the top. That's why first_must_match=False.
         self.search(
             "disney",
                 [ Common(title=re.compile("disney"), first_must_match=False),
@@ -1067,7 +1067,7 @@ class TestTitleAudienceConflict(SearchTest):
 
     def test_title_match_with_audience_name_children(self):
         self.search(
-            "Children of blood and bone",
+            "Children blood",
             FirstMatch(title="Children of Blood and Bone")
         )
 
@@ -1079,7 +1079,7 @@ class TestTitleAudienceConflict(SearchTest):
 
     def test_tales_of_a_fourth_grade_nothing(self):
         self.search(
-            "tales of a fourth grade nothing",
+            "fourth grade nothing",
             FirstMatch(title="Tales of a Fourth Grade Nothing")
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ uwsgi
 loggly-python-handler
 mock
 py-bcrypt
+pyspellchecker
 Flask-Babel
 money
 pymarc

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2203,6 +2203,11 @@ class TestWorkController(CirculationControllerTest):
         [contribution] = self.english_1.presentation_edition.contributions
         contributor = contribution.contributor
 
+        # The contributor is created with both .sort_name and
+        # .display_name, but we want to test what happens when both
+        # pieces of data aren't avaiable, so unset .sort_name.
+        contributor.sort_name = None
+
         # No contributor name -> ProblemDetail
         with self.request_context_with_library('/'):
             response = m('', None, None)
@@ -2218,7 +2223,7 @@ class TestWorkController(CirculationControllerTest):
         eq_(NO_SUCH_LANE.uri, response.uri)
         eq_("Unknown contributor: Unknown Author", response.detail)
 
-        contributor = contributor.sort_name
+        contributor = contributor.display_name
 
         # Search index misconfiguration -> Problem detail
         self.assert_bad_search_index_gives_problem_detail(
@@ -2266,7 +2271,7 @@ class TestWorkController(CirculationControllerTest):
         cached = self._db.query(CachedFeed).one()
         eq_(CachedFeed.CONTRIBUTOR_TYPE, cached.type)
         eq_(
-            'Bull, John-eng,spa-Children,Young+Adult',
+            'John Bull-eng,spa-Children,Young+Adult',
             cached.unique_key
         )
 
@@ -2622,10 +2627,10 @@ class TestWorkController(CirculationControllerTest):
 
         # Here's the sublane for books by this contributor.
         [same_contributor_href, same_contributor_entry] = by_collection_link[
-            'Bull, John'
+            'John Bull'
         ]
         eq_("Same author and series", same_contributor_entry['title'])
-        expected_contributor_link = urllib.quote('contributor/Bull, John/eng/')
+        expected_contributor_link = urllib.quote('contributor/John Bull/eng/')
         assert same_contributor_href.endswith(expected_contributor_link)
 
         # Here's the sublane for recommendations from NoveList.


### PR DESCRIPTION
This branch updates the search integration tests to take into account changes in NYPL's collection since October, and changes to the search index itself, which go in https://github.com/NYPL-Simplified/server_core/pull/1095.

The primary ticket here is https://jira.nypl.org/browse/SIMPLY-2133, but there are some smaller ones, which I reference inline.

I added a decorator `@known_to_fail`, which inverts the normal sense of a unit test. An exception will be raised if one of these tests succeeds, and the test will 'pass' so long as a known problem persists.

This makes it possible to represent problems we know we have without having to fix them immediately. We can also make tradeoffs, fixing some tests while breaking others. If we only count the number of tests that fail, we don't have the information necessary to make decisions.

I ran this test suite against the current 3.0 branch and against the new branch I'm working on, which overhauls our query algorithm. In both cases I was using an index created by the new branch. I used this to make further improvements to the query algorithm.

There are now 274 tests in the suite.

In 3.0 beta branch, I see:
 49 expected failures
 55 unexpected failures
 7 unexpected successes
 177 total successes

In the branch I'm working on, I se:
 57 expected failures
 0 errors
 0 unexpected successes
217 total successes

So the new system is doing much better and the code is less complicated. The queries we're sending out are much _more_ complicated, and there is a performance hit, which I talk about in the [core branch](https://github.com/NYPL-Simplified/server_core/pull/1095).