### PR TITLE
Add a maximum number of times a SIP message can be resent

### DIFF
--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -395,7 +395,7 @@ class SIPClient(Constants):
         parsed = None
         retries = 0
         while not parsed:
-            if retries > self.MAXIMUM_RETRIES:
+            if retries >= self.MAXIMUM_RETRIES:
                 # Only retry MAXIMUM_RETRIES times in case we we are sending
                 # a message the ILS doesn't like, so we don't retry forever
                 raise IOError('Maximum SIP retries reached')

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -184,6 +184,9 @@ class SIPClient(Constants):
 
     log = logging.getLogger("SIPClient")
 
+    # Maximum retries of a SIP message before failing.
+    MAXIMUM_RETRIES = 5
+
     # These are the subfield names associated with the 'patron status'
     # field as specified in the SIP2 spec.
     CHARGE_PRIVILEGES_DENIED = 'charge privileges denied'
@@ -390,7 +393,12 @@ class SIPClient(Constants):
         original_message = message_creator(*args, **kwargs)
         message_with_checksum = self.append_checksum(original_message)
         parsed = None
+        retries = 0
         while not parsed:
+            if retries > self.MAXIMUM_RETRIES:
+                # Only retry MAXIMUM_RETRIES times in case we we are sending
+                # a message the ILS doesn't like, so we don't retry forever
+                raise IOError('Maximum SIP retries reached')
             self.send(message_with_checksum)
             response = self.read_message()
             try:
@@ -402,6 +410,7 @@ class SIPClient(Constants):
                 message_with_checksum = self.append_checksum(
                     original_message, include_sequence_number=False
                 )
+            retries += 1
         return parsed
 
     def login_message(self, login_user_id, login_password, location_code="",

--- a/tests/sip/test_client.py
+++ b/tests/sip/test_client.py
@@ -160,6 +160,21 @@ class TestBasicProtocol(object):
         # The login request eventually succeeded.
         eq_({'login_ok': '1', '_status': '94'}, response)
 
+    def test_maximum_resend(self):
+        sip = MockSIPClient(login_user_id='user_id', login_password='password')
+
+        # We will keep sending retry messages until we reach the maximum
+        sip.queue_response('96')
+        sip.queue_response('96')
+        sip.queue_response('96')
+        sip.queue_response('96')
+        sip.queue_response('96')
+
+        # After reaching the maximum the client should give an IOError
+        assert_raises(IOError, sip.login)
+
+        # We should send as many requests as we are allowed retries
+        eq_(sip.MAXIMUM_RETRIES, len(sip.requests))
 
 class TestLogin(object):
 


### PR DESCRIPTION
I hit a case where a ILS was causing the SIP client to go into an infinite loop of retries because the message we were sending was missing a value they required. This caused a 96 message, which causes us to resend. Since we didn't add the required data they responded with a retry message. 

This will eliminate the infinite loop of retries should this situation arise again in the future.