### PR TITLE
Integration tests for synonyms and posessives

### DIFF
--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -730,6 +730,28 @@ class TestPosessives(SearchTest):
             FirstMatch(title="The Policewomen's Bureau"),
         )
 
+class TestSynonyms(SearchTest):
+    # Test synonyms that could be (but currently aren't) defined in
+    # the search index.
+
+    @known_to_fail
+    def test_and_is_ampersand(self):
+        # There are books called "Black & White" and books called
+        # "Black And White". When '&' and 'and' are synonyms, all
+        # these books should get the same score.
+        self.search(
+            "black and white",
+            AtLeastOne(title="Black & White"),
+        )
+
+    @known_to_fail
+    def test_ampersand_is_and(self):
+        # The result we're looking for is second, behind "The
+        # Cheesemaker's Apprentice".
+        self.search(
+            "master and apprentice",
+            FirstMatch(title="Master & Apprentice (Star Wars)"),
+        )
 
 class TestUnownedTitle(SearchTest):
     # These are title searches for books not owned by NYPL.

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -710,21 +710,21 @@ class TestPosessives(SearchTest):
 
     def test_police_women_no_apostrophe(self):
         self.search(
-            "policewomen bureau",
+            "policewomens bureau",
             FirstMatch(title="The Policewomen's Bureau"),
         )
 
     def test_police_women_no_posessive(self):
         self.search(
-            "policewomens bureau",
+            "policewomen bureau",
             FirstMatch(title="The Policewomen's Bureau"),
         )
 
     @known_to_fail
     def test_police_women_extra_space(self):
-        # The extra space and the stemming means we match on 'police'
-        # and 'women', two very common words, and not the relatively
-        # uncommon 'policewomen'.
+        # The extra space means this parses to 'police' and 'women',
+        # two very common words, and not the relatively uncommon
+        # 'policewomen'.
         self.search(
             "police womens bureau",
             FirstMatch(title="The Policewomen's Bureau"),

--- a/integration_tests/test_search.py
+++ b/integration_tests/test_search.py
@@ -637,18 +637,6 @@ class TestTitleMatch(SearchTest):
             ]
         )
 
-    def test_possessives(self):
-        # Verify that possessives are stemmed.
-        self.search(
-            "washington war",
-            AtLeastOne(title="George Washington's War")
-        )
-
-        self.search(
-            "washingtons war",
-            AtLeastOne(title="George Washington's War")
-        )
-
 
     def test_it(self):
         # The book "It" is correctly prioritized over books whose titles contain
@@ -663,6 +651,83 @@ class TestTitleMatch(SearchTest):
         self.search(
             "girl on the train",
             FirstMatch(title="The Girl On The Train")
+        )
+
+class TestPosessives(SearchTest):
+    """Test searches for book titles that contain posessives."""
+
+    def test_washington_partial(self):
+        self.search(
+            "washington war",
+            AtLeastOne(title="George Washington's War")
+        )
+
+    def test_washington_full_no_apostrophe(self):
+        self.search(
+            "george washingtons war",
+            FirstMatch(title="George Washington's War")
+        )
+
+    @known_to_fail
+    def test_washington_partial_apostrophe(self):
+        # The apostrophe is stripped and the 's' is stemmed. This is
+        # normally a good thing, but here the query is parsed as
+        # "washington war", and the first result is "The Washington
+        # War". Parsing this as "washington ' s war" would give better
+        # results here.
+        #
+        # Since most people don't type the apostrophe, the tradeoff is
+        # worth it.
+        self.search(
+            "washington's war",
+            FirstMatch(title="George Washington's War")
+        )
+
+    def test_washington_full_apostrophe(self):
+        self.search(
+            "george washington's war",
+            FirstMatch(title="George Washington's War")
+        )
+
+    def test_bankers(self):
+        self.search(
+            "bankers wife",
+            FirstMatch(title="The Banker's Wife")
+        )
+
+    def test_brother(self):
+        # The entire posessive is omitted.
+        self.search(
+            "my brother shadow",
+            FirstMatch(title="My Brother's Shadow"),
+        )
+
+    def test_police_women_apostrophe(self):
+        self.search(
+            "policewomen's bureau",
+            FirstMatch(title="The Policewomen's Bureau"),
+        )
+
+    def test_police_women_no_apostrophe(self):
+        self.search(
+            "policewomen bureau",
+            FirstMatch(title="The Policewomen's Bureau"),
+        )
+
+    def test_police_women_no_posessive(self):
+        self.search(
+            "policewomens bureau",
+            FirstMatch(title="The Policewomen's Bureau"),
+        )
+
+    @known_to_fail
+    def test_police_women_extra_space(self):
+        # The extra space and the stemming means we match on 'police'
+        # and 'women', two very common words, and not the relatively
+        # uncommon 'policewomen'.
+        self.search(
+            "police womens bureau",
+            FirstMatch(title="The Policewomen's Bureau"),
         )
 
 


### PR DESCRIPTION
This branch adds integration tests for https://jira.nypl.org/browse/SIMPLY-575 and https://jira.nypl.org/browse/SIMPLY-2166. The synonym tests fail (I tried a quick fix and couldn't get it to work); the posessive tests pass.