### PR TITLE
Validate lists of urls and emails

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1709,8 +1709,10 @@ class SettingsController(AdminCirculationManagerController):
             return UNKNOWN_PROTOCOL
 
     def _get_settings(self):
-        [protocol] = [p for p in self.protocols if p.get("name") == flask.request.form.get("protocol")]
-        return protocol.get("settings")
+        if hasattr(self, 'protocols'):
+            [protocol] = [p for p in self.protocols if p.get("name") == flask.request.form.get("protocol")]
+            return protocol.get("settings")
+        return []
 
     def validate_formats(self, settings=None, validator=None):
         # If the service has self.protocols set, we can extract the list of settings here;

--- a/api/admin/validator.py
+++ b/api/admin/validator.py
@@ -55,9 +55,12 @@ class Validator(object):
             email_inputs = [settings]
 
         # Now check that each email input is in a valid format
-        for email in email_inputs:
-            if not self._is_email(email):
-                return INVALID_EMAIL.detailed(_('"%(email)s" is not a valid email address.', email=email))
+        for emails in email_inputs:
+            if not isinstance(emails, list):
+                emails = [emails]
+            for email in emails:
+                if not self._is_email(email):
+                    return INVALID_EMAIL.detailed(_('"%(email)s" is not a valid email address.', email=email))
 
     def _is_email(self, email):
         """Email addresses must be in the format 'x@y.z'."""
@@ -156,4 +159,4 @@ class Validator(object):
             return form.get("value")
         elif len(value) == 1:
             return value[0]
-        return value
+        return filter(lambda x: x != None and x != "", value)

--- a/api/admin/validator.py
+++ b/api/admin/validator.py
@@ -70,12 +70,15 @@ class Validator(object):
         # Find the fields that have to do with URLs and are not blank.
         url_inputs = self._extract_inputs(settings, "url", content.get("form"), should_zip=True)
 
-        for field, url in url_inputs:
-            # In a few special cases, we want to allow a value that isn't a normal URL;
-            # for example, the patron web client URL can be set to "*".
-            allowed = field.get("allowed") or []
-            if not self._is_url(url, allowed):
-                return INVALID_URL.detailed(_('"%(url)s" is not a valid URL.', url=url))
+        for field, urls in url_inputs:
+            if not isinstance(urls, list):
+                urls = [urls]
+            for url in urls:
+                # In a few special cases, we want to allow a value that isn't a normal URL;
+                # for example, the patron web client URL can be set to "*".
+                allowed = field.get("allowed") or []
+                if not self._is_url(url, allowed):
+                    return INVALID_URL.detailed(_('"%(url)s" is not a valid URL.', url=url))
 
     def _is_url(self, url, allowed):
         has_protocol = any([url.startswith(protocol + "://") for protocol in "http", "https"])

--- a/tests/admin/test_validator.py
+++ b/tests/admin/test_validator.py
@@ -6,6 +6,7 @@ from nose.tools import (
 import json
 from api.admin.validator import Validator
 from api.config import Configuration
+from api.shared_collection import BaseSharedCollectionAPI
 from StringIO import StringIO
 from werkzeug import MultiDict
 
@@ -61,6 +62,11 @@ class TestValidator():
         response = Validator().validate_url(Configuration.LIBRARY_SETTINGS, {"form": form})
         eq_(response.detail, '"invalid_url" is not a valid URL.')
         eq_(response.status_code, 400)
+
+        # Two valid in a list
+        form = MultiDict([(BaseSharedCollectionAPI.EXTERNAL_LIBRARY_URLS, "http://library1.com"), (BaseSharedCollectionAPI.EXTERNAL_LIBRARY_URLS, "http://library2.com")])
+        response = Validator().validate_url(BaseSharedCollectionAPI.SETTINGS, {"form": form})
+        eq_(response, None)
 
     def test_validate_number(self):
         valid = "10"

--- a/tests/admin/test_validator.py
+++ b/tests/admin/test_validator.py
@@ -42,6 +42,22 @@ class TestValidator():
         eq_(response.detail, '"invalid_format" is not a valid email address.')
         eq_(response.status_code, 400)
 
+        # Two valid in a list
+        form = MultiDict([('help-email', valid), ('help-email', 'valid2@email.com')])
+        response = Validator().validate_email(Configuration.LIBRARY_SETTINGS, {"form": form})
+        eq_(response, None)
+
+        # One valid and one empty in a list
+        form = MultiDict([('help-email', valid), ('help-email', '')])
+        response = Validator().validate_email(Configuration.LIBRARY_SETTINGS, {"form": form})
+        eq_(response, None)
+
+        # One valid and one invalid in a list
+        form = MultiDict([('help-email', valid), ('help-email', invalid)])
+        response = Validator().validate_email(Configuration.LIBRARY_SETTINGS, {"form": form})
+        eq_(response.detail, '"invalid_format" is not a valid email address.')
+        eq_(response.status_code, 400)
+
     def test_validate_url(self):
         valid = "https://valid_url.com"
         invalid = "invalid_url"
@@ -67,6 +83,17 @@ class TestValidator():
         form = MultiDict([(BaseSharedCollectionAPI.EXTERNAL_LIBRARY_URLS, "http://library1.com"), (BaseSharedCollectionAPI.EXTERNAL_LIBRARY_URLS, "http://library2.com")])
         response = Validator().validate_url(BaseSharedCollectionAPI.SETTINGS, {"form": form})
         eq_(response, None)
+
+        # One valid and one empty in a list
+        form = MultiDict([(BaseSharedCollectionAPI.EXTERNAL_LIBRARY_URLS, "http://library1.com"), (BaseSharedCollectionAPI.EXTERNAL_LIBRARY_URLS, "")])
+        response = Validator().validate_url(BaseSharedCollectionAPI.SETTINGS, {"form": form})
+        eq_(response, None)
+
+        # One valid and one invalid in a list
+        form = MultiDict([(BaseSharedCollectionAPI.EXTERNAL_LIBRARY_URLS, "http://library1.com"), (BaseSharedCollectionAPI.EXTERNAL_LIBRARY_URLS, invalid)])
+        response = Validator().validate_url(BaseSharedCollectionAPI.SETTINGS, {"form": form})
+        eq_(response.detail, '"invalid_url" is not a valid URL.')
+        eq_(response.status_code, 400)
 
     def test_validate_number(self):
         valid = "10"


### PR DESCRIPTION
This fixes a bug that prevents adding external library URLs to an ODL collection. I did the same thing for emails, just in case, though I don't know of anywhere we use a list of emails.