### PR TITLE
Add ao field value to requests

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1119,6 +1119,10 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
 
     SETTINGS = []
 
+    # Each library and authentication mechanism may have an ILS-assigned
+    # branch or institution ID used in the SIP2 AO field.
+    INSTITUTION_ID = "institution_id"
+
     # Each library and authentication mechanism may have a regular
     # expression for deriving a patron's external type from their
     # authentication identifier.
@@ -1188,6 +1192,9 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
                            "using the method chosen in <em>Library Identifier Restriction Type</em>. " +
                            "This value is not used if <em>Library Identifier Restriction Type</em> " +
                            "is set to 'No restriction'."),
+        },
+        { "key": INSTITUTION_ID, "label": _("Institution ID"),
+          "description": _("A specific identifier for the library or branch, if used in patron authentication")
         }
     ]
 
@@ -1262,6 +1269,10 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
                 self.library_identifier_restriction = restriction.strip()
             else:
                 self.library_identifier_restriction = restriction
+
+        self.institution_id = ConfigurationSetting.for_library_and_externalintegration(
+            _db, self.INSTITUTION_ID, library, integration
+        ).value or ''
 
     @classmethod
     def _restriction_matches(cls, field, restriction, match_type):

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -20,6 +20,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
     # Constants for integration configuration settings.
     PORT = "port"
     LOCATION_CODE = "location code"
+    INSTITUTION_ID = "institution_id"
     FIELD_SEPARATOR = "field separator"
     USE_SSL = "use_ssl"
     SSL_CERTIFICATE = "ssl_certificate"
@@ -31,6 +32,9 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         { "key": ExternalIntegration.USERNAME, "label": _("Login User ID") },
         { "key": ExternalIntegration.PASSWORD, "label": _("Login Password") },
         { "key": LOCATION_CODE, "label": _("Location Code") },
+        { "key": INSTITUTION_ID, "label": _("Institution ID"),
+          "description": _("An identifier of a specific library or branch for patron authentication if used")
+        },
         { "key": USE_SSL, "label": _("Connect over SSL?"),
           "description": _("Some SIP2 servers require or allow clients to connect securely over SSL. Other servers don't support SSL, and require clients to use an ordinary socket connection."),
           "type": "select",
@@ -113,6 +117,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         self.login_user_id = integration.username
         self.login_password = integration.password
         self.location_code = integration.setting(self.LOCATION_CODE).value
+        self.institution_id = integration.setting(self.INSTITUTION_ID).value or ''
         self.field_separator = integration.setting(self.FIELD_SEPARATOR).value or '|'
         self.use_ssl = integration.setting(self.USE_SSL).json_value
         self.ssl_cert = integration.setting(self.SSL_CERTIFICATE).value
@@ -127,7 +132,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
                 sip = SIPClient(
                     target_server=self.server, target_port=self.port,
                     login_user_id=self.login_user_id, login_password=self.login_password,
-                    location_code=self.location_code, separator=self.field_separator,
+                    location_code=self.location_code, institution_id=self.institution_id, separator=self.field_separator,
                     use_ssl=self.use_ssl, ssl_cert=self.ssl_cert, ssl_key=self.ssl_key
                 )
             sip.connect()
@@ -173,7 +178,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             sip = SIPClient(
                 target_server=self.server, target_port=self.port,
                 login_user_id=self.login_user_id, login_password=self.login_password,
-                location_code=self.location_code, separator=self.field_separator,
+                location_code=self.location_code, institution_id=self.institution_id, separator=self.field_separator,
                 use_ssl=self.use_ssl, ssl_cert=self.ssl_cert, ssl_key=self.ssl_key
             )
         

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -20,7 +20,6 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
     # Constants for integration configuration settings.
     PORT = "port"
     LOCATION_CODE = "location code"
-    INSTITUTION_ID = "institution_id"
     FIELD_SEPARATOR = "field separator"
     USE_SSL = "use_ssl"
     SSL_CERTIFICATE = "ssl_certificate"
@@ -32,9 +31,6 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         { "key": ExternalIntegration.USERNAME, "label": _("Login User ID") },
         { "key": ExternalIntegration.PASSWORD, "label": _("Login Password") },
         { "key": LOCATION_CODE, "label": _("Location Code") },
-        { "key": INSTITUTION_ID, "label": _("Institution ID"),
-          "description": _("An identifier of a specific library or branch for patron authentication if used")
-        },
         { "key": USE_SSL, "label": _("Connect over SSL?"),
           "description": _("Some SIP2 servers require or allow clients to connect securely over SSL. Other servers don't support SSL, and require clients to use an ordinary socket connection."),
           "type": "select",
@@ -117,7 +113,6 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         self.login_user_id = integration.username
         self.login_password = integration.password
         self.location_code = integration.setting(self.LOCATION_CODE).value
-        self.institution_id = integration.setting(self.INSTITUTION_ID).value or ''
         self.field_separator = integration.setting(self.FIELD_SEPARATOR).value or '|'
         self.use_ssl = integration.setting(self.USE_SSL).json_value
         self.ssl_cert = integration.setting(self.SSL_CERTIFICATE).value

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -235,7 +235,7 @@ class SIPClient(Constants):
     ]
 
     def __init__(self, target_server, target_port, login_user_id=None,
-                 login_password=None, location_code=None, institution_id=None, separator=None,
+                 login_password=None, location_code=None, institution_id='', separator=None,
                  use_ssl=False, ssl_cert=None, ssl_key=None
     ):
         """Initialize a client for (but do not connect to) a SIP2 server.
@@ -826,7 +826,7 @@ class MockSIPClient(SIPClient):
     """
 
     def __init__(self, login_user_id=None, login_password=None, separator="|",
-                 target_server=None, target_port=None, location_code=None, institution_id=None):
+                 target_server=None, target_port=None, location_code=None, institution_id=''):
         super(MockSIPClient, self).__init__(
             None, None, login_user_id=login_user_id,
             login_password=login_password, separator=separator

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -235,7 +235,7 @@ class SIPClient(Constants):
     ]
 
     def __init__(self, target_server, target_port, login_user_id=None,
-                 login_password=None, location_code=None, separator=None,
+                 login_password=None, location_code=None, institution_id=None, separator=None,
                  use_ssl=False, ssl_cert=None, ssl_key=None
     ):
         """Initialize a client for (but do not connect to) a SIP2 server.
@@ -253,6 +253,7 @@ class SIPClient(Constants):
         if target_port:
             self.target_port = int(target_port)
         self.location_code = location_code
+        self.institution_id = institution_id
         self.separator = separator or '|'
 
         self.use_ssl = use_ssl or ssl_cert or ssl_key
@@ -425,7 +426,7 @@ class SIPClient(Constants):
         )
 
     def end_session_message(
-            self, patron_identifier, patron_password="", institution_id="",
+            self, patron_identifier, patron_password="",
             terminal_password="",
     ):
         """
@@ -447,7 +448,7 @@ class SIPClient(Constants):
         timestamp = self.now()
 
         message = (code + timestamp +
-                   "AO" + institution_id + self.separator +
+                   "AO" + self.institution_id + self.separator +
                    "AA" + patron_identifier + self.separator +
                    "AC" + terminal_password
         )
@@ -469,7 +470,7 @@ class SIPClient(Constants):
         )
 
     def patron_information_request(
-            self, patron_identifier, patron_password="", institution_id="",
+            self, patron_identifier, patron_password="",
             terminal_password="",
             language=None, summary=None
     ):
@@ -495,7 +496,7 @@ class SIPClient(Constants):
         summary = summary or self.summary()
 
         message = (code + language + timestamp + summary
-                   + "AO" + institution_id + self.separator +
+                   + "AO" + self.institution_id + self.separator +
                    "AA" + patron_identifier + self.separator +
                    "AC" + terminal_password
         )
@@ -825,7 +826,7 @@ class MockSIPClient(SIPClient):
     """
 
     def __init__(self, login_user_id=None, login_password=None, separator="|",
-                 target_server=None, target_port=None, location_code=None):
+                 target_server=None, target_port=None, location_code=None, institution_id=None):
         super(MockSIPClient, self).__init__(
             None, None, login_user_id=login_user_id,
             login_password=login_password, separator=separator

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -829,7 +829,7 @@ class MockSIPClient(SIPClient):
                  target_server=None, target_port=None, location_code=None, institution_id=''):
         super(MockSIPClient, self).__init__(
             None, None, login_user_id=login_user_id,
-            login_password=login_password, separator=separator
+            login_password=login_password, separator=separator, institution_id=institution_id
         )
 
         self.requests = []

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -50,12 +50,14 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         integration.username = "user1"
         integration.password = "pass1"
         integration.setting(p.FIELD_SEPARATOR).value = "\t"
+        integration.setting(p.INSTITUTION_ID).value = "MAIN"
         provider = p(self._default_library, integration)
 
         # A SIPClient was initialized based on the integration values.
         eq_("user1", provider.login_user_id)
         eq_("pass1", provider.login_password)
         eq_("\t", provider.field_separator)
+        eq_("MAIN", provider.institution_id)
         eq_("server.com", provider.server)
 
         # Default port is 6001.

--- a/tests/sip/test_client.py
+++ b/tests/sip/test_client.py
@@ -317,7 +317,7 @@ class TestPatronResponse(object):
         )
         assert with_code.endswith("COlogin_password|CPlocation_code")
 
-    def test_institution_id_field_is_required(self):
+    def test_institution_id_field_is_always_provided(self):
         without_institution_arg = self.sip.patron_information_request(
             "patron_identifier", "patron_password"
         )
@@ -325,8 +325,8 @@ class TestPatronResponse(object):
 
     def test_institution_id_field_value_provided(self):
         # Fake value retrieved from DB
-        self.sip.institution_id='MAIN'
-        with_institution_provided = self.sip.patron_information_request(
+        sip = MockSIPClient(institution_id='MAIN')
+        with_institution_provided = sip.patron_information_request(
             "patron_identifier", "patron_password"
         )
         assert with_institution_provided.startswith('AOMAIN|', 33)

--- a/tests/sip/test_client.py
+++ b/tests/sip/test_client.py
@@ -321,7 +321,7 @@ class TestPatronResponse(object):
         without_institution_arg = self.sip.patron_information_request(
             "patron_identifier", "patron_password"
         )
-        assert without_institution_arg.startswith('AO|', 31)
+        assert without_institution_arg.startswith('AO|', 33)
 
     def test_institution_id_field_value_provided(self):
         # Fake value retrieved from DB
@@ -329,7 +329,7 @@ class TestPatronResponse(object):
         with_institution_provided = self.sip.patron_information_request(
             "patron_identifier", "patron_password"
         )
-        assert with_institution_provided.startswith('AOMAIN|', 31)
+        assert with_institution_provided.startswith('AOMAIN|', 33)
 
     def test_patron_password_is_optional(self):
         without_password = self.sip.patron_information_request(

--- a/tests/sip/test_client.py
+++ b/tests/sip/test_client.py
@@ -317,6 +317,22 @@ class TestPatronResponse(object):
         )
         assert with_code.endswith("COlogin_password|CPlocation_code")
 
+    def test_institution_id_field_is_required(self):
+        without_institution_arg = self.sip.patron_information_request(
+            "patron_identifier", "patron_password"
+        )
+        assert without_institution_arg.startswith('AO|', 31)
+
+    def test_institution_id_field_value_is_optional(self):
+        with_institution_blank = self.sip.patron_information_request(
+            "patron_identifier", "patron_password", institution_id=''
+        )
+        assert with_institution_blank.startswith('AO|', 31)
+        with_institution_provided = self.sip.patron_information_request(
+            "patron_identifier", "patron_password", institution_id='MAIN'
+        )
+        assert with_institution_provided.startswith('AOMAIN|', 31)
+
     def test_patron_password_is_optional(self):
         without_password = self.sip.patron_information_request(
             "patron_identifier"

--- a/tests/sip/test_client.py
+++ b/tests/sip/test_client.py
@@ -323,13 +323,11 @@ class TestPatronResponse(object):
         )
         assert without_institution_arg.startswith('AO|', 31)
 
-    def test_institution_id_field_value_is_optional(self):
-        with_institution_blank = self.sip.patron_information_request(
-            "patron_identifier", "patron_password", institution_id=''
-        )
-        assert with_institution_blank.startswith('AO|', 31)
+    def test_institution_id_field_value_provided(self):
+        # Fake value retrieved from DB
+        self.sip.institution_id='MAIN'
         with_institution_provided = self.sip.patron_information_request(
-            "patron_identifier", "patron_password", institution_id='MAIN'
+            "patron_identifier", "patron_password"
         )
         assert with_institution_provided.startswith('AOMAIN|', 31)
 


### PR DESCRIPTION
Addresses Jira ticket [https://jira.nypl.org/browse/SIMPLY-2138](https://jira.nypl.org/browse/SIMPLY-2138). Adds an optional Institution ID field to the Admin interface patron authentication integration form, as a per-integration, per-library setting, following Slack discussion. This enables specification of an institution_id value for an ILS that requires a value for the AO field. Adding it in the per-library section facilitates creating one patron auth integration to manage the case where a shared/consortial ILS uses separate IDs to distinguish libraries.