### PR TITLE
The circulation manager should start up no matter what kind of exception is raised by during search engine initialization.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -286,9 +286,9 @@ class CirculationManager(object):
         try:
             self._external_search = self.setup_search()
             self.external_search_initialization_exception = None
-        except CannotLoadConfiguration, e:
+        except Exception, e:
             self.log.error(
-                "Exception loading search configuration: %s", e
+                "Exception initializing search engine: %s", e
             )
             self._external_search = None
             self.external_search_initialization_exception = e

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -514,7 +514,7 @@ class TestCirculationManager(CirculationControllerTest):
 
         # The reason why is stored here.
         ex = circulation.external_search_initialization_exception
-        assert isinstance(ex, CannotLoadConfiguration)
+        assert isinstance(ex, Exception)
         eq_("doomed!", ex.message)
 
     def test_exception_during_short_client_token_initialization_is_stored(self):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -505,7 +505,7 @@ class TestCirculationManager(CirculationControllerTest):
 
             @property
             def setup_search(self):
-                raise CannotLoadConfiguration("doomed!")
+                raise Exception("doomed!")
 
         circulation = BadSearch(self._db, testing=True)
 
@@ -3372,7 +3372,7 @@ class TestFeedController(CirculationControllerTest):
 
             @property
             def setup_search(self):
-                raise CannotLoadConfiguration("doomed!")
+                raise Exception("doomed!")
 
         circulation = BadSearch(self._db, testing=True)
 


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-2179.
There are a lot of different problems that can happen when initializing the search server, not just problems that are obviously configuration-related. However, none of them are so bad that they should stop the app server from starting up, since a working admin interface may be necessary to resolving the problem.