### PR TITLE
Update styling for server-rendered components

### DIFF
--- a/api/admin/template_styles.py
+++ b/api/admin/template_styles.py
@@ -20,6 +20,7 @@ error_style = body_style + """
     border-color: #D0343A;
 """
 input_style = """
+    border-radius: .25em;
     display: block;
     padding: 10px;
     border: 1px solid #403d37;
@@ -37,8 +38,9 @@ section_style = """
     align-items: center;
 """
 button_style = """
-    background: #3a7dfd;
+    background: #1B7FA7;
     border-color: transparent;
+    border-radius: .25em;
     color: #fff;
     padding: 10px;
     font-size: 1rem;
@@ -49,10 +51,11 @@ button_style = """
 """
 
 link_style = """
-    background: #3a7dfd;
+    background: #1B7FA7;
     text-align: center;
     text-decoration: none;
-    border-color: #3a7dfd;
+    border-color: #1B7FA7;
+    border-radius: .25em;
     color: #fff;
     padding: 10px;
     font-size: 1rem;


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-1919.  Changed the background-color and border-radius of buttons and links on the server-side-rendered components (the log in form and the invalid credentials error message) to make them visually consistent with the styling we're now using for the rest of the interface (toned-down blue with slightly rounded corners, rather than bright blue with sharp corners).

Before:
<img width="766" alt="Screen Shot 2019-08-07 at 3 50 34 PM" src="https://user-images.githubusercontent.com/42178216/62654211-4c859300-b92d-11e9-95b2-46294c915390.png">
<img width="804" alt="Screen Shot 2019-08-07 at 3 38 13 PM" src="https://user-images.githubusercontent.com/42178216/62654215-4ee7ed00-b92d-11e9-8857-7ea19589bd2a.png">

<hr />

After:
<img width="668" alt="Screen Shot 2019-08-07 at 3 50 42 PM" src="https://user-images.githubusercontent.com/42178216/62654165-3677d280-b92d-11e9-97e2-b9e7cda51d4f.png">
<img width="621" alt="Screen Shot 2019-08-07 at 4 05 58 PM" src="https://user-images.githubusercontent.com/42178216/62654184-42fc2b00-b92d-11e9-90fc-887cc13eeba2.png">
