### PR TITLE
Make Python 2 code forwards-compatible with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
   - psql -c 'create user simplified_test;' -U postgres
   - psql -c 'create database simplified_circulation_test;' -U postgres
   - psql -c 'grant all privileges on database simplified_circulation_test to simplified_test;' -U postgres
-  # - cd docs && make html && cd ..
+  - cd docs && make html && cd ..
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
   - psql -c 'create user simplified_test;' -U postgres
   - psql -c 'create database simplified_circulation_test;' -U postgres
   - psql -c 'grant all privileges on database simplified_circulation_test to simplified_test;' -U postgres
-  - cd docs && make html && cd ..
+  # - cd docs && make html && cd ..
 
 env:
   global:

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1788,6 +1788,8 @@ class SitewideRegistrationController(SettingsController):
 
         ignore, private_key = self.manager.sitewide_key_pair
         decryptor = Configuration.cipher(private_key)
+        # We use the standard library's b64decode because decrypt()
+        # only takes a bytestring.
         shared_secret = decryptor.decrypt(
             stdlib_base64.b64decode(shared_secret)
         )

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1,4 +1,5 @@
 from nose.tools import set_trace
+import base64 as stdlib_base64
 import logging
 import sys
 import os
@@ -1787,7 +1788,9 @@ class SitewideRegistrationController(SettingsController):
 
         ignore, private_key = self.manager.sitewide_key_pair
         decryptor = Configuration.cipher(private_key)
-        shared_secret = decryptor.decrypt(base64.b64decode(shared_secret))
+        shared_secret = decryptor.decrypt(
+            stdlib_base64.b64decode(shared_secret)
+        )
         integration.password = unicode(shared_secret)
 
     def get_catalog(self, do_get, url):

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1583,7 +1583,7 @@ class SettingsController(AdminCirculationManagerController):
             # making the configuration changes necessary to fix
             # this problem.
             message = _("Exception getting self-test results for %s %s: %s")
-            args = (self.type, item.name, str(e))
+            args = (self.type, item.name, unicode(e))
             logging.warn(message, *args, exc_info=e)
             self_test_results = dict(exception=message % args)
 
@@ -1799,7 +1799,7 @@ class SitewideRegistrationController(SettingsController):
         try:
             response = do_get(url)
         except Exception as e:
-            return REMOTE_INTEGRATION_FAILED.detailed(str(e))
+            return REMOTE_INTEGRATION_FAILED.detailed(unicode(e))
 
         if isinstance(response, ProblemDetail):
             return response
@@ -1859,7 +1859,7 @@ class SitewideRegistrationController(SettingsController):
                 headers=headers
             )
         except Exception as e:
-            return REMOTE_INTEGRATION_FAILED.detailed(str(e))
+            return REMOTE_INTEGRATION_FAILED.detailed(unicode(e))
         return response
 
     def get_shared_secret(self, response):

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -2,7 +2,6 @@ from nose.tools import set_trace
 import logging
 import sys
 import os
-import base64
 import random
 import json
 import jwt
@@ -63,6 +62,7 @@ from core.model import (
 from core.lane import (Lane, WorkList)
 from core.log import (LogConfiguration, SysLogger, Loggly, CloudwatchLogs)
 from core.util.problem_detail import ProblemDetail
+from core.util.string_helpers import base64
 from core.metadata_layer import (
     Metadata,
     LinkData,
@@ -298,7 +298,8 @@ class AdminController(object):
 
     def generate_csrf_token(self):
         """Generate a random CSRF token."""
-        return base64.b64encode(os.urandom(24)).decode("utf8")
+        # NOTE: We don't use random_string here -- maybe we could.
+        return base64.b64encode(os.urandom(24))
 
 class AdminCirculationManagerController(CirculationManagerController):
     """Parent class that provides methods for verifying an admin's roles."""

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -2,8 +2,6 @@ from nose.tools import set_trace
 import base64 as stdlib_base64
 import logging
 import sys
-import os
-import random
 import json
 import jwt
 import re
@@ -63,7 +61,10 @@ from core.model import (
 from core.lane import (Lane, WorkList)
 from core.log import (LogConfiguration, SysLogger, Loggly, CloudwatchLogs)
 from core.util.problem_detail import ProblemDetail
-from core.util.string_helpers import base64
+from core.util.string_helpers import (
+    base64,
+    random_string,
+)
 from core.metadata_layer import (
     Metadata,
     LinkData,
@@ -299,8 +300,7 @@ class AdminController(object):
 
     def generate_csrf_token(self):
         """Generate a random CSRF token."""
-        # NOTE: We don't use random_string here -- maybe we could.
-        return base64.b64encode(os.urandom(24))
+        return random_string(24)
 
 class AdminCirculationManagerController(CirculationManagerController):
     """Parent class that provides methods for verifying an admin's roles."""

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -173,14 +173,19 @@ def setup_admin_controllers(manager):
     manager.admin_library_settings_controller = LibrarySettingsController(manager)
     from api.admin.controller.individual_admin_settings import IndividualAdminSettingsController
     manager.admin_individual_admin_settings_controller = IndividualAdminSettingsController(manager)
-    from api.admin.controller.sitewide_services import *
+    from api.admin.controller.sitewide_services import (
+        SitewideServicesController,
+        LoggingServicesController,
+        SearchServicesController,
+        StorageServicesController,
+    )
     manager.admin_sitewide_services_controller = SitewideServicesController(manager)
     manager.admin_logging_services_controller = LoggingServicesController(manager)
     from api.admin.controller.search_service_self_tests import SearchServiceSelfTestsController
     manager.admin_search_service_self_tests_controller = SearchServiceSelfTestsController(manager)
     manager.admin_search_services_controller = SearchServicesController(manager)
     manager.admin_storage_services_controller = StorageServicesController(manager)
-    from api.admin.controller.catalog_services import *
+    from api.admin.controller.catalog_services import CatalogServicesController
     manager.admin_catalog_services_controller = CatalogServicesController(manager)
 
 class AdminController(object):
@@ -293,7 +298,7 @@ class AdminController(object):
 
     def generate_csrf_token(self):
         """Generate a random CSRF token."""
-        return base64.b64encode(os.urandom(24))
+        return base64.b64encode(os.urandom(24)).decode("utf8")
 
 class AdminCirculationManagerController(CirculationManagerController):
     """Parent class that provides methods for verifying an admin's roles."""
@@ -1576,7 +1581,7 @@ class SettingsController(AdminCirculationManagerController):
             # making the configuration changes necessary to fix
             # this problem.
             message = _("Exception getting self-test results for %s %s: %s")
-            args = (self.type, item.name, e.message)
+            args = (self.type, item.name, str(e))
             logging.warn(message, *args, exc_info=e)
             self_test_results = dict(exception=message % args)
 
@@ -1790,7 +1795,7 @@ class SitewideRegistrationController(SettingsController):
         try:
             response = do_get(url)
         except Exception as e:
-            return REMOTE_INTEGRATION_FAILED.detailed(e.message)
+            return REMOTE_INTEGRATION_FAILED.detailed(str(e))
 
         if isinstance(response, ProblemDetail):
             return response
@@ -1850,7 +1855,7 @@ class SitewideRegistrationController(SettingsController):
                 headers=headers
             )
         except Exception as e:
-            return REMOTE_INTEGRATION_FAILED.detailed(e.message)
+            return REMOTE_INTEGRATION_FAILED.detailed(str(e))
         return response
 
     def get_shared_secret(self, response):

--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -255,7 +255,7 @@ class LibrarySettingsController(SettingsController):
             width, height = image.size
             if width > 135 or height > 135:
                 image.thumbnail((135, 135), Image.ANTIALIAS)
-            buffer = StringIO()
+            buffer = BytesIO()
             image.save(buffer, format="PNG")
             b64 = base64.b64encode(buffer.getvalue())
             return "data:image/png;base64,%s" % b64

--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -5,7 +5,7 @@ from flask_babel import lazy_gettext as _
 import json
 from pypostalcode import PostalCodeDatabase
 import re
-from StringIO import StringIO
+from io import BytesIO
 import urllib
 import uszipcode
 import uuid

--- a/api/admin/controller/work_editor.py
+++ b/api/admin/controller/work_editor.py
@@ -53,7 +53,7 @@ from core.model import (
     Subject,
     Work
 )
-import base64
+import base64 as stdlib_base64
 from datetime import date, datetime, timedelta
 import json
 import os
@@ -758,8 +758,8 @@ class WorkController(AdminCirculationManagerController):
 
         buffer = BytesIO()
         image.save(buffer, format="PNG")
-        b64 = base64.b64encode(buffer.getvalue())
-        value = b"data:image/png;base64,%s" % b64.decode("utf8")
+        b64 = stdlib_base64.b64encode(buffer.getvalue())
+        value = b"data:image/png;base64,%s" % b64
 
         return Response(value, 200)
 

--- a/api/admin/controller/work_editor.py
+++ b/api/admin/controller/work_editor.py
@@ -759,7 +759,7 @@ class WorkController(AdminCirculationManagerController):
         buffer = BytesIO()
         image.save(buffer, format="PNG")
         b64 = base64.b64encode(buffer.getvalue())
-        value = "data:image/png;base64,%s" % b64.decode("utf8")
+        value = b"data:image/png;base64,%s" % b64.decode("utf8")
 
         return Response(value, 200)
 

--- a/api/admin/controller/work_editor.py
+++ b/api/admin/controller/work_editor.py
@@ -58,7 +58,7 @@ from datetime import date, datetime, timedelta
 import json
 import os
 from PIL import Image, ImageDraw, ImageFont
-from StringIO import StringIO
+from io import BytesIO
 import textwrap
 import urllib
 

--- a/api/admin/controller/work_editor.py
+++ b/api/admin/controller/work_editor.py
@@ -744,8 +744,8 @@ class WorkController(AdminCirculationManagerController):
     def preview_book_cover(self, identifier_type, identifier):
         """Return a preview of the submitted cover image information.
 
-        :return: A Response in which the entity-body is a Unicode string containing
-        a base64-encoded image.
+        :return: A Response in which the entity-body is a Unicode
+                 string containing a base64-encoded image.
         """
         self.require_librarian(flask.request.library)
         work = self.load_work(flask.request.library, identifier_type, identifier)

--- a/api/admin/controller/work_editor.py
+++ b/api/admin/controller/work_editor.py
@@ -744,8 +744,8 @@ class WorkController(AdminCirculationManagerController):
     def preview_book_cover(self, identifier_type, identifier):
         """Return a preview of the submitted cover image information.
 
-        :return: A Response in which the entity-body is a Unicode
-                 string containing a base64-encoded image.
+        :return: A Response in which the entity-body is a bytestring
+                 containing a base64-encoded image.
         """
         self.require_librarian(flask.request.library)
         work = self.load_work(flask.request.library, identifier_type, identifier)

--- a/api/admin/google_oauth_admin_authentication_provider.py
+++ b/api/admin/google_oauth_admin_authentication_provider.py
@@ -116,7 +116,7 @@ class GoogleOAuthAdminAuthenticationProvider(AdminAuthenticationProvider):
             try:
                 credentials = self.client.step2_exchange(auth_code)
             except GoogleClient.FlowExchangeError, e:
-                return self.google_error_problem_detail(str(e)), None
+                return self.google_error_problem_detail(unicode(e)), None
             email = credentials.id_token.get('email')
             if not self.staff_email(_db, email):
                 return INVALID_ADMIN_CREDENTIALS, None

--- a/api/admin/google_oauth_admin_authentication_provider.py
+++ b/api/admin/google_oauth_admin_authentication_provider.py
@@ -116,7 +116,7 @@ class GoogleOAuthAdminAuthenticationProvider(AdminAuthenticationProvider):
             try:
                 credentials = self.client.step2_exchange(auth_code)
             except GoogleClient.FlowExchangeError, e:
-                return self.google_error_problem_detail(e.message), None
+                return self.google_error_problem_detail(str(e)), None
             email = credentials.id_token.get('email')
             if not self.staff_email(_db, email):
                 return INVALID_ADMIN_CREDENTIALS, None

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -797,6 +797,7 @@ class AuthdataUtility(object):
 
         # PYTHON3 TODO This is an OrderedDict so that the sample
         # JWT we use in tests will be the same across versions.
+        # In Python 3 it can be made a regular dict.
         payload = OrderedDict()
         payload['iss'] = iss                       # Issuer
         if sub:

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -1,4 +1,5 @@
 import argparse
+from collections import OrderedDict
 from nose.tools import set_trace
 import json
 import logging
@@ -793,7 +794,11 @@ class AuthdataUtility(object):
 
     def _encode(self, iss=None, sub=None, iat=None, exp=None):
         """Helper method split out separately for use in tests."""
-        payload = dict(iss=iss)                    # Issuer
+
+        # PYTHON3 TODO This is an OrderedDict so that the sample
+        # JWT we use in tests will be the same across versions.
+        payload = OrderedDict()
+        payload['iss'] = iss                       # Issuer
         if sub:
             payload['sub'] = sub                   # Subject
         if iat:

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -201,7 +201,7 @@ class AdobeVendorIDRequestHandler(object):
             data = parser.process(data)
         except Exception, e:
             logging.error("Error processing %s", data, exc_info=e)
-            return self.error_document(self.AUTH_ERROR_TYPE, str(e))
+            return self.error_document(self.AUTH_ERROR_TYPE, unicode(e))
         user_id = label = None
         if not data:
             return self.error_document(
@@ -238,7 +238,7 @@ class AdobeVendorIDRequestHandler(object):
             label = urn_to_label(data['user'])
         except Exception, e:
             return self.error_document(
-                self.ACCOUNT_INFO_ERROR_TYPE, str(e))
+                self.ACCOUNT_INFO_ERROR_TYPE, unicode(e))
 
         if label:
             return self.ACCOUNT_INFO_RESPONSE_TEMPLATE % dict(label=label)

--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -41,7 +41,7 @@ from core.scripts import Script
 # the standard library's base64 in one case, when we want to get back
 # a bytestring.
 import base64 as stdlib_base64
-from core.util.binary import base64
+from core.util.string_helpers import base64
 
 class AdobeVendorIDController(object):
 

--- a/api/annotations.py
+++ b/api/annotations.py
@@ -1,5 +1,6 @@
 from nose.tools import set_trace
 from pyld import jsonld
+import io
 import json
 from datetime import datetime
 import os
@@ -28,9 +29,7 @@ def load_document(url):
         base_path = os.path.join(os.path.split(__file__)[0], 'jsonld')
         jsonld_file = os.path.join(base_path, files[url])
 
-        # TODO PYTHON3 we can decode the data on the way in
-        # by passing encoding="utf8" into the constructor.
-        data = open(jsonld_file).read().decode("utf8")
+        data = io.open(jsonld_file, encoding="utf8").read()
         doc = {
             "contextUrl": None,
             "documentUrl": url,

--- a/api/annotations.py
+++ b/api/annotations.py
@@ -28,10 +28,9 @@ def load_document(url):
         base_path = os.path.join(os.path.split(__file__)[0], 'jsonld')
         jsonld_file = os.path.join(base_path, files[url])
 
-        # Most of the time when we open a file, it's an image or EPUB
-        # and we open it in binary mode. Here, it's JSON-LD, which must be
-        # encoded as UTF-8, so we can read it as a Unicode string.
-        data = open(jsonld_file, encoding="utf8").read()
+        # TODO PYTHON3 we can decode the data on the way in
+        # by passing encoding="utf8" into the constructor.
+        data = open(jsonld_file).read().decode("utf8")
         doc = {
             "contextUrl": None,
             "documentUrl": url,

--- a/api/annotations.py
+++ b/api/annotations.py
@@ -27,11 +27,11 @@ def load_document(url):
     if url in files:
         base_path = os.path.join(os.path.split(__file__)[0], 'jsonld')
         jsonld_file = os.path.join(base_path, files[url])
-        data = open(jsonld_file).read()
+        data = open(jsonld_file, encoding="utf8").read()
         doc = {
             "contextUrl": None,
             "documentUrl": url,
-            "document": data.decode('utf-8')
+            "document": data
         }
         return doc
     else:

--- a/api/annotations.py
+++ b/api/annotations.py
@@ -27,6 +27,10 @@ def load_document(url):
     if url in files:
         base_path = os.path.join(os.path.split(__file__)[0], 'jsonld')
         jsonld_file = os.path.join(base_path, files[url])
+
+        # Most of the time when we open a file, it's an image or EPUB
+        # and we open it in binary mode. Here, it's JSON-LD, which must be
+        # encoded as UTF-8, so we can read it as a Unicode string.
         data = open(jsonld_file, encoding="utf8").read()
         doc = {
             "contextUrl": None,

--- a/api/app.py
+++ b/api/app.py
@@ -45,8 +45,8 @@ def initialize_database(autoinitialize=True):
     _db.commit()
     logging.getLogger().info("Application debug mode==%r" % app.debug)
 
-import routes
-import admin.routes
+from . import routes
+from .admin import routes
 
 def run(url=None):
     base_url = url or u'http://localhost:6500/'

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1,6 +1,7 @@
 from nose.tools import set_trace
 from api.annotations import AnnotationWriter
 from api.opds import LibraryAnnotator
+from collections import OrderedDict
 from config import (
     Configuration,
     CannotLoadConfiguration,
@@ -825,13 +826,12 @@ class LibraryAuthenticator(object):
         When the patron uses the bearer token in the Authenticate header,
         it will be decoded with `decode_bearer_token_from_header`.
         """
-        payload = dict(
-            token=provider_token,
-            # I'm not sure this is the correct way to use an
-            # Issuer claim (https://tools.ietf.org/html/rfc7519#section-4.1.1).
-            # Maybe we should use something custom instead.
-            iss=provider_name,
-        )
+        payload = OrderedDict()
+        payload['token'] = provider_token
+        # I'm not sure this is the correct way to use an
+        # Issuer claim (https://tools.ietf.org/html/rfc7519#section-4.1.1).
+        # Maybe we should use something custom instead.
+        payload['iss'] = provider_name
         return jwt.encode(
             payload, self.bearer_token_signing_secret, algorithm='HS256'
         ).decode("utf8")

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -834,7 +834,7 @@ class LibraryAuthenticator(object):
         )
         return jwt.encode(
             payload, self.bearer_token_signing_secret, algorithm='HS256'
-        )
+        ).decode("utf8")
 
     def decode_bearer_token_from_header(self, header):
         """Extract auth provider name and access token from an Authenticate

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -826,6 +826,8 @@ class LibraryAuthenticator(object):
         When the patron uses the bearer token in the Authenticate header,
         it will be decoded with `decode_bearer_token_from_header`.
         """
+        # PYTHON3 TODO: This can be turned into a regular dict once we
+        # convert to Python 3.
         payload = OrderedDict()
         payload['token'] = provider_token
         # I'm not sure this is the correct way to use an

--- a/api/axis.py
+++ b/api/axis.py
@@ -67,7 +67,7 @@ from core.opds_import import (
 from core.testing import DatabaseTest
 
 from core.util import LanguageCodes
-from core.util.binary import UnicodeAwareBase64
+from core.util.string_helpers import UnicodeAwareBase64
 from core.util.xmlparser import XMLParser
 from core.util.http import (
     HTTP,
@@ -190,8 +190,14 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasCollectionSelfTests):
 
     @property
     def authorization_headers(self):
+        # NOTE: Presumably we were asked to use UTF-16 LE when
+        # accessing this API, but I don't see it mentioned in the
+        # documentation. Anyway, that's why we're not using
+        # core.util.string_helpers.base64 -- it assumes the proper
+        # encoding is UTF-8.
+        base64 = UnicodeAwareBase64(encoding="utf_16_le")
+
         authorization = u":".join([self.username, self.password, self.library_id])
-        authorization = authorization.encode("utf_16_le")
         authorization = base64.standard_b64encode(authorization)
         return dict(Authorization="Basic " + authorization)
 

--- a/api/axis.py
+++ b/api/axis.py
@@ -1,4 +1,3 @@
-import base64
 import json
 import logging
 import os
@@ -68,6 +67,7 @@ from core.opds_import import (
 from core.testing import DatabaseTest
 
 from core.util import LanguageCodes
+from core.util.binary import UnicodeAwareBase64
 from core.util.xmlparser import XMLParser
 from core.util.http import (
     HTTP,
@@ -176,12 +176,6 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasCollectionSelfTests):
             raise CannotLoadConfiguration(
                 "Axis 360 configuration is incomplete."
             )
-
-        # Use utf8 instead of unicode encoding
-        settings = [self.library_id, self.username, self.password]
-        self.library_id, self.username, self.password = (
-            setting.encode('utf8') for setting in settings
-        )
 
         self.token = None
         self.collection_id = collection.id

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -541,7 +541,7 @@ class BibliothecaAPI(BaseCirculationAPI, HasSelfTests):
             license document via Bibliotheca, or a dictionary
             representing such a document loaded into JSON form.
         """
-        if isinstance(findaway_license, basestring):
+        if isinstance(findaway_license, (bytes, unicode)):
             findaway_license = json.loads(findaway_license)
 
         kwargs = {}

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1,7 +1,7 @@
 import json
 from lxml import etree
 
-from cStringIO import StringIO
+from io import BytesIO
 import itertools
 from datetime import datetime, timedelta
 import os

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -74,7 +74,7 @@ from core.monitor import (
     IdentifierSweepMonitor,
     TimelineMonitor,
 )
-from core.util.binary import base64
+from core.util.string_helpers import base64
 from core.util.xmlparser import XMLParser
 from core.util.http import (
     BadResponseException,

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -407,7 +407,7 @@ class CirculationAPI(object):
                 except CannotLoadConfiguration, e:
                     self.log.error(
                         "Error loading configuration for %s: %s",
-                        collection.name, str(e)
+                        collection.name, unicode(e)
                     )
                     self.initialization_exceptions[collection.id] = e
                 if api:

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -407,7 +407,7 @@ class CirculationAPI(object):
                 except CannotLoadConfiguration, e:
                     self.log.error(
                         "Error loading configuration for %s: %s",
-                        collection.name, e.message
+                        collection.name, str(e)
                     )
                     self.initialization_exceptions[collection.id] = e
                 if api:

--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -142,9 +142,9 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
             bearer token.
         """
         payload = self._remote_exchange_payload(_db, code)
-        authorization = base64.b64encode(
-            self.client_id + ":" + self.client_secret
-        )
+        base_authorization = self.client_id + ":" + self.client_secret
+        authorization = base64.b64encode(base_authorization.encode("utf8"))
+        authorization = authorization.decode("utf8")
         headers = {
             'Authorization': 'Basic %s' % authorization,
             'Content-Type': 'application/json',

--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -1,6 +1,5 @@
 from nose.tools import set_trace
 import logging
-import base64
 import json
 import os
 import datetime
@@ -23,6 +22,7 @@ from core.model import (
     Patron,
 )
 from core.util.http import HTTP
+from core.util.string_helpers import base64
 from api.problem_details import *
 
 
@@ -143,8 +143,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
         """
         payload = self._remote_exchange_payload(_db, code)
         base_authorization = self.client_id + ":" + self.client_secret
-        authorization = base64.b64encode(base_authorization.encode("utf8"))
-        authorization = authorization.decode("utf8")
+        authorization = base64.b64encode(base_authorization)
         headers = {
             'Authorization': 'Basic %s' % authorization,
             'Content-Type': 'application/json',

--- a/api/config.py
+++ b/api/config.py
@@ -608,8 +608,8 @@ class Configuration(CoreConfiguration):
         if not public or not private:
             key = RSA.generate(2048)
             encryptor = PKCS1_OAEP.new(key)
-            public = key.publickey().exportKey()
-            private = key.exportKey()
+            public = key.publickey().exportKey().decode("utf8")
+            private = key.exportKey().decode("utf8")
             setting.value = json.dumps([public, private])
         return public, private
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -85,7 +85,7 @@ from core.opds import (
     AcquisitionFeed,
     NavigationFeed,
 )
-from core.util.binary import base64
+from core.util.string_helpers import base64
 from core.util.opds_writer import (
      OPDSFeed,
 )

--- a/api/controller.py
+++ b/api/controller.py
@@ -1336,7 +1336,7 @@ class LoanController(CirculationManagerController):
                 part=part, fulfill_part_url=fulfill_part_url
             )
         except DeliveryMechanismConflict, e:
-            return DELIVERY_CONFLICT.detailed(e.message)
+            return DELIVERY_CONFLICT.detailed(str(e))
         except NoActiveLoan, e:
             return NO_ACTIVE_LOAN.detailed(
                     _('Can\'t fulfill loan because you have no active loan for this book.'),

--- a/api/controller.py
+++ b/api/controller.py
@@ -5,7 +5,6 @@ import sys
 import urllib
 import urlparse
 import datetime
-import base64
 from wsgiref.handlers import format_date_time
 from time import mktime
 import os
@@ -86,6 +85,7 @@ from core.opds import (
     AcquisitionFeed,
     NavigationFeed,
 )
+from core.util.binary import base64
 from core.util.opds_writer import (
      OPDSFeed,
 )
@@ -1692,7 +1692,7 @@ class WorkController(CirculationManagerController):
             )
         except ValueError, e:
             # No related books were found.
-            return NO_SUCH_LANE.detailed(e.message)
+            return NO_SUCH_LANE.detailed(str(e))
 
         facets = load_facets_from_request(
             worklist=lane, base_class=FeaturedFacets,

--- a/api/controller.py
+++ b/api/controller.py
@@ -1119,12 +1119,12 @@ class LoanController(CirculationManagerController):
         except PatronAuthorizationFailedException, e:
             problem_doc = INVALID_CREDENTIALS
         except PatronLoanLimitReached, e:
-            problem_doc = LOAN_LIMIT_REACHED.with_debug(str(e))
+            problem_doc = LOAN_LIMIT_REACHED.with_debug(unicode(e))
         except PatronHoldLimitReached, e:
             problem_doc = e.as_problem_detail_document()
         except DeliveryMechanismError, e:
             return BAD_DELIVERY_MECHANISM.with_debug(
-                str(e), status_code=e.status_code
+                unicode(e), status_code=e.status_code
             )
         except OutstandingFines, e:
             problem_doc = OUTSTANDING_FINES.detailed(
@@ -1135,16 +1135,16 @@ class LoanController(CirculationManagerController):
         except AuthorizationBlocked, e:
             return e.as_problem_detail_document(debug=False)
         except CannotLoan, e:
-            problem_doc = CHECKOUT_FAILED.with_debug(str(e))
+            problem_doc = CHECKOUT_FAILED.with_debug(unicode(e))
         except CannotHold, e:
-            problem_doc = HOLD_FAILED.with_debug(str(e))
+            problem_doc = HOLD_FAILED.with_debug(unicode(e))
         except CannotRenew, e:
-            problem_doc = RENEW_FAILED.with_debug(str(e))
+            problem_doc = RENEW_FAILED.with_debug(unicode(e))
         except NotFoundOnRemote, e:
             problem_doc = NOT_FOUND_ON_REMOTE
         except CirculationException, e:
             # Generic circulation error.
-            problem_doc = CHECKOUT_FAILED.with_debug(str(e))
+            problem_doc = CHECKOUT_FAILED.with_debug(unicode(e))
 
         if problem_doc:
             return problem_doc
@@ -1336,7 +1336,7 @@ class LoanController(CirculationManagerController):
                 part=part, fulfill_part_url=fulfill_part_url
             )
         except DeliveryMechanismConflict, e:
-            return DELIVERY_CONFLICT.detailed(str(e))
+            return DELIVERY_CONFLICT.detailed(unicode(e))
         except NoActiveLoan, e:
             return NO_ACTIVE_LOAN.detailed(
                     _('Can\'t fulfill loan because you have no active loan for this book.'),
@@ -1344,15 +1344,15 @@ class LoanController(CirculationManagerController):
             )
         except CannotFulfill, e:
             return CANNOT_FULFILL.with_debug(
-                str(e), status_code=e.status_code
+                unicode(e), status_code=e.status_code
             )
         except FormatNotAvailable, e:
             return NO_ACCEPTABLE_FORMAT.with_debug(
-                str(e), status_code=e.status_code
+                unicode(e), status_code=e.status_code
             )
         except DeliveryMechanismError, e:
             return BAD_DELIVERY_MECHANISM.with_debug(
-                str(e), status_code=e.status_code
+                unicode(e), status_code=e.status_code
             )
 
         headers = dict()
@@ -1459,7 +1459,7 @@ class LoanController(CirculationManagerController):
                 return COULD_NOT_MIRROR_TO_REMOTE.detailed(title, status_code=503)
             except CannotReturn, e:
                 title = _("Loan deleted locally but remote failed.")
-                return COULD_NOT_MIRROR_TO_REMOTE.detailed(title, 503).with_debug(str(e))
+                return COULD_NOT_MIRROR_TO_REMOTE.detailed(title, 503).with_debug(unicode(e))
         elif hold:
             if not self.circulation.can_revoke_hold(pool, hold):
                 title = _("Cannot release a hold once it enters reserved state.")
@@ -1468,7 +1468,7 @@ class LoanController(CirculationManagerController):
                 self.circulation.release_hold(patron, credential, pool)
             except CannotReleaseHold, e:
                 title = _("Hold released locally but remote failed.")
-                return CANNOT_RELEASE_HOLD.detailed(title, 503).with_debug(str(e))
+                return CANNOT_RELEASE_HOLD.detailed(title, 503).with_debug(unicode(e))
 
         work = pool.work
         annotator = self.manager.annotator(None)
@@ -1692,7 +1692,7 @@ class WorkController(CirculationManagerController):
             )
         except ValueError, e:
             # No related books were found.
-            return NO_SUCH_LANE.detailed(str(e))
+            return NO_SUCH_LANE.detailed(unicode(e))
 
         facets = load_facets_from_request(
             worklist=lane, base_class=FeaturedFacets,
@@ -1940,9 +1940,9 @@ class SharedCollectionController(CirculationManagerController):
         try:
             response = self.shared_collection.register(collection, url)
         except InvalidInputException, e:
-            return INVALID_REGISTRATION.detailed(str(e))
+            return INVALID_REGISTRATION.detailed(unicode(e))
         except AuthorizationFailedException, e:
-            return INVALID_CREDENTIALS.detailed(str(e))
+            return INVALID_CREDENTIALS.detailed(unicode(e))
         except RemoteInitiatedServerError, e:
             return e.as_problem_detail_document(debug=False)
 
@@ -2004,11 +2004,11 @@ class SharedCollectionController(CirculationManagerController):
         try:
             loan = self.shared_collection.borrow(collection, client, pool, hold)
         except AuthorizationFailedException, e:
-            return INVALID_CREDENTIALS.detailed(str(e))
+            return INVALID_CREDENTIALS.detailed(unicode(e))
         except NoAvailableCopies, e:
-            return NO_AVAILABLE_LICENSE.detailed(str(e))
+            return NO_AVAILABLE_LICENSE.detailed(unicode(e))
         except CannotLoan, e:
-            return CHECKOUT_FAILED.detailed(str(e))
+            return CHECKOUT_FAILED.detailed(unicode(e))
         except RemoteIntegrationException, e:
             return e.as_problem_detail_document(debug=False)
         if loan and isinstance(loan, Loan):
@@ -2036,11 +2036,11 @@ class SharedCollectionController(CirculationManagerController):
         try:
             self.shared_collection.revoke_loan(collection, client, loan)
         except AuthorizationFailedException, e:
-            return INVALID_CREDENTIALS.detailed(str(e))
+            return INVALID_CREDENTIALS.detailed(unicode(e))
         except NotCheckedOut, e:
-            return NO_ACTIVE_LOAN.detailed(str(e))
+            return NO_ACTIVE_LOAN.detailed(unicode(e))
         except CannotReturn, e:
-            return COULD_NOT_MIRROR_TO_REMOTE.detailed(str(e))
+            return COULD_NOT_MIRROR_TO_REMOTE.detailed(unicode(e))
         return Response(_("Success"), 200)
 
     def fulfill(self, collection_name, loan_id, mechanism_id, do_get=HTTP.get_with_timeout):
@@ -2074,9 +2074,9 @@ class SharedCollectionController(CirculationManagerController):
         try:
             fulfillment = self.shared_collection.fulfill(collection, client, loan, mechanism)
         except AuthorizationFailedException, e:
-            return INVALID_CREDENTIALS.detailed(str(e))
+            return INVALID_CREDENTIALS.detailed(unicode(e))
         except CannotFulfill, e:
-            return CANNOT_FULFILL.detailed(str(e))
+            return CANNOT_FULFILL.detailed(unicode(e))
         except RemoteIntegrationException, e:
             return e.as_problem_detail_document(debug=False)
         headers = dict()
@@ -2129,11 +2129,11 @@ class SharedCollectionController(CirculationManagerController):
         try:
             self.shared_collection.revoke_hold(collection, client, hold)
         except AuthorizationFailedException, e:
-            return INVALID_CREDENTIALS.detailed(str(e))
+            return INVALID_CREDENTIALS.detailed(unicode(e))
         except NotOnHold, e:
-            return NO_ACTIVE_HOLD.detailed(str(e))
+            return NO_ACTIVE_HOLD.detailed(unicode(e))
         except CannotReleaseHold, e:
-            return CANNOT_RELEASE_HOLD.detailed(str(e))
+            return CANNOT_RELEASE_HOLD.detailed(unicode(e))
         return Response(_("Success"), 200)
 
 class StaticFileController(CirculationManagerController):

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -104,7 +104,8 @@ class OPDSImportCoverageProvider(CollectionCoverageProvider):
         # that a simplified:message that a normal OPDSImporter would
         # consider a 'failure' should actually be considered a
         # success.
-        for failure_or_identifier in error_messages_by_id.values():
+        # TODO PYTHON 3 easier not to sort
+        for failure_or_identifier in sorted(error_messages_by_id.values()):
             if isinstance(failure_or_identifier, CoverageFailure):
                 failure_or_identifier.collection = self.collection_or_not
             results.append(failure_or_identifier)

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -104,7 +104,7 @@ class OPDSImportCoverageProvider(CollectionCoverageProvider):
         # that a simplified:message that a normal OPDSImporter would
         # consider a 'failure' should actually be considered a
         # success.
-        for failure_or_identifier in sorted(error_messages_by_id.values()):
+        for failure_or_identifier in error_messages_by_id.values():
             if isinstance(failure_or_identifier, CoverageFailure):
                 failure_or_identifier.collection = self.collection_or_not
             results.append(failure_or_identifier)

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -104,7 +104,7 @@ class OPDSImportCoverageProvider(CollectionCoverageProvider):
         # that a simplified:message that a normal OPDSImporter would
         # consider a 'failure' should actually be considered a
         # success.
-        # TODO PYTHON 3 easier not to sort
+        # TODO PYTHON3 easier not to sort
         for failure_or_identifier in sorted(error_messages_by_id.values()):
             if isinstance(failure_or_identifier, CoverageFailure):
                 failure_or_identifier.collection = self.collection_or_not

--- a/api/enki.py
+++ b/api/enki.py
@@ -547,7 +547,7 @@ class BibliographicParser(object):
         if isinstance(json_data, basestring):
             json_data = json.loads(json_data)
         returned_titles = json_data.get("result", {}).get("titles", [])
-	for book in returned_titles:
+        for book in returned_titles:
             data = self.extract_bibliographic(book)
             if data:
                 yield data

--- a/api/feedbooks.py
+++ b/api/feedbooks.py
@@ -1,7 +1,7 @@
 import datetime
 import feedparser
 from nose.tools import set_trace
-from StringIO import StringIO
+from io import BytesIO
 from zipfile import ZipFile
 from lxml import etree
 import os

--- a/api/feedbooks.py
+++ b/api/feedbooks.py
@@ -271,7 +271,7 @@ class FeedbooksOPDSImporter(OPDSImporter):
                 )
             except ValueError as e:
                 # Invalid EPUB
-                self.log.warning("%s: %s" % (representation.url, str(e)))
+                self.log.warning("%s: %s" % (representation.url, unicode(e)))
                 return
 
             css_paths = []

--- a/api/feedbooks.py
+++ b/api/feedbooks.py
@@ -263,7 +263,7 @@ class FeedbooksOPDSImporter(OPDSImporter):
             # There is no CSS to replace. Do nothing.
             return
 
-        new_zip_content = StringIO()
+        new_zip_content = BytesIO()
         with EpubAccessor.open_epub(representation.url, content=representation.content) as (zip_file, package_path):
             try:
                 manifest_element = EpubAccessor.get_element_from_package(
@@ -271,7 +271,7 @@ class FeedbooksOPDSImporter(OPDSImporter):
                 )
             except ValueError as e:
                 # Invalid EPUB
-                self.log.warning("%s: %s" % (representation.url, e.message))
+                self.log.warning("%s: %s" % (representation.url, str(e)))
                 return
 
             css_paths = []

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -93,7 +93,7 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
             response = self.request(url)
         except requests.exceptions.ConnectionError, e:
             raise RemoteInitiatedServerError(
-                str(e.message),
+                str(e),
                 self.NAME
             )
         if response.status_code != 200:

--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -93,7 +93,7 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
             response = self.request(url)
         except requests.exceptions.ConnectionError, e:
             raise RemoteInitiatedServerError(
-                str(e),
+                unicode(e),
                 self.NAME
             )
         if response.status_code != 200:

--- a/api/firstbook2.py
+++ b/api/firstbook2.py
@@ -99,7 +99,7 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
             response = self.request(url)
         except requests.exceptions.ConnectionError, e:
             raise RemoteInitiatedServerError(
-                str(e),
+                unicode(e),
                 self.NAME
             )
         if response.status_code != 200:

--- a/api/firstbook2.py
+++ b/api/firstbook2.py
@@ -99,7 +99,7 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
             response = self.request(url)
         except requests.exceptions.ConnectionError, e:
             raise RemoteInitiatedServerError(
-                str(e.message),
+                str(e),
                 self.NAME
             )
         if response.status_code != 200:
@@ -121,7 +121,7 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
             pin=pin,
             iat=now,
         )
-        return jwt.encode(payload, self.secret, algorithm=self.ALGORITHM)
+        return jwt.encode(payload, self.secret, algorithm=self.ALGORITHM).decode("utf8")
 
     def request(self, url):
         """Make an HTTP request.

--- a/api/google_analytics_provider.py
+++ b/api/google_analytics_provider.py
@@ -101,6 +101,9 @@ class GoogleAnalyticsProvider(object):
                     'cd12': "true" if license_pool.open_access else "false",
                 })
         # urlencode doesn't like unicode strings so we convert them to utf8
+        #
+        # TODO PYTHON3 - Presumably urlencode is okay with Unicode
+        # strings in Python 3, and there's a simpler way to do this.
         fields = {k: unicodedata.normalize("NFKD", unicode(v)).encode("utf8") for k, v in fields.iteritems()}
 
         params = re.sub(r"=None(&?)", r"=\1", urllib.urlencode(fields))

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -379,7 +379,12 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         return data
 
     def _extract_text_nodes(self, content):
-        """Parse the HTML representations sent by the Millenium Patron API."""
+        """Parse the HTML representations sent by the Millenium Patron API.
+
+        :param content: Content from an HTTP request -- probably a bytestring.
+        """
+        if isinstance(content, bytes):
+            content = content.decode("utf8")
         for line in content.split("\n"):
             if line.startswith('<HTML><BODY>'):
                 line = line[12:]

--- a/api/nyt.py
+++ b/api/nyt.py
@@ -137,8 +137,11 @@ class NYTBestSellerAPI(NYTAPI, HasSelfTests):
             content = json.loads(representation.content)
             return content
 
+        content = representation.content
+        if content is not None:
+            content = content.decode("utf8")
         diagnostic = "Response from %s was: %r" % (
-            url, representation.content
+            url, content
         )
 
         if status == 403:

--- a/api/nyt.py
+++ b/api/nyt.py
@@ -140,7 +140,7 @@ class NYTBestSellerAPI(NYTAPI, HasSelfTests):
         content = representation.content
         if content is not None:
             content = content.decode("utf8")
-        diagnostic = "Response from %s was: %r" % (
+        diagnostic = "Response from %s was: '%s'" % (
             url, content
         )
 

--- a/api/nyt.py
+++ b/api/nyt.py
@@ -138,7 +138,7 @@ class NYTBestSellerAPI(NYTAPI, HasSelfTests):
             return content
 
         content = representation.content
-        if content is not None:
+        if isinstance(content, bytes):
             content = content.decode("utf8")
         diagnostic = "Response from %s was: '%s'" % (
             url, content

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-import base64
 import datetime
 import json
 import isbnlib
@@ -73,6 +72,7 @@ from core.config import (
 
 from core.testing import DatabaseTest
 
+from core.util.binary import base64
 from core.util.http import (
     HTTP,
     BadResponseException,
@@ -216,7 +216,7 @@ class OdiloRepresentationExtractor(object):
             try:
                 published = datetime.datetime.strptime(published, "%Y%m%d")
             except ValueError as e:
-                cls.log.warn('Cannot parse publication date from: ' + published + ', message: ' + e.message)
+                cls.log.warn('Cannot parse publication date from: ' + published + ', message: ' + str(e))
 
         # yyyyMMdd --> record last modification date
         last_update = book.get('modificationDate')
@@ -224,7 +224,7 @@ class OdiloRepresentationExtractor(object):
             try:
                 last_update = datetime.datetime.strptime(last_update, "%Y%m%d")
             except ValueError as e:
-                cls.log.warn('Cannot parse last update date from: ' + last_update + ', message: ' + e.message)
+                cls.log.warn('Cannot parse last update date from: ' + last_update + ', message: ' + str(e))
 
         language = book.get('language', 'spa')
 
@@ -391,10 +391,9 @@ class OdiloAPI(BaseCirculationAPI, HasSelfTests):
         if not self.client_key or not self.client_secret or not self.library_api_base_url:
             raise CannotLoadConfiguration("Odilo configuration is incomplete.")
 
-        # Use utf8 instead of unicode encoding
         settings = [self.client_key, self.client_secret, self.library_api_base_url]
         self.client_key, self.client_secret, self.library_api_base_url = (
-            setting.encode('utf8') for setting in settings
+            setting for setting in settings
         )
 
         # Get set up with up-to-date credentials from the API.

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -216,7 +216,7 @@ class OdiloRepresentationExtractor(object):
             try:
                 published = datetime.datetime.strptime(published, "%Y%m%d")
             except ValueError as e:
-                cls.log.warn('Cannot parse publication date from: ' + published + ', message: ' + str(e))
+                cls.log.warn('Cannot parse publication date from: ' + published + ', message: ' + unicode(e))
 
         # yyyyMMdd --> record last modification date
         last_update = book.get('modificationDate')
@@ -224,7 +224,7 @@ class OdiloRepresentationExtractor(object):
             try:
                 last_update = datetime.datetime.strptime(last_update, "%Y%m%d")
             except ValueError as e:
-                cls.log.warn('Cannot parse last update date from: ' + last_update + ', message: ' + str(e))
+                cls.log.warn('Cannot parse last update date from: ' + last_update + ', message: ' + unicode(e))
 
         language = book.get('language', 'spa')
 

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -72,7 +72,7 @@ from core.config import (
 
 from core.testing import DatabaseTest
 
-from core.util.binary import base64
+from core.util.string_helpers import base64
 from core.util.http import (
     HTTP,
     BadResponseException,

--- a/api/odl.py
+++ b/api/odl.py
@@ -1,6 +1,5 @@
 from nose.tools import set_trace
 
-import base64
 import json
 import uuid
 import datetime
@@ -59,6 +58,7 @@ from circulation import (
     HoldInfo,
 )
 from core.analytics import Analytics
+from core.util.binary import base64
 from core.util.http import (
     HTTP,
     BadResponseException,
@@ -189,7 +189,9 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI):
         username = self.username
         password = self.password
         headers = dict(headers or {})
-        auth_header = "Basic %s" % base64.b64encode("%s:%s" % (username, password))
+        auth_header = "Basic %s" % base64.b64encode(
+            "%s:%s" % (username, password)
+        )
         headers['Authorization'] = auth_header
 
         return HTTP.get_with_timeout(url, headers=headers)
@@ -526,7 +528,7 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI):
             # The licenses will have to go through some number of cycles
             # before one of them gets to this hold. This leavs out the first cycle -
             # it's already started so we'll handle it separately.
-            cycles = (hold.position - licenses_reserved - 1) / pool.licenses_owned
+            cycles = (hold.position - licenses_reserved - 1) // pool.licenses_owned
 
             # Each of the owned licenses is currently either on loan or reserved.
             # Figure out which license this hold will eventually get if every

--- a/api/odl.py
+++ b/api/odl.py
@@ -58,7 +58,7 @@ from circulation import (
     HoldInfo,
 )
 from core.analytics import Analytics
-from core.util.binary import base64
+from core.util.string_helpers import base64
 from core.util.http import (
     HTTP,
     BadResponseException,

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -34,7 +34,7 @@ from circulation import (
     LoanInfo,
     FulfillmentInfo,
 )
-from core.util.binary import base64
+from core.util.string_helpers import base64
 from core.util.http import HTTP
 from core.testing import (
     DatabaseTest,

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -1,6 +1,5 @@
 from nose.tools import set_trace
 
-import base64
 import datetime
 import feedparser
 import json
@@ -35,6 +34,7 @@ from circulation import (
     LoanInfo,
     FulfillmentInfo,
 )
+from core.util.binary import base64
 from core.util.http import HTTP
 from core.testing import (
     DatabaseTest,
@@ -128,7 +128,8 @@ class OPDSForDistributorsAPI(BaseCirculationAPI, HasSelfTests):
 
         def refresh(credential):
             headers = dict()
-            auth_header = "Basic %s" % base64.b64encode("%s:%s" % (self.username, self.password))
+            creds = "%s:%s" % (self.username, self.password)
+            auth_header = "Basic %s" % base64.b64encode(creds)
             headers['Authorization'] = auth_header
             headers['Content-Type'] = "application/x-www-form-urlencoded"
             body = dict(grant_type='client_credentials')

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -418,7 +418,7 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
 
         except Exception, e:
             self.log.error("Item circulation request failed: %r", e, exc_info=e)
-            raise RemoteInitiatedServerError(str(e), action)
+            raise RemoteInitiatedServerError(unicode(e), action)
 
         self.validate_response(response=response, message=message, action=action)
 
@@ -495,7 +495,7 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
             transaction_id = int(resp_obj)
         except Exception, e:
             self.log.error("Item hold request failed: %r", e, exc_info=e)
-            raise CannotHold(str(e))
+            raise CannotHold(unicode(e))
 
         self.log.debug("Patron %s/%s reserved item %s with transaction id %s.", patron.authorization_identifier,
             patron_rbdigital_id, item_rbdigital_id, resp_obj)
@@ -970,7 +970,7 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
                     message = resp_obj.get('message', None)
         except Exception, e:
             self.log.error("Patron checkouts failed: %r", e, exc_info=e)
-            raise RemoteInitiatedServerError(str(e), action)
+            raise RemoteInitiatedServerError(unicode(e), action)
 
         self.validate_response(response=response, message=message, action=action)
 
@@ -1051,7 +1051,7 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
                     message = resp_obj.get('message', None)
         except Exception, e:
             self.log.error("Patron holds failed: %r", e, exc_info=e)
-            raise RemoteInitiatedServerError(str(e), action)
+            raise RemoteInitiatedServerError(unicode(e), action)
 
         self.validate_response(response=response, message=message, action=action)
 
@@ -2020,9 +2020,9 @@ class RBDigitalBibliographicCoverageProvider(BibliographicCoverageProvider):
         try:
             response_dictionary = self.api.get_metadata_by_isbn(identifier)
         except BadResponseException as error:
-            return self.failure(identifier, str(error))
+            return self.failure(identifier, unicode(error))
         except IOError as error:
-            return self.failure(identifier, str(error))
+            return self.failure(identifier, unicode(error))
 
         if not response_dictionary:
             message = "Cannot find RBDigital metadata for %r" % identifier

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -75,7 +75,7 @@ from core.monitor import (
 
 from core.testing import DatabaseTest
 from core.util import LanguageCodes
-from core.util.binary import random_string
+from core.util.string_helpers import random_string
 from core.util.http import (
     BadResponseException,
     HTTP,

--- a/api/registry.py
+++ b/api/registry.py
@@ -368,6 +368,8 @@ class Registration(object):
         it could not be decrypted.
         """
         try:
+            # We don't want to use the base64 replacement from core.util.binary
+            # here, because cipher.decrypt will only take a bytestring.
             shared_secret = cipher.decrypt(base64.b64decode(shared_secret))
         except ValueError, e:
             return SHARED_SECRET_DECRYPTION_ERROR.detailed(

--- a/api/registry.py
+++ b/api/registry.py
@@ -368,8 +368,9 @@ class Registration(object):
         it could not be decrypted.
         """
         try:
-            # We don't want to use the base64 replacement from core.util.binary
-            # here, because cipher.decrypt will only take a bytestring.
+            # We don't want to use the base64 replacement from
+            # core.util.string_helpers, because cipher.decrypt will
+            # only take a bytestring.
             shared_secret = cipher.decrypt(base64.b64decode(shared_secret))
         except ValueError, e:
             return SHARED_SECRET_DECRYPTION_ERROR.detailed(

--- a/api/shared_collection.py
+++ b/api/shared_collection.py
@@ -1,7 +1,6 @@
 from nose.tools import set_trace
 import logging
 import flask
-import base64
 import json
 from flask_babel import lazy_gettext as _
 
@@ -14,6 +13,7 @@ from core.model import (
 from circulation_exceptions import *
 from config import Configuration
 from core.config import CannotLoadConfiguration
+from core.util.binary import base64
 from core.util.http import HTTP
 
 class SharedCollectionAPI(object):
@@ -54,7 +54,7 @@ class SharedCollectionAPI(object):
                 except CannotLoadConfiguration, e:
                     self.log.error(
                         "Error loading configuration for %s: %s",
-                        collection.name, e.message
+                        collection.name, str(e)
                     )
                     self.initialization_exceptions[collection.id] = e
                 if api:
@@ -139,7 +139,7 @@ class SharedCollectionAPI(object):
             client, ignore = IntegrationClient.register(self._db, start_url)
 
         shared_secret = client.shared_secret
-        encrypted_secret = encryptor.encrypt(str(shared_secret))
+        encrypted_secret = encryptor.encrypt(shared_secret.encode("utf8"))
         return dict(metadata=dict(shared_secret=base64.b64encode(encrypted_secret)))
 
     def check_client_authorization(self, collection, client):

--- a/api/shared_collection.py
+++ b/api/shared_collection.py
@@ -54,7 +54,7 @@ class SharedCollectionAPI(object):
                 except CannotLoadConfiguration, e:
                     self.log.error(
                         "Error loading configuration for %s: %s",
-                        collection.name, str(e)
+                        collection.name, unicode(e)
                     )
                     self.initialization_exceptions[collection.id] = e
                 if api:

--- a/api/shared_collection.py
+++ b/api/shared_collection.py
@@ -13,7 +13,7 @@ from core.model import (
 from circulation_exceptions import *
 from config import Configuration
 from core.config import CannotLoadConfiguration
-from core.util.binary import base64
+from core.util.string_helpers import base64
 from core.util.http import HTTP
 
 class SharedCollectionAPI(object):

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -139,7 +139,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
 
         except IOError, e:
             raise RemoteIntegrationException(
-                self.server or 'unknown server', str(e)
+                self.server or 'unknown server', unicode(e)
             )
 
     def _remote_patron_lookup(self, patron_or_patrondata):

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -139,7 +139,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
 
         except IOError, e:
             raise RemoteIntegrationException(
-                self.server or 'unknown server', e.message
+                self.server or 'unknown server', str(e)
             )
 
     def _remote_patron_lookup(self, patron_or_patrondata):

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -352,12 +352,12 @@ class SIPClient(Constants):
         tmp_ssl_cert_path = None
         tmp_ssl_key_path = None
         if self.ssl_cert:
-            fd, tmp_ssl_cert_path = tempfile.mkstemp()
-            os.write(fd, self.ssl_cert)
+            fd, tmp_ssl_cert_path = tempfile.mkstemp('wb')
+            os.write(fd, self.ssl_cert.encode("ascii"))
             os.close(fd)
         if self.ssl_key:
-            fd, tmp_ssl_key_path = tempfile.mkstemp()
-            os.write(fd, self.ssl_key)
+            fd, tmp_ssl_key_path = tempfile.mkstemp('wb')
+            os.write(fd, self.ssl_key.encode("ascii"))
             os.close(fd)
         connection = self.make_insecure_connection()
         connection = ssl.wrap_socket(

--- a/api/util/patron.py
+++ b/api/util/patron.py
@@ -1,7 +1,8 @@
 import datetime
 from api.config import Configuration
 from api.circulation_exceptions import *
-
+from nose.tools import set_trace
+from core.util import MoneyUtility
 
 class PatronUtility(object):
     """Apply circulation-specific logic to Patron model objects."""
@@ -64,7 +65,8 @@ class PatronUtility(object):
 
         if patron.fines:
             max_fines = Configuration.max_outstanding_fines(patron.library)
-            if max_fines is not None and patron.fines > max_fines.amount:
+            fines = MoneyUtility.parse(patron.fines)
+            if max_fines is not None and fines.amount > max_fines.amount:
                 raise OutstandingFines()
 
         from api.authenticator import PatronData

--- a/scripts.py
+++ b/scripts.py
@@ -1683,7 +1683,7 @@ class NovelistSnapshotScript(TimestampScript, LibraryInputScript):
             try:
                 api = NoveListAPI.from_config(library)
             except CannotLoadConfiguration as e:
-                self.log.info(e.message)
+                self.log.info(str(e))
                 continue
             if (api):
                 response = api.put_items_novelist(library)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,5 +13,5 @@ def sample_data(filename, sample_data_dir):
     resource_path = os.path.join(base_path, "files", sample_data_dir)
     path = os.path.join(resource_path, filename)
 
-    with open(path) as f:
+    with open(path, "rb") as f:
         return f.read()

--- a/tests/admin/controller/test_admin_auth_services.py
+++ b/tests/admin/controller/test_admin_auth_services.py
@@ -14,7 +14,7 @@ from core.model import (
     ExternalIntegration,
     get_one,
 )
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestAdminAuthServices(SettingsControllerTest):
     def test_admin_auth_services_get_with_no_services(self):
@@ -130,7 +130,7 @@ class TestAdminAuthServices(SettingsControllerTest):
 
         # The auth service was created and configured properly.
         auth_service = ExternalIntegration.admin_authentication(self._db)
-        eq_(auth_service.protocol, response.response[0])
+        eq_(auth_service.protocol, response.response[0].decode("utf8"))
         eq_("oauth", auth_service.name)
         eq_("http://url2", auth_service.url)
         eq_("username", auth_service.username)
@@ -171,7 +171,7 @@ class TestAdminAuthServices(SettingsControllerTest):
             response = self.manager.admin_auth_services_controller.process_admin_auth_services()
             eq_(response.status_code, 200)
 
-        eq_(auth_service.protocol, response.response[0])
+        eq_(auth_service.protocol, response.response[0].decode("utf8"))
         eq_("oauth", auth_service.name)
         eq_("http://url2", auth_service.url)
         eq_("user2", auth_service.username)

--- a/tests/admin/controller/test_analytics_services.py
+++ b/tests/admin/controller/test_analytics_services.py
@@ -17,7 +17,7 @@ from core.model import (
     get_one,
     Library,
 )
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestAnalyticsServices(SettingsControllerTest):
 
@@ -205,7 +205,7 @@ class TestAnalyticsServices(SettingsControllerTest):
             eq_(response.status_code, 201)
 
         service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.ANALYTICS_GOAL)
-        eq_(service.id, int(response.response[0]))
+        eq_(service.id, int(response.response[0].decode("utf8")))
         eq_(GoogleAnalyticsProvider.__module__, service.protocol)
         eq_("http://test", service.url)
         eq_([library], service.libraries)
@@ -249,7 +249,7 @@ class TestAnalyticsServices(SettingsControllerTest):
             response = self.manager.admin_analytics_services_controller.process_analytics_services()
             eq_(response.status_code, 200)
 
-        eq_(ga_service.id, int(response.response[0]))
+        eq_(ga_service.id, int(response.response[0].decode("utf8")))
         eq_(GoogleAnalyticsProvider.__module__, ga_service.protocol)
         eq_("http://test", ga_service.url)
         eq_([l2], ga_service.libraries)

--- a/tests/admin/controller/test_catalog_services.py
+++ b/tests/admin/controller/test_catalog_services.py
@@ -16,7 +16,7 @@ from core.model import (
     create,
     get_one,
 )
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 from core.s3 import S3Uploader
 
 class TestCatalogServicesController(SettingsControllerTest):
@@ -209,7 +209,7 @@ class TestCatalogServicesController(SettingsControllerTest):
             eq_(response.status_code, 201)
 
         service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.CATALOG_GOAL)
-        eq_(service.id, int(response.response[0]))
+        eq_(service.id, int(response.response[0].decode("utf8")))
         eq_(ME.NAME, service.protocol)
         eq_("exporter name", service.name)
         eq_(ExternalIntegration.S3, service.setting(ME.STORAGE_PROTOCOL).value)
@@ -250,7 +250,7 @@ class TestCatalogServicesController(SettingsControllerTest):
             response = self.manager.admin_catalog_services_controller.process_catalog_services()
             eq_(response.status_code, 200)
 
-        eq_(service.id, int(response.response[0]))
+        eq_(service.id, int(response.response[0].decode("utf8")))
         eq_(ME.NAME, service.protocol)
         eq_("exporter name", service.name)
         eq_(ExternalIntegration.S3, service.setting(ME.STORAGE_PROTOCOL).value)

--- a/tests/admin/controller/test_cdn_services.py
+++ b/tests/admin/controller/test_cdn_services.py
@@ -13,7 +13,7 @@ from core.model import (
     ExternalIntegration,
     get_one,
 )
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestCDNServices(SettingsControllerTest):
     def test_cdn_services_get_with_no_services(self):
@@ -123,7 +123,7 @@ class TestCDNServices(SettingsControllerTest):
             eq_(response.status_code, 201)
 
         service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.CDN_GOAL)
-        eq_(service.id, int(response.response[0]))
+        eq_(service.id, int(response.response[0].decode("utf8")))
         eq_(ExternalIntegration.CDN, service.protocol)
         eq_("http://cdn_url", service.url)
         eq_("mirrored domain", service.setting(Configuration.CDN_MIRRORED_DOMAIN_KEY).value)
@@ -148,7 +148,7 @@ class TestCDNServices(SettingsControllerTest):
             response = self.manager.admin_cdn_services_controller.process_cdn_services()
             eq_(response.status_code, 200)
 
-        eq_(cdn_service.id, int(response.response[0]))
+        eq_(cdn_service.id, int(response.response[0].decode("utf8")))
         eq_(ExternalIntegration.CDN, cdn_service.protocol)
         eq_("http://new_cdn_url", cdn_service.url)
         eq_("new mirrored domain", cdn_service.setting(Configuration.CDN_MIRRORED_DOMAIN_KEY).value)

--- a/tests/admin/controller/test_collection_registrations.py
+++ b/tests/admin/controller/test_collection_registrations.py
@@ -18,7 +18,7 @@ from core.model import (
     Library,
 )
 from core.util.http import HTTP
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestCollectionRegistration(SettingsControllerTest):
     """Test the process of registering a specific collection with

--- a/tests/admin/controller/test_collection_self_tests.py
+++ b/tests/admin/controller/test_collection_self_tests.py
@@ -8,7 +8,7 @@ from api.admin.problem_details import *
 from api.axis import (Axis360API, MockAxis360API)
 from core.opds_import import (OPDSImporter, OPDSImportMonitor)
 from core.selftest import HasSelfTests
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestCollectionSelfTests(SettingsControllerTest):
     def test_collection_self_tests_with_no_identifier(self):

--- a/tests/admin/controller/test_collections.py
+++ b/tests/admin/controller/test_collections.py
@@ -20,7 +20,7 @@ from core.model import (
 )
 from werkzeug import MultiDict
 
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestCollectionSettings(SettingsControllerTest):
     def test_collections_get_with_no_collections(self):
@@ -359,7 +359,7 @@ class TestCollectionSettings(SettingsControllerTest):
 
         # The collection was created and configured properly.
         collection = get_one(self._db, Collection, name="New Collection")
-        eq_(collection.id, int(response.response[0]))
+        eq_(collection.id, int(response.response[0].decode("utf8")))
         eq_("New Collection", collection.name)
         eq_("acctid", collection.external_account_id)
         eq_("username", collection.external_integration.username)
@@ -394,7 +394,7 @@ class TestCollectionSettings(SettingsControllerTest):
 
         # The collection was created and configured properly.
         child = get_one(self._db, Collection, name="Child Collection")
-        eq_(child.id, int(response.response[0]))
+        eq_(child.id, int(response.response[0].decode("utf8")))
         eq_("Child Collection", child.name)
         eq_("child-acctid", child.external_account_id)
 
@@ -435,7 +435,7 @@ class TestCollectionSettings(SettingsControllerTest):
             response = self.manager.admin_collection_settings_controller.process_collections()
             eq_(response.status_code, 200)
 
-        eq_(collection.id, int(response.response[0]))
+        eq_(collection.id, int(response.response[0].decode("utf8")))
 
         # The collection has been changed.
         eq_("user2", collection.external_integration.username)
@@ -465,7 +465,7 @@ class TestCollectionSettings(SettingsControllerTest):
             response = self.manager.admin_collection_settings_controller.process_collections()
             eq_(response.status_code, 200)
 
-        eq_(collection.id, int(response.response[0]))
+        eq_(collection.id, int(response.response[0].decode("utf8")))
 
         # The collection is the same.
         eq_("user2", collection.external_integration.username)
@@ -494,7 +494,7 @@ class TestCollectionSettings(SettingsControllerTest):
             response = self.manager.admin_collection_settings_controller.process_collections()
             eq_(response.status_code, 200)
 
-        eq_(collection.id, int(response.response[0]))
+        eq_(collection.id, int(response.response[0].decode("utf8")))
 
         # The collection now has a parent.
         eq_(parent, collection.parent)
@@ -640,7 +640,7 @@ class TestCollectionSettings(SettingsControllerTest):
             response = self.manager.admin_collection_settings_controller.process_collections()
             eq_(response.status_code, 200)
 
-        eq_(collection.id, int(response.response[0]))
+        eq_(collection.id, int(response.response[0].decode("utf8")))
 
         # The settings associated with the collection+library were removed
         # when the connection between collection and library was deleted.

--- a/tests/admin/controller/test_controller.py
+++ b/tests/admin/controller/test_controller.py
@@ -512,10 +512,11 @@ class TestSignInController(AdminControllerTest):
         with self.app.test_request_context('/admin/sign_in?redirect=foo'):
             response = self.manager.admin_sign_in_controller.sign_in()
             eq_(200, response.status_code)
-            assert "GOOGLE REDIRECT" in response.data.decode("utf8")
-            assert "Sign in with Google" in response.data.decode("utf8")
-            assert "Email" not in response.data.decode("utf8")
-            assert "Password" not in response.data.decode("utf8")
+            data = response.data.decode("utf8")
+            assert "GOOGLE REDIRECT" in data
+            assert "Sign in with Google" in data
+            assert "Email" not in data
+            assert "Password" not in data
 
         # If there are multiple auth providers, the login page
         # shows them all.
@@ -523,10 +524,11 @@ class TestSignInController(AdminControllerTest):
         with self.app.test_request_context('/admin/sign_in?redirect=foo'):
             response = self.manager.admin_sign_in_controller.sign_in()
             eq_(200, response.status_code)
-            assert "GOOGLE REDIRECT" in response.data.decode("utf8")
-            assert "Sign in with Google" in response.data.decode("utf8")
-            assert "Email" in response.data.decode("utf8")
-            assert "Password" in response.data.decode("utf8")
+            data = response.data.decode("utf8")
+            assert "GOOGLE REDIRECT" in data
+            assert "Sign in with Google" in data
+            assert "Email" in data
+            assert "Password" in data
 
         # Redirects to the redirect parameter if an admin is signed in.
         with self.app.test_request_context('/admin/sign_in?redirect=foo'):

--- a/tests/admin/controller/test_discovery_services.py
+++ b/tests/admin/controller/test_discovery_services.py
@@ -13,7 +13,7 @@ from core.model import (
     ExternalIntegration,
     get_one,
 )
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestDiscoveryServices(SettingsControllerTest):
 
@@ -121,7 +121,7 @@ class TestDiscoveryServices(SettingsControllerTest):
             eq_(response.status_code, 201)
 
         service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.DISCOVERY_GOAL)
-        eq_(service.id, int(response.response[0]))
+        eq_(service.id, int(response.response[0].decode("utf8")))
         eq_(ExternalIntegration.OPDS_REGISTRATION, service.protocol)
         eq_("http://registry_url", service.url)
 
@@ -143,7 +143,7 @@ class TestDiscoveryServices(SettingsControllerTest):
             response = self.manager.admin_discovery_services_controller.process_discovery_services()
             eq_(response.status_code, 200)
 
-        eq_(discovery_service.id, int(response.response[0]))
+        eq_(discovery_service.id, int(response.response[0].decode("utf8")))
         eq_(ExternalIntegration.OPDS_REGISTRATION, discovery_service.protocol)
         eq_("http://new_registry_url", discovery_service.url)
 

--- a/tests/admin/controller/test_individual_admins.py
+++ b/tests/admin/controller/test_individual_admins.py
@@ -42,11 +42,16 @@ class TestIndividualAdmins(SettingsControllerTest):
         admin5, ignore = create(self._db, Admin, email="admin5@l2.org")
         admin5.add_role(AdminRole.LIBRARIAN, library2)
 
+        # TODO PYTHON3 - It's easier not to sort these dicts. Replace
+        # eq_sorted with eq_.
+        def eq_sorted(x, y):
+            eq_(sorted(x), sorted(x))
+
         with self.request_context_with_admin("/", admin=admin1):
             # A system admin can see all other admins' roles.
             response = self.manager.admin_individual_admin_settings_controller.process_get()
             admins = response.get("individualAdmins")
-            eq_([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
+            eq_sorted([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
                  {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": self._default_library.short_name }, { "role": AdminRole.SITEWIDE_LIBRARIAN }]},
                  {"email": "admin3@nypl.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": self._default_library.short_name }]},
                  {"email": "admin4@l2.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": library2.short_name }]},
@@ -58,7 +63,7 @@ class TestIndividualAdmins(SettingsControllerTest):
             # A sitewide librarian or library manager can also see all admins' roles.
             response = self.manager.admin_individual_admin_settings_controller.process_get()
             admins = response.get("individualAdmins")
-            eq_([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
+            eq_sorted([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
                  {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": self._default_library.short_name }, { "role": AdminRole.SITEWIDE_LIBRARIAN }]},
                  {"email": "admin3@nypl.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": self._default_library.short_name }]},
                  {"email": "admin4@l2.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": library2.short_name }]},
@@ -71,7 +76,7 @@ class TestIndividualAdmins(SettingsControllerTest):
             # roles that affect their libraries.
             response = self.manager.admin_individual_admin_settings_controller.process_get()
             admins = response.get("individualAdmins")
-            eq_([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
+            eq_sorted([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
                  {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": self._default_library.short_name }, { "role": AdminRole.SITEWIDE_LIBRARIAN }]},
                  {"email": "admin3@nypl.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": self._default_library.short_name }]},
                  {"email": "admin4@l2.org", "roles": []},
@@ -82,7 +87,7 @@ class TestIndividualAdmins(SettingsControllerTest):
         with self.request_context_with_admin("/", admin=admin4):
             response = self.manager.admin_individual_admin_settings_controller.process_get()
             admins = response.get("individualAdmins")
-            eq_([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
+            eq_sorted([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
                  {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.SITEWIDE_LIBRARIAN }]},
                  {"email": "admin3@nypl.org", "roles": []},
                  {"email": "admin4@l2.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": library2.short_name }]},
@@ -93,7 +98,7 @@ class TestIndividualAdmins(SettingsControllerTest):
         with self.request_context_with_admin("/", admin=admin5):
             response = self.manager.admin_individual_admin_settings_controller.process_get()
             admins = response.get("individualAdmins")
-            eq_([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
+            eq_sorted([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
                  {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.SITEWIDE_LIBRARIAN }]},
                  {"email": "admin3@nypl.org", "roles": []},
                  {"email": "admin4@l2.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": library2.short_name }]},

--- a/tests/admin/controller/test_individual_admins.py
+++ b/tests/admin/controller/test_individual_admins.py
@@ -16,7 +16,7 @@ from core.model import (
     get_one,
 )
 
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestIndividualAdmins(SettingsControllerTest):
 
@@ -46,55 +46,60 @@ class TestIndividualAdmins(SettingsControllerTest):
             # A system admin can see all other admins' roles.
             response = self.manager.admin_individual_admin_settings_controller.process_get()
             admins = response.get("individualAdmins")
-            eq_(sorted([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
-                        {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": self._default_library.short_name }, { "role": AdminRole.SITEWIDE_LIBRARIAN }]},
-                        {"email": "admin3@nypl.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": self._default_library.short_name }]},
-                        {"email": "admin4@l2.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": library2.short_name }]},
-                        {"email": "admin5@l2.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": library2.short_name }]}]),
-                sorted(admins))
+            eq_([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
+                 {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": self._default_library.short_name }, { "role": AdminRole.SITEWIDE_LIBRARIAN }]},
+                 {"email": "admin3@nypl.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": self._default_library.short_name }]},
+                 {"email": "admin4@l2.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": library2.short_name }]},
+                 {"email": "admin5@l2.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": library2.short_name }]}],
+                admins
+            )
 
         with self.request_context_with_admin("/", admin=admin2):
             # A sitewide librarian or library manager can also see all admins' roles.
             response = self.manager.admin_individual_admin_settings_controller.process_get()
             admins = response.get("individualAdmins")
-            eq_(sorted([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
-                        {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": self._default_library.short_name }, { "role": AdminRole.SITEWIDE_LIBRARIAN }]},
-                        {"email": "admin3@nypl.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": self._default_library.short_name }]},
-                        {"email": "admin4@l2.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": library2.short_name }]},
-                        {"email": "admin5@l2.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": library2.short_name }]}]),
-                sorted(admins))
+            eq_([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
+                 {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": self._default_library.short_name }, { "role": AdminRole.SITEWIDE_LIBRARIAN }]},
+                 {"email": "admin3@nypl.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": self._default_library.short_name }]},
+                 {"email": "admin4@l2.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": library2.short_name }]},
+                 {"email": "admin5@l2.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": library2.short_name }]}],
+                admins
+            )
 
         with self.request_context_with_admin("/", admin=admin3):
             # A librarian or library manager of a specific library can see all admins, but only
             # roles that affect their libraries.
             response = self.manager.admin_individual_admin_settings_controller.process_get()
             admins = response.get("individualAdmins")
-            eq_(sorted([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
-                        {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": self._default_library.short_name }, { "role": AdminRole.SITEWIDE_LIBRARIAN }]},
-                        {"email": "admin3@nypl.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": self._default_library.short_name }]},
-                        {"email": "admin4@l2.org", "roles": []},
-                        {"email": "admin5@l2.org", "roles": []}]),
-                sorted(admins))
+            eq_([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
+                 {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": self._default_library.short_name }, { "role": AdminRole.SITEWIDE_LIBRARIAN }]},
+                 {"email": "admin3@nypl.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": self._default_library.short_name }]},
+                 {"email": "admin4@l2.org", "roles": []},
+                 {"email": "admin5@l2.org", "roles": []}],
+                admins
+            )
 
         with self.request_context_with_admin("/", admin=admin4):
             response = self.manager.admin_individual_admin_settings_controller.process_get()
             admins = response.get("individualAdmins")
-            eq_(sorted([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
-                        {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.SITEWIDE_LIBRARIAN }]},
-                        {"email": "admin3@nypl.org", "roles": []},
-                        {"email": "admin4@l2.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": library2.short_name }]},
-                        {"email": "admin5@l2.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": library2.short_name }]}]),
-                sorted(admins))
+            eq_([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
+                 {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.SITEWIDE_LIBRARIAN }]},
+                 {"email": "admin3@nypl.org", "roles": []},
+                 {"email": "admin4@l2.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": library2.short_name }]},
+                 {"email": "admin5@l2.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": library2.short_name }]}],
+                admins
+            )
 
         with self.request_context_with_admin("/", admin=admin5):
             response = self.manager.admin_individual_admin_settings_controller.process_get()
             admins = response.get("individualAdmins")
-            eq_(sorted([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
-                        {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.SITEWIDE_LIBRARIAN }]},
-                        {"email": "admin3@nypl.org", "roles": []},
-                        {"email": "admin4@l2.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": library2.short_name }]},
-                        {"email": "admin5@l2.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": library2.short_name }]}]),
-                sorted(admins))
+            eq_([{"email": "admin1@nypl.org", "roles": [{ "role": AdminRole.SYSTEM_ADMIN }]},
+                 {"email": "admin2@nypl.org", "roles": [{ "role": AdminRole.SITEWIDE_LIBRARIAN }]},
+                 {"email": "admin3@nypl.org", "roles": []},
+                 {"email": "admin4@l2.org", "roles": [{ "role": AdminRole.LIBRARY_MANAGER, "library": library2.short_name }]},
+                 {"email": "admin5@l2.org", "roles": [{ "role": AdminRole.LIBRARIAN, "library": library2.short_name }]}],
+                admins
+            )
 
     def test_individual_admins_post_errors(self):
         with self.request_context_with_admin("/", method="POST"):
@@ -281,7 +286,7 @@ class TestIndividualAdmins(SettingsControllerTest):
 
         # The admin was created.
         admin_match = Admin.authenticate(self._db, "admin@nypl.org", "pass")
-        eq_(admin_match.email, response.response[0])
+        eq_(admin_match.email, response.response[0].decode("utf8"))
         assert admin_match
         assert admin_match.has_password("pass")
 
@@ -300,7 +305,7 @@ class TestIndividualAdmins(SettingsControllerTest):
             eq_(response.status_code, 201)
 
         admin_match = Admin.authenticate(self._db, "admin2@nypl.org", "pass")
-        eq_(admin_match.email, response.response[0])
+        eq_(admin_match.email, response.response[0].decode("utf8"))
         assert admin_match
         assert admin_match.has_password("pass")
 
@@ -326,7 +331,7 @@ class TestIndividualAdmins(SettingsControllerTest):
             response = self.manager.admin_individual_admin_settings_controller.process_post()
             eq_(response.status_code, 200)
 
-        eq_(admin.email, response.response[0])
+        eq_(admin.email, response.response[0].decode("utf8"))
 
         # The password was changed.
         old_password_match = Admin.authenticate(self._db, "admin@nypl.org", "password")
@@ -385,7 +390,7 @@ class TestIndividualAdmins(SettingsControllerTest):
             self._db.delete(admin)
 
         # Creating an admin that's not a system admin will fail.
-        with self.app.test_request_context("/", method="POST"):
+        with self.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
                 ("email", "first_admin@nypl.org"),
                 ("password", "pass"),
@@ -395,7 +400,7 @@ class TestIndividualAdmins(SettingsControllerTest):
             self._db.rollback()
 
         # The password is required.
-        with self.app.test_request_context("/", method="POST"):
+        with self.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
                 ("email", "first_admin@nypl.org"),
                 ("roles", json.dumps([{ "role": AdminRole.SYSTEM_ADMIN }])),
@@ -405,7 +410,7 @@ class TestIndividualAdmins(SettingsControllerTest):
             eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
 
         # Creating a system admin with a password works.
-        with self.app.test_request_context("/", method="POST"):
+        with self.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
                 ("email", "first_admin@nypl.org"),
                 ("password", "pass"),
@@ -416,7 +421,7 @@ class TestIndividualAdmins(SettingsControllerTest):
 
         # The admin was created.
         admin_match = Admin.authenticate(self._db, "first_admin@nypl.org", "pass")
-        eq_(admin_match.email, response.response[0])
+        eq_(admin_match.email, response.response[0].decode("utf8"))
         assert admin_match
         assert admin_match.has_password("pass")
 

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -274,9 +274,15 @@ class TestLibrarySettings(SettingsControllerTest):
         eq_("data:image/png;base64,%s" % base64.b64encode(image_data),
             ConfigurationSetting.for_library(Configuration.LOGO, library).value)
         eq_(validator.was_called, True)
-        eq_('{"US": ["06759", "everywhere", "MD", "Boston, MA"], "CA": []}',
+
+        # TODO PYTHON3 - It's easier not to sort these dicts. Replace
+        # eq_sorted with eq_.
+        def eq_sorted(x, y):
+            eq_(sorted(x), sorted(y))
+
+        eq_sorted('{"US": ["06759", "everywhere", "MD", "Boston, MA"], "CA": []}',
             ConfigurationSetting.for_library(Configuration.LIBRARY_SERVICE_AREA, library).value)
-        eq_('{"US": ["Broward County, FL"], "CA": ["Manitoba", "Quebec"]}',
+        eq_sorted('{"US": ["Broward County, FL"], "CA": ["Manitoba", "Quebec"]}',
             ConfigurationSetting.for_library(Configuration.LIBRARY_FOCUS_AREA, library).value)
 
         # When the library was created, default lanes were also created

--- a/tests/admin/controller/test_library_registrations.py
+++ b/tests/admin/controller/test_library_registrations.py
@@ -18,7 +18,7 @@ from core.model import (
     Library,
 )
 from core.util.http import HTTP
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestLibraryRegistration(SettingsControllerTest):
     """Test the process of registering a library with a RemoteRegistry."""

--- a/tests/admin/controller/test_metadata_services.py
+++ b/tests/admin/controller/test_metadata_services.py
@@ -18,7 +18,7 @@ from core.model import (
     get_one,
     Library,
 )
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestMetadataServices(SettingsControllerTest):
 
@@ -181,7 +181,7 @@ class TestMetadataServices(SettingsControllerTest):
             self._db, ExternalIntegration,
             goal=ExternalIntegration.METADATA_GOAL
         )
-        eq_(service.id, int(response.response[0]))
+        eq_(service.id, int(response.response[0].decode("utf8")))
         eq_(ExternalIntegration.NOVELIST, service.protocol)
         eq_("user", service.username)
         eq_("pass", service.password)

--- a/tests/admin/controller/test_patron_auth.py
+++ b/tests/admin/controller/test_patron_auth.py
@@ -27,7 +27,7 @@ from core.model import (
     get_one,
     Library,
 )
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestPatronAuth(SettingsControllerTest):
 
@@ -392,7 +392,7 @@ class TestPatronAuth(SettingsControllerTest):
             eq_(mock_controller.validate_formats_call_count, 1)
 
         auth_service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.PATRON_AUTH_GOAL)
-        eq_(auth_service.id, int(response.response[0]))
+        eq_(auth_service.id, int(response.response[0].decode("utf8")))
         eq_(SimpleAuthenticationProvider.__module__, auth_service.protocol)
         eq_("user", auth_service.setting(BasicAuthenticationProvider.TEST_IDENTIFIER).value)
         eq_("pass", auth_service.setting(BasicAuthenticationProvider.TEST_PASSWORD).value)
@@ -416,7 +416,7 @@ class TestPatronAuth(SettingsControllerTest):
                                goal=ExternalIntegration.PATRON_AUTH_GOAL,
                                protocol=MilleniumPatronAPI.__module__)
         assert auth_service2 != auth_service
-        eq_(auth_service2.id, int(response.response[0]))
+        eq_(auth_service2.id, int(response.response[0].decode("utf8")))
         eq_("url", auth_service2.url)
         eq_("user", auth_service2.setting(BasicAuthenticationProvider.TEST_IDENTIFIER).value)
         eq_("pass", auth_service2.setting(BasicAuthenticationProvider.TEST_PASSWORD).value)
@@ -461,7 +461,7 @@ class TestPatronAuth(SettingsControllerTest):
             eq_(response.status_code, 200)
             eq_(mock_controller.validate_formats_call_count, 1)
 
-        eq_(auth_service.id, int(response.response[0]))
+        eq_(auth_service.id, int(response.response[0].decode("utf8")))
         eq_(SimpleAuthenticationProvider.__module__, auth_service.protocol)
         eq_("user", auth_service.setting(BasicAuthenticationProvider.TEST_IDENTIFIER).value)
         eq_("pass", auth_service.setting(BasicAuthenticationProvider.TEST_PASSWORD).value)

--- a/tests/admin/controller/test_patron_auth_self_tests.py
+++ b/tests/admin/controller/test_patron_auth_self_tests.py
@@ -10,7 +10,7 @@ from core.selftest import (
     SelfTestResult,
 )
 from api.simple_authentication import SimpleAuthenticationProvider
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 from core.model import (
     create,
     ExternalIntegration,
@@ -84,7 +84,7 @@ class TestPatronAuthSelfTests(SettingsControllerTest):
         with self.request_context_with_admin("/", method="POST"):
             response = self.manager.admin_patron_auth_service_self_tests_controller.process_patron_auth_service_self_tests(auth_service.id)
             eq_(response._status, "200 OK")
-            eq_("Successfully ran new self tests", response.data)
+            eq_("Successfully ran new self tests", response.data.decode("utf8"))
 
         # run_self_tests was called with the database twice (the
         # second time to be used in the ExternalSearchIntegration

--- a/tests/admin/controller/test_search_service_self_tests.py
+++ b/tests/admin/controller/test_search_service_self_tests.py
@@ -11,7 +11,7 @@ from core.selftest import (
     HasSelfTests,
     SelfTestResult,
 )
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 from core.model import (
     create,
     ExternalIntegration,
@@ -68,7 +68,7 @@ class TestSearchServiceSelfTests(SettingsControllerTest):
         with self.request_context_with_admin("/", method="POST"):
             response = m(search_service.id)
             eq_(response._status, "200 OK")
-            eq_("Successfully ran new self tests", response.data)
+            eq_("Successfully ran new self tests", response.data.decode("utf8"))
 
         # run_self_tests was called with the database twice (the
         # second time to be used in the ExternalSearchIntegration

--- a/tests/admin/controller/test_search_services.py
+++ b/tests/admin/controller/test_search_services.py
@@ -13,7 +13,7 @@ from core.model import (
     get_one,
     ExternalIntegration,
 )
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestSearchServices(SettingsControllerTest):
     def test_search_services_get_with_no_services(self):
@@ -141,7 +141,7 @@ class TestSearchServices(SettingsControllerTest):
             eq_(response.status_code, 201)
 
         service = get_one(self._db, ExternalIntegration, goal=ExternalIntegration.SEARCH_GOAL)
-        eq_(service.id, int(response.response[0]))
+        eq_(service.id, int(response.response[0].decode("utf8")))
         eq_(ExternalIntegration.ELASTICSEARCH, service.protocol)
         eq_("http://search_url", service.url)
         eq_("works-index-prefix", service.setting(ExternalSearchIndex.WORKS_INDEX_PREFIX_KEY).value)
@@ -169,7 +169,7 @@ class TestSearchServices(SettingsControllerTest):
             response = self.manager.admin_search_services_controller.process_services()
             eq_(response.status_code, 200)
 
-        eq_(search_service.id, int(response.response[0]))
+        eq_(search_service.id, int(response.response[0].decode("utf8")))
         eq_(ExternalIntegration.ELASTICSEARCH, search_service.protocol)
         eq_("http://new_search_url", search_service.url)
         eq_("new-works-index-prefix", search_service.setting(ExternalSearchIndex.WORKS_INDEX_PREFIX_KEY).value)

--- a/tests/admin/controller/test_sitewide_registration.py
+++ b/tests/admin/controller/test_sitewide_registration.py
@@ -3,7 +3,6 @@ from nose.tools import (
     eq_,
     assert_raises
 )
-import base64
 import flask
 import json
 import jwt
@@ -15,8 +14,12 @@ from core.model import (
     ExternalIntegration,
 )
 from core.testing import MockRequestsResponse
+from core.util.binary import (
+    base64, 
+    random_string,
+)
 from core.util.problem_detail import ProblemDetail
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestSitewideRegistration(SettingsControllerTest):
 
@@ -78,7 +81,7 @@ class TestSitewideRegistration(SettingsControllerTest):
             assert response.detail.startswith(
                 "Remote service returned a problem detail document:"
             )
-            assert unicode(MULTIPLE_BASIC_AUTH_SERVICES.detail) in response.detail
+            assert str(MULTIPLE_BASIC_AUTH_SERVICES.detail) in response.detail
 
         # If no registration link is available, a ProblemDetail is returned
         catalog = dict(id=self._url, links=[])
@@ -161,8 +164,8 @@ class TestSitewideRegistration(SettingsControllerTest):
         )
 
         # A registration document with an encrypted secret
-        shared_secret = os.urandom(24).encode('hex')
-        encrypted_secret = base64.b64encode(encryptor.encrypt(shared_secret))
+        shared_secret = random_string(24)
+        encrypted_secret = base64.b64encode(encryptor.encrypt(shared_secret.encode("utf8")))
         registration = dict(
             id = metadata_wrangler_service.url,
             metadata = dict(shared_secret=encrypted_secret)

--- a/tests/admin/controller/test_sitewide_registration.py
+++ b/tests/admin/controller/test_sitewide_registration.py
@@ -14,7 +14,7 @@ from core.model import (
     ExternalIntegration,
 )
 from core.testing import MockRequestsResponse
-from core.util.binary import (
+from core.util.string_helpers import (
     base64, 
     random_string,
 )
@@ -81,7 +81,7 @@ class TestSitewideRegistration(SettingsControllerTest):
             assert response.detail.startswith(
                 "Remote service returned a problem detail document:"
             )
-            assert str(MULTIPLE_BASIC_AUTH_SERVICES.detail) in response.detail
+            assert unicode(MULTIPLE_BASIC_AUTH_SERVICES.detail) in response.detail
 
         # If no registration link is available, a ProblemDetail is returned
         catalog = dict(id=self._url, links=[])

--- a/tests/admin/controller/test_sitewide_services.py
+++ b/tests/admin/controller/test_sitewide_services.py
@@ -10,7 +10,7 @@ from core.model import (
     ExternalIntegration,
 )
 from core.s3 import S3Uploader, MockS3Uploader
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 
 class TestSitewideServices(SettingsControllerTest):
     def test_sitewide_service_management(self):

--- a/tests/admin/controller/test_sitewide_settings.py
+++ b/tests/admin/controller/test_sitewide_settings.py
@@ -10,7 +10,7 @@ from core.model import (
     AdminRole,
     ConfigurationSetting
 )
-from test_controller import SettingsControllerTest
+from .test_controller import SettingsControllerTest
 from werkzeug import ImmutableMultiDict, MultiDict
 import flask
 
@@ -85,7 +85,7 @@ class TestSitewideSettings(SettingsControllerTest):
 
         # The setting was created.
         setting = ConfigurationSetting.sitewide(self._db, Configuration.DATABASE_LOG_LEVEL)
-        eq_(setting.key, response.response[0])
+        eq_(setting.key, response.response[0].decode("utf8"))
         eq_("10", setting.value)
 
     def test_sitewide_settings_post_edit(self):
@@ -101,7 +101,7 @@ class TestSitewideSettings(SettingsControllerTest):
             eq_(response.status_code, 200)
 
         # The setting was changed.
-        eq_(setting.key, response.response[0])
+        eq_(setting.key, response.response[0].decode("utf8"))
         eq_("ERROR", setting.value)
 
     def test_sitewide_setting_delete(self):

--- a/tests/admin/controller/test_work_editor.py
+++ b/tests/admin/controller/test_work_editor.py
@@ -7,7 +7,6 @@ from api.admin.exceptions import *
 from api.admin.problem_details import *
 import feedparser
 from werkzeug import ImmutableMultiDict, MultiDict
-import base64
 import flask
 import functools
 import json
@@ -47,6 +46,7 @@ from core.testing import (
     NeverSuccessfulCoverageProvider,
     MockRequestsResponse,
 )
+from core.util.string_helpers import base64
 from datetime import date, datetime, timedelta
 
 class TestWorkController(AdminControllerTest):
@@ -940,7 +940,7 @@ class TestWorkController(AdminControllerTest):
         buffer = BytesIO()
         original.save(buffer, format="PNG")
         image_data = buffer.getvalue()
-        expect = "data:image/png;base64,%s" % base64.b64encode(image_data).decode("utf8")
+        expect = "data:image/png;base64,%s" % base64.b64encode(image_data)
 
         with self.request_context_with_library_and_admin("/"):
             flask.request.form = MultiDict([

--- a/tests/admin/test_geographic_validator.py
+++ b/tests/admin/test_geographic_validator.py
@@ -65,7 +65,7 @@ class TestGeographicValidator(SettingsControllerTest):
 
         # Validator converts Canadian 2-letter abbreviations into province names, without needing to ask the registry.
         response = mock.validate_geographic_areas('["NL"]', self._db)
-        eq_(response, '{"CA": ["Newfoundland and Labrador"], "US": []}')
+        eq_(response, '{"US": [], "CA": ["Newfoundland and Labrador"]}')
         eq_(mock.value, None)
 
         # County with wrong state
@@ -97,7 +97,7 @@ class TestGeographicValidator(SettingsControllerTest):
         # The registry successfully finds the place
         mock.find_location_through_registry = mock.mock_find_location_through_registry_success
         response = mock.validate_geographic_areas('["Victoria, BC"]', self._db)
-        eq_(response, '{"CA": ["Victoria, BC"], "US": []}')
+        eq_(response, '{"US": [], "CA": ["Victoria, BC"]}')
 
     def test_find_location_through_registry(self):
         get = self.do_request

--- a/tests/admin/test_geographic_validator.py
+++ b/tests/admin/test_geographic_validator.py
@@ -65,7 +65,13 @@ class TestGeographicValidator(SettingsControllerTest):
 
         # Validator converts Canadian 2-letter abbreviations into province names, without needing to ask the registry.
         response = mock.validate_geographic_areas('["NL"]', self._db)
-        eq_(response, '{"US": [], "CA": ["Newfoundland and Labrador"]}')
+
+        # TODO PYTHON3 - It's easier not to sort these dicts. Replace
+        # eq_sorted with eq_.
+        def eq_sorted(x, y):
+            eq_(sorted(x), sorted(x))
+
+        eq_sorted(response, '{"US": [], "CA": ["Newfoundland and Labrador"]}')
         eq_(mock.value, None)
 
         # County with wrong state
@@ -97,7 +103,7 @@ class TestGeographicValidator(SettingsControllerTest):
         # The registry successfully finds the place
         mock.find_location_through_registry = mock.mock_find_location_through_registry_success
         response = mock.validate_geographic_areas('["Victoria, BC"]', self._db)
-        eq_(response, '{"US": [], "CA": ["Victoria, BC"]}')
+        eq_sorted(response, '{"US": [], "CA": ["Victoria, BC"]}')
 
     def test_find_location_through_registry(self):
         get = self.do_request

--- a/tests/admin/test_google_oauth_admin_authentication_provider.py
+++ b/tests/admin/test_google_oauth_admin_authentication_provider.py
@@ -47,7 +47,7 @@ class TestGoogleOAuthAdminAuthenticationProvider(DatabaseTest):
         # Successful case creates a dict of admin details
         success, redirect = self.google.callback(self._db, {'code' : 'abc'})
         eq_('example@nypl.org', success['email'])
-        default_credentials = json.dumps({"id_token": {"email": "example@nypl.org", "hd": "nypl.org"}})
+        default_credentials = json.dumps({"id_token": {"hd": "nypl.org", "email": "example@nypl.org"}})
         eq_(default_credentials, success['credentials'])
         eq_(GoogleOAuthAdminAuthenticationProvider.NAME, success["type"])
         [role] = success.get("roles")

--- a/tests/admin/test_google_oauth_admin_authentication_provider.py
+++ b/tests/admin/test_google_oauth_admin_authentication_provider.py
@@ -47,8 +47,8 @@ class TestGoogleOAuthAdminAuthenticationProvider(DatabaseTest):
         # Successful case creates a dict of admin details
         success, redirect = self.google.callback(self._db, {'code' : 'abc'})
         eq_('example@nypl.org', success['email'])
-        default_credentials = json.dumps({"id_token": {"hd": "nypl.org", "email": "example@nypl.org"}})
-        eq_(default_credentials, success['credentials'])
+        default_credentials = {"id_token": {"hd": "nypl.org", "email": "example@nypl.org"}}
+        eq_(default_credentials, json.loads(success['credentials']))
         eq_(GoogleOAuthAdminAuthenticationProvider.NAME, success["type"])
         [role] = success.get("roles")
         eq_(AdminRole.LIBRARIAN, role.get("role"))

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -753,14 +753,14 @@ class TestAuthdataUtility(VendorIDTest):
         eq_(("http://my-library.org/", "Patron identifier"), decoded)
 
     def test_encode(self):
-        """Test that _encode gives a known value with known input."""
+        # Test that _encode gives a known value with known input.
 
         # Three pieces of data go into our JWT.
         patron_identifier = "Patron identifier"
         now = datetime.datetime(2016, 1, 1, 12, 0, 0)
         expires = datetime.datetime(2018, 1, 1, 12, 0, 0)
 
-        raw_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOi8vbXktbGlicmFyeS5vcmcvIiwic3ViIjoiUGF0cm9uIGlkZW50aWZpZXIiLCJpYXQiOjE0NTE2NDk2MDAuMCwiZXhwIjoxNTE0ODA4MDAwLjB9.Ua11tFCpC4XAgwhR6jFyoxfHy4s1zt2Owg4dOoCefYA'
+        raw_jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwOi8vbXktbGlicmFyeS5vcmcvIiwic3ViIjoiUGF0cm9uIGlkZW50aWZpZXIiLCJpYXQiOjE0NTE2NDk2MDAuMCwiZXhwIjoxNTE0ODA4MDAwLjB9.wKAnFfJVfJP55CIyD7PntFZrtWVTwDcXHjL-quTndzc'
         base64_encoded_jwt = base64.b64encode(raw_jwt).strip()
 
         # We can't call self.authdata._decode to peek into raw_jwt,
@@ -768,8 +768,8 @@ class TestAuthdataUtility(VendorIDTest):
         # test and you need to look at the pieces that make up
         # raw_jwt, you can call PyJWT._load(), like so:
         from jwt.api_jwt import _jwt_global_obj
-        loaded_jwt = _jwt_global_obj._load(raw_jwt)
-        payload = loaded_jwt[0]
+        expect_jwt = _jwt_global_obj._load(raw_jwt)
+        payload = expect_jwt[0]
         payload_dict = json.loads(payload)
         eq_("Patron identifier", payload_dict['sub'])
 
@@ -777,6 +777,8 @@ class TestAuthdataUtility(VendorIDTest):
         authdata = self.authdata._encode(
             self.authdata.library_uri, patron_identifier, now, expires
         )
+        actual_jwt = _jwt_global_obj._load(base64.b64decode(authdata))
+        eq_(expect_jwt, actual_jwt)
         eq_(base64_encoded_jwt, authdata)
 
 

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -1,4 +1,3 @@
-import base64
 import json
 from nose.tools import (
     set_trace,
@@ -17,6 +16,7 @@ import datetime
 
 from api.problem_details import *
 from api.adobe_vendor_id import (
+    base64,
     AdobeSignInRequestParser,
     AdobeAccountInfoRequestParser,
     AdobeVendorIDController,
@@ -428,16 +428,16 @@ class TestVendorIDModel(VendorIDTest):
 
 class TestVendorIDRequestParsers(object):
 
-    username_sign_in_request = """<signInRequest method="standard" xmlns="http://ns.adobe.com/adept">
+    username_sign_in_request = b"""<signInRequest method="standard" xmlns="http://ns.adobe.com/adept">
 <username>Vendor username</username>
 <password>Vendor password</password>
 </signInRequest>"""
 
-    authdata_sign_in_request = """<signInRequest method="authData" xmlns="http://ns.adobe.com/adept">
+    authdata_sign_in_request = b"""<signInRequest method="authData" xmlns="http://ns.adobe.com/adept">
 <authData> dGhpcyBkYXRhIHdhcyBiYXNlNjQgZW5jb2RlZA== </authData>
 </signInRequest>"""
 
-    accountinfo_request = """<accountInfoRequest method="standard" xmlns="http://ns.adobe.com/adept">
+    accountinfo_request = b"""<accountInfoRequest method="standard" xmlns="http://ns.adobe.com/adept">
 <user>urn:uuid:0xxxxxxx-xxxx-1xxx-xxxx-yyyyyyyyyyyy</user>
 </accountInfoRequest >"""
 
@@ -528,7 +528,8 @@ class TestVendorIDRequestHandler(object):
 
     def test_handle_username_authdata_request_success(self):
         doc = self.authdata_sign_in_request % dict(
-            authdata=base64.b64encode("The secret token"))
+            authdata=base64.b64encode("The secret token")
+        )
         result = self._handler.handle_signin_request(
             doc, self._standard_login, self._authdata_login)
         assert result.startswith('<signInResponse xmlns="http://ns.adobe.com/adept">\n<user>test-uuid</user>\n<label>Human-readable label for user1</label>\n</signInResponse>')
@@ -542,14 +543,16 @@ class TestVendorIDRequestHandler(object):
 
     def test_handle_username_authdata_request_failure(self):
         doc = self.authdata_sign_in_request % dict(
-            authdata=base64.b64encode("incorrect"))
+            authdata=base64.b64encode("incorrect")
+        )
         result = self._handler.handle_signin_request(
             doc, self._standard_login, self._authdata_login)
         eq_('<error xmlns="http://ns.adobe.com/adept" data="E_1045_AUTH Incorrect token."/>', result)
 
     def test_failure_send_login_request_to_accountinfo(self):
         doc = self.authdata_sign_in_request % dict(
-            authdata=base64.b64encode("incorrect"))
+            authdata=base64.b64encode("incorrect")
+        )
         result = self._handler.handle_accountinfo_request(
             doc, self._userinfo)
         eq_('<error xmlns="http://ns.adobe.com/adept" data="E_1045_ACCOUNT_INFO Request document in wrong format."/>', result)
@@ -740,6 +743,7 @@ class TestAuthdataUtility(VendorIDTest):
         vendor_id, authdata = self.authdata.encode(patron_identifier)
         eq_("The Vendor ID", vendor_id)
 
+        authdata = authdata.encode("utf8")
         # A mischievious party in the middle decodes our authdata
         # without telling us.
         authdata = base64.decodestring(authdata)
@@ -750,16 +754,31 @@ class TestAuthdataUtility(VendorIDTest):
 
     def test_encode(self):
         """Test that _encode gives a known value with known input."""
+
+        # Three pieces of data go into our JWT.
         patron_identifier = "Patron identifier"
         now = datetime.datetime(2016, 1, 1, 12, 0, 0)
         expires = datetime.datetime(2018, 1, 1, 12, 0, 0)
+
+        raw_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOi8vbXktbGlicmFyeS5vcmcvIiwic3ViIjoiUGF0cm9uIGlkZW50aWZpZXIiLCJpYXQiOjE0NTE2NDk2MDAuMCwiZXhwIjoxNTE0ODA4MDAwLjB9.Ua11tFCpC4XAgwhR6jFyoxfHy4s1zt2Owg4dOoCefYA'
+        base64_encoded_jwt = base64.b64encode(raw_jwt).strip()
+
+        # We can't call self.authdata._decode to peek into raw_jwt,
+        # because it expired in 2018.  But if you're debugging this
+        # test and you need to look at the pieces that make up
+        # raw_jwt, you can call PyJWT._load(), like so:
+        from jwt.api_jwt import _jwt_global_obj
+        loaded_jwt = _jwt_global_obj._load(raw_jwt)
+        payload = loaded_jwt[0]
+        payload_dict = json.loads(payload)
+        eq_("Patron identifier", payload_dict['sub'])
+
+        # Encoding the three pieces of data gets a known value.
         authdata = self.authdata._encode(
             self.authdata.library_uri, patron_identifier, now, expires
         )
-        eq_(
-            base64.encodestring('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwOi8vbXktbGlicmFyeS5vcmcvIiwiaWF0IjoxNDUxNjQ5NjAwLjAsInN1YiI6IlBhdHJvbiBpZGVudGlmaWVyIiwiZXhwIjoxNTE0ODA4MDAwLjB9.n7VRVv3gIyLmNxTzNRTEfCdjoky0T0a1Jhehcag1oQw'),
-            authdata
-        )
+        eq_(base64_encoded_jwt, authdata)
+
 
     def test_decode_from_another_library(self):
 
@@ -880,7 +899,7 @@ class TestAuthdataUtility(VendorIDTest):
         # The signature comes from signing the token with the
         # secret associated with this library.
         expect_signature = self.authdata.short_token_signer.sign(
-            token, self.authdata.short_token_signing_key
+            token.encode("utf8"), self.authdata.short_token_signing_key
         )
         eq_(expect_signature, signature)
 
@@ -906,7 +925,7 @@ class TestAuthdataUtility(VendorIDTest):
         # If our secret for a library doesn't match the other
         # library's short token signing key, we can't decode the
         # authdata.
-        foreign_authdata.short_token_signing_key = 'A new secret'
+        foreign_authdata.short_token_signing_key = b'A new secret'
         vendor_id, token = foreign_authdata.encode_short_client_token(
             patron_identifier
         )
@@ -969,7 +988,7 @@ class TestAuthdataUtility(VendorIDTest):
         """Test our special variant of base64 encoding designed to avoid
         triggering an Adobe bug.
         """
-        value = "!\tFN6~'Es52?X!#)Z*_S"
+        value = b"!\tFN6~'Es52?X!#)Z*_S"
 
         encoded = AuthdataUtility.adobe_base64_encode(value)
         eq_('IQlGTjZ:J0VzNTI;WCEjKVoqX1M@', encoded)
@@ -1003,7 +1022,7 @@ class TestAuthdataUtility(VendorIDTest):
     def test_decode_two_part_short_client_token_uses_adobe_base64_encoding(self):
 
         # The base64 encoding of this signature has a plus sign in it.
-        signature = 'LbU}66%\\-4zt>R>_)\n2Q'
+        signature = b'LbU}66%\\-4zt>R>_)\n2Q'
         encoded_signature = AuthdataUtility.adobe_base64_encode(signature)
 
         # We replace the plus sign with a colon.
@@ -1171,4 +1190,4 @@ class TestAdobeVendorIDController(VendorIDTest):
         # The authdata returned is the one stored as a Credential
         # for the Patron.
         [credential] = patron.credentials
-        eq_(credential.credential, response.data)
+        eq_(credential.credential, response.data.decode("utf8"))

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -432,8 +432,8 @@ class TestAnnotationParser(AnnotationTest):
         eq_(self.identifier.id, annotation.identifier_id)
         eq_(Annotation.IDLING, annotation.motivation)
         eq_(True, annotation.active)
-        eq_(json.dumps(data["http://www.w3.org/ns/oa#hasTarget"][0]), annotation.target)
-        eq_(json.dumps(data["http://www.w3.org/ns/oa#hasBody"][0]), annotation.content)
+        eq_(data["http://www.w3.org/ns/oa#hasTarget"][0], json.loads(annotation.target))
+        eq_(data["http://www.w3.org/ns/oa#hasBody"][0], json.loads(annotation.content))
 
     def test_parse_compacted_jsonld(self):
         self.pool.loan_to(self.patron)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1072,7 +1072,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
 
         # A token is created and signed with the bearer token.
         token1 = authenticator.create_bearer_token(oauth1.NAME, "some token")
-        eq_("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b2tlbiI6InNvbWUgdG9rZW4iLCJpc3MiOiJvYXV0aDEifQ.toy4qdoziL99SN4q9DRMdN-3a0v81CfVjwJVFNUt_mk",
+        eq_(u"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b2tlbiI6InNvbWUgdG9rZW4iLCJpc3MiOiJvYXV0aDEifQ.toy4qdoziL99SN4q9DRMdN-3a0v81CfVjwJVFNUt_mk",
             token1
         )
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -684,11 +684,11 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         # initialization_exceptions.
         not_configured = auth.initialization_exceptions[misconfigured.id]
         assert isinstance(not_configured, CannotLoadConfiguration)
-        eq_('First Book server not configured.', not_configured.message)
+        eq_('First Book server not configured.', str(not_configured))
 
         not_found = auth.initialization_exceptions[unknown.id]
         assert isinstance(not_found, ImportError)
-        eq_('No module named unknown protocol', not_found.message)
+        eq_("No module named 'unknown protocol'", str(not_found))
 
     def test_register_fails_when_integration_has_wrong_goal(self):
         integration = self._external_integration(
@@ -798,8 +798,10 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         # But you can't create an Authenticator that uses OAuth
         # without providing a secret.
         assert_raises_regexp(
-            LibraryAuthenticator,
+            CannotLoadConfiguration,
             "OAuth providers are configured, but secret for signing bearer tokens is not.",
+            LibraryAuthenticator,
+            _db=self._db,
             library=self._default_library,
             oauth_providers=[oauth]
         )
@@ -1070,7 +1072,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
 
         # A token is created and signed with the bearer token.
         token1 = authenticator.create_bearer_token(oauth1.NAME, "some token")
-        eq_("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJvYXV0aDEiLCJ0b2tlbiI6InNvbWUgdG9rZW4ifQ.Ve-bbEN4mdWQdR-VA6gbrK2xOz2KRbmPhttmTTCA0ng",
+        eq_("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b2tlbiI6InNvbWUgdG9rZW4iLCJpc3MiOiJvYXV0aDEifQ.toy4qdoziL99SN4q9DRMdN-3a0v81CfVjwJVFNUt_mk",
             token1
         )
 
@@ -1887,7 +1889,7 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         [result] = list(provider._run_self_tests(_db))
         eq_(_db, provider.called_with)
         eq_(False, result.success)
-        eq_("Nope", result.exception.message)
+        eq_("Nope", str(result.exception))
 
         # If we can authenticate a test patron, the patron and their
         # password are passed into the next test.

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -657,11 +657,10 @@ class TestLibraryAuthenticator(AuthenticatorTest):
         eq_([], list(authenticator.providers))
 
     def test_configuration_exception_during_from_config_stored(self):
-        """If the initialization of an AuthenticationProvider from config
-        raises CannotLoadConfiguration or ImportError, the exception
-        is stored with the LibraryAuthenticator rather than being
-        propagated.
-        """
+        # If the initialization of an AuthenticationProvider from config
+        # raises CannotLoadConfiguration or ImportError, the exception
+        # is stored with the LibraryAuthenticator rather than being
+        # propagated.
 
         # Create an integration destined to raise CannotLoadConfiguration..
         misconfigured = self._external_integration(
@@ -688,7 +687,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
 
         not_found = auth.initialization_exceptions[unknown.id]
         assert isinstance(not_found, ImportError)
-        eq_("No module named 'unknown protocol'", str(not_found))
+        eq_("No module named unknown protocol", unicode(not_found))
 
     def test_register_fails_when_integration_has_wrong_goal(self):
         integration = self._external_integration(

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2635,7 +2635,9 @@ class TestOAuthController(AuthenticatorTest):
         params = dict(provider=self.oauth1.NAME)
         response = self.controller.oauth_authentication_redirect(params, self._db)
         eq_(302, response.status_code)
-        expected_state = dict(redirect_uri="", provider=self.oauth1.NAME)
+        # TODO PYTHON3 the dict keys are in a different order, so the
+        # string comes out different.
+        expected_state = dict(provider=self.oauth1.NAME, redirect_uri="")
         expected_state = urllib.quote(json.dumps(expected_state))
         eq_("http://oauth1.com/?state=" + expected_state, response.location)
 

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -164,8 +164,8 @@ class TestAxis360API(Axis360Test):
             no_patron_credential.name
         )
         eq_(False, no_patron_credential.success)
-        eq_("Library has no test patron configured.",
-            str(no_patron_credential.exception))
+        eq_(u"Library has no test patron configured.",
+            unicode(no_patron_credential.exception))
 
         eq_("Asking for circulation events for the last five minutes",
             recent_circulation_events.name)
@@ -203,7 +203,7 @@ class TestAxis360API(Axis360Test):
         [failure] = api._run_self_tests(self._db)
         eq_("Refreshing bearer token", failure.name)
         eq_(False, failure.success)
-        eq_("no way", str(failure.exception))
+        eq_(u"no way", unicode(failure.exception))
 
     def test_create_identifier_strings(self):
         identifier = self._identifier()

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -149,8 +149,8 @@ class TestBibliothecaAPI(BibliothecaAPITest):
             no_patron_credential.name
         )
         eq_(False, no_patron_credential.success)
-        eq_("Library has no test patron configured.",
-            str(no_patron_credential.exception))
+        eq_(u"Library has no test patron configured.",
+            unicode(no_patron_credential.exception))
 
         eq_("Asking for circulation events for the last five minutes",
             recent_circulation_events.name)

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -150,7 +150,7 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         )
         eq_(False, no_patron_credential.success)
         eq_("Library has no test patron configured.",
-            no_patron_credential.exception.message)
+            str(no_patron_credential.exception))
 
         eq_("Asking for circulation events for the last five minutes",
             recent_circulation_events.name)
@@ -183,9 +183,8 @@ class TestBibliothecaAPI(BibliothecaAPITest):
             self.api.full_url("/foo"))
 
     def test_request_signing(self):
-        """Confirm a known correct result for the Bibliotheca request signing
-        algorithm.
-        """
+        # Confirm a known correct result for the Bibliotheca request signing
+        # algorithm.
         self.api.queue_response(200)
         response = self.api.request("some_url")
         [request] = self.api.requests
@@ -351,7 +350,7 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         data = self.sample_data("item_metadata_single.xml")
         # Change the ID in the test data so it looks like it's talking
         # about the LicensePool we just created.
-        data = data.replace("ddf4gr9", pool.identifier.identifier)
+        data = data.replace(b"ddf4gr9", pool.identifier.identifier.encode("utf8"))
 
         # Update availability using that data.
         self.api.queue_response(200, content=data)

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -1124,7 +1124,7 @@ class TestConfigurationFailures(DatabaseTest):
         # constructor has been stored in initialization_exceptions.
         e = circulation.initialization_exceptions[self._default_collection.id]
         assert isinstance(e, CannotLoadConfiguration)
-        eq_("doomed!", str(e))
+        eq_(u"doomed!", unicode(e))
 
 
 class TestAPIAwareFulfillmentInfo(DatabaseTest):

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -1124,7 +1124,7 @@ class TestConfigurationFailures(DatabaseTest):
         # constructor has been stored in initialization_exceptions.
         e = circulation.initialization_exceptions[self._default_collection.id]
         assert isinstance(e, CannotLoadConfiguration)
-        eq_("doomed!", e.message)
+        eq_("doomed!", str(e))
 
 
 class TestAPIAwareFulfillmentInfo(DatabaseTest):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,7 +46,10 @@ class TestConfiguration(DatabaseTest):
         eq_(new_private, private_key)
 
     def test_cipher(self):
-        """Test the cipher() helper method."""
+        # Test the cipher() helper method.
+
+        # Note that the cipher only accepts bytes, and returns
+        # encrypted bytes.
 
         # Generate a public/private key pair.
         key = RSA.generate(2048)
@@ -57,13 +60,14 @@ class TestConfiguration(DatabaseTest):
         # Pass the public key into cipher() to get something that can
         # encrypt.
         encryptor = Configuration.cipher(public)
-        encrypted = encryptor.encrypt("some text")
+        encrypted = encryptor.encrypt(b"some text")
+        assert isinstance(encrypted, bytes)
 
         # Pass the private key into cipher() to get something that can
         # decrypt.
         decryptor = Configuration.cipher(private)
         decrypted = decryptor.decrypt(encrypted)
-        eq_("some text", decrypted)
+        eq_(b"some text", decrypted)
 
     def test_collection_language_method_performs_estimate(self):
         C = Configuration

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -169,7 +169,7 @@ import json
 import urllib
 from core.analytics import Analytics
 from core.util.authentication_for_opds import AuthenticationForOPDSDocument
-from core.util.binary import base64
+from core.util.string_helpers import base64
 from api.registry import Registration
 
 class ControllerTest(VendorIDTest):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -550,7 +550,7 @@ class TestCirculationManager(CirculationControllerTest):
         # The reason why is stored here.
         ex = circulation.external_search_initialization_exception
         assert isinstance(ex, Exception)
-        eq_("doomed!", str(ex))
+        eq_(u"doomed!", unicode(ex))
 
     def test_exception_during_short_client_token_initialization_is_stored(self):
 
@@ -571,7 +571,9 @@ class TestCirculationManager(CirculationControllerTest):
         # configuration was stored here.
         ex = self.manager.short_client_token_initialization_exceptions[self.library.id]
         assert isinstance(ex, CannotLoadConfiguration)
-        assert str(ex).startswith("Short Client Token configuration is incomplete")
+        assert unicode(ex).startswith(
+            u"Short Client Token configuration is incomplete"
+        )
 
     def test_setup_adobe_vendor_id_does_not_override_existing_configuration(self):
         # Our circulation manager is perfectly happy with its Adobe Vendor ID
@@ -2122,7 +2124,7 @@ class TestAnnotationController(CirculationControllerTest):
 
             # The response contains the annotation in the db.
             item = json.loads(response.data.decode("utf8"))
-            assert str(annotation.id) in item['id']
+            assert unicode(annotation.id) in item['id']
             eq_(annotation.motivation, item['motivation'])
 
     def test_detail(self):

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -770,9 +770,8 @@ class TestMetadataWranglerCollectionReaper(MetadataWranglerCoverageProviderTest)
         eq_(sorted(results), sorted([valid_id, mapped_id]))
 
     def test_finalize_batch(self):
-        """Metadata Wrangler sync coverage records are deleted from the db
-        when the the batch is finalized if the item has been reaped.
-        """
+        # Metadata Wrangler sync coverage records are deleted from the db
+        # when the the batch is finalized if the item has been reaped.
 
         # Create an identifier that has been imported and one that's
         # been reaped.
@@ -806,7 +805,11 @@ class TestMetadataWranglerCollectionReaper(MetadataWranglerCoverageProviderTest)
 
         # The syncing record has been deleted from the database
         assert doubly_sync_record not in remaining_records
-        eq_(sorted([sync_cr, reaped_cr, doubly_reap_record]), sorted(remaining_records))
+        sort_by = lambda x: x.id
+        eq_(
+            sorted([sync_cr, reaped_cr, doubly_reap_record], key=sort_by),
+            sorted(remaining_records, key=sort_by)
+        )
 
 
 class TestMetadataUploadCoverageProvider(DatabaseTest):

--- a/tests/test_custom_index.py
+++ b/tests/test_custom_index.py
@@ -143,8 +143,8 @@ class TestCOPPAGate(DatabaseTest):
         # which has been cached as .navigation_feed.
         eq_("200 OK", response.status)
         eq_(OPDSFeed.NAVIGATION_FEED_TYPE, response.headers['Content-Type'])
-        eq_("fake feed", response.data)
-        eq_(response.data, gate.navigation_feed)
+        eq_("fake feed", response.data.decode("utf8"))
+        eq_(response.data.decode("utf8"), gate.navigation_feed)
 
     def test__navigation_feed(self):
         """Test the code that builds an OPDS navigation feed."""
@@ -233,7 +233,7 @@ class TestCOPPAGate(DatabaseTest):
 
     def test_navigation_entry(self):
         """navigation_entry creates an OPDS entry with a subsection link."""
-        entry = etree.tostring(
+        entry = etree.tounicode(
             COPPAGate.navigation_entry(
                 "some href", "some title", "some content"
             )
@@ -243,7 +243,7 @@ class TestCOPPAGate(DatabaseTest):
                 '<id>some href</id>',
                 '<title>some title</title>',
                 '<content type="text">some content</content>',
-                '<link href="some href" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="subsection"/>',
+                '<link href="some href" rel="subsection" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>',
                 '<updated',
         ):
             assert expect in entry

--- a/tests/test_custom_index.py
+++ b/tests/test_custom_index.py
@@ -232,19 +232,21 @@ class TestCOPPAGate(DatabaseTest):
         assert '<updated>' in feed
 
     def test_navigation_entry(self):
-        """navigation_entry creates an OPDS entry with a subsection link."""
+        # navigation_entry creates an OPDS entry with a subsection link.
         entry = etree.tounicode(
             COPPAGate.navigation_entry(
                 "some href", "some title", "some content"
             )
         )
-        assert entry.startswith('<entry ')
+        assert entry.startswith(u'<entry ')
+
+        # TODO PYTHON 3 Attrs in different order in link tag.
         for expect in (
-                '<id>some href</id>',
-                '<title>some title</title>',
-                '<content type="text">some content</content>',
-                '<link href="some href" rel="subsection" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>',
-                '<updated',
+                u'<id>some href</id>',
+                u'<title>some title</title>',
+                u'<content type="text">some content</content>',
+                u'<link href="some href" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="subsection"/>',
+                u'<updated',
         ):
             assert expect in entry
 

--- a/tests/test_enki.py
+++ b/tests/test_enki.py
@@ -170,7 +170,7 @@ class TestEnkiAPI(BaseEnkiTest):
         )
         eq_(False, no_patron_activity.success)
         eq_("Library has no test patron configured.",
-            no_patron_activity.exception.message)
+            str(no_patron_activity.exception))
 
         eq_(
             "Checking patron activity, using test patron for library %s" % with_default_patron.name,

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -5,7 +5,7 @@ from nose.tools import (
     eq_,
     set_trace,
 )
-from StringIO import StringIO
+from io import BytesIO
 from zipfile import ZipFile
 from . import (
     DatabaseTest,

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -236,7 +236,7 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         # The very first request made is going to be to the
         # REPLACEMENT_CSS_KEY URL.
         self.http.queue_response(
-            200, content="Some new CSS", media_type="text/css",
+            200, content=b"Some new CSS", media_type="text/css",
         )
         ignore, importer = self._importer(**settings)
 
@@ -246,7 +246,7 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
 
         # OPDSImporter.content_modifier has been set to call replace_css
         # when necessary.
-        eq_("Some new CSS", importer.new_css)
+        eq_("Some new CSS", importer.new_css.decode("utf8"))
         eq_(importer.replace_css, importer.content_modifier)
 
         # The requests to the various copies of the book will succeed,
@@ -305,7 +305,7 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         eq_(True, pool.open_access)
 
         # The mirrored content contains the modified CSS.
-        content = StringIO(self.mirror.content[0])
+        content = BytesIO(self.mirror.content[0])
         with ZipFile(content) as zip:
             # The zip still contains the original epub's files.
             assert "META-INF/container.xml" in zip.namelist()
@@ -314,11 +314,11 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
 
             # The content of an old file hasn't changed.
             with zip.open("mimetype") as f:
-                eq_("application/epub+zip\r\n", f.read())
+                eq_("application/epub+zip\r\n", f.read().decode("utf8"))
 
             # The content of CSS files has been changed to the new value.
             with zip.open("OPS/css/about.css") as f:
-                eq_("Some new CSS", f.read())
+                eq_("Some new CSS", f.read().decode("utf8"))
 
     def test_in_copyright_book_not_mirrored(self):
 

--- a/tests/test_google_analytics_provider.py
+++ b/tests/test_google_analytics_provider.py
@@ -97,9 +97,9 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
         eq_(str(now), params['cd1'][0])
         eq_(lp.identifier.identifier, params['cd2'][0])
         eq_(lp.identifier.type, params['cd3'][0])
-        eq_(unicodedata.normalize("NFKD", work.title),
+        eq_(unicodedata.normalize("NFKD", work.title).encode("utf8"),
             params['cd4'][0])
-        eq_(unicodedata.normalize("NFKD", work.author),
+        eq_(unicodedata.normalize("NFKD", work.author).encode("utf8"),
             params['cd5'][0])
         eq_("fiction", params['cd6'][0])
         eq_("audience", params['cd7'][0])

--- a/tests/test_google_analytics_provider.py
+++ b/tests/test_google_analytics_provider.py
@@ -97,9 +97,9 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
         eq_(str(now), params['cd1'][0])
         eq_(lp.identifier.identifier, params['cd2'][0])
         eq_(lp.identifier.type, params['cd3'][0])
-        eq_(unicodedata.normalize("NFKD", work.title).encode('utf8'),
+        eq_(unicodedata.normalize("NFKD", work.title),
             params['cd4'][0])
-        eq_(unicodedata.normalize("NFKD", work.author).encode('utf8'),
+        eq_(unicodedata.normalize("NFKD", work.author),
             params['cd5'][0])
         eq_("fiction", params['cd6'][0])
         eq_("audience", params['cd7'][0])

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -84,11 +84,11 @@ class TestLaneCreation(DatabaseTest):
         for lane in lanes:
             eq_(self._default_library, lane.library)
             # They all are restricted to English and Spanish.
-            eq_(x.languages, languages)
+            eq_(lane.languages, languages)
 
             # They have no restrictions on media type -- that's handled
             # with entry points.
-            eq_(None, x.media)
+            eq_(None, lane.media)
 
         eq_(
             ['Fiction', 'Nonfiction', 'Young Adult Fiction',

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -224,21 +224,20 @@ class TestMWCollectionUpdateMonitor(MonitorTest):
         eq_(Timestamp.CLEAR_VALUE, new_timestamp.finish)
 
     def test_no_import_loop(self):
-        """We stop processing a feed's 'next' link if it links to a URL we've
-        already seen.
-        """
+        # We stop processing a feed's 'next' link if it links to a URL we've
+        # already seen.
 
         data = sample_data('metadata_updates_response.opds', 'opds')
         self.lookup.queue_response(
             200, {'content-type' : OPDSFeed.ACQUISITION_FEED_TYPE}, data
         )
-        data = data.replace("http://next-link/", "http://different-link/")
+        data = data.replace(b"http://next-link/", b"http://different-link/")
         self.lookup.queue_response(
             200, {'content-type' : OPDSFeed.ACQUISITION_FEED_TYPE}, data
         )
 
         # This introduces a loop.
-        data = data.replace("http://next-link/", "http://next-link/")
+        data = data.replace(b"http://next-link/", b"http://next-link/")
         self.lookup.queue_response(
             200, {'content-type' : OPDSFeed.ACQUISITION_FEED_TYPE}, data
         )

--- a/tests/test_novelist.py
+++ b/tests/test_novelist.py
@@ -242,7 +242,7 @@ class TestNoveListAPI(DatabaseTest):
 
         # If a recent Representation exists, it is returned.
         representation, is_new = self._representation(url=url)
-        representation.content = 'content'
+        representation.content = b'content'
         representation.fetched_at = datetime.datetime.utcnow() - datetime.timedelta(days=3)
         result = self.novelist.cached_representation(url)
         eq_(representation, result)

--- a/tests/test_nyt.py
+++ b/tests/test_nyt.py
@@ -133,9 +133,8 @@ class TestNYTBestSellerAPI(NYTBestSellerAPITest):
         eq_("Combined Print & E-Book Fiction", list_info['display_name'])
 
     def test_request_failure(self):
-        """Verify that certain unexpected HTTP results are turned into
-        IntegrationExceptions.
-        """
+        # Verify that certain unexpected HTTP results are turned into
+        # IntegrationExceptions.
         self.api.api_key = "some key"
         def result_403(*args, **kwargs):
             return 403, None, None

--- a/tests/test_nyt.py
+++ b/tests/test_nyt.py
@@ -151,7 +151,7 @@ class TestNYTBestSellerAPI(NYTBestSellerAPITest):
             self.api.request("some path")
             raise Exception("Expected an IntegrationException!")
         except IntegrationException, e:
-            eq_("Unknown API error (status 500)", str(e))
+            eq_(u"Unknown API error (status 500)", unicode(e))
             assert e.debug_message.startswith("Response from")
             assert e.debug_message.endswith("was: 'bad value'")
 

--- a/tests/test_nyt.py
+++ b/tests/test_nyt.py
@@ -152,7 +152,7 @@ class TestNYTBestSellerAPI(NYTBestSellerAPITest):
             self.api.request("some path")
             raise Exception("Expected an IntegrationException!")
         except IntegrationException, e:
-            eq_("Unknown API error (status 500)", e.message)
+            eq_("Unknown API error (status 500)", str(e))
             assert e.debug_message.startswith("Response from")
             assert e.debug_message.endswith("was: 'bad value'")
 

--- a/tests/test_odilo.py
+++ b/tests/test_odilo.py
@@ -318,7 +318,7 @@ class TestOdiloAPI(OdiloAPITest):
         )
         eq_(False, loans_failure.success)
         eq_("Library has no test patron configured.",
-            loans_failure.exception.message)
+            str(loans_failure.exception))
 
     def test_run_self_tests_short_circuit(self):
         """If OdiloAPI.check_creds can't get credentials, the rest of
@@ -333,7 +333,7 @@ class TestOdiloAPI(OdiloAPITest):
 
         # Only one test will be run.
         [check_creds] = self.api._run_self_tests(self._db)
-        eq_("Failure!", check_creds.exception.message)
+        eq_("Failure!", str(check_creds.exception))
 
 
 class TestOdiloCirculationAPI(OdiloAPITest):

--- a/tests/test_odilo.py
+++ b/tests/test_odilo.py
@@ -317,8 +317,8 @@ class TestOdiloAPI(OdiloAPITest):
             loans_failure.name
         )
         eq_(False, loans_failure.success)
-        eq_("Library has no test patron configured.",
-            str(loans_failure.exception))
+        eq_(u"Library has no test patron configured.",
+            unicode(loans_failure.exception))
 
     def test_run_self_tests_short_circuit(self):
         """If OdiloAPI.check_creds can't get credentials, the rest of
@@ -333,7 +333,7 @@ class TestOdiloAPI(OdiloAPITest):
 
         # Only one test will be run.
         [check_creds] = self.api._run_self_tests(self._db)
-        eq_("Failure!", str(check_creds.exception))
+        eq_(u"Failure!", unicode(check_creds.exception))
 
 
 class TestOdiloCirculationAPI(OdiloAPITest):

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -7,7 +7,6 @@ import os
 import json
 import datetime
 import re
-import base64
 import urllib
 import urlparse
 

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -37,6 +37,7 @@ from api.odl import (
     SharedODLImporter,
 )
 from api.circulation_exceptions import *
+from core.util.binary import base64
 from core.util.http import (
     BadResponseException,
     RemoteIntegrationException,
@@ -49,7 +50,7 @@ class BaseODLTest(object):
     @classmethod
     def get_data(cls, filename):
         path = os.path.join(cls.resource_path, filename)
-        return open(path).read()
+        return open(path, 'rb').read()
 
 class TestODLAPI(DatabaseTest, BaseODLTest):
 
@@ -1446,7 +1447,8 @@ class TestSharedODLAPI(DatabaseTest, BaseODLTest):
         def do_get(url, headers=None, allowed_response_codes=None):
             eq_("test url", url)
             eq_("test header value", headers.get("test_key"))
-            eq_("Bearer " + base64.b64encode("secret"), headers.get("Authorization"))
+            eq_("Bearer " + base64.b64encode("secret"),
+                headers.get("Authorization"))
             eq_(["200"], allowed_response_codes)
         api._get("test url", headers=dict(test_key="test header value"),
                  patron=self.patron, allowed_response_codes=["200"],

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -37,7 +37,7 @@ from api.odl import (
     SharedODLImporter,
 )
 from api.circulation_exceptions import *
-from core.util.binary import base64
+from core.util.string_helpers import base64
 from core.util.http import (
     BadResponseException,
     RemoteIntegrationException,

--- a/tests/test_onix.py
+++ b/tests/test_onix.py
@@ -23,7 +23,7 @@ class TestONIXExtractor(object):
         """Parse an ONIX file into Metadata objects."""
 
         file = self.sample_data("onix_example.xml")
-        metadata_records = ONIXExtractor().parse(StringIO(file), "MIT Press")
+        metadata_records = ONIXExtractor().parse(BytesIO(file), "MIT Press")
 
         eq_(1, len(metadata_records))
 

--- a/tests/test_onix.py
+++ b/tests/test_onix.py
@@ -2,7 +2,7 @@ from nose.tools import (
     eq_,
     set_trace,
 )
-from StringIO import StringIO
+from io import BytesIO
 import os
 
 from . import sample_data

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1,4 +1,3 @@
-import base64
 from collections import defaultdict
 import contextlib
 import datetime

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -165,8 +165,8 @@ class TestOverdriveAPI(OverdriveAPITest):
             no_patron_credential.name
         )
         eq_(False, no_patron_credential.success)
-        eq_("Library has no test patron configured.",
-            str(no_patron_credential.exception))
+        eq_(u"Library has no test patron configured.",
+            unicode(no_patron_credential.exception))
 
         eq_(
             "Checking Patron Authentication privileges, using test patron for library %s" % with_default_patron.name,
@@ -195,7 +195,7 @@ class TestOverdriveAPI(OverdriveAPITest):
 
         # Only one test will be run.
         [check_creds] = self.api._run_self_tests(self._db)
-        eq_("Failure!", str(check_creds.exception))
+        eq_(u"Failure!", unicode(check_creds.exception))
 
     def test_default_notification_email_address(self):
         """Test the ability of the Overdrive API to detect an email address

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -166,7 +166,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         )
         eq_(False, no_patron_credential.success)
         eq_("Library has no test patron configured.",
-            no_patron_credential.exception.message)
+            str(no_patron_credential.exception))
 
         eq_(
             "Checking Patron Authentication privileges, using test patron for library %s" % with_default_patron.name,
@@ -195,7 +195,7 @@ class TestOverdriveAPI(OverdriveAPITest):
 
         # Only one test will be run.
         [check_creds] = self.api._run_self_tests(self._db)
-        eq_("Failure!", check_creds.exception.message)
+        eq_("Failure!", str(check_creds.exception))
 
     def test_default_notification_email_address(self):
         """Test the ability of the Overdrive API to detect an email address
@@ -975,7 +975,7 @@ class TestSyncBookshelf(OverdriveAPITest):
 
         # All four loans in the sample data were created.
         eq_(4, len(loans))
-        eq_(loans.sort(), patron.loans.sort())
+        eq_(loans, patron.loans)
 
         # We have created previously unknown LicensePools and
         # Identifiers.
@@ -1004,7 +1004,7 @@ class TestSyncBookshelf(OverdriveAPITest):
                 (Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM),
                 (Representation.PDF_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM),
             ],
-            sorted(mechanisms)
+            sorted(mechanisms, key=lambda x: (x[0], x[1] or ""))
         )
 
         # There are no holds.
@@ -1015,7 +1015,7 @@ class TestSyncBookshelf(OverdriveAPITest):
         self.api.queue_response(200, content=holds_data)
         loans, holds = self.circulation.sync_bookshelf(patron, "dummy pin")
         eq_(4, len(loans))
-        eq_(loans.sort(), patron.loans.sort())
+        eq_(loans, patron.loans)
 
     def test_sync_bookshelf_removes_loans_not_present_on_remote(self):
         loans_data, json_loans = self.sample_json("shelf_with_some_checked_out_books.json")
@@ -1073,14 +1073,14 @@ class TestSyncBookshelf(OverdriveAPITest):
         loans, holds = self.circulation.sync_bookshelf(patron, "dummy pin")
         # All four loans in the sample data were created.
         eq_(4, len(holds))
-        eq_(sorted(holds), sorted(patron.holds))
+        eq_(holds, patron.holds)
 
         # Running the sync again leaves all four holds in place.
         self.api.queue_response(200, content=loans_data)
         self.api.queue_response(200, content=holds_data)
         loans, holds = self.circulation.sync_bookshelf(patron, "dummy pin")
         eq_(4, len(holds))
-        eq_(sorted(holds), sorted(patron.holds))
+        eq_(holds, patron.holds)
 
     def test_sync_bookshelf_removes_holds_not_present_on_remote(self):
         loans_data, json_loans = self.sample_json("no_loans.json")

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -180,7 +180,7 @@ class TestRBDigitalAPI(RBDigitalAPITest):
         )
         eq_(False, no_patron_credential.success)
         eq_("Library has no test patron configured.",
-            no_patron_credential.exception.message)
+            str(no_patron_credential.exception))
 
         eq_("Checking patron activity, using test patron for library %s" % with_default_patron.name,
             patron_activity.name)
@@ -212,7 +212,8 @@ class TestRBDigitalAPI(RBDigitalAPITest):
 
         # We gave up after the first test failed.
         eq_("Counting ebooks in collection", result.name)
-        eq_("Invalid library id is provided or permission denied", result.exception.message)
+        eq_("Invalid library id is provided or permission denied",
+            str(result.exception))
         eq_(repr(error), result.exception.debug_message)
 
     def test_external_integration(self):
@@ -672,11 +673,11 @@ class TestRBDigitalAPI(RBDigitalAPITest):
 
         # The dummy identifier is the input identifier plus
         # 6 random characters.
-        eq_(auth + "N098QO", remote_auth)
+        eq_(auth + "71HFE8", remote_auth)
 
         # It's different every time.
         remote_auth = self.api.dummy_patron_identifier(auth)
-        eq_(auth + "W3F17I", remote_auth)
+        eq_(auth + "6Y5R21", remote_auth)
 
     def test_dummy_email_address(self):
 
@@ -1291,13 +1292,12 @@ class TestRBDigitalAPI(RBDigitalAPITest):
                       patron, None, pool)
 
     def test_update_licensepool_for_identifier(self):
-        """Test the RBDigital implementation of the update_availability method
-        defined by the CirculationAPI interface.
-        """
+        # Test the RBDigital implementation of the update_availability method
+        # defined by the CirculationAPI interface.
 
         # Update a LicensePool that doesn't exist yet, and it gets created.
         identifier = self._identifier(identifier_type=Identifier.RB_DIGITAL_ID)
-        isbn = identifier.identifier.encode("ascii")
+        isbn = identifier.identifier
 
         # The BibliographicCoverageProvider gets called for a new license pool.
         self.api.queue_response(200, content=json.dumps({}))
@@ -1328,7 +1328,7 @@ class TestRBDigitalAPI(RBDigitalAPITest):
         pool.patrons_in_hold_queue = 3
         eq_(None, pool.last_checked)
 
-        isbn = pool.identifier.identifier.encode("ascii")
+        isbn = pool.identifier.identifier
 
         pool, is_new, circulation_changed = self.api.update_licensepool_for_identifier(
             isbn, False, 'eaudio'
@@ -1411,7 +1411,7 @@ class TestCirculationMonitor(RBDigitalAPITest):
 
         # Modify the data so that it appears to be talking about the
         # book we just created.
-        new_identifier = pool_ebook.identifier.identifier.encode("ascii")
+        new_identifier = pool_ebook.identifier.identifier
         datastr = datastr.replace("9781781107041", new_identifier)
         monitor.api.queue_response(status_code=200, content=datastr)
 

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -673,11 +673,11 @@ class TestRBDigitalAPI(RBDigitalAPITest):
 
         # The dummy identifier is the input identifier plus
         # 6 random characters.
-        eq_(auth + "71HFE8", remote_auth)
+        eq_(auth + "N098QO", remote_auth)
 
         # It's different every time.
         remote_auth = self.api.dummy_patron_identifier(auth)
-        eq_(auth + "6Y5R21", remote_auth)
+        eq_(auth + "W3F17I", remote_auth)
 
     def test_dummy_email_address(self):
 

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -179,8 +179,8 @@ class TestRBDigitalAPI(RBDigitalAPITest):
             no_patron_credential.name
         )
         eq_(False, no_patron_credential.success)
-        eq_("Library has no test patron configured.",
-            str(no_patron_credential.exception))
+        eq_(u"Library has no test patron configured.",
+            unicode(no_patron_credential.exception))
 
         eq_("Checking patron activity, using test patron for library %s" % with_default_patron.name,
             patron_activity.name)
@@ -212,8 +212,8 @@ class TestRBDigitalAPI(RBDigitalAPITest):
 
         # We gave up after the first test failed.
         eq_("Counting ebooks in collection", result.name)
-        eq_("Invalid library id is provided or permission denied",
-            str(result.exception))
+        eq_(u"Invalid library id is provided or permission denied",
+            unicode(result.exception))
         eq_(repr(error), result.exception.debug_message)
 
     def test_external_integration(self):

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -1625,6 +1625,7 @@ class TestRBDigitalRepresentationExtractor(RBDigitalAPITest):
         eq_(u"Laura Flanagan Guskin", narrator.display_name)
         eq_([Contributor.NARRATOR_ROLE], narrator.roles)
 
+        # TODO PYTHON3 it's better not to sort this list.
         subjects = sorted(metadata.subjects, key=lambda x: x.identifier)
 
         eq_([(None, u"FICTION / Humorous / General", Subject.BISAC, 100),

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -18,7 +18,7 @@ from core.model import (
     ConfigurationSetting,
     ExternalIntegration,
 )
-from core.util.binary import (
+from core.util.string_helpers import (
     base64,
     random_string,
 )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,7 +5,6 @@ from nose.tools import (
 import json
 from Crypto.PublicKey import RSA
 from Crypto.Cipher import PKCS1_OAEP
-import base64
 import os
 from . import (
     DatabaseTest
@@ -18,6 +17,10 @@ from core.util.problem_detail import (
 from core.model import (
     ConfigurationSetting,
     ExternalIntegration,
+)
+from core.util.binary import (
+    base64,
+    random_string,
 )
 from api.adobe_vendor_id import AuthdataUtility
 from api.config import Configuration
@@ -310,7 +313,7 @@ class TestRegistration(DatabaseTest):
         results = registration._process_registration_result_called_with
         message, cipher, actual_stage = results
         eq_("you did it!", message)
-        eq_(cipher._key.exportKey(), private_key)
+        eq_(cipher._key.exportKey(), private_key.encode("utf8"))
         eq_(actual_stage, stage)
 
         # If a nonexistent stage is provided a ProblemDetail is the result.
@@ -515,7 +518,7 @@ class TestRegistration(DatabaseTest):
         key2 = RSA.generate(2048)
         encryptor2 = PKCS1_OAEP.new(key2)
 
-        shared_secret = os.urandom(24).encode('hex')
+        shared_secret = random_string(24).encode("utf8")
         encrypted_secret = base64.b64encode(encryptor.encrypt(shared_secret))
 
         # Success.
@@ -652,7 +655,7 @@ class TestLibraryRegistrationScript(DatabaseTest):
             # library registry.
             eq_(
                 RemoteRegistry.DEFAULT_LIBRARY_REGISTRY_URL,
-                x[0].integration.url
+                i[0].integration.url
             )
 
     def test_process_library(self):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -216,7 +216,7 @@ class RouteTest(ControllerTest):
         response = self.request(url, http_method)
         eq_(401, response.status_code)
         eq_("authenticated_patron_from_request called without authorizing",
-            response.data)
+            response.data.decode("utf8"))
 
         # Set a variable so that authenticated_patron_from_request
         # will succeed, and try again.
@@ -707,7 +707,7 @@ class TestHealthCheck(RouteTest):
         # This is how we know we actually called health_check() and
         # not a mock method -- the Response returned by the mock
         # system would have an explanatory message in its .data.
-        eq_("", response.data)
+        eq_("", response.data.decode("utf8"))
 
 
 class TestExceptionHandler(RouteTest):
@@ -735,7 +735,7 @@ class TestExceptionHandler(RouteTest):
             eq_(value_error, routes.h.handled)
 
             # The Response is created was passed along.
-            eq_("handled it", result.data)
+            eq_("handled it", result.data.decode("utf8"))
             eq_(500, result.status_code)
 
         # werkzeug HTTPExceptions are _not_ run through

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1015,7 +1015,7 @@ class TestDirectoryImportScript(DatabaseTest):
         eq_(True, metadata.annotated)
 
         # Now let's try it with some files 'on disk'.
-        with open(self.sample_cover_path('test-book-cover.png')) as fh:
+        with open(self.sample_cover_path('test-book-cover.png'), "rb") as fh:
             image = fh.read()
         mock_filesystem = {
             'cover directory' : (
@@ -1056,7 +1056,7 @@ class TestDirectoryImportScript(DatabaseTest):
 
         # The EPUB Representation was cleared out after the upload, to
         # save database space.
-        eq_("I'm an EPUB.", mirror.content[0])
+        eq_(b"I'm an EPUB.", mirror.content[0])
         eq_(None, epub.content)
 
     def test_annotate_metadata(self):

--- a/tests/test_selftest.py
+++ b/tests/test_selftest.py
@@ -40,8 +40,8 @@ class TestHasSelfTests(DatabaseTest):
         [result] = h.default_patrons(not_in_library)
         eq_("Acquiring test patron credentials.", result.name)
         eq_(False, result.success)
-        eq_("Collection is not associated with any libraries.",
-            str(result.exception))
+        eq_(u"Collection is not associated with any libraries.",
+            unicode(result.exception))
         eq_(
             "Add the collection to a library that has a patron authentication service.",
             result.exception.debug_message

--- a/tests/test_selftest.py
+++ b/tests/test_selftest.py
@@ -79,7 +79,7 @@ class TestHasSelfTests(DatabaseTest):
             "Acquiring test patron credentials for library %s" % no_default_patron.name,
             failure.name
         )
-        eq_("Library has no test patron configured.", str(failure.exception))
+        eq_(u"Library has no test patron configured.", unicode(failure.exception))
         eq_("You can specify a test patron when you configure the library's patron authentication service.", failure.exception.debug_message)
 
         # The test patron for the library that has one was looked up,

--- a/tests/test_selftest.py
+++ b/tests/test_selftest.py
@@ -41,7 +41,7 @@ class TestHasSelfTests(DatabaseTest):
         eq_("Acquiring test patron credentials.", result.name)
         eq_(False, result.success)
         eq_("Collection is not associated with any libraries.",
-            result.exception.message)
+            str(result.exception))
         eq_(
             "Add the collection to a library that has a patron authentication service.",
             result.exception.debug_message
@@ -79,7 +79,7 @@ class TestHasSelfTests(DatabaseTest):
             "Acquiring test patron credentials for library %s" % no_default_patron.name,
             failure.name
         )
-        eq_("Library has no test patron configured.", failure.exception.message)
+        eq_("Library has no test patron configured.", str(failure.exception))
         eq_("You can specify a test patron when you configure the library's patron authentication service.", failure.exception.debug_message)
 
         # The test patron for the library that has one was looked up,

--- a/tests/test_shared_collection.py
+++ b/tests/test_shared_collection.py
@@ -88,7 +88,7 @@ class TestSharedCollectionAPI(DatabaseTest):
         # constructor has been stored in initialization_exceptions.
         e = shared_collection.initialization_exceptions[self._default_collection.id]
         assert isinstance(e, CannotLoadConfiguration)
-        eq_("doomed!", str(e))
+        eq_(u"doomed!", unicode(e))
 
     def test_api_for_licensepool(self):
         collection = self._collection(protocol=ODLAPI.NAME)

--- a/tests/test_shared_collection.py
+++ b/tests/test_shared_collection.py
@@ -168,8 +168,8 @@ class TestSharedCollectionAPI(DatabaseTest):
         client = get_one(self._db, IntegrationClient, url=IntegrationClient.normalize_url("http://library.org/"))
         shared_secret = response.get("metadata", {}).get("shared_secret")
 
-        # The encrypted shared secret is a bytestring, so we don't
-        # want to use core.util.binary.base64.
+        # The encrypted shared secret is a bytestring, so we want
+        # to use the standard base64, not core.util.string_helpers.base64.
         decrypted_secret = encryptor.decrypt(base64.b64decode(shared_secret))
 
         # However, we do want to convert the _decrypted_ shared secret

--- a/tests/test_shared_collection.py
+++ b/tests/test_shared_collection.py
@@ -14,7 +14,6 @@ from api.shared_collection import (
     SharedCollectionAPI,
     BaseSharedCollectionAPI,
 )
-from core.config import CannotLoadConfiguration
 from api.odl import ODLAPI
 from core.model import (
     ConfigurationSetting,
@@ -27,6 +26,7 @@ from core.model import (
 from api.circulation import FulfillmentInfo
 
 from . import DatabaseTest
+from core.config import CannotLoadConfiguration
 from core.testing import MockRequestsResponse
 
 class MockAPI(BaseSharedCollectionAPI):
@@ -88,7 +88,7 @@ class TestSharedCollectionAPI(DatabaseTest):
         # constructor has been stored in initialization_exceptions.
         e = shared_collection.initialization_exceptions[self._default_collection.id]
         assert isinstance(e, CannotLoadConfiguration)
-        eq_("doomed!", e.message)
+        eq_("doomed!", str(e))
 
     def test_api_for_licensepool(self):
         collection = self._collection(protocol=ODLAPI.NAME)
@@ -158,7 +158,7 @@ class TestSharedCollectionAPI(DatabaseTest):
 
         # Here's an auth document with a valid key.
         key = RSA.generate(2048)
-        public_key = key.publickey().exportKey()
+        public_key = key.publickey().exportKey().decode("utf8")
         encryptor = PKCS1_OAEP.new(key)
         auth_response = json.dumps({"public_key": { "type": "RSA", "value": public_key },
                                     "links": [{"href": "http://library.org", "rel": "start"}]})
@@ -166,7 +166,15 @@ class TestSharedCollectionAPI(DatabaseTest):
 
         # An IntegrationClient has been created.
         client = get_one(self._db, IntegrationClient, url=IntegrationClient.normalize_url("http://library.org/"))
-        decrypted_secret = encryptor.decrypt(base64.b64decode(response.get("metadata", {}).get("shared_secret")))
+        shared_secret = response.get("metadata", {}).get("shared_secret")
+
+        # The encrypted shared secret is a bytestring, so we don't
+        # want to use core.util.binary.base64.
+        decrypted_secret = encryptor.decrypt(base64.b64decode(shared_secret))
+
+        # However, we do want to convert the _decrypted_ shared secret
+        # into a Unicode string.
+        decrypted_secret = decrypted_secret.decode("utf8")
         eq_(client.shared_secret, decrypted_secret)
 
     def test_borrow(self):


### PR DESCRIPTION
Like https://github.com/NYPL-Simplified/server_core/pull/1102, this branch rewrites a bunch of code that can't be automatically converted to Python 3, into code that either works in both versions or can be converted to Python 3.

The pitfalls are mostly the same as in the core branch, but there are two problems we encountered here for the first time.

* In Python 3, you can't `import *` from inside a function.
* Some tests had some problems with the Python 3 version of werkzeug, because we were mocking `flask.request.form` without also touching `flask.request.stream` and `flask.request.files`. This put the request into an inconsistent state and triggered an infinite loop. The simplest solution was to write a new context manager which makes sure all three values are set.