### PR TITLE
Bring in cover images from the Bibliotheca API to use while waiting for metadata wrangler results

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -247,7 +247,8 @@ class BibliothecaAPI(BaseCirculationAPI, HasSelfTests):
         else:
             return self._request_with_timeout(
                 method, url, data=body, headers=headers,
-                allow_redirects=False)
+                allow_redirects=False, timeout=60
+            )
 
     def get_bibliographic_info_for(self, editions, max_age=None):
         results = dict()
@@ -760,8 +761,29 @@ class ItemListParser(XMLParser):
                 LinkData(rel=Hyperlink.DESCRIPTION, content=description)
             )
 
+        # Presume all images from Bibliotheca are JPEG.
+        media_type = Representation.JPEG_MEDIA_TYPE
         cover_url = value("CoverLinkURL").replace("&amp;", "&")
-        links.append(LinkData(rel=Hyperlink.IMAGE, href=cover_url))
+        cover_link = LinkData(
+            rel=Hyperlink.IMAGE, href=cover_url,
+            media_type=media_type
+        )
+
+        # Unless the URL format has drastically changed, we should be
+        # able to generate a thumbnail URL based on the full-size
+        # cover URL found in the response document.
+        #
+        # NOTE: this is an undocumented feature of the Bibliotheca API
+        # which was discovered by investigating the BookLinkURL.
+        if '/delivery/img' in cover_url:
+            thumbnail_url = cover_url + "&size=NORMAL"
+            thumbnail = LinkData(
+                rel=Hyperlink.THUMBNAIL_IMAGE,
+                href=thumbnail_url,
+                media_type=media_type
+            )
+            cover_link.thumbnail = thumbnail
+        links.append(cover_link)
 
         alternate_url = value("BookLinkURL").replace("&amp;", "&")
         links.append(LinkData(rel='alternate', href=alternate_url))

--- a/tests/files/bibliotheca/item_metadata_list.xml
+++ b/tests/files/bibliotheca/item_metadata_list.xml
@@ -21,7 +21,7 @@
     <AvailableCopies>1</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-ddf4gr9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=ddf4gr9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=ddf4gr9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
     <Genre>Children&amp;#39;s Health, Mystery &amp;amp; Detective,</Genre>
   </Item>
@@ -47,7 +47,7 @@
     <AvailableCopies>1</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-apfve89</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=apfve89&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=apfve89&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -72,7 +72,7 @@
     <AvailableCopies>0</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-aneb3r9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=aneb3r9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=aneb3r9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -97,7 +97,7 @@
     <AvailableCopies>1</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-aneacr9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=aneacr9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=aneacr9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -122,7 +122,7 @@
     <AvailableCopies>5</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-d48eg9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=d48eg9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=d48eg9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -147,7 +147,7 @@
     <AvailableCopies>1</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-d4y489</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=d4y489&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=d4y489&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -172,7 +172,7 @@
     <AvailableCopies>2</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-3x2v89</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=3x2v89&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=3x2v89&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -197,7 +197,7 @@
     <AvailableCopies>1</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-drdarr9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=drdarr9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=drdarr9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -222,7 +222,7 @@
     <AvailableCopies>0</AvailableCopies>
     <OnHoldCount>6</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-drc8189</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=drc8189&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=drc8189&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -247,7 +247,7 @@
     <AvailableCopies>1</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-3xycg9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=3xycg9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=3xycg9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -272,7 +272,7 @@
     <AvailableCopies>1</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-d6gv89</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=d6gv89&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=d6gv89&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -297,7 +297,7 @@
     <AvailableCopies>0</AvailableCopies>
     <OnHoldCount>2</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-amk5qg9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=amk5qg9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=amk5qg9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -322,7 +322,7 @@
     <AvailableCopies>1</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-d6dn89</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=d6dn89&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=d6dn89&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -347,7 +347,7 @@
     <AvailableCopies>1</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-dpubyr9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=dpubyr9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=dpubyr9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -372,7 +372,7 @@
     <AvailableCopies>2</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-y14m89</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=y14m89&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=y14m89&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -397,7 +397,7 @@
     <AvailableCopies>0</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-dpswhz9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=dpswhz9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=dpswhz9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -422,7 +422,7 @@
     <AvailableCopies>2</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-aghtkr9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=aghtkr9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=aghtkr9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -447,7 +447,7 @@
     <AvailableCopies>2</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-agho1r9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=agho1r9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=agho1r9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -472,7 +472,7 @@
     <AvailableCopies>0</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-q6vaz9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=q6vaz9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=q6vaz9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -497,7 +497,7 @@
     <AvailableCopies>1</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-dxhon89</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=dxhon89&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=dxhon89&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -522,7 +522,7 @@
     <AvailableCopies>3</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-ausndr9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=ausndr9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=ausndr9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -547,7 +547,7 @@
     <AvailableCopies>2</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-d5uwr9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=d5uwr9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=d5uwr9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -572,7 +572,7 @@
     <AvailableCopies>2</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-aghvfr9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=aghvfr9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=aghvfr9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -597,7 +597,7 @@
     <AvailableCopies>1</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-3x5xz9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=3x5xz9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=3x5xz9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
   <Item>
@@ -622,7 +622,7 @@
     <AvailableCopies>2</AvailableCopies>
     <OnHoldCount>0</OnHoldCount>
     <BookLinkURL>http://ebook.3m.com/library/nypl-document_id-bfgngz9</BookLinkURL>
-    <CoverLinkURL>http://ebook.3m.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=bfgngz9&amp;amp;token=nobody</CoverLinkURL>
+    <CoverLinkURL>http://images.yourcloudlibrary.com/delivery/img?type=DOCUMENTIMAGE&amp;amp;documentID=bfgngz9&amp;amp;token=nobody</CoverLinkURL>
     <LibraryUrlName>nypl</LibraryUrlName>
   </Item>
 </ArrayOfItem>

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -1192,9 +1192,21 @@ class TestItemListParser(BibliothecaAPITest):
         eq_("alternate", alternate.rel)
         assert alternate.href.startswith("http://ebook.3m.com/library")
 
+        # We have a full-size image...
         eq_(Hyperlink.IMAGE, image.rel)
+        eq_(Representation.JPEG_MEDIA_TYPE, image.media_type)
         assert image.href.startswith("http://ebook.3m.com/delivery")
+        assert 'documentID=ddf4gr9' in image.href
+        assert '&size=NORMAL' not in image.href
 
+        # ... and a thumbnail, which we obtained by adding an argument
+        # to the main image URL.
+        thumbnail = image.thumbnail
+        eq_(Hyperlink.THUMBNAIL_IMAGE, thumbnail.rel)
+        eq_(Representation.JPEG_MEDIA_TYPE, thumbnail.media_type)
+        eq_(thumbnail.href, image.href + "&size=NORMAL")
+
+        # We have a description.
         eq_(Hyperlink.DESCRIPTION, description.rel)
         assert description.content.startswith("<b>Winner")
 


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2263. It's just like https://github.com/NYPL-Simplified/circulation/pull/1303, but for the Bibliotheca API instead of Axis 360.

The URL hack I used in this branch is less official than the one used in the Axis 360 branch, but I'll email Bibliotheca about it to confirm.

Existing sites will pick up the thumbnail images the next time they run bin/bibliotheca_circulation_sweep.