### PR TITLE
Optimize analytics export

### DIFF
--- a/api/local_analytics_exporter.py
+++ b/api/local_analytics_exporter.py
@@ -154,7 +154,8 @@ class LocalAnalyticsExporter(object):
 
         # Concatenate the lower and upper bounds with a dash in the
         # middle. If both lower and upper bound are empty, just give
-        # the empty string.
+        # the empty string. This simulates the behavior of
+        # Work.target_age_string.
         target_age_string = select([
             case(
                 [

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ Flask-Babel
 money
 pymarc
 accept-types
+unicodecsv
 uszipcode
 pypostalcode
 watchtower # for cloudwatch logging

--- a/tests/admin/controller/test_controller.py
+++ b/tests/admin/controller/test_controller.py
@@ -1769,7 +1769,7 @@ class TestDashboardController(AdminControllerTest):
         eq_(identifier.identifier, row[2])
         eq_(identifier.type, row[3])
         eq_(edition.title, row[4])
-        eq_(genres[0].name, row[11])
+        eq_(genres[0].name, row[12])
 
     def test_stats_patrons(self):
         with self.request_context_with_admin("/"):

--- a/tests/test_local_analytics_exporter.py
+++ b/tests/test_local_analytics_exporter.py
@@ -40,7 +40,6 @@ class TestLocalAnalyticsExporter(DatabaseTest):
         ordered_genre_string = ",".join(
             [genres[2].name, genres[1].name, genres[0].name]
         )
-        print "Expecting %s" % ordered_genre_string
         get_one_or_create(self._db, WorkGenre, work=w2, genre=genres[1], affinity=0.5)
         types = [
             CirculationEvent.DISTRIBUTOR_CHECKIN,


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-2275. It makes the generation of CSV analytics reports 15-16 times faster.

I got most of this improvement by optimizing the query to only ask the database for fields that will actually be used in the CSV. Most of the rest comes from the fact that the genre lookup is done in a subquery -- this is modelled after the subqueries in `Work.to_search_documents`.

While I was at it I put _all_ of the data massage in the database query, making it possible to simply dump the result rows into a CSV writer. And I replaced `UnicodeCSVWriter` with the `unicodecsv` package, which lets us get rid of code and speeds up the actual writing of the CSV by about ten percent.

Functional differences from before:

* I added an 'imprint' field after the 'publisher' field. If you think it's bad to alter the ordering of these fields (for backwards compatibility) I'll put it at the end instead. We'll be adding a couple more fields in the near future -- "library" and "location".
* LocalAnalyticsExporter.export() now outputs a bytestring, not a string object. This doesn't make a difference in Python 2 and should improve Python 3 compatibility, since the CSV will be dumped right into a bytestream -- either standard output or an HTTP response body.