### PR TITLE
Add dialects to SIP authentication

### DIFF
--- a/api/sip/dialect.py
+++ b/api/sip/dialect.py
@@ -1,0 +1,26 @@
+class Dialect:
+    """Describe a SIP2 dialect.
+    """
+
+    # Constants for each class
+    GENERIC_ILS = 'GenericILS'
+    AG_VERSO = 'AutoGraphicsVerso'
+
+    # Settings defined in each class
+    sendEndSession = None
+
+    # Map a string to the correct class
+    @staticmethod
+    def load_dialect(dialect):
+        if dialect == Dialect.GENERIC_ILS:
+            return GenericILS
+        elif dialect == Dialect.AG_VERSO:
+            return AutoGraphicsVerso
+        else:
+            return None
+
+class GenericILS(Dialect):
+    sendEndSession = True
+
+class AutoGraphicsVerso(Dialect):
+    sendEndSession = False

--- a/tests/sip/test_client.py
+++ b/tests/sip/test_client.py
@@ -12,6 +12,10 @@ from api.sip.client import (
     MockSIPClient,
     SIPClient,
 )
+from api.sip.dialect import (
+    GenericILS,
+    AutoGraphicsVerso
+)
 
 class MockSocket(object):
     def __init__(self, *args, **kwargs):
@@ -399,3 +403,23 @@ class TestPatronResponse(object):
                 'too many items billed',
         ]:
             eq_(parsed[no], False)
+
+class TestClientDialects(object):
+
+    def setup(self):
+        self.sip = MockSIPClient()
+
+    def test_generic_dialect(self):
+        # Generic ILS should send end_session message
+        self.sip.dialect = GenericILS
+        self.sip.queue_response("36Y201610210000142637AO3|AA25891000331441|AF|AG")
+        self.sip.end_session('username', 'password')
+        eq_(self.sip.read_count, 1)
+        eq_(self.sip.write_count, 1)
+
+    def test_ag_dialect(self):
+        # AG VERSO ILS shouldn't end_session message
+        self.sip.dialect = AutoGraphicsVerso
+        self.sip.end_session('username', 'password')
+        eq_(self.sip.read_count, 0)
+        eq_(self.sip.write_count, 0)


### PR DESCRIPTION
## Related Ticket

https://jira.nypl.org/browse/SIMPLY-2258

## What does this Pull Request do?

Add two dialects to start with 'Generic ILS' and 'AG Verso'
 - Generic ILS is the same as the SIP connector was before
 - AG Verso dialect doesn't send the end session message as the ILS does not support that message.

## Interested parties
@leonardr  