### PR TITLE
Select the generic ILS dialect by default.

### DIFF
--- a/api/sip/dialect.py
+++ b/api/sip/dialect.py
@@ -12,12 +12,10 @@ class Dialect:
     # Map a string to the correct class
     @staticmethod
     def load_dialect(dialect):
-        if dialect == Dialect.GENERIC_ILS:
-            return GenericILS
-        elif dialect == Dialect.AG_VERSO:
+        if dialect == Dialect.AG_VERSO:
             return AutoGraphicsVerso
         else:
-            return None
+            return GenericILS
 
 class GenericILS(Dialect):
     sendEndSession = True


### PR DESCRIPTION
Follow up to: https://github.com/NYPL-Simplified/circulation/pull/1309

Found a bug when using an existing DB without the new setting, it would fail due to getting none as the ILS SIP dialect. This changes the default to the GenericILS.