### PR TITLE
Make the patron's neighborhood available to analytics code for the duration of a request

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1243,7 +1243,6 @@ class DashboardController(AdminCirculationManagerController):
         events = map(lambda result: {
             "id": result.id,
             "type": result.type,
-            "patron_id": result.foreign_patron_id,
             "time": result.start,
             "book": {
                 "title": result.license_pool.work.title,

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -120,6 +120,7 @@ class PatronData(object):
                  fines=None,
                  block_reason=None,
                  library_identifier=None,
+                 neighborhood=None,
                  complete=True,
     ):
         """Store basic information about a patron.
@@ -177,11 +178,19 @@ class PatronData(object):
         :param library_identifier: A string pulled from the ILS that
         is used to determine if this user belongs to the current library.
 
+        :param neighborhood: A string pulled from the ILS that
+        identifies the patron's geographic location in a deliberately
+        imprecise way that makes sense to the library -- maybe the
+        patron's ZIP code or the name of their home branch. This data
+        is never stored in a way that can be associated with an
+        individual patron. Depending on library policy, this data may
+        be associated with circulation events -- but a circulation
+        event is not associated with the patron who triggered it.
+
         :param complete: Does this PatronData represent the most
         complete data we are likely to get for this patron from this
         data source, or is it an abbreviated version of more complete
         data we could get some other way?
-
         """
         self.permanent_id = permanent_id
 
@@ -201,6 +210,11 @@ class PatronData(object):
         # We do not store email address in the database, but we need
         # to have it available for notifications.
         self.email_address = email_address
+
+        # We do not store the patron's neighborhood in the database
+        # record, but we may need it to store in the database records
+        # for circulation events triggered by this patron.
+        self.neighborhood = neighborhood
 
     def __repr__(self):
         return "<PatronData permanent_id=%r authorization_identifier=%r username=%r>" % (

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -365,6 +365,12 @@ class PatronData(object):
         if patron:
             self.apply(patron)
         __transaction.commit()
+
+        # Set patron.neighborhood so it can be accessed during request processing.
+        # This is not part of the database code above because this information is
+        # not stored in the database.
+        patron.neighborhood = self.neighborhood
+
         return patron, is_new
 
     @property
@@ -1890,6 +1896,13 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
         are updated.
         """
         patrondata.apply(patron)
+
+        # The Patron model does not store .neighborhood, so this won't
+        # write to the database, but this will make any neighborhood
+        # information available through the course of the active
+        # request -- through flask.request.patron.neighborhood.
+        patron.neighborhood = patrondata.neighborhood
+
         if self.external_type_regular_expression:
             self.update_patron_external_type(patron)
 

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -35,6 +35,8 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
     RECORD_NUMBER_FIELD = 'RECORD #[p81]'
     PATRON_TYPE_FIELD = 'P TYPE[p47]'
     EXPIRATION_FIELD = 'EXP DATE[p43]'
+    HOME_BRANCH_FIELD = 'HOME LIBR[p53]'
+    ADDRESS_FIELD = 'ADDRESS[pa]'
     BARCODE_FIELD = 'P BARCODE[pb]'
     USERNAME_FIELD = 'ALT ID[pu]'
     FINES_FIELD = 'MONEY OWED[p96]'
@@ -61,6 +63,14 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
     AUTHENTICATION_MODE = 'auth_mode'
     PIN_AUTHENTICATION_MODE = 'pin'
     FAMILY_NAME_AUTHENTICATION_MODE = 'family_name'
+
+    NEIGHBORHOOD_MODE = 'neighborhood_mode'
+    NO_NEIGHBORHOOD_MODE = 'disabled'
+    HOME_BRANCH_NEIGHBORHOOD_MODE = 'home_branch'
+    POSTAL_CODE_NEIGHBORHOOD_MODE = 'postal_code'
+    NEIGHBORHOOD_MODES = set(
+        [NO_NEIGHBORHOOD_MODE, HOME_BRANCH_NEIGHBORHOOD_MODE, POSTAL_CODE_NEIGHBORHOOD_MODE]
+    )
 
     # The field to use when seeing which values of MBLOCK[p56] mean a patron
     # is blocked. By default, any value other than '-' indicates a block.
@@ -97,7 +107,19 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
               { "key": FAMILY_NAME_AUTHENTICATION_MODE, "label": _("Family Name") },
           ],
           "default": PIN_AUTHENTICATION_MODE
-        }
+        },
+        {
+            "key": NEIGHBORHOOD_MODE,
+            "label": _("Patron neighborhood field"),
+            "description": _("It's sometimes possible to guess a patron's neighborhood from their ILS record. You can use this when analyzing circulation activity by neighborhood. If you don't need to do this, it's better for patron privacy to disable this feature."),
+            "type": "select",
+            "options": [
+                { "key": NO_NEIGHBORHOOD_MODE, "label": _("Disable this feature") },
+                { "key": HOME_BRANCH_NEIGHBORHOOD_MODE, "label": _("Patron's home library branch is their neighborhood.") },
+                { "key": POSTAL_CODE_NEIGHBORHOOD_MODE, "label": _("Patron's postal code is their neighborhood.") },
+            ],
+            "default": NO_NEIGHBORHOOD_MODE,
+        },
     ] + BasicAuthenticationProvider.SETTINGS
 
     # Replace library settings to allow text in identifier field.
@@ -152,6 +174,16 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         self.auth_mode = auth_mode
 
         self.block_types = integration.setting(self.BLOCK_TYPES).value or None
+
+        neighborhood_mode = integration.setting(
+            self.NEIGHBORHOOD_MODE
+        ).value or self.NO_NEIGHBORHOOD_MODE
+        if neighborhood_mode not in self.NEIGHBORHOOD_MODES:
+            raise CannotLoadConfiguration(
+                "Unrecognized Millenium Patron API neighborhood mode: %s." % neighborhood_mode
+            )
+        self.neighborhood_mode = neighborhood_mode
+
 
     # Begin implementation of BasicAuthenticationProvider abstract
     # methods.
@@ -286,6 +318,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
         username = authorization_expires = personal_name = PatronData.NO_VALUE
         email_address = fines = external_type = PatronData.NO_VALUE
         block_reason = PatronData.NO_VALUE
+        neighborhood = PatronData.NO_VALUE
 
         potential_identifiers = []
         for k, v in self._extract_text_nodes(content):
@@ -333,6 +366,12 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
                     )
             elif k == self.PATRON_TYPE_FIELD:
                 external_type = v
+            elif (k == self.HOME_BRANCH_FIELD
+                  and self.neighborhood_mode == self.HOME_BRANCH_NEIGHBORHOOD_MODE):
+                neighborhood = v.strip()
+            elif (k == self.ADDRESS_FIELD
+                  and self.neighborhood_mode == self.POSTAL_CODE_NEIGHBORHOOD_MODE):
+                neighborhood = self.extract_postal_code(v)
             elif k == self.ERROR_MESSAGE_FIELD:
                 # An error has occured. Most likely the patron lookup
                 # failed.
@@ -374,6 +413,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
             fines=fines,
             block_reason=block_reason,
             library_identifier=library_identifier,
+            neighborhood=neighborhood,
             complete=True
         )
         return data
@@ -391,6 +431,26 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
                 self.log.warn("Unexpected line in patron dump: %s", line)
                 continue
             yield kv.split('=', 1)
+
+    # A number of regular expressions for finding postal codes in
+    # freeform addresses, with more reliable techniques at the front.
+    POSTAL_CODE_RES = [
+        re.compile(x) for x in [
+            "[^0-9]([0-9]{5})-[0-9]{4}$", # ZIP+4 at end
+            "[^0-9]([0-9]{5})$", # ZIP at end
+            ".*[^0-9]([0-9]{5})-[0-9]{4}[^0-9]", # ZIP+4 as close to end as possible without being at the end
+            ".*[^0-9]([0-9]{5})[^0-9]", # ZIP as close to end as possible without being at the end
+        ]
+    ]
+
+    @classmethod
+    def extract_postal_code(cls, address):
+        """Try to extract a postal code from an address."""
+        for r in cls.POSTAL_CODE_RES:
+            match = r.search(address)
+            if match:
+                return match.groups()[0]
+        return None
 
 
 class MockMilleniumPatronAPI(MilleniumPatronAPI):

--- a/api/simple_authentication.py
+++ b/api/simple_authentication.py
@@ -28,6 +28,8 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
 
     ADDITIONAL_TEST_IDENTIFIERS = 'additional_test_identifiers'
 
+    TEST_NEIGHBORHOOD = 'neighborhood'
+
     basic_settings = list(BasicAuthenticationProvider.SETTINGS)
     for setting in basic_settings:
         if setting['key'] == BasicAuthenticationProvider.TEST_PASSWORD:
@@ -38,6 +40,10 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
           "label": _("Additional test identifiers"),
           "type": "list",
           "description": _("Identifiers for additional patrons to use in testing. The identifiers will all use the same test password as the first identifier."),
+        },
+        { "key": TEST_NEIGHBORHOOD,
+          "label": _("Test neighborhood"),
+          "description": _("For analytics purposes, all patrons will be 'from' this neighborhood."),
         }
     ]
 
@@ -59,6 +65,8 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
             for identifier in additional_identifiers:
                 self.test_identifiers += [identifier, identifier + "_username"]
 
+        self.test_neighborhood = integration.setting(self.TEST_NEIGHBORHOOD).value or None
+
     def remote_authenticate(self, username, password):
         "Fake 'remote' authentication."
         if not username or (self.collects_password and not password):
@@ -67,10 +75,10 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
         if not self.valid_patron(username, password):
             return None
 
-        return self.generate_patrondata(username)
+        return self.generate_patrondata(username, self.test_neighborhood)
 
     @classmethod
-    def generate_patrondata(cls, authorization_identifier):
+    def generate_patrondata(cls, authorization_identifier, neighborhood=None):
 
         if authorization_identifier.endswith("_username"):
             username = authorization_identifier
@@ -88,6 +96,7 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
             personal_name=personal_name,
             authorization_expires = None,
             fines = None,
+            neighborhood=neighborhood,
         )
         return patrondata
 

--- a/tests/admin/controller/test_controller.py
+++ b/tests/admin/controller/test_controller.py
@@ -1713,7 +1713,6 @@ class TestDashboardController(AdminControllerTest):
 
     def test_circulation_events(self):
         [lp] = self.english_1.license_pools
-        patron_id = "patronid"
         types = [
             CirculationEvent.DISTRIBUTOR_CHECKIN,
             CirculationEvent.DISTRIBUTOR_CHECKOUT,
@@ -1726,7 +1725,7 @@ class TestDashboardController(AdminControllerTest):
             get_one_or_create(
                 self._db, CirculationEvent,
                 license_pool=lp, type=type, start=time, end=time,
-                foreign_patron_id=patron_id)
+            )
             time += timedelta(minutes=1)
 
         with self.request_context_with_library_and_admin("/"):
@@ -1737,7 +1736,6 @@ class TestDashboardController(AdminControllerTest):
         eq_(types[::-1], [event['type'] for event in events])
         eq_([self.english_1.title]*len(types), [event['book']['title'] for event in events])
         eq_([url]*len(types), [event['book']['url'] for event in events])
-        eq_([patron_id]*len(types), [event['patron_id'] for event in events])
 
         # request fewer events
         with self.request_context_with_library_and_admin("/?num=2"):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -49,11 +49,11 @@ from api.lanes import (
     SeriesLane,
 )
 from api.authenticator import (
-    BasicAuthenticationProvider,
     CirculationPatronProfileStorage,
     OAuthController,
     LibraryAuthenticator,
 )
+from api.simple_authentication import SimpleAuthenticationProvider
 from core.app_server import (
     cdn_url_for,
     load_lending_policy,
@@ -301,9 +301,10 @@ class ControllerTest(VendorIDTest):
                 protocol="api.simple_authentication",
                 goal=ExternalIntegration.PATRON_AUTH_GOAL
             )
-            p = BasicAuthenticationProvider
+            p = SimpleAuthenticationProvider
             integration.setting(p.TEST_IDENTIFIER).value = "unittestuser"
             integration.setting(p.TEST_PASSWORD).value = "unittestpassword"
+            integration.setting(p.TEST_NEIGHBORHOOD).value = "Unit Test West"
             library.integrations.append(integration)
 
         for k, v in [
@@ -694,6 +695,11 @@ class TestBaseController(CirculationControllerTest):
         with self.request_context_with_library("/"):
             value = self.controller.authenticated_patron(self.valid_credentials)
             assert isinstance(value, Patron)
+
+            # The test neighborhood configured in the SimpleAuthenticationProvider
+            # has been associated with the authenticated Patron object for the
+            # duration of this request.
+            eq_("Unit Test West", value.neighborhood)
 
     def test_authentication_sends_proper_headers(self):
 

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -80,6 +80,12 @@ class TestMilleniumPatronAPI(DatabaseTest):
         eq_("http://example.com/", api.root)
         eq_(["a", "b"], [x.pattern for x in api.blacklist])
 
+        assert_raises_regexp(
+            CannotLoadConfiguration,
+            "Unrecognized Millenium Patron API neighborhood mode: nope.",
+            self.mock_api, neighborhood_mode="nope"
+        )
+
     def test__remote_patron_lookup_no_such_patron(self):
         self.api.enqueue("dump.no such barcode.html")
         patrondata = PatronData(authorization_identifier="bad barcode")

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -46,7 +46,9 @@ class MockAPI(MilleniumPatronAPI):
 class TestMilleniumPatronAPI(DatabaseTest):
 
     def mock_api(self, url="http://url/", blacklist=[], auth_mode=None, verify_certificate=True,
-                 block_types=None, password_keyboard=None, library_identifier_field=None):
+                 block_types=None, password_keyboard=None, library_identifier_field=None,
+                 neighborhood_mode=None
+    ):
         integration = self._external_integration(self._str)
         integration.url = url
         integration.setting(MilleniumPatronAPI.IDENTIFIER_BLACKLIST).value = json.dumps(blacklist)
@@ -56,6 +58,8 @@ class TestMilleniumPatronAPI(DatabaseTest):
 
         if auth_mode:
             integration.setting(MilleniumPatronAPI.AUTHENTICATION_MODE).value = auth_mode
+        if neighborhood_mode:
+            integration.setting(MilleniumPatronAPI.NEIGHBORHOOD_MODE).value = neighborhood_mode
         if password_keyboard:
             integration.setting(MilleniumPatronAPI.PASSWORD_KEYBOARD).value = password_keyboard
 
@@ -382,6 +386,27 @@ class TestMilleniumPatronAPI(DatabaseTest):
         patrondata = api.patron_dump_to_patrondata('alice', content)
         eq_("10", patrondata.library_identifier)
 
+    def test_neighborhood(self):
+        # The value of PatronData.neighborhood depends on the 'neighborhood mode' setting.
+
+        # Default behavior is not to gather neighborhood information at all.
+        api = self.mock_api()
+        content = api.sample_data("dump.success.html")
+        patrondata = api.patron_dump_to_patrondata('alice', content)
+        eq_(PatronData.NO_VALUE, patrondata.neighborhood)
+
+        # Patron neighborhood may be the identifier of their home library branch.
+        api = self.mock_api(neighborhood_mode=MilleniumPatronAPI.HOME_BRANCH_NEIGHBORHOOD_MODE)
+        content = api.sample_data("dump.success.html")
+        patrondata = api.patron_dump_to_patrondata('alice', content)
+        eq_("mm", patrondata.neighborhood)
+
+        # Or it may be the ZIP code of their home address.
+        api = self.mock_api(neighborhood_mode=MilleniumPatronAPI.POSTAL_CODE_NEIGHBORHOOD_MODE)
+        patrondata = api.patron_dump_to_patrondata('alice', content)
+        eq_("10001", patrondata.neighborhood)
+
+
     def test_authorization_identifier_blacklist(self):
         """A patron has two authorization identifiers. Ordinarily the second
         one (which would normally be preferred), but it contains a
@@ -517,3 +542,20 @@ class TestMilleniumPatronAPI(DatabaseTest):
         self.api = self.mock_api(auth_mode = "family_name")
         self.api.enqueue("dump.no such barcode.html")
         eq_(False, self.api.remote_authenticate("44444444444447", "somebody"))
+
+    def test_extract_postal_code(self):
+        # Test our heuristics for extracting postal codes from address fields.
+        m = MilleniumPatronAPI.extract_postal_code
+        eq_("93203", m("1 Main Street$Arvin CA 93203"))
+        eq_("93203", m("10145 Main Street$Arvin CA 93203"))
+        eq_("93203", m("10145 Main Street$Arvin CA$93203"))
+        eq_("93203", m("10145-6789 Main Street$Arvin CA 93203-1234"))
+        eq_("93203", m("10145-6789 Main Street$Arvin CA 93203-1234 (old address)"))
+        eq_("93203", m("10145-6789 Main Street$Arvin CA 93203 (old address)"))
+        eq_("93203", m("10145-6789 Main Street Apartment #12345$Arvin CA 93203 (old address)"))
+
+        eq_(None, m("10145 Main Street Apartment 123456$Arvin CA"))
+        eq_(None, m("10145 Main Street$Arvin CA"))
+
+        # Some cases where we incorrectly detect a ZIP code where there is none.
+        eq_('12345', m("10145 Main Street, Apartment #12345$Arvin CA"))

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -557,6 +557,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
 
         eq_(None, m("10145 Main Street Apartment 123456$Arvin CA"))
         eq_(None, m("10145 Main Street$Arvin CA"))
+        eq_(None, m("123 Main Street"))
 
         # Some cases where we incorrectly detect a ZIP code where there is none.
         eq_('12345', m("10145 Main Street, Apartment #12345$Arvin CA"))

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -547,6 +547,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
         # Test our heuristics for extracting postal codes from address fields.
         m = MilleniumPatronAPI.extract_postal_code
         eq_("93203", m("1 Main Street$Arvin CA 93203"))
+        eq_("93203", m("1 Main Street\nArvin CA 93203"))
         eq_("93203", m("10145 Main Street$Arvin CA 93203"))
         eq_("93203", m("10145 Main Street$Arvin CA$93203"))
         eq_("93203", m("10145-6789 Main Street$Arvin CA 93203-1234"))


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-2270. It allows an AuthenticationProvider to communicate a patron's geographic neighborhood by setting the new field `PatronData.neighborhood` when creating a `PatronData` object. This value will be available as `flask.request.patron.neighborhood` for the duration of the request, but since there is no `Patron.neighborhood` field in the model, the information will not be written to the database.

`flask.request.patron.neighborhood` should always be set, but if this feature is disabled or the ILS in use doesn't support it, the value will be `None`.

A future branch will associate this information with appropriate circulation events; this branch is solely about moving the information from the ILS to `flask.request.patron`.

I implemented neighborhood gathering for two of our authentication providers:

* You can set a 'test neighborhood' when configuring the `SimpleAuthenticationProvider`. All authenticated patrons will be given that `.neighborhood`. This is used in the test setup in `test_controller.py`.

* When configuring the `MilleniumPatronAPI` you may choose to extract neighborhood data from the `HOME LIBR[p53]` field (which names the library branch the patron has designated their 'home' branch). You may instead choose to try and extract a ZIP code from the `ADDRESS[pa]` field. And of course you can turn the whole feature off.