### PR TITLE
Propagate the neighborhood of a user-triggered circulation event to the analytics handler

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1878,10 +1878,17 @@ class AnalyticsController(CirculationManagerController):
         # same book.
         if event_type in CirculationEvent.CLIENT_EVENTS:
             library = flask.request.library
+            patron = flask.request.patron
+            neighborhood = None
+            if patron:
+                neighborhood = getattr(patron, 'neighborhood', None)
             pools = self.load_licensepools(library, identifier_type, identifier)
             if isinstance(pools, ProblemDetail):
                 return pools
-            self.manager.analytics.collect_event(library, pools[0], event_type, datetime.datetime.utcnow())
+            self.manager.analytics.collect_event(
+                library, pools[0], event_type, datetime.datetime.utcnow(),
+                neighborhood=neighborhood
+            )
             return Response({}, 200)
         else:
             return INVALID_ANALYTICS_EVENT_TYPE

--- a/api/google_analytics_provider.py
+++ b/api/google_analytics_provider.py
@@ -67,6 +67,11 @@ class GoogleAnalyticsProvider(object):
 
 
     def collect_event(self, library, license_pool, event_type, time, **kwargs):
+
+        # Explicitly destroy any neighborhood information -- we don't
+        # want to send this to third-party sources.
+        kwargs.pop("neighborhood", None)
+
         client_id = uuid.uuid4()
         fields = {
             'v': 1,

--- a/api/testing.py
+++ b/api/testing.py
@@ -235,7 +235,6 @@ class MockCirculationAPI(CirculationAPI):
             self.remotes[source] = remote
         return self.remotes[source]
 
-
 class MockSharedCollectionAPI(SharedCollectionAPI):
     def __init__(self, *args, **kwargs):
         super(MockSharedCollectionAPI, self).__init__(*args, **kwargs)

--- a/api/testing.py
+++ b/api/testing.py
@@ -235,6 +235,7 @@ class MockCirculationAPI(CirculationAPI):
             self.remotes[source] = remote
         return self.remotes[source]
 
+
 class MockSharedCollectionAPI(SharedCollectionAPI):
     def __init__(self, *args, **kwargs):
         super(MockSharedCollectionAPI, self).__init__(*args, **kwargs)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -79,6 +79,7 @@ from core.entrypoint import (
     EverythingEntryPoint,
     AudiobooksEntryPoint,
 )
+from core.local_analytics_provider import LocalAnalyticsProvider
 from core.model import (
     Annotation,
     CachedMARCFile,
@@ -3789,6 +3790,9 @@ class TestAnalyticsController(CirculationControllerTest):
             goal=ExternalIntegration.ANALYTICS_GOAL,
             protocol="core.local_analytics_provider",
         )
+        integration.setting(
+            LocalAnalyticsProvider.LOCATION_SOURCE
+        ).value = LocalAnalyticsProvider.LOCATION_SOURCE_NEIGHBORHOOD
         self.manager.analytics = Analytics(self._db)
 
         with self.request_context_with_library("/"):
@@ -3817,9 +3821,10 @@ class TestAnalyticsController(CirculationControllerTest):
                 eq_(None, circulation_event.location)
                 self._db.delete(circulation_event)
 
-        # If the patron has an associated neighborhood, the
-        # CirculationEvent is created with that neighborhood as its
-        # location.
+        # If the patron has an associated neighborhood, and the
+        # analytics controller is set up to use patron neighborhood as
+        # event location, then the CirculationEvent is created with
+        # that neighborhood as its location.
         patron.neighborhood = "Mars Grid 4810579"
         with self.request_context_with_library("/"):
             flask.request.patron = patron

--- a/tests/test_google_analytics_provider.py
+++ b/tests/test_google_analytics_provider.py
@@ -85,7 +85,16 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
         work.target_age = NumericRange(10, 15)
         [lp] = work.license_pools
         now = datetime.datetime.utcnow()
-        ga.collect_event(self._default_library, lp, CirculationEvent.DISTRIBUTOR_CHECKIN, now)
+        ga.collect_event(
+            self._default_library, lp, CirculationEvent.DISTRIBUTOR_CHECKIN, now,
+            neighborhood="Neighborhood will not be sent"
+        )
+
+        # Neighborhood information is not being sent -- that's for
+        # local consumption only.
+        assert 'Neighborhood' not in ga.params
+
+        # Let's take a look at what _is_ being sent.
         params = urlparse.parse_qs(ga.params)
 
         eq_(1, ga.count)


### PR DESCRIPTION
This branch completes the work of https://jira.nypl.org/browse/SIMPLY-2271.

There are two ways for the circ manager to trigger a circulation event: it can happen in `CirculationAPI` because a patron did something like check out a book, or it can happen in `AnalyticsController` because a client such as SimplyE explicitly reported an event that happened clientside.

This branch changes both `CirculationAPI` and `AnalyticsController` to look in `flask.request.patron.neighborhood` and if it's there, to pass it on to the analytics handlers. 

https://github.com/NYPL-Simplified/circulation/pull/1311 is in charge of making `flask.request.patron.neighborhood` show up when appropriate, and https://github.com/NYPL-Simplified/server_core/pull/1114 is in charge of taking that information and putting it in the database. This is the bit in the middle.