### PR TITLE
Fetch TOS information from discovery services before displaying information about them

### DIFF
--- a/api/admin/controller/discovery_service_library_registrations.py
+++ b/api/admin/controller/discovery_service_library_registrations.py
@@ -41,7 +41,7 @@ class DiscoveryServiceLibraryRegistrationsController(SettingsController):
         else:
             return self.process_post(registration_class, do_get, do_post)
 
-    def process_get(self):
+    def process_get(self, do_get=HTTP.debuggable_get):
         """Make a list of all discovery services, each with the
         list of libraries registered with that service and the
         status of the registration."""
@@ -50,6 +50,9 @@ class DiscoveryServiceLibraryRegistrationsController(SettingsController):
         for registry in RemoteRegistry.for_protocol_and_goal(
                 self._db, ExternalIntegration.OPDS_REGISTRATION, self.goal
         ):
+            access_problem, terms_of_service_link, terms_of_service_html = (
+                registry.fetch_registration_document(do_get=do_get)
+            )
             libraries = []
             for registration in registry.registrations:
                 library_info = self.get_library_info(registration)
@@ -59,6 +62,9 @@ class DiscoveryServiceLibraryRegistrationsController(SettingsController):
             services.append(
                 dict(
                     id=registry.integration.id,
+                    access_problem=access_problem,
+                    terms_of_service_link=terms_of_service_link,
+                    terms_of_service_html=terms_of_service_html,
                     libraries=libraries,
                 )
             )

--- a/api/registry.py
+++ b/api/registry.py
@@ -111,20 +111,6 @@ class RemoteRegistry(object):
             return response
         return self._extract_catalog_information(response)
 
-    def fetch_registration_document(self, do_get=HTTP.debuggable_get):
-        catalog = self.fetch_catalog(do_get=do_get)
-        if isinstance(catalog, ProblemDetail):
-            return catalog
-        registration_url, vendor_id = catalog
-
-        response = do_get(registration_url)
-        if isinstance(response, ProblemDetail):
-            return response
-        terms_of_service_link, terms_of_service_html = (
-            self._extract_registration_information(response)
-        )
-        return terms_of_service_link, terms_of_service_html
-
     @classmethod
     def _extract_catalog_information(cls, response):
         """From an OPDS catalog, extract information that's essential to
@@ -152,6 +138,20 @@ class RemoteRegistry(object):
         if not register_url:
             return REMOTE_INTEGRATION_FAILED.detailed(_("The service at %(url)s did not provide a register link.", url=response.url))
         return register_url, vendor_id
+
+    def fetch_registration_document(self, do_get=HTTP.debuggable_get):
+        catalog = self.fetch_catalog(do_get=do_get)
+        if isinstance(catalog, ProblemDetail):
+            return catalog
+        registration_url, vendor_id = catalog
+
+        response = do_get(registration_url)
+        if isinstance(response, ProblemDetail):
+            return response
+        terms_of_service_link, terms_of_service_html = (
+            self._extract_registration_information(response)
+        )
+        return terms_of_service_link, terms_of_service_html
 
     @classmethod
     def _extract_registration_information(cls, response):

--- a/api/registry.py
+++ b/api/registry.py
@@ -359,7 +359,7 @@ class Registration(object):
         # Before we can start the registration protocol, we must fetch
         # the remote catalog's URL and extract the link to the
         # registration resource that kicks off the protocol.
-        result = self.registry_fetch_catalog(catalog_url, do_get)
+        result = self.registry.fetch_catalog(catalog_url, do_get)
         if isinstance(result, ProblemDetail):
             return result
         register_url, vendor_id = result

--- a/api/registry.py
+++ b/api/registry.py
@@ -102,8 +102,8 @@ class RemoteRegistry(object):
         """Fetch the root catalog for this RemoteRegistry.
 
         :return: A ProblemDetail if there's a problem communicating
-        with the service or parsing the catalog; otherwise a 2-tuple
-        (registration URL, Adobe vendor ID).
+            with the service or parsing the catalog; otherwise a 2-tuple
+            (registration URL, Adobe vendor ID).
         """
         catalog_url = catalog_url or self.integration.url
         response = do_get(catalog_url)
@@ -133,8 +133,8 @@ class RemoteRegistry(object):
         :param response: A requests-style Response object.
 
         :return A ProblemDetail if there's a problem accessing the
-        catalog; otherwise a 2-tuple (registration URL, Adobe vendor
-        ID).
+            catalog; otherwise a 2-tuple (registration URL, Adobe vendor
+            ID).
         """
         result = cls._extract_links(response)
         if isinstance(result, ProblemDetail):

--- a/api/registry.py
+++ b/api/registry.py
@@ -140,6 +140,15 @@ class RemoteRegistry(object):
         return register_url, vendor_id
 
     def fetch_registration_document(self, do_get=HTTP.debuggable_get):
+        """Fetch a discovery service's registration document and extract
+        useful information from it.
+
+        :return: A ProblemDetail if there's a problem accessing the
+            service; otherwise, a 2-tuple (terms_of_service_link,
+            terms_of_service_html), containing information about the
+            Terms of Service that govern a circulation manager's
+            registration with the discovery service.
+        """
         catalog = self.fetch_catalog(do_get=do_get)
         if isinstance(catalog, ProblemDetail):
             return catalog
@@ -161,6 +170,13 @@ class RemoteRegistry(object):
         The registration document is completely optional, so an
         invalid or unintelligible document is treated the same as a
         missing document.
+
+        :return: A 2-tuple (terms_of_service_link,
+            terms_of_service_html), containing information about the
+            Terms of Service that govern a circulation manager's
+            registration with the discovery service. If the
+            registration document is missing or malformed, both values
+            will be None.
         """
         tos_link = None
         tos_html = None
@@ -187,6 +203,12 @@ class RemoteRegistry(object):
 
     @classmethod
     def _extract_links(cls, response):
+        """Parse an OPDS 1 or OPDS feed out of a Requests response object.
+
+        :return: A 2-tuple (parsed_catalog, links),
+           with `links` being a list of dictionaries, each containing
+           one OPDS link.
+        """
         # The response must contain either an OPDS 2 catalog or an OPDS 1 feed.
         type = response.headers.get("Content-Type")
         if type and type.startswith(cls.OPDS_2_TYPE):
@@ -204,7 +226,12 @@ class RemoteRegistry(object):
 
     @classmethod
     def _decode_data_url(cls, url):
-        """Convert a data: URL to a string."""
+        """Convert a data: URL to a string of sanitized HTML.
+
+        :raise ValueError: If the data: URL is invalid, in an
+            unexpected format, or does not have a supported media type.
+        :return: A string.
+        """
         if not url.startswith("data:"):
             raise ValueError("Not a data: URL: %s" % url)
         parts = url.split(",")

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,7 @@ PyLD==0.7.3
 pycryptodome
 wcag-contrast-ratio
 uritemplate
+html-sanitizer
 
 # A NYPL-specific requirement
 newrelic

--- a/tests/admin/controller/test_library_registrations.py
+++ b/tests/admin/controller/test_library_registrations.py
@@ -24,6 +24,9 @@ class TestLibraryRegistration(SettingsControllerTest):
     """Test the process of registering a library with a RemoteRegistry."""
 
     def test_discovery_service_library_registrations_get(self):
+        # TODO: GET now makes HTTP requests. It needs to take a mock
+        # do_get and we need to test various scenarios where it gets
+        # or doesn't get various things.
         discovery_service, ignore = create(
             self._db, ExternalIntegration,
             protocol=ExternalIntegration.OPDS_REGISTRATION,

--- a/tests/admin/controller/test_library_registrations.py
+++ b/tests/admin/controller/test_library_registrations.py
@@ -4,6 +4,7 @@ from nose.tools import (
     assert_raises
 )
 import flask
+import json
 from werkzeug import MultiDict
 from api.admin.exceptions import *
 from api.registry import (
@@ -17,6 +18,10 @@ from core.model import (
     ExternalIntegration,
     Library,
 )
+from core.testing import (
+    DummyHTTPClient,
+    MockRequestsResponse,
+)
 from core.util.http import HTTP
 from test_controller import SettingsControllerTest
 
@@ -24,56 +29,169 @@ class TestLibraryRegistration(SettingsControllerTest):
     """Test the process of registering a library with a RemoteRegistry."""
 
     def test_discovery_service_library_registrations_get(self):
-        # TODO: GET now makes HTTP requests. It needs to take a mock
-        # do_get and we need to test various scenarios where it gets
-        # or doesn't get various things.
+        # Here's a discovery service.
         discovery_service, ignore = create(
             self._db, ExternalIntegration,
             protocol=ExternalIntegration.OPDS_REGISTRATION,
             goal=ExternalIntegration.DISCOVERY_GOAL,
         )
+
+        # We'll be making a mock request to this URL later.
+        discovery_service.setting(ExternalIntegration.URL).value = (
+            "http://service-url/"
+        )
+
+        # We successfully registered this library with the service.
         succeeded, ignore = create(
             self._db, Library, name="Library 1", short_name="L1",
         )
-        ConfigurationSetting.for_library_and_externalintegration(
-            self._db, "library-registration-status", succeeded, discovery_service,
-            ).value = "success"
-        ConfigurationSetting.for_library_and_externalintegration(
-            self._db, "library-registration-stage", succeeded, discovery_service,
-            ).value = "production"
+        config = ConfigurationSetting.for_library_and_externalintegration
+        config(
+            self._db, "library-registration-status", succeeded,
+            discovery_service
+        ).value = "success"
+
+        # We tried to register this library with the service but were
+        # unsuccessful.
+        config(
+            self._db, "library-registration-stage", succeeded,
+            discovery_service
+        ).value = "production"
         failed, ignore = create(
             self._db, Library, name="Library 2", short_name="L2",
         )
-        ConfigurationSetting.for_library_and_externalintegration(
+        config(
             self._db, "library-registration-status", failed, discovery_service,
-            ).value = "failure"
-        ConfigurationSetting.for_library_and_externalintegration(
+        ).value = "failure"
+        config(
             self._db, "library-registration-stage", failed, discovery_service,
-            ).value = "testing"
+        ).value = "testing"
+
+        # We've never tried to register this library with the service.
         unregistered, ignore = create(
             self._db, Library, name="Library 3", short_name="L3",
         )
         discovery_service.libraries = [succeeded, failed]
 
-        controller = self.manager.admin_discovery_service_library_registrations_controller
-        with self.request_context_with_admin("/", method="GET"):
-            response = controller.process_discovery_service_library_registrations()
+        # When a client sends a GET request to the controller, the
+        # controller is going to call
+        # RemoteRegistry.fetch_registration_document() to try and find
+        # the discovery services' terms of service. That's going to
+        # make one or two HTTP requests.
 
-            serviceInfo = response.get("library_registrations")
-            eq_(1, len(serviceInfo))
-            eq_(discovery_service.id, serviceInfo[0].get("id"))
+        # First, let's try the scenario where the discovery serivce is
+        # working and has a terms-of-service.
+        client = DummyHTTPClient()
 
-            libraryInfo = serviceInfo[0].get("libraries")
-            expected = [
-                dict(short_name=succeeded.short_name, status="success", stage="production"),
-                dict(short_name=failed.short_name, status="failure", stage="testing"),
+        # In this case we'll make two requests. The first request will
+        # ask for the root catalog, where we'll look for a
+        # registration link.
+        root_catalog = dict(
+            links=[dict(href="http://register-here/", rel="register")]
+        )
+        client.queue_requests_response(
+            200, RemoteRegistry.OPDS_2_TYPE,
+            content=json.dumps(root_catalog)
+        )
+
+        # The second request will fetch that registration link -- then
+        # we'll look for TOS data inside.
+        registration_document = dict(
+            links=[
+                dict(
+                    rel="terms-of-service", type="text/html",
+                    href="http://tos/"
+                ),
+                dict(
+                    rel="terms-of-service", type="text/html",
+                    href="data:text/html;charset=utf-8;base64,PHA+SG93IGFib3V0IHRoYXQgVE9TPC9wPg=="
+                )
             ]
-            eq_(expected, libraryInfo)
+        )
+        client.queue_requests_response(
+            200, RemoteRegistry.OPDS_2_TYPE,
+            content=json.dumps(registration_document)
+        )
 
+        controller = self.manager.admin_discovery_service_library_registrations_controller
+        m = controller.process_discovery_service_library_registrations
+        with self.request_context_with_admin("/", method="GET"):
+            response = m(do_get=client.do_get)
+            # The document we get back from the controller is a
+            # dictionary with useful information on all known
+            # discovery integrations -- just one, in this case.
+            [service] = response["library_registrations"]
+            eq_(discovery_service.id, service["id"])
+
+            # The two mock HTTP requests we predicted actually
+            # happened.  The target of the first request is the URL to
+            # the discovery service's main catalog. The second request
+            # is to the "register" link found in that catalog.
+            eq_(["http://service-url/", "http://register-here/"],
+                client.requests)
+
+            # The TOS link and TOS HTML snippet were recovered from
+            # the registration document served in response to the
+            # second HTTP request, and included in the dictionary.
+            eq_("http://tos/", service['terms_of_service_link'])
+            eq_("<p>How about that TOS</p>", service['terms_of_service_html'])
+            eq_(None, service['access_problem'])
+
+            # The dictionary includes a 'libraries' object, a list of
+            # dictionaries with information about the relationships
+            # between this discovery integration and every library
+            # that's tried to register with it.
+            info1, info2 = service["libraries"]
+
+            # Here's the library that successfully registered.
+            eq_(
+                info1,
+                dict(short_name=succeeded.short_name, status="success",
+                     stage="production")
+            )
+
+            # And here's the library that tried to register but
+            # failed.
+            eq_(
+                info2,
+                dict(short_name=failed.short_name, status="failure",
+                     stage="testing")
+            )
+
+            # Note that `unregistered`, the library that never tried
+            # to register with this discover service, is not included.
+
+            # Now let's try the controller method again, except this
+            # time the discovery service's web server is down. The
+            # first request will return a ProblemDetail document, and
+            # there will be no second request.
+            client.requests = []
+            client.queue_requests_response(
+                502, content=REMOTE_INTEGRATION_FAILED,
+            )
+            response = m(do_get=client.do_get)
+
+            # Everything looks good, except that there's no TOS data
+            # available.
+            [service] = response["library_registrations"]
+            eq_(discovery_service.id, service["id"])
+            eq_(2, len(service['libraries']))
+            eq_(None, service['terms_of_service_link'])
+            eq_(None, service['terms_of_service_html'])
+
+            # The problem detail document that prevented the TOS data
+            # from showing up has been converted to a dictionary and
+            # included in the dictionary of information for this
+            # discovery service.
+            eq_(REMOTE_INTEGRATION_FAILED.uri,
+                service['access_problem']['type'])
+
+            # When the user lacks the SYSTEM_ADMIN role, the
+            # controller won't even start processing their GET
+            # request.
             self.admin.remove_role(AdminRole.SYSTEM_ADMIN)
             self._db.flush()
-            assert_raises(AdminNotAuthorized,
-                         controller.process_discovery_service_library_registrations)
+            assert_raises(AdminNotAuthorized, m)
 
     def test_discovery_service_library_registrations_post(self):
         """Test what might happen when you POST to

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -527,9 +527,7 @@ class TestRegistration(DatabaseTest):
             Configuration.KEY_PAIR, library
         )
         public_key, private_key = Configuration.key_pair(key_pair_setting)
-        result = registration.push(
-            stage, url_for, catalog_url, do_get, do_post
-        )
+        result = push()
         eq_("all done!", result)
 
         # But there were many steps towards this result.

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -476,8 +476,6 @@ class TestRegistration(DatabaseTest):
 
         class MockRegistration(Registration):
 
-            do_get_called_with = []
-
             def _create_registration_payload(self, url_for, stage):
                 self.payload_ingredients = (url_for, stage)
                 return dict(payload="this is it")


### PR DESCRIPTION
This branch represents work towards https://jira.nypl.org/browse/SIMPLY-2283. I thought most of this work was done a while ago, but no big deal.

Each discovery service (e.g. the library registry for the SimplyE mobile app) has the ability to provide a link to a terms-of-service document in its registration document. As of https://jira.nypl.org/browse/SIMPLY-2277, a discovery service may provide a snippet of HTML that includes a terms-of-service link and provides human-readable context.

However, the `DiscoveryServiceLibraryRegistrationsController` never actually grabs a discovery service's registration document, and so the TOS information is never made available to the admin interface UI. The text you see during library registration that says "I have read and agree to the terms and conditions" is hard-coded.

This branch changes `DiscoveryServiceLibraryRegistrationsController` so that a discovery service's TOS link and TOS HTML snippet are made available in the dictionary sent out to the admin interface for that service. If there's a problem accessing the discovery service (probably because the server is down), a serialized problem detail document is also sent out -- this will allow the admin interface to flag discovery services that are currently not working.

The main underlying change I made is to move the code that fetches a discovery service's root catalog and registration document from `Registration` to `RemoteRegistry`. We now need this information twice: during the registration process, but also _before_ the registration process, when we're displaying the form.