### PR TITLE
Get neighborhood analytics working end-to-end

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1878,7 +1878,9 @@ class AnalyticsController(CirculationManagerController):
         # same book.
         if event_type in CirculationEvent.CLIENT_EVENTS:
             library = flask.request.library
-            patron = flask.request.patron
+            # Authentication on the AnalyticsController is optional,
+            # so flask.request.patron may or may not be set.
+            patron = getattr(flask.request, 'patron', None)
             neighborhood = None
             if patron:
                 neighborhood = getattr(patron, 'neighborhood', None)

--- a/api/opds.py
+++ b/api/opds.py
@@ -53,7 +53,10 @@ from core.app_server import cdn_url_for
 from adobe_vendor_id import AuthdataUtility
 from annotations import AnnotationWriter
 from circulation import BaseCirculationAPI
-from config import Configuration
+from config import (
+    CannotLoadConfiguration,
+    Configuration,
+)
 from novelist import NoveListAPI
 from core.analytics import Analytics
 
@@ -1131,7 +1134,12 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         cached = self._adobe_id_tags.get(cache_key)
         if cached is None:
             cached = []
-            authdata = AuthdataUtility.from_config(self.library)
+            authdata = None
+            try:
+                authdata = AuthdataUtility.from_config(self.library)
+            except CannotLoadConfiguration as e:
+                logging.error("Cannot load Short Client Token configuration; outgoing OPDS entries will not have DRM autodiscovery support", exc_info=e)
+                return []
             if authdata:
                 vendor_id, token = authdata.short_client_token_for_patron(patron_identifier)
                 drm_licensor = OPDSFeed.makeelement("{%s}licensor" % OPDSFeed.DRM_NS)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -212,11 +212,16 @@ class RouteTest(ControllerTest):
         authenticated request to `url` and verify the results, as with
         assert_request_calls
         """
+        authentication_required = kwargs.pop("authentication_required", True)
+
         http_method = kwargs.pop('http_method', 'GET')
         response = self.request(url, http_method)
-        eq_(401, response.status_code)
-        eq_("authenticated_patron_from_request called without authorizing",
-            response.data)
+        if authentication_required:
+            eq_(401, response.status_code)
+            eq_("authenticated_patron_from_request called without authorizing",
+                response.data)
+        else:
+            eq_(200, response.status_code)
 
         # Set a variable so that authenticated_patron_from_request
         # will succeed, and try again.
@@ -599,9 +604,13 @@ class TestAnalyticsController(RouteTest):
 
     def test_track_analytics_event(self):
         url = '/analytics/<identifier_type>/an/identifier/<event_type>'
-        self.assert_request_calls(
+
+        # This controller can be called either authenticated or
+        # unauthenticated.
+        self.assert_authenticated_request_calls(
             url, self.controller.track_event,
-            "<identifier_type>", "an/identifier", "<event_type>"
+            "<identifier_type>", "an/identifier", "<event_type>",
+            authentication_required=False
         )
 
 


### PR DESCRIPTION
This branch gets an end-to-end test of https://jira.nypl.org/browse/SIMPLY-2177 working.

There are three things I had to change:

1. The AnalyticsController doesn't require authentication, but I changed its implementation in a way that assumed `flask.request.patron` was always set. I defined a new decorator method, `@allows_auth`, which works like `@requires_auth` with one exception: it calls the decorated method whether or not authentication succeeds.

2. When we authenticate a patron through Millenium using only the /pintest endpoint, we create a function that, when called, will use the /dump endpoint to find their neighborhood. https://github.com/NYPL-Simplified/server_core/pull/1115 guarantees that this function will be called when we're about to issue a CirculationEvent.

3. TBD