### PR TITLE
No overdrive hold notification address

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -763,7 +763,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
             document
         )
         return self.process_place_hold_response(
-            response, patron, pin, overdrive_id
+            response, patron, pin, licensepool
         )
 
     def process_place_hold_response(self, response, patron, pin, licensepool):

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -710,39 +710,68 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
         )
 
     def default_notification_email_address(self, patron, pin):
-        site_default = super(OverdriveAPI, self).default_notification_email_address(
-            patron, pin
-        )
+        """Find the email address this patron wants to use for hold
+        notifications.
+
+        :return: The email address Overdrive has on record for
+           this patron's hold notifications, or None if there is
+           no such address.
+        """
+        # We do _not_ want to call the superclass here. That will find
+        # a per-library default that trashes all of its input, which
+        # we don't want to use.
+        #
+        # Instead, we will ask _Overdrive_ if this patron has a
+        # preferred email address for notifications.
+        address = None
         response = self.patron_request(
             patron, pin, self.PATRON_INFORMATION_ENDPOINT
         )
-        if response.status_code != 200:
+        if response.status_code == 200:
+            data = response.json()
+            address = data.get('lastHoldEmail')
+        else:
             self.log.error(
                 "Unable to get patron information for %s: %s",
                 patron.authorization_identifier,
                 response.content
             )
-            # Use the site-wide default rather than allow a hold to fail.
-            return site_default
-        data = response.json()
-        return data.get('lastHoldEmail') or site_default
+        return address
 
     def place_hold(self, patron, pin, licensepool, notification_email_address):
         """Place a book on hold.
 
-        :return: A HoldInfo object
+        :return: A HoldData object, if a hold was successfully placed,
+            or the book was already on hold.
+        :raise: A CirculationException explaining why no hold
+            could be placed.
         """
         if not notification_email_address:
             notification_email_address = self.default_notification_email_address(
                 patron, pin
             )
-
         overdrive_id = licensepool.identifier.identifier
-        headers, document = self.fill_out_form(
-            reserveId=overdrive_id, emailAddress=notification_email_address)
+        form_fields = dict(reserveId=overdrive_id)
+        if notification_email_address:
+            form_fields['emailAddress'] = notification_email_address
+        else:
+            form_fields['ignoreHoldEmail'] = True
+
+        headers, document = self.fill_out_form(**form_fields)
         response = self.patron_request(
             patron, pin, self.HOLDS_ENDPOINT, headers,
-            document)
+            document
+        )
+        return self.process_place_hold_response(response)
+
+    def process_place_hold_response(self, response):
+        """Process the response to a HOLDS_ENDPOINT request.
+
+        :return: A HoldData object, if a hold was successfully placed,
+            or the book was already on hold.
+        :raise: A CirculationException explaining why no hold
+            could be placed.
+        """
         if response.status_code == 400:
             error = response.json()
             if not error or not 'errorCode' in error:
@@ -752,7 +781,8 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
                 # There's nothing we can do but refresh the queue info.
                 hold = self.get_hold(patron, pin, overdrive_id)
                 position, start_date = self.extract_data_from_hold_response(
-                    hold)
+                    hold
+                )
                 return HoldInfo(
                     licensepool.collection,
                     licensepool.data_source.name,
@@ -774,7 +804,8 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
             # The book was placed on hold.
             data = response.json()
             position, start_date = self.extract_data_from_hold_response(
-                data)
+                data
+            )
             return HoldInfo(
                 licensepool.collection,
                 licensepool.data_source.name,

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -300,7 +300,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         # Finally, process_place_hold_response was called on
         # the return value of patron_request
         eq_(
-            ("A mock response", patron, pin, pool.identifier.identifier),
+            ("A mock response", patron, pin, pool),
              api.process_place_hold_response_called_with
         )
         eq_("OK, I processed it.", response)

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -22,6 +22,7 @@ from api.overdrive import (
 from api.authenticator import BasicAuthenticationProvider
 from api.circulation import (
     CirculationAPI,
+    HoldInfo,
 )
 from api.circulation_exceptions import *
 from api.config import Configuration
@@ -260,8 +261,12 @@ class TestOverdriveAPI(OverdriveAPITest):
                 self.patron_request_called_with = (args, kwargs)
                 return "A mock response"
 
-            def process_place_hold_response(self, response):
-                self.process_place_hold_response_called_with = response
+            def process_place_hold_response(
+                self, response, patron, pin, licensepool
+            ):
+                self.process_place_hold_response_called_with = (
+                    response, patron, pin, licensepool
+                )
                 return "OK, I processed it."
 
         # First, test the case where no notification email address is
@@ -284,7 +289,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         fields = api.fill_out_form_called_with
         identifier = str(pool.identifier.identifier)
         eq_(dict(ignoreHoldEmail=True, reserveId=identifier), fields)
-        
+
         # patron_request was called with the filled-out form and other
         # information necessary to authenticate the request.
         args, kwargs = api.patron_request_called_with
@@ -292,7 +297,7 @@ class TestOverdriveAPI(OverdriveAPITest):
             args)
         eq_({}, kwargs)
 
-        # Finally, process_place_hold_response was called on 
+        # Finally, process_place_hold_response was called on
         # the return value of patron_request
         eq_("A mock response", api.process_place_hold_response_called_with)
         eq_("OK, I processed it.", response)
@@ -317,6 +322,106 @@ class TestOverdriveAPI(OverdriveAPITest):
         eq_("OK, I processed it.", response)
         fields = api.fill_out_form_called_with
         eq_(dict(emailAddress="another@addre.ss", reserveId=identifier), fields)
+
+    def test_process_place_hold_response(self):
+        # Verify that we can handle various error and non-error responses
+        # to a HOLDS_ENDPOINT request.
+
+        ignore, successful_hold = self.sample_json("successful_hold.json")
+        class Mock(MockOverdriveAPI):
+            def get_hold(self, patron, pin, overdrive_id):
+                # Return a sample hold representation rather than
+                # making another API request.
+                self.get_hold_called_with = (patron, pin, overdrive_id)
+                return successful_hold
+
+        api = Mock(self._db, self.collection)
+
+        def process_error_response(message):
+            # Attempt to process a response that resulted in an error.
+            if isinstance(message, basestring):
+                data = dict(errorCode=message)
+            else:
+                data = message
+            response = MockRequestsResponse(400, content=data)
+            return api.process_place_hold_response(response, None, None, None)
+
+        # Some error messages result in specific CirculationExceptions.
+        assert_raises(
+            CannotRenew, process_error_response, "NotWithinRenewalWindow"
+        )
+        assert_raises(
+            PatronHoldLimitReached, process_error_response,
+            "PatronExceededHoldLimit"
+        )
+
+        # An unrecognized error message results in a generic
+        # CannotHold.
+        assert_raises(CannotHold, process_error_response, "SomeOtherError")
+
+        # Same if the error message is missing or the response can't be
+        # processed.
+        assert_raises(CannotHold, process_error_response, dict())
+        assert_raises(CannotHold, process_error_response, None)
+
+        # Same if the error code isn't in the 4xx or 2xx range
+        # (which shouldn't happen in real life).
+        response = MockRequestsResponse(999)
+        assert_raises(
+            CannotHold, api.process_place_hold_response,
+            response, None, None, None
+        )
+
+        # At this point patron and book details become important --
+        # we're going to return a HoldInfo object and potentially make
+        # another API request.
+        patron = self._patron()
+        pin = object()
+        licensepool = self._licensepool(edition=None)
+
+        # The remaining tests will end up running the same code on the
+        # same data, so they will return the same HoldInfo. Define a
+        # helper method to make this easier.
+        def assert_correct_holdinfo(x):
+            assert isinstance(x, HoldInfo)
+            eq_(licensepool.collection, x.collection(self._db))
+            eq_(licensepool.data_source.name, x.data_source_name)
+            eq_(identifier.identifier, x.identifier)
+            eq_(identifier.type, x.identifier_type)
+            eq_(datetime(2015, 3, 26, 11, 30, 29), x.start_date)
+            eq_(None, x.end_date)
+            eq_(1, x.hold_position)
+
+        # Test the case where the 'error' is that the book is already
+        # on hold.
+        already_on_hold = dict(errorCode="AlreadyOnWaitList")
+        response = MockRequestsResponse(400, content=already_on_hold)
+        result = api.process_place_hold_response(
+            response, patron, pin, licensepool
+        )
+
+        # get_hold() was called with the arguments we expect.
+        identifier = licensepool.identifier
+        eq_((patron, pin, identifier.identifier),
+            api.get_hold_called_with)
+
+        # The result was converted into a HoldInfo object. The
+        # effective result is exactly as if we had successfully put
+        # the book on hold.
+        assert_correct_holdinfo(result)
+
+        # Finally, let's test the case where there was no hold and now
+        # there is.
+        api.get_hold_called_with = None
+        response = MockRequestsResponse(200, content=successful_hold)
+        result = api.process_place_hold_response(
+            response, patron, pin, licensepool
+        )
+        assert_correct_holdinfo(result)
+
+        # Here, get_hold was _not_ called, because the hold didn't
+        # already exist.
+        eq_(None, api.get_hold_called_with)
 
     def test_checkin(self):
 
@@ -1224,7 +1329,7 @@ class TestOverdriveCirculationMonitor(OverdriveAPITest):
     def test_run(self):
         # An end-to-end test verifying that this Monitor manages its
         # state across multiple runs.
-        # 
+        #
         # This tests a lot of code that's technically not in Monitor,
         # but when the Monitor API changes, it may require changes to
         # this particular monitor, and it's good to have a test that
@@ -1291,7 +1396,7 @@ class TestOverdriveCirculationMonitor(OverdriveAPITest):
 
         class MockMonitor(OverdriveCirculationMonitor):
 
-            recently_changed_ids_called_with = None 
+            recently_changed_ids_called_with = None
             should_stop_calls = []
             def recently_changed_ids(self, start, cutoff):
                 self.recently_changed_ids_called_with = (start, cutoff)
@@ -1430,15 +1535,15 @@ class TestNewTitlesOverdriveCollectionMonitor(OverdriveAPITest):
         )
         eq_(0, monitor.consecutive_unchanged_books)
         m = monitor.should_stop
-        
+
         # This book hasn't been changed, but we're under the limit, so we should
         # keep going.
         eq_(False, m(object(), object(), False))
         eq_(1, monitor.consecutive_unchanged_books)
-        
+
         eq_(False, m(object(), object(), False))
         eq_(2, monitor.consecutive_unchanged_books)
-        
+
         # This book has changed, so our counter gets reset.
         eq_(False, m(object(), object(), True))
         eq_(0, monitor.consecutive_unchanged_books)

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -307,8 +307,9 @@ class TestOverdriveAPI(OverdriveAPITest):
 
         # Now we need to test two more cases.
         #
-        # First, a default hold notification address is available.
-        email = "holds@libra.ry"
+        # First, the patron has a holds notification address
+        # registered with Overdrive.
+        email = "holds@patr.on"
         api.DEFAULT_NOTIFICATION_EMAIL_ADDRESS = email
         response = api.place_hold(patron, pin, pool, None)
 
@@ -320,7 +321,8 @@ class TestOverdriveAPI(OverdriveAPITest):
         eq_(dict(emailAddress=email, reserveId=identifier), fields)
 
         # Finally, test that when a specific address is passed in, it
-        # takes precedence over the site default.
+        # takes precedence over the patron's holds notification address.
+
         response = api.place_hold(patron, pin, pool, "another@addre.ss")
         eq_("OK, I processed it.", response)
         fields = api.fill_out_form_called_with

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -299,7 +299,10 @@ class TestOverdriveAPI(OverdriveAPITest):
 
         # Finally, process_place_hold_response was called on
         # the return value of patron_request
-        eq_("A mock response", api.process_place_hold_response_called_with)
+        eq_(
+            ("A mock response", patron, pin, pool.identifier.identifier),
+             api.process_place_hold_response_called_with
+        )
         eq_("OK, I processed it.", response)
 
         # Now we need to test two more cases.


### PR DESCRIPTION
This branch resolves https://jira.nypl.org/browse/SIMPLY-2295 by changing the behavior of the Overdrive API client when a patron places a hold. If the patron has not previously registered an email notification address with Overdrive, we tell Overdrive not to send a hold availability notification at all. Previously we sent them the site-wide default notification email address, which is supposed to bounce or trash all incoming email.

The site-wide default address still exists, since other vendor API clients use it, but the Overdrive client ignores it even if it is set.

Most of the code in this branch is tests for the previously untested place_hold method. For easier testing I split it into two methods, one to make the request and one to process the response.

I tested this against the live Overdrive API and it basically works, with one big caveat.

The first time you place a hold through the Overdrive API, and provide a hold notification address, that address is permanently associated with your Overdrive patron account. So there are a lot of NYPL patrons whose Overdrive hold notification address is `holdnotifications@librarysimplified.org`, and similarly for other libraries.

When we're about to place a hold on your behalf, we ask Overdrive if you have a hold notification address. If you do, we pass that address right back to Overdrive and don't set `ignoreHoldEmail`.

Even if we do set `ignoreHoldEmail`, if the patron has a hold notification address on the Overdrive side, Overdrive will ignore the value of `ignoreHoldEmail` and use the patron's hold notification address anyway. Theoretically, we could detect this scenario and tell Overdrive to avoid it, but Overdrive would do it anyway.

Basically, anyone who's ever placed an Overdrive hold before will keep using the "trash everything" email address as their hold notification address. Only patrons who've never placed an Overdrive hold before will trigger the `ignoreHoldEmail` code path.