### PR TITLE
Include location in the CSV export of circulation events.

### DIFF
--- a/api/local_analytics_exporter.py
+++ b/api/local_analytics_exporter.py
@@ -38,7 +38,7 @@ class LocalAnalyticsExporter(object):
         header = [
             "time", "event", "identifier", "identifier_type", "title", "author",
             "fiction", "audience", "publisher", "imprint", "language",
-            "target_age", "genres"
+            "target_age", "genres", "location"
         ]
         output = BytesIO()
         writer = csv.writer(output, encoding="utf-8")
@@ -104,6 +104,7 @@ class LocalAnalyticsExporter(object):
                 Edition.publisher,
                 Edition.imprint,
                 Edition.language,
+                CirculationEvent.location,
             ],
         ).select_from(
             join(
@@ -205,6 +206,7 @@ class LocalAnalyticsExporter(object):
                 events.language,
                 target_age_string.label('target_age'),
                 genres.label('genres'),
+                events.location,
             ]
         ).select_from(
             events_alias

--- a/tests/test_local_analytics_exporter.py
+++ b/tests/test_local_analytics_exporter.py
@@ -205,8 +205,7 @@ class TestLocalAnalyticsExporter(DatabaseTest):
         for type in new_types:
             get_one_or_create(
                 self._db, CirculationEvent,
-                license_pool=lp1, type=type, start=time, end=time, location="10001"
-            )
+                license_pool=lp1, type=type, start=time, end=time, location="10001")
             time += timedelta(minutes=1)
 
         output = exporter.export(self._db, today, time + timedelta(minutes=1), user_added_locations)
@@ -231,7 +230,6 @@ class TestLocalAnalyticsExporter(DatabaseTest):
         # to gather information from, so it should not be returned even though
         # it has a location.
         eq_(num, len(rows))
-
         # The last event in new_types should not be returned
         eq_(new_types[:-1], [row[1] for row in rows])
 


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2325 by including the location of a CirculationEvent in the CSV row when it's exported to CSV.

I also cleaned up TestLocalAnalyticsExporter.test_export quite a bit. There was a lot of code devoted to verifying that most of the data in most of the rows is always the same. I was able to drastically reduce the amount of code by defining the "always the same" data as a constant and just checking each row against that constant.