### PR TITLE
Tell core code to suppress the verbose OPDS entry, not the standard one

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -626,6 +626,7 @@ class Configuration(CoreConfiguration):
         """
         return PKCS1_OAEP.new(RSA.import_key(key))
 
+CoreConfiguration.DEFAULT_OPDS_FORMAT = Configuration.DEFAULT_OPDS_FORMAT
 
 @contextlib.contextmanager
 def empty_config():

--- a/api/config.py
+++ b/api/config.py
@@ -626,6 +626,14 @@ class Configuration(CoreConfiguration):
         """
         return PKCS1_OAEP.new(RSA.import_key(key))
 
+# We changed Configuration.DEFAULT_OPDS_FORMAT, but the Configuration
+# class from core still has the old value. Change that one to match,
+# so that core code that checks this constant will get the right
+# value.
+#
+# TODO: We should come up with a better solution for this, probably
+# involving a registry of Configuration objects that returns the
+# appropriate one in any situation. This is a source of subtle bugs.
 CoreConfiguration.DEFAULT_OPDS_FORMAT = Configuration.DEFAULT_OPDS_FORMAT
 
 @contextlib.contextmanager

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from nose.tools import (
 )
 import json
 
+from core.config import Configuration as CoreConfiguration
 from core.model import (
     ConfigurationSetting
 )
@@ -180,3 +181,8 @@ class TestConfiguration(DatabaseTest):
         setting.value = "100"
         max_fines = m(self._default_library)
         eq_(100, max_fines.amount)
+
+    def test_default_opds_format(self):
+        # Initializing the Configuration object modifies the corresponding
+        # object in core, so that core code will behave appropriately.
+        eq_(Configuration.DEFAULT_OPDS_FORMAT, CoreConfiguration.DEFAULT_OPDS_FORMAT)


### PR DESCRIPTION
This is a tiny branch but it needs a lot of explanation.

In `core/lane.py:DatabaseBackedWorkList._defer_unused_fields`, we apply an optimization to a database query that's going to fetch a bunch of Work objects. A Work has two precalculated OPDS feeds, one verbose and one standard, but any given application generally only needs one or the other. (This itself is a thing we could optimize in the future.) The `Configuration.DEFAULT_OPDS_FORMAT` constant says which field the application needs, and `_defer_unused_fields` stops the other one from being delivered over the network from the database.

The default value of DEFAULT_OPDS_FORMAT is "verbose_opds_entry" -- this is the OPDS entry used by the metadata wrangler. In `circulation/api/config.py`, we define a subclass of `Configuration` and set its DEFAULT_OPDS_FORMAT to "simple_opds_entry". The goal here is to suppress "verbose_opds_entry" while building lane feeds, to reduce the network traffic from the database.

But setting a class constant in a subclass doesn't change the value in the superclass, so `Configuration.DEFAULT_OPDS_FORMAT` is still "verbose_opds_entry". The Lane code is in core, so it doesn't know any better than to check `Configuration.DEFAULT_OPDS_FORMAT`. The end result is that we're grabbing the useless (for our purposes) verbose_opds_entry field and suppressing the simple_opds_entry field. This causes another database hit for every Work in the lane, just to get the simple_opds_entry field.

This branch fixes the problem by setting `core.config.Configuration.DEFAULT_OPDS_FORMAT` to the same value as `api.Configuration.DEFAULT_OPDS_FORMAT`. In this context I think it's okay to reach in and change the class constant because it's intended to be a configuration constant on the application level.

@aslagle Please weigh in if you can see a better way to do this easily. We can do it with a configuration registry but I don't want to make that big a change as part of a performance optimization.