### PR TITLE
Prohibit multiple discovery mechanisms with the same URL

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1660,6 +1660,10 @@ class SettingsController(AdminCirculationManagerController):
         differently. Since this isn't an exact science, this doesn't
         need to catch all variant URLs, only the most common ones.
         """
+        if not url:
+            # None has no variants.
+            return
+
         # A URL is a 'variant' of itself.
         yield url
 
@@ -1690,8 +1694,11 @@ class SettingsController(AdminCirculationManagerController):
         is up to you -- it's a good general rule but there are
         conceivable exceptions.
 
-        This method is used by discovery_services and metadata_services.
+        This method is used by metadata_services.
         """
+        if not url:
+            return
+
         # Look for the given URL as well as minor variations.
         #
         # We can't use urlparse to ignore minor differences in URLs

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1660,8 +1660,8 @@ class SettingsController(AdminCirculationManagerController):
         differently. Since this isn't an exact science, this doesn't
         need to catch all variant URLs, only the most common ones.
         """
-        if not url:
-            # None has no variants.
+        if not Validator()._is_url(url, []):
+            # An invalid URL has no variants.
             return
 
         # A URL is a 'variant' of itself.
@@ -1694,7 +1694,7 @@ class SettingsController(AdminCirculationManagerController):
         is up to you -- it's a good general rule but there are
         conceivable exceptions.
 
-        This method is used by metadata_services.
+        This method is used by discovery_services.
         """
         if not url:
             return

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1650,6 +1650,38 @@ class SettingsController(AdminCirculationManagerController):
             # changes to an existing service unless you've also changed its name.
             return INTEGRATION_NAME_ALREADY_IN_USE
 
+    @classmethod
+    def url_variants(cls, url, check_protocol_variant=True):
+        """Generate minor variants of a URL -- HTTP vs HTTPS, trailing slash
+        vs not, etc.
+
+        Technically these are all distinct URLs, but in real life they
+        generally mean someone typed the same URL slightly
+        differently. Since this isn't an exact science, this doesn't
+        need to catch all variant URLs, only the most common ones.
+        """
+        # A URL is a 'variant' of itself.
+        yield url
+
+        # Adding or removing a slash creates a variant.
+        if url.endswith("/"):
+            yield url[:-1]
+        else:
+            yield url + '/'
+
+        # Changing protocols may create one or more variants.
+        https = "https://"
+        http = "http://"
+        if check_protocol_variant:
+            protocol_variant = None
+            if url.startswith(https):
+                protocol_variant = url.replace(https, http, 1)
+            elif url.startswith(http):
+                protocol_variant = url.replace(http, https, 1)
+            if protocol_variant:
+                for v in cls.url_variants(protocol_variant, False):
+                    yield v
+
     def check_url_unique(self, new_service, url, protocol, goal):
         """Enforce a rule that a given circulation manager can only have
         one integration that uses a given URL for a certain purpose.
@@ -1660,14 +1692,11 @@ class SettingsController(AdminCirculationManagerController):
 
         This method is used by discovery_services and metadata_services.
         """
-        # Treat HTTP and HTTPS URLs as interchangeable.
-        urls = [url]
-        https = "https://"
-        http = "http://"
-        if url.startswith(https):
-            urls.append(url.replace(https, http, 1))
-        elif url.startswith(http):
-            urls.append(url.replace(http, https, 1))
+        # Look for the given URL as well as minor variations.
+        #
+        # We can't use urlparse to ignore minor differences in URLs
+        # because we're doing the comparison in the database.
+        urls = list(self.url_variants(url))
 
         qu = self._db.query(ExternalIntegration).join(
             ExternalIntegration.settings

--- a/api/admin/controller/discovery_services.py
+++ b/api/admin/controller/discovery_services.py
@@ -93,6 +93,12 @@ class DiscoveryServicesController(SettingsController):
             self._db.rollback()
             return name_error
 
+        url = flask.request.form.get("url")
+        url_error = self.check_url_unique(service, url, protocol, self.goal)
+        if url_error:
+            self._db.rollback()
+            return url_error
+
         protocol_error = self.set_protocols(service, protocol)
         if protocol_error:
             self._db.rollback()

--- a/api/admin/controller/discovery_services.py
+++ b/api/admin/controller/discovery_services.py
@@ -94,10 +94,12 @@ class DiscoveryServicesController(SettingsController):
             return name_error
 
         url = flask.request.form.get("url")
-        url_error = self.check_url_unique(service, url, protocol, self.goal)
-        if url_error:
+        url_not_unique = self.check_url_unique(
+            service, url, protocol, self.goal
+        )
+        if url_not_unique:
             self._db.rollback()
-            return url_error
+            return url_not_unique
 
         protocol_error = self.set_protocols(service, protocol)
         if protocol_error:

--- a/api/admin/controller/metadata_services.py
+++ b/api/admin/controller/metadata_services.py
@@ -69,6 +69,12 @@ class MetadataServicesController(SitewideRegistrationController):
             self._db.rollback()
             return name_error
 
+        url = flask.request.form.get("url")
+        url_error = self.check_url_unique(service, url, protocol, self.goal)
+        if url_error:
+            self._db.rollback()
+            return url_error
+
         protocol_error = self.set_protocols(service, protocol)
         if protocol_error:
             self._db.rollback()

--- a/api/admin/controller/metadata_services.py
+++ b/api/admin/controller/metadata_services.py
@@ -69,12 +69,6 @@ class MetadataServicesController(SitewideRegistrationController):
             self._db.rollback()
             return name_error
 
-        url = flask.request.form.get("url")
-        url_error = self.check_url_unique(service, url, protocol, self.goal)
-        if url_error:
-            self._db.rollback()
-            return url_error
-
         protocol_error = self.set_protocols(service, protocol)
         if protocol_error:
             self._db.rollback()

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -268,6 +268,13 @@ INTEGRATION_NAME_ALREADY_IN_USE = pd(
     detail=_("The integration name must be unique, and there's already an integration with the specified name."),
 )
 
+INTEGRATION_URL_ALREADY_IN_USE = pd(
+    "http://librarysimplified.org/terms/problem/integration-url-already-in-use",
+    status_code=400,
+    title=_("Integration URL already in use"),
+    detail=_("There's already an integration of this type for this URL."),
+)
+
 INTEGRATION_GOAL_CONFLICT = pd(
     "http://librarysimplified.org/terms/problem/integration-goal-conflict",
     status_code=409,

--- a/api/admin/validator.py
+++ b/api/admin/validator.py
@@ -83,7 +83,10 @@ class Validator(object):
                 if not self._is_url(url, allowed):
                     return INVALID_URL.detailed(_('"%(url)s" is not a valid URL.', url=url))
 
-    def _is_url(self, url, allowed):
+    @classmethod
+    def _is_url(cls, url, allowed):
+        if not url:
+            return False
         has_protocol = any([url.startswith(protocol + "://") for protocol in "http", "https"])
         return has_protocol or (url in allowed)
 

--- a/tests/admin/controller/test_controller.py
+++ b/tests/admin/controller/test_controller.py
@@ -2366,11 +2366,18 @@ class TestSettingsController(SettingsControllerTest):
         eq_(False, is_dupe(original.url, "different protocol", goal))
         eq_(False, is_dupe(original.url, protocol, "different goal"))
 
+        # If you're not considering a URL at all, we assume no
+        # duplicate.
+        eq_(False, is_dupe(None, protocol, goal))
+
     def test_url_variants(self):
         # Test the helper method that generates slight variants of
         # any given URL.
         def m(url):
             return list(SettingsController.url_variants(url))
+
+        # No URL, no variants.
+        eq_([], m(None))
 
         # Variants of an HTTP URL with a trailing slash.
         eq_(

--- a/tests/admin/controller/test_controller.py
+++ b/tests/admin/controller/test_controller.py
@@ -2378,6 +2378,7 @@ class TestSettingsController(SettingsControllerTest):
 
         # No URL, no variants.
         eq_([], m(None))
+        eq_([], m("not a url"))
 
         # Variants of an HTTP URL with a trailing slash.
         eq_(

--- a/tests/admin/test_validator.py
+++ b/tests/admin/test_validator.py
@@ -201,3 +201,20 @@ class TestValidator():
             'validate_language_code',
             'validate_image'
         ])
+
+    def test__is_url(self):
+        m = Validator._is_url
+
+        eq_(False, m(None, []))
+        eq_(False, m("", []))
+        eq_(False, m("not a url", []))
+
+        # Only HTTP and HTTP URLs are allowed.
+        eq_(True, m("http://server.com/", []))
+        eq_(True, m("https://server.com/", []))
+        eq_(False, m("gopher://server.com/", []))
+        eq_(False, m("http:/server.com/", []))
+
+        # You can make specific URLs go through even if they
+        # wouldn't normally pass.
+        eq_(True, m("Not a URL", ["Not a URL", "Also not a URL"]))


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-2342. It introduces a new data validation method, `SettingsController.check_url_unique`, which returns a problem detail document if the user is trying to create a situation where there are multiple ExternalIntegrations with the same protocol, goal, and URL. It also catches cases where the URLs are very slightly different (e.g. HTTP vs. HTTPS versions of the same URL).

I call this method in discovery_services.py to put a stop to situations (which I now have three reports of) where the SimplyE library registry is registered multiple times. This can cause a lot of problems including seemingly "duplicate" libraries showing up in SimplyE.

I initially tried to add this to `metadata_services.py` as well, but the point is moot with metadata integrations because you can only have one metadata integration, period.

It might make sense to call this data validation method from other controllers, to stop other kinds of duplicate services from being created, but I think you'd have a better feel for that than I do.