### PR TITLE
Update the overdrive_format_sweep script

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -1203,6 +1203,9 @@ class OverdriveFormatSweep(IdentifierSweepMonitor):
         pools = identifier.licensed_through
         for pool in pools:
             self.api.update_formats(pool)
+            # if there are multiple pools they should all have the same formats
+            # so we break after processing the first one
+            break
 
 
 class OverdriveAdvantageAccountListScript(Script):


### PR DESCRIPTION
## Issue

On one of our CM servers with many Overdrive advantage collections I was seeing a large number of duplicated updates in the logs for `overdrive_format_sweep`.

It turns out that it was doing multiple updates, one for every licensepool it belonged to, even if all the updates were the same. This was causing unnecessary database updates.

Example log:
```
{"host": "33d391a9e2d3", "name": "Abstract metadata layer", "level": "INFO", "timestamp": "2019-10-21T19:15:43.574781", "app": "simplified", "message": "APPLYING METADATA TO EDITION: The Road to Character", "filename": "metadata_layer.py"}
{"host": "33d391a9e2d3", "name": "root", "level": "INFO", "timestamp": "2019-10-21T19:15:44.783159", "app": "simplified", "message": "Presentation changed for Edition The Road to Character (by David Brooks, pub=Random House Publishing Group, ident=Overdrive ID/d60094ef-23de-476e-ba4e-d5c3ee20fb94, pwid=e1087dd0-2142-5eac-8c72-cde8ab83852c, language=eng, cover=u'http://book-covers.nypl.org/Overdrive/Overdrive%20ID/d60094ef-23de-476e-ba4e-d5c3ee20fb94/%257BD60094EF-23DE-476E-BA4E-D5C3EE20FB94%257DImg100.jpg')", "filename": "edition.py"}
{"host": "33d391a9e2d3", "name": "Abstract metadata layer", "level": "INFO", "timestamp": "2019-10-21T19:15:45.284945", "app": "simplified", "message": "APPLYING METADATA TO EDITION: The Road to Character", "filename": "metadata_layer.py"}
{"host": "33d391a9e2d3", "name": "root", "level": "INFO", "timestamp": "2019-10-21T19:15:46.594225", "app": "simplified", "message": "Presentation changed for Edition The Road to Character (by David Brooks, pub=Random House Publishing Group, ident=Overdrive ID/d60094ef-23de-476e-ba4e-d5c3ee20fb94, pwid=e1087dd0-2142-5eac-8c72-cde8ab83852c, language=eng, cover=u'http://book-covers.nypl.org/Overdrive/Overdrive%20ID/d60094ef-23de-476e-ba4e-d5c3ee20fb94/%257BD60094EF-23DE-476E-BA4E-D5C3EE20FB94%257DImg100.jpg')", "filename": "edition.py"}
{"host": "33d391a9e2d3", "name": "Abstract metadata layer", "level": "INFO", "timestamp": "2019-10-21T19:15:47.064822", "app": "simplified", "message": "APPLYING METADATA TO EDITION: The Road to Character", "filename": "metadata_layer.py"}
{"host": "33d391a9e2d3", "name": "root", "level": "INFO", "timestamp": "2019-10-21T19:15:48.511163", "app": "simplified", "message": "Presentation changed for Edition The Road to Character (by David Brooks, pub=Random House Publishing Group, ident=Overdrive ID/d60094ef-23de-476e-ba4e-d5c3ee20fb94, pwid=e1087dd0-2142-5eac-8c72-cde8ab83852c, language=eng, cover=u'http://book-covers.nypl.org/Overdrive/Overdrive%20ID/d60094ef-23de-476e-ba4e-d5c3ee20fb94/%257BD60094EF-23DE-476E-BA4E-D5C3EE20FB94%257DImg100.jpg')", "filename": "edition.py"}
{"host": "33d391a9e2d3", "name": "Abstract metadata layer", "level": "INFO", "timestamp": "2019-10-21T19:15:49.049532", "app": "simplified", "message": "APPLYING METADATA TO EDITION: The Road to Character", "filename": "metadata_layer.py"}
{"host": "33d391a9e2d3", "name": "root", "level": "INFO", "timestamp": "2019-10-21T19:15:50.345374", "app": "simplified", "message": "Presentation changed for Edition The Road to Character (by David Brooks, pub=Random House Publishing Group, ident=Overdrive ID/d60094ef-23de-476e-ba4e-d5c3ee20fb94, pwid=e1087dd0-2142-5eac-8c72-cde8ab83852c, language=eng, cover=u'http://book-covers.nypl.org/Overdrive/Overdrive%20ID/d60094ef-23de-476e-ba4e-d5c3ee20fb94/%257BD60094EF-23DE-476E-BA4E-D5C3EE20FB94%257DImg100.jpg')", "filename": "edition.py"}
{"host": "33d391a9e2d3", "name": "Overdrive Format Sweep", "level": "INFO", "timestamp": "2019-10-21T19:15:50.361318", "app": "simplified", "message": "Completed Overdrive ID/d60094ef-23de-476e-ba4e-d5c3ee20fb94 ID=46364 prim_ed=43862 (\"The Road to Character\")", "filename": "monitor.py"}
```

## Solution

Update so it only checks and updates the format infomration once even if the item is in multiple license pools, for example if you have many Overdrive Advantage collections within you CM. Added a test to verify this is the case.

## Interested Parties
@leonardr 