### PR TITLE
Setting up a Local Analytics service if it doesn't exist when the app starts up.

### DIFF
--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -30,6 +30,7 @@ from api.routes import (
 
 import urllib
 from datetime import timedelta
+from core.local_analytics_provider import LocalAnalyticsProvider
 
 # An admin's session will expire after this amount of time and
 # the admin will have to log in again.
@@ -44,6 +45,9 @@ def setup_admin(_db=None):
     app.secret_key = ConfigurationSetting.sitewide_secret(
         _db, Configuration.SECRET_KEY
     )
+    # Create a default Local Analytics service if one does not
+    # already exist.
+    local_analytics = LocalAnalyticsProvider.initialize(_db)
 
 def allows_admin_auth_setup(f):
     @wraps(f)

--- a/tests/admin/controller/test_analytics_services.py
+++ b/tests/admin/controller/test_analytics_services.py
@@ -65,7 +65,6 @@ class TestAnalyticsServices(SettingsControllerTest):
             response = self.manager.admin_analytics_services_controller.process_analytics_services()
             [local_analytics, service] = response.get("analytics_services")
 
-            set_trace()
             [library] = service.get("libraries")
             eq_(self._default_library.short_name, library.get("short_name"))
             eq_("trackingid", library.get(GoogleAnalyticsProvider.TRACKING_ID))

--- a/tests/admin/controller/test_controller.py
+++ b/tests/admin/controller/test_controller.py
@@ -251,21 +251,8 @@ class TestViewController(AdminControllerTest):
             assert token in response.headers.get('Set-Cookie')
 
     def test_show_circ_events_download(self):
-        # The local analytics provider isn't configured yet.
-        with self.app.test_request_context('/admin'):
-            flask.session['admin_email'] = self.admin.email
-            flask.session['auth_type'] = PasswordAdminAuthenticationProvider.NAME
-            response = self.manager.admin_view_controller("collection", "book")
-            eq_(200, response.status_code)
-            html = response.response[0]
-            assert 'showCircEventsDownload: false' in html
-
-        # Create the local analytics integration.
-        local_service, ignore = create(
-            self._db, ExternalIntegration,
-            protocol=LocalAnalyticsProvider.__module__,
-            goal=ExternalIntegration.ANALYTICS_GOAL,
-        )
+        # The local analytics provider will be configured by default if
+        # there isn't one.
         with self.app.test_request_context('/admin'):
             flask.session['admin_email'] = self.admin.email
             flask.session['auth_type'] = PasswordAdminAuthenticationProvider.NAME


### PR DESCRIPTION
Resolves [SIMPLY-2346](https://jira.nypl.org/browse/SIMPLY-2346).
Get one or create a Local Analytics service so one will always exist, even if it's the default one.