### PR TITLE
Stop exporting patron's personal name from Clever login process

### DIFF
--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -40,6 +40,13 @@ CLEVER_NOT_ELIGIBLE = pd(
     _("Your Clever account is not eligible to access this application."),
 )
 
+CLEVER_UNKNOWN_SCHOOL = pd(
+    "http://librarysimplified.org/terms/problem/clever-unknown-school",
+    401,
+    _("Clever did not provide the necessary information about your school to verify eligibility."),
+    _("Clever did not provide the necessary information about your school to verify eligibility."),
+)
+
 
 # Load Title I NCES ID data from json.
 TITLE_I_NCES_IDS = None
@@ -269,8 +276,14 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
 
         # TODO: check student free and reduced lunch status as well
 
+        if school_nces_id is None:
+            self.log.error(
+                "No NCES ID found in Clever school data: %s", repr(school)
+            )
+            return CLEVER_UNKNOWN_SCHOOL
+
         if school_nces_id not in TITLE_I_NCES_IDS:
-            self.log.info("%s didn't match a Title I NCES ID" % school_nces_id)
+            self.log.info("%s didn't match a Title I NCES ID", school_nces_id)
             return CLEVER_NOT_ELIGIBLE
 
         if result['type'] == 'student':
@@ -289,7 +302,6 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
             permanent_id=identifier,
             authorization_identifier=identifier,
             external_type=external_type,
-            personal_name = user_data.get('name'),
             complete=True
         )
         return patrondata

--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -194,21 +194,6 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
           which uniquely identifies a given patron but contains no
           personal information about them.
 
-        * The patron's personal name is passed out of this method
-          through the PatronData object. This information cannot be
-          persisted to the server-side database, because there's no
-          place to store it. You can verify this by looking at the
-          PatronData class in authenticator.py and the Patron class in
-          core/model/patron.py.
-
-          Upon login, the patron's personal name is sent via HTTP to
-          the authorized client, running on a device being operated by
-          the patron. (See the OAuthController.oauth_authentication_callback()
-          method for this.) Access to this information is important in an
-          environment where devices are shared across a classroom. When
-          the patron logs out, the Open eBooks client destroys this
-          information.
-
         * If the patron is a student, their grade level
           ("Kindergarten" through "12") is converted into an Open
           eBooks patron type ("E" for "Early Grades", "M" for "Middle

--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -219,15 +219,12 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
 
         To summarize, an opaque ID associated with the patron is
         persisted to the database, as is a coarse-grained indicator of
-        the patron's age. The patron's personal name is available to
-        the server for the duration of the current request, but cannot
-        be persisted to the database. The patron's personal name is
-        made available to the authorized client, which destroys that
-        information on logout. No other information about the patron
-        makes it out of this method.
+        the patron's age. No other information about the patron makes
+        it out of this method.
 
         :return: A ProblemDetail if there's a problem. Otherwise, a PatronData
             with the data listed above.
+
         """
         bearer_headers = {
             'Authorization': 'Bearer %s' % token


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2372. Open eBooks doesn't actually use the patron's personal name, and we can't make Open eBooks consistently greet patrons by name (since FirstBook doesn't know the patron's name), so I'm removing the code that sends it out, as a way of reducing the system's privacy footprint.

Theoretically, some other OAuth provider could still send the patron's name to the client via `oauth_callback`, and the client could use it to greet the patron by name. I just removed the code that does this for Clever.

This code also adds a more specific error message for a problem we're seeing, where we ask Clever for information on a school that definitely has an NCES ID, but Clever doesn't provide the NCES ID. Without this change, people who are eligible for Open eBooks are being told that they're not eligible.