### PR TITLE
Added distributor and medium to the Google Analytics output.

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -867,17 +867,13 @@ class CirculationAPI(object):
             self.log.warn("LicensePoolDeliveryMechanism passed into fulfill_open_access, should be DeliveryMechanism.")
             delivery_mechanism = delivery_mechanism.delivery_mechanism
         fulfillment = None
-        self.log.error("Trying to fulfill open access with %s %r", delivery_mechanism.id, delivery_mechanism)
         for lpdm in licensepool.delivery_mechanisms:
-            self.log.error("considering %s %r", lpdm.delivery_mechanism.id, lpdm.delivery_mechanism)
             if not (lpdm.resource and lpdm.resource.representation
                     and lpdm.resource.representation.url):
                 # This LicensePoolDeliveryMechanism can't actually
                 # be used for fulfillment.
-                self.log.error("nope")
                 continue
-            if (lpdm.delivery_mechanism.media_type == delivery_mechanism.media_type
-                and lpdm.delivery_mechanism.drm_scheme == delivery_mechanism.drm_scheme):
+            if lpdm.delivery_mechanism == delivery_mechanism:
                 # We found it! This is how the patron wants
                 # the book to be delivered.
                 fulfillment = lpdm
@@ -886,7 +882,6 @@ class CirculationAPI(object):
         if not fulfillment:
             # There is just no way to fulfill this loan the way the
             # patron wants.
-            self.log.error("Giving up.")
             raise FormatNotAvailable()
 
         rep = fulfillment.resource.representation

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -867,11 +867,14 @@ class CirculationAPI(object):
             self.log.warn("LicensePoolDeliveryMechanism passed into fulfill_open_access, should be DeliveryMechanism.")
             delivery_mechanism = delivery_mechanism.delivery_mechanism
         fulfillment = None
+        self.log.error("Trying to fulfill open access with %r", delivery_mechanism)
         for lpdm in licensepool.delivery_mechanisms:
+            self.log.error("considering %r", lpdm)   
             if not (lpdm.resource and lpdm.resource.representation
                     and lpdm.resource.representation.url):
                 # This LicensePoolDeliveryMechanism can't actually
                 # be used for fulfillment.
+                self.log.error("nope")
                 continue
             if lpdm.delivery_mechanism == delivery_mechanism:
                 # We found it! This is how the patron wants
@@ -882,6 +885,7 @@ class CirculationAPI(object):
         if not fulfillment:
             # There is just no way to fulfill this loan the way the
             # patron wants.
+            self.log.error("Giving up.")
             raise FormatNotAvailable()
 
         rep = fulfillment.resource.representation

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -867,16 +867,17 @@ class CirculationAPI(object):
             self.log.warn("LicensePoolDeliveryMechanism passed into fulfill_open_access, should be DeliveryMechanism.")
             delivery_mechanism = delivery_mechanism.delivery_mechanism
         fulfillment = None
-        self.log.error("Trying to fulfill open access with %r", delivery_mechanism)
+        self.log.error("Trying to fulfill open access with %s %r", delivery_mechanism.id, delivery_mechanism)
         for lpdm in licensepool.delivery_mechanisms:
-            self.log.error("considering %r", lpdm)   
+            self.log.error("considering %s %r", lpdm.delivery_mechanism.id, lpdm.delivery_mechanism)
             if not (lpdm.resource and lpdm.resource.representation
                     and lpdm.resource.representation.url):
                 # This LicensePoolDeliveryMechanism can't actually
                 # be used for fulfillment.
                 self.log.error("nope")
                 continue
-            if lpdm.delivery_mechanism == delivery_mechanism:
+            if (lpdm.delivery_mechanism.media_type == delivery_mechanism.media_type
+                and lpdm.delivery_mechanism.drm_scheme == delivery_mechanism.drm_scheme):
                 # We found it! This is how the patron wants
                 # the book to be delivered.
                 fulfillment = lpdm

--- a/api/google_analytics_provider.py
+++ b/api/google_analytics_provider.py
@@ -37,6 +37,8 @@ class GoogleAnalyticsProvider(object):
                     "<li>language</li>" +
                     "<li>genre</li>" +
                     "<li>open_access</li>" +
+                    "<li>distributor</li>" +
+                    "<li>medium</li>" +
                     "</ol></p>" +
                     "<p>Each dimension should have the scope set to 'Hit' and the 'Active' box checked.</p>" +
                     "<p>Then go to Tracking Info and get the tracking id for the property.  Select your " +
@@ -105,6 +107,16 @@ class GoogleAnalyticsProvider(object):
                     'cd11': work.top_genre(),
                     'cd12': "true" if license_pool.open_access else "false",
                 })
+
+            # Backwards compatibility requires that new dimensions be
+            # added to the end of the list. For the sake of
+            # consistency, this code that sets values for those new
+            # dimensions runs after the original implementation.
+            fields.update({'cd13' : license_pool.data_source.name})
+            if work and edition:
+                fields.update({'cd14' : edition.medium})
+
+
         # urlencode doesn't like unicode strings so we convert them to utf8
         fields = {k: unicodedata.normalize("NFKD", unicode(v)).encode("utf8") for k, v in fields.iteritems()}
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1318,8 +1318,9 @@ class TestLoanController(CirculationControllerTest):
             response = self.manager.loans.fulfill(
                 self.pool.id, fulfillable_mechanism.delivery_mechanism.id,
             )
-            if response.status_code != 302:
-                raise Exception(response.data)
+            if isinstance(response, ProblemDetail):
+                j, status, headers = response.response
+                raise Exception(repr(j))
             eq_(302, response.status_code)
             eq_(fulfillable_mechanism.resource.representation.public_url, response.headers.get("Location"))
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1303,9 +1303,10 @@ class TestLoanController(CirculationControllerTest):
             )
 
             # Make sure the two delivery mechanisms are incompatible.
-            mech1.delivery_mechanism.drm_scheme = "DRM type 1"
-            mech2.delivery_mechanism.drm_scheme = "DRM type 2"
+            mech1.delivery_mechanism.drm_scheme = DeliveryMechanism.ADOBE_DRM
+            mech2.delivery_mechanism.drm_scheme = DeliveryMechanism.NO_DRM
             fulfillable_mechanism = mech2
+            self._db.commit()
 
             expects = [url_for('fulfill',
                                license_pool_id=self.pool.id,
@@ -1363,7 +1364,7 @@ class TestLoanController(CirculationControllerTest):
             )
 
             eq_(409, response.status_code)
-            assert "You already fulfilled this loan as application/epub+zip (DRM type 2), you can't also do it as application/pdf (DRM type 1)" in response.detail
+            assert "You already fulfilled this loan as application/epub+zip (DRM-free), you can't also do it as application/pdf (application/vnd.adobe.adept+xml)" in response.detail
 
             # If the remote server fails, we get a problem detail.
             def doomed_get(url, headers, **kwargs):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1318,6 +1318,8 @@ class TestLoanController(CirculationControllerTest):
             response = self.manager.loans.fulfill(
                 self.pool.id, fulfillable_mechanism.delivery_mechanism.id,
             )
+            if not isinstance(response.status_code, 302):
+                raise Exception(response.data)
             eq_(302, response.status_code)
             eq_(fulfillable_mechanism.resource.representation.public_url, response.headers.get("Location"))
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1188,6 +1188,7 @@ class TestLoanController(CirculationControllerTest):
     def setup(self):
         super(TestLoanController, self).setup()
         self.pool = self.english_1.license_pools[0]
+        [self.mech1] = self.pool.delivery_mechanisms
         self.mech2 = self.pool.set_delivery_mechanism(
             Representation.PDF_MEDIA_TYPE, DeliveryMechanism.NO_DRM,
             RightsStatus.CC_BY, None
@@ -1297,25 +1298,29 @@ class TestLoanController(CirculationControllerTest):
             [entry] = feed['entries']
             fulfillment_links = [x['href'] for x in entry['links']
                                 if x['rel'] == OPDSFeed.ACQUISITION_REL]
-            [mech1, mech2] = sorted(
-                self.pool.delivery_mechanisms,
-                key=lambda x: x.delivery_mechanism.default_client_can_fulfill
-            )
+
+            assert self.mech1.resource is not None
 
             # Make sure the two delivery mechanisms are incompatible.
-            mech1.delivery_mechanism.drm_scheme = "DRM Scheme 1"
-            mech2.delivery_mechanism.drm_scheme = "DRM Scheme 2"
-            fulfillable_mechanism = mech2
+            self.mech1.delivery_mechanism.drm_scheme = "DRM Scheme 1"
+            self.mech2.delivery_mechanism.drm_scheme = "DRM Scheme 2"
+            fulfillable_mechanism = self.mech1
             self._db.commit()
 
             expects = [url_for('fulfill',
                                license_pool_id=self.pool.id,
                                mechanism_id=mech.delivery_mechanism.id,
                                library_short_name=self.library.short_name,
-                               _external=True) for mech in [mech1, mech2]]
+                               _external=True) for mech in [self.mech1, self.mech2]]
             eq_(set(expects), set(fulfillment_links))
 
-            # Now let's try to fulfill the loan.
+            # Make sure the first delivery mechanism has the data necessary
+            # to carry out an open source fulfillment.
+            assert self.mech1.resource is not None
+            assert self.mech1.resource.representation is not None
+            assert self.mech1.resource.representation.url is not None
+
+            # Now let's try to fulfill the loan using the first delivery mechanism.
             response = self.manager.loans.fulfill(
                 self.pool.id, fulfillable_mechanism.delivery_mechanism.id,
             )
@@ -1360,11 +1365,11 @@ class TestLoanController(CirculationControllerTest):
             # But we can't use some other mechanism -- we're stuck with
             # the first one we chose.
             response = self.manager.loans.fulfill(
-                self.pool.id, mech1.delivery_mechanism.id
+                self.pool.id, self.mech2.delivery_mechanism.id
             )
 
             eq_(409, response.status_code)
-            assert "You already fulfilled this loan as application/epub+zip (DRM Scheme 2), you can't also do it as application/pdf (DRM Scheme 1)" in response.detail
+            assert "You already fulfilled this loan as application/epub+zip (DRM Scheme 1), you can't also do it as application/pdf (DRM Scheme 2)" in response.detail
 
             # If the remote server fails, we get a problem detail.
             def doomed_get(url, headers, **kwargs):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1318,7 +1318,7 @@ class TestLoanController(CirculationControllerTest):
             response = self.manager.loans.fulfill(
                 self.pool.id, fulfillable_mechanism.delivery_mechanism.id,
             )
-            if not isinstance(response.status_code, 302):
+            if response.status_code != 302:
                 raise Exception(response.data)
             eq_(302, response.status_code)
             eq_(fulfillable_mechanism.resource.representation.public_url, response.headers.get("Location"))

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1364,7 +1364,7 @@ class TestLoanController(CirculationControllerTest):
             )
 
             eq_(409, response.status_code)
-            assert "You already fulfilled this loan as application/epub+zip (DRM Scheme 1), you can't also do it as application/pdf (DRM Scheme 2)" in response.detail
+            assert "You already fulfilled this loan as application/epub+zip (DRM Scheme 2), you can't also do it as application/pdf (DRM Scheme 1)" in response.detail
 
             # If the remote server fails, we get a problem detail.
             def doomed_get(url, headers, **kwargs):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1303,8 +1303,8 @@ class TestLoanController(CirculationControllerTest):
             )
 
             # Make sure the two delivery mechanisms are incompatible.
-            mech1.delivery_mechanism.drm_scheme = DeliveryMechanism.ADOBE_DRM
-            mech2.delivery_mechanism.drm_scheme = DeliveryMechanism.NO_DRM
+            mech1.delivery_mechanism.drm_scheme = "DRM Scheme 1"
+            mech2.delivery_mechanism.drm_scheme = "DRM Scheme 2"
             fulfillable_mechanism = mech2
             self._db.commit()
 
@@ -1364,7 +1364,7 @@ class TestLoanController(CirculationControllerTest):
             )
 
             eq_(409, response.status_code)
-            assert "You already fulfilled this loan as application/epub+zip (DRM-free), you can't also do it as application/pdf (application/vnd.adobe.adept+xml)" in response.detail
+            assert "You already fulfilled this loan as application/epub+zip (DRM Scheme 1), you can't also do it as application/pdf (DRM Scheme 2)" in response.detail
 
             # If the remote server fails, we get a problem detail.
             def doomed_get(url, headers, **kwargs):

--- a/tests/test_google_analytics_provider.py
+++ b/tests/test_google_analytics_provider.py
@@ -15,6 +15,7 @@ from core.model import (
     CirculationEvent,
     ConfigurationSetting,
     DataSource,
+    EditionConstants,
     ExternalIntegration,
     LicensePool
 )
@@ -117,6 +118,8 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
         eq_("lang", params['cd10'][0])
         eq_("Folklore", params['cd11'][0])
         eq_("true", params['cd12'][0])
+        eq_(DataSource.GUTENBERG, params['cd13'][0])
+        eq_(EditionConstants.BOOK_MEDIUM, params['cd14'][0])
 
     def test_collect_event_without_work(self):
         integration, ignore = create(

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1490,6 +1490,10 @@ class TestLibraryAnnotator(VendorIDTest):
         )
         eq_(2, len(links))
         indirects = []
+
+        # This sorts the links so that the first link corresponds
+        # to the delivery mechanism for the first link.
+        links = sorted(links, key=lambda x: x.attrib['href'], reverse=True)
         for link in links:
             # Both links should have the same subtags.
             [availability, copies, holds, indirect] = sorted(


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2340. It adds two more custom dimensions to the Google Analytics output: the distributor of the LicensePool (so we can compare usage of books we get from different sources) and the medium (so we can compare audiobooks vs ebooks).

This change will need a special release note explaining how to do the migration on the Google Analytics side; this is the subject of https://jira.nypl.org/browse/SIMPLY-2382.