### PR TITLE
Look at recent Enki circulation events using getRecentActivityTime endpoint instead of getRecentActivity

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1330,22 +1330,6 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
             return default_start_time
         return None
 
-    def slice_timespan(self, start, cutoff, increment):
-        """Slice a span of time into segements no large than [increment].
-
-        This lets you divide up a task like "gather the entire
-        circulation history for a collection" into chunks of one day.
-        """
-        slice_start = start
-        while slice_start < cutoff:
-            full_slice = True
-            slice_cutoff = slice_start + increment
-            if slice_cutoff > cutoff:
-                slice_cutoff = cutoff
-                full_slice = False
-            yield slice_start, slice_cutoff, full_slice
-            slice_start = slice_start + increment
-
     def catch_up_from(self, start, cutoff, progress):
         added_books = 0
         i = 0

--- a/api/enki.py
+++ b/api/enki.py
@@ -206,7 +206,7 @@ class EnkiAPI(BaseCirculationAPI, HasSelfTests):
 
         # Look for the error indicator and raise
         # RemoteIntegrationException if it appears.
-        if self.ERROR_INDICATOR in response.content:
+        if response.content and self.ERROR_INDICATOR in response.content:
             raise RemoteIntegrationException(url, "An unknown error occured")
         return response
 
@@ -749,7 +749,6 @@ class EnkiImport(CollectionMonitor, TimelineMonitor):
 
         :param start: Find all books that changed since this date.
         """
-        start = datetime.datetime(2019, 11, 11)
         if start is None:
             # This is the first time the monitor has run, so it's
             # important that we get the entire collection, even though that

--- a/api/enki.py
+++ b/api/enki.py
@@ -25,6 +25,7 @@ from selftest import (
 
 from core.util.http import (
     HTTP,
+    RemoteIntegrationException,
     RequestTimedOut,
 )
 
@@ -100,6 +101,12 @@ class EnkiAPI(BaseCirculationAPI, HasSelfTests):
         (epub, no_drm): 'free',
         (epub, adobe_drm): 'acs',
     }
+
+    # Enki API serves all responses with a 200 error code and a
+    # text/html Content-Type. However, there's a string that
+    # reliably shows up in error pages which is unlikely to show up
+    # in normal API operation.
+    ERROR_INDICATOR = '<h1>Oops, an error occurred</h1>'
 
     SET_DELIVERY_MECHANISM_AT = BaseCirculationAPI.FULFILL_STEP
     SERVICE_NAME = "Enki"
@@ -178,8 +185,9 @@ class EnkiAPI(BaseCirculationAPI, HasSelfTests):
                 params=None, retry_on_timeout=True, **kwargs):
         """Make an HTTP request to the Enki API."""
         headers = dict(extra_headers)
+        response = None
         try:
-            return self._request(
+            response = self._request(
                 method, url, headers=headers, data=data,
                 params=params,
                 **kwargs
@@ -195,6 +203,12 @@ class EnkiAPI(BaseCirculationAPI, HasSelfTests):
                 data, params, retry_on_timeout=False,
                 **kwargs
             )
+
+        # Look for the error indicator and raise
+        # RemoteIntegrationException if it appears.
+        if self.ERROR_INDICATOR in response.content:
+            raise RemoteIntegrationException(url, "An unknown error occured")
+        return response
 
     def _request(self, method, url, headers, data, params, **kwargs):
         """Actually make an HTTP request.
@@ -217,17 +231,22 @@ class EnkiAPI(BaseCirculationAPI, HasSelfTests):
         now = datetime.datetime.utcnow()
         return int((now - since).total_seconds() / 60)
 
-    def recent_activity(self, since):
-        """Find recent circulation events that affected loans or holds.
+    def recent_activity(self, start, end):
+        """Find circulation events from a certain timeframe that affected
+        loans or holds.
 
-        :param since: A DateTime
+        :param start: A DateTime
         :yield: A sequence of CirculationData objects.
         """
-        minutes = self._minutes_since(since)
+        epoch = datetime.datetime.utcfromtimestamp(0)
+        start = int((start - epoch).total_seconds())
+        end = int((end - epoch).total_seconds())
+
         url = self.base_url + self.item_endpoint
         args = dict(
-            method='getRecentActivity',
-            minutes=minutes,
+            method='getRecentActivityTime',
+            stime=str(start),
+            etime=str(end)
         )
         response = self.request(url, params=args)
         data = json.loads(response.content)
@@ -730,6 +749,7 @@ class EnkiImport(CollectionMonitor, TimelineMonitor):
 
         :param start: Find all books that changed since this date.
         """
+        start = datetime.datetime(2019, 11, 11)
         if start is None:
             # This is the first time the monitor has run, so it's
             # important that we get the entire collection, even though that
@@ -784,9 +804,31 @@ class EnkiImport(CollectionMonitor, TimelineMonitor):
         return new_titles, circulation_changes
 
     def update_circulation(self, since):
-        """Process circulation events that happened since `since`."""
+        """Process circulation events that happened since `since`.
+
+        :return: The total number of circulation events.
+        """
         circulation_changes = 0
-        for circulation in self.api.recent_activity(since):
+        # Slice the time since `since` into two-hour increments.
+        # Experimentation shows that the Enki API can grab about 60
+        # hours of activity at once before timing out, so this puts us
+        # well below that threshold.
+        now = datetime.datetime.utcnow()
+        for start, end, full_slice in self.slice_timespan(
+            since, now, datetime.timedelta(hours=2)
+        ):
+            circulation_changes += self._update_circulation(start, end)
+        return circulation_changes
+
+    def _update_circulation(self, start, end):
+        """Process circulation events that happened between
+        `start` and `end`.
+
+        :return: The number of circulation events between `start`
+        and `end`.
+        """
+        circulation_changes = 0
+        for circulation in self.api.recent_activity(start, end):
             circulation_changes += 1
             license_pool, is_new = circulation.license_pool(
                 self._db, self.collection

--- a/tests/test_enki.py
+++ b/tests/test_enki.py
@@ -246,21 +246,22 @@ class TestEnkiAPI(BaseEnkiTest):
         )
         eq_(60, EnkiAPI._minutes_since(an_hour_ago))
 
-    def test__recent_activity(self):
-        one_minute_ago = datetime.datetime.utcnow() - datetime.timedelta(
-            minutes=1
-        )
+    def test_recent_activity(self):
+        now = datetime.datetime.utcnow()
+        epoch = datetime.datetime(1970, 1, 1)
+        epoch_plus_one_hour = epoch + datetime.timedelta(hours=1)
         data = self.get_data("get_recent_activity.json")
         self.api.queue_response(200, content=data)
-        activity = list(self.api.recent_activity(one_minute_ago))
+        activity = list(self.api.recent_activity(epoch, epoch_plus_one_hour))
         eq_(43, len(activity))
         for i in activity:
             assert isinstance(i, CirculationData)
         [method, url, headers, data, params, kwargs] = self.api.requests.pop()
         eq_("get", method)
         eq_("https://enkilibrary.org/API/ItemAPI", url)
-        eq_("getRecentActivity", params['method'])
-        eq_(1, params['minutes'])
+        eq_("getRecentActivityTime", params['method'])
+        eq_('0', params['stime'])
+        eq_('3600', params['etime'])
 
         # Unlike some API calls, it's not necessary to pass 'lib' in here.
         assert 'lib' not in params


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1221 and https://jira.nypl.org/browse/SIMPLY-1848. Instead of using the `getRecentActivity` endpoint to get all activity since the last time the EnkiImporter monitor ran (which can crash the Enki API), we split up the timeline since that time into two-hour chunks and ask the Enki API about one chunk at a time -- similar to what we do with Bibliotheca -- using the `getRecentActivityTime` endpoint.