### PR TITLE
Change RecommendationLane.modify_search_filter to return the filter 

### DIFF
--- a/api/lanes.py
+++ b/api/lanes.py
@@ -912,6 +912,7 @@ class RecommendationLane(WorkBasedLane):
             filter.match_nothing = True
         else:
             filter.identifiers = self.recommendations
+        return filter
 
 
 class SeriesFacets(DefaultSortOrderFacets):

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -533,7 +533,8 @@ class TestRecommendationLane(LaneTest):
         lane = RecommendationLane(self._default_library, self.work, '', novelist_api=mock_api)
         filter = Filter()
         eq_(False, filter.match_nothing)
-        lane.modify_search_filter_hook(filter)
+        modified = lane.modify_search_filter_hook(filter)
+        eq_(modified, filter)
         eq_(True, filter.match_nothing)
 
         # When there are recommendations, the Filter is modified to
@@ -543,7 +544,8 @@ class TestRecommendationLane(LaneTest):
         lane.recommendations = [i1, i2]
         filter = Filter()
         eq_([], filter.identifiers)
-        lane.modify_search_filter_hook(filter)
+        modified = lane.modify_search_filter_hook(filter)
+        eq_(modified, filter)
         eq_([i1, i2], filter.identifiers)
         eq_(False, filter.match_nothing)
 


### PR DESCRIPTION
Previously the filter was being modified in place but not returned, which caused https://jira.nypl.org/browse/SIMPLY-2410.

I don't think the old behavior is wrong, it just wasn't supported. So I also wrote https://github.com/NYPL-Simplified/server_core/pull/1137 to stop the problem from happening again.