### PR TITLE
to_response_parameters always returns a dictionary, even if it's empty.

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -394,7 +394,7 @@ class PatronData(object):
         """
         if self.personal_name:
             return dict(name=self.personal_name)
-        return None
+        return {}
 
     @property
     def to_dict(self):

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -432,6 +432,11 @@ class TestPatronData(AuthenticatorTest):
         params = self.data.to_response_parameters
         eq_(dict(name="4"), params)
 
+        self.data.personal_name = None
+        params = self.data.to_response_parameters
+        eq_(dict(), params)
+
+
 class TestCirculationPatronProfileStorage(ControllerTest):
 
     def test_profile_document(self):


### PR DESCRIPTION
This branch fixes a potential crash in the iOS Open eBooks app. According to @kyles-ep the JSON parser sometimes has a problem treating `null` as a valid JSON value.

This change makes sure that `to_response_parameters` always returns a dictionary. An empty dictionary won't trigger the iOS problem.