### PR TITLE
Add library name as an analytics dimension

### DIFF
--- a/api/google_analytics_provider.py
+++ b/api/google_analytics_provider.py
@@ -39,6 +39,7 @@ class GoogleAnalyticsProvider(object):
                     "<li>open_access</li>" +
                     "<li>distributor</li>" +
                     "<li>medium</li>" +
+                    "<li>library</li>" +
                     "</ol></p>" +
                     "<p>Each dimension should have the scope set to 'Hit' and the 'Active' box checked.</p>" +
                     "<p>Then go to Tracking Info and get the tracking id for the property.  Select your " +
@@ -115,7 +116,7 @@ class GoogleAnalyticsProvider(object):
             fields.update({'cd13' : license_pool.data_source.name})
             if work and edition:
                 fields.update({'cd14' : edition.medium})
-
+        fields.update({'cd15' : library.short_name})
 
         # urlencode doesn't like unicode strings so we convert them to utf8
         fields = {k: unicodedata.normalize("NFKD", unicode(v)).encode("utf8") for k, v in fields.iteritems()}

--- a/api/google_analytics_provider.py
+++ b/api/google_analytics_provider.py
@@ -116,7 +116,8 @@ class GoogleAnalyticsProvider(object):
             fields.update({'cd13' : license_pool.data_source.name})
             if work and edition:
                 fields.update({'cd14' : edition.medium})
-        fields.update({'cd15' : library.short_name})
+        if library:
+            fields.update({'cd15' : library.short_name})
 
         # urlencode doesn't like unicode strings so we convert them to utf8
         fields = {k: unicodedata.normalize("NFKD", unicode(v)).encode("utf8") for k, v in fields.iteritems()}

--- a/tests/test_google_analytics_provider.py
+++ b/tests/test_google_analytics_provider.py
@@ -120,6 +120,7 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
         eq_("true", params['cd12'][0])
         eq_(DataSource.GUTENBERG, params['cd13'][0])
         eq_(EditionConstants.BOOK_MEDIUM, params['cd14'][0])
+        eq_(self._default_library.short_name, params['cd15'][0])
 
     def test_collect_event_without_work(self):
         integration, ignore = create(
@@ -163,6 +164,9 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
         eq_(None, params.get('cd10'))
         eq_(None, params.get('cd11'))
         eq_(None, params.get('cd12'))
+        eq_([source.name], params.get('cd13'))
+        eq_(None, params.get('cd14'))
+        eq_([self._default_library.short_name], params.get('cd15'))
 
     def test_collect_event_without_license_pool(self):
         integration, ignore = create(
@@ -198,3 +202,6 @@ class TestGoogleAnalyticsProvider(DatabaseTest):
         eq_(None, params.get('cd10'))
         eq_(None, params.get('cd11'))
         eq_(None, params.get('cd12'))
+        eq_(None, params.get('cd13'))
+        eq_(None, params.get('cd14'))
+        eq_([self._default_library.short_name], params.get('cd15'))


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-514 by adding the library's short name as a Google Analytics dimension. When you have a whole bunch of libraries sharing a single GA account, this makes it possible to group analytics events by which library they happened to.

This is based off of my earlier branch, https://github.com/NYPL-Simplified/circulation/pull/1353/files. I noticed a couple more tests where I should have changed that branch to look at `cd13` and `cd14`. I added the missing tests here along with tests that look at `cd15`. Note that `cd15` is pretty much guaranteed to be present, even if lots of other analytics dimensions are missing.