### PR TITLE
Fixing wrong function call for Enki's API recent_activity

### DIFF
--- a/api/enki.py
+++ b/api/enki.py
@@ -146,7 +146,7 @@ class EnkiAPI(BaseCirculationAPI, HasSelfTests):
             """Count recent circulation events that affected loans or holds.
             """
             one_hour_ago = now - datetime.timedelta(hours=1)
-            count = len(list(self.recent_activity(since=one_hour_ago)))
+            count = len(list(self.recent_activity(one_hour_ago, now)))
             return "%s circulation events in the last hour" % count
 
         yield self.run_test(

--- a/tests/test_enki.py
+++ b/tests/test_enki.py
@@ -112,8 +112,8 @@ class TestEnkiAPI(BaseEnkiTest):
     def test__run_self_tests(self):
         # Mock every method that will be called by the self-test.
         class Mock(MockEnkiAPI):
-            def recent_activity(self, since):
-                self.recent_activity_called_with = since
+            def recent_activity(self, start, end):
+                self.recent_activity_called_with = (start, end)
                 yield 1
                 yield 2
 
@@ -157,7 +157,9 @@ class TestEnkiAPI(BaseEnkiTest):
         now = datetime.datetime.utcnow()
         one_hour_ago = now - datetime.timedelta(hours=1)
         one_day_ago = now - datetime.timedelta(hours=24)
-        assert (api.recent_activity_called_with - one_hour_ago).total_seconds() < 2
+        start, end = api.recent_activity_called_with
+        assert (start - one_hour_ago).total_seconds() < 2
+        assert (end - now).total_seconds() < 2
         eq_(True, circulation_changes.success)
         eq_("2 circulation events in the last hour", circulation_changes.result)
 


### PR DESCRIPTION
Encountered this small issue while going through the admin and testing different configuration settings changes (my issue is related to SQLite and threading). Seems it's only relevant to Enki.

![Screen Shot 2019-12-09 at 2 54 42 PM](https://user-images.githubusercontent.com/1280564/70467916-1b140400-1a94-11ea-9d73-6d9ed2faff24.png)
