### PR TITLE
No language lanes

### DIFF
--- a/api/lanes.py
+++ b/api/lanes.py
@@ -50,7 +50,6 @@ from core.model import (
 
 from core.util import LanguageCodes
 from novelist import NoveListAPI
-from core.util.problem_detail import ProblemDetail
 
 def load_lanes(_db, library):
     """Return a WorkList that reflects the current lane structure of the

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -50,6 +50,7 @@ from core.model import (
 
 from core.util import LanguageCodes
 from novelist import NoveListAPI
+from core.util.problem_detail import ProblemDetail
 
 def load_lanes(_db, library):
     """Return a WorkList that reflects the current lane structure of the
@@ -280,8 +281,6 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
     )
     if nyt_integration:
         include_best_sellers = True
-
-    language_identifier = LanguageCodes.name_for_languageset(languages)
 
     sublanes = []
     if include_best_sellers:
@@ -683,7 +682,8 @@ def create_world_languages_lane(
     return priority
 
 def create_lane_for_small_collection(_db, library, parent, languages, priority=0):
-    """Create a lane (with sublanes) for a small collection based on language.
+    """Create a lane (with sublanes) for a small collection based on language,
+    if the language exists in the lookup table.
 
     :param parent: The parent of the new lane.
     """
@@ -699,6 +699,8 @@ def create_lane_for_small_collection(_db, library, parent, languages, priority=0
         genres=[],
     )
     language_identifier = LanguageCodes.name_for_languageset(languages)
+    if not language_identifier:
+        return 0
     sublane_priority = 0
 
     adult_fiction, ignore = create(
@@ -743,7 +745,8 @@ def create_lane_for_small_collection(_db, library, parent, languages, priority=0
     return priority
 
 def create_lane_for_tiny_collection(_db, library, parent, languages, priority=0):
-    """Create a single lane for a tiny collection based on language.
+    """Create a single lane for a tiny collection based on language,
+    if the language exists in the lookup table.
 
     :param parent: The parent of the new lane.
     """
@@ -754,6 +757,9 @@ def create_lane_for_tiny_collection(_db, library, parent, languages, priority=0)
         languages = [languages]
 
     name = LanguageCodes.name_for_languageset(languages)
+    if not name:
+        return 0
+
     language_lane, ignore = create(
         _db, Lane, library=library,
         display_name=name,

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -697,9 +697,15 @@ def create_lane_for_small_collection(_db, library, parent, languages, priority=0
         media=[Edition.BOOK_MEDIUM],
         genres=[],
     )
-    language_identifier = LanguageCodes.name_for_languageset(languages)
-    if not language_identifier:
+
+    try:
+        language_identifier = LanguageCodes.name_for_languageset(languages)
+    except ValueError as e:
+        logging.getLogger().warn(
+            "Could not create a lane for small collection with languages %s", languages
+        )
         return 0
+
     sublane_priority = 0
 
     adult_fiction, ignore = create(
@@ -754,9 +760,13 @@ def create_lane_for_tiny_collection(_db, library, parent, languages, priority=0)
 
     if isinstance(languages, basestring):
         languages = [languages]
-
-    name = LanguageCodes.name_for_languageset(languages)
-    if not name:
+    
+    try:
+        name = LanguageCodes.name_for_languageset(languages)
+    except ValueError as e:
+        logging.getLogger().warn(
+            "Could not create a lane for tiny collection with languages %s", languages
+        )
         return 0
 
     language_lane, ignore = create(

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -226,27 +226,15 @@ class TestLaneCreation(DatabaseTest):
             [x.fiction for x in sublanes]
         )
 
-        # Even if a language name is not found, create the lane
-        # if other languages are found
+        # If a language name is not found, don't create any lanes.
         languages = ['eng', 'mul', 'chi']
         parent = self._lane()
         priority = create_lane_for_small_collection(
             self._db, self._default_library, parent, languages, priority=2
         )
-        lane = self._db.query(Lane).filter(Lane.parent==parent).one()
-        eq_(u"English/Chinese", lane.display_name)
-        eq_(priority, 3)
-
-        # If the language does not have a name, don't create the lane
-        languages = ['gaa']
-        parent = self._lane()
-        priority = create_lane_for_small_collection(
-            self._db, self._default_library, parent, languages, priority=2
-        )
         lane = self._db.query(Lane).filter(Lane.parent==parent)
-        eq_(lane.count(), 0)
         eq_(priority, 0)
-
+        eq_(lane.count(), 0)
 
     def test_lane_for_tiny_collection(self):
         parent = self._lane()
@@ -262,25 +250,15 @@ class TestLaneCreation(DatabaseTest):
         eq_(u'Deutsch', lane.display_name)
         eq_([], lane.children)
 
-        # No lane should be created when the language has no name
-        new_parent = self._lane()
-        new_priority = create_lane_for_tiny_collection(
-            self._db, self._default_library, new_parent, 'gaa',
-            priority=3
-        )
-        eq_(0, new_priority)
-        lane = self._db.query(Lane).filter(Lane.parent==new_parent)
-        eq_(lane.count(), 0)
-
-        # Don't include a language that has no name in the lane display name
+        # No lane should be created when the language has no name.
         new_parent = self._lane()
         new_priority = create_lane_for_tiny_collection(
             self._db, self._default_library, new_parent, ['spa', 'gaa', 'eng'],
             priority=3
         )
-        eq_(4, new_priority)
-        lane = self._db.query(Lane).filter(Lane.parent==new_parent).one()
-        eq_(u'español/English', lane.display_name)
+        eq_(0, new_priority)
+        lane = self._db.query(Lane).filter(Lane.parent==new_parent)
+        eq_(lane.count(), 0)
 
     def test_create_default_lanes(self):
         library = self._default_library


### PR DESCRIPTION
Resolves [SIMPLY-458](https://jira.nypl.org/browse/SIMPLY-458) along with [PR in core](https://github.com/NYPL-Simplified/server_core/pull/1142).

When a language code is encountered with a name, creating lanes breaks. Instead of creating no lanes, skip over the bad language code and missing name.