### PR TITLE
Introduce a standard 'noreply' address as a default for DEFAULT_NOTIFICATION_EMAIL_ADDRESS.

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -226,7 +226,7 @@ class Configuration(CoreConfiguration):
         },
         {
             "key": DEFAULT_NOTIFICATION_EMAIL_ADDRESS,
-            "label": _("Default email address to use when sending vendor hold notifications"),
+            "label": _("Trash email address for vendor hold notifications"),
             "description": _('This address must trash all email sent to it. Vendor hold notifications contain sensitive patron information, but <a href="https://confluence.nypl.org/display/SIM/About+Hold+Notifications" target="_blank">cannot be forwarded to patrons</a> because they contain vendor-specific instructions.<br/>The default address will work, but for greater security, set up your own address that trashes all incoming email.'),
             "default": STANDARD_NOREPLY_EMAIL_ADDRESS,
             "required": True,

--- a/api/config.py
+++ b/api/config.py
@@ -226,7 +226,7 @@ class Configuration(CoreConfiguration):
         },
         {
             "key": DEFAULT_NOTIFICATION_EMAIL_ADDRESS,
-            "label": _("Trash email address for vendor hold notifications"),
+            "label": _("Write-only email address for vendor hold notifications"),
             "description": _('This address must trash all email sent to it. Vendor hold notifications contain sensitive patron information, but <a href="https://confluence.nypl.org/display/SIM/About+Hold+Notifications" target="_blank">cannot be forwarded to patrons</a> because they contain vendor-specific instructions.<br/>The default address will work, but for greater security, set up your own address that trashes all incoming email.'),
             "default": STANDARD_NOREPLY_EMAIL_ADDRESS,
             "required": True,

--- a/api/config.py
+++ b/api/config.py
@@ -55,6 +55,7 @@ class Configuration(CoreConfiguration):
     # The name of the per-library setting that sets the default email
     # address to use when notifying patrons of changes.
     DEFAULT_NOTIFICATION_EMAIL_ADDRESS = u"default_notification_email_address"
+    STANDARD_NOREPLY_EMAIL_ADDRESS = "noreply@librarysimplified.org"
 
     # The name of the per-library setting that sets the email address
     # of the Designated Agent for copyright complaints
@@ -226,7 +227,8 @@ class Configuration(CoreConfiguration):
         {
             "key": DEFAULT_NOTIFICATION_EMAIL_ADDRESS,
             "label": _("Default email address to use when sending vendor hold notifications"),
-            "description": _('This should be an address controlled by the library which rejects or trashes all email sent to it. Vendor hold notifications contain sensitive patron information, but <a href="https://confluence.nypl.org/display/SIM/About+Hold+Notifications" target="_blank">cannot be forwarded to patrons</a> because they contain vendor-specific instructions.'),
+            "description": _('This address must trash all email sent to it. Vendor hold notifications contain sensitive patron information, but <a href="https://confluence.nypl.org/display/SIM/About+Hold+Notifications" target="_blank">cannot be forwarded to patrons</a> because they contain vendor-specific instructions.<br/>The default address will work, but for greater security, set up your own address that trashes all incoming email.'),
+            "default": STANDARD_NOREPLY_EMAIL_ADDRESS,
             "required": True,
             "format": "email",
         },


### PR DESCRIPTION
This branch completes https://jira.nypl.org/browse/SIMPLY-2454 by setting a default value for DEFAULT_NOTIFICATION_EMAIL_ADDRESS that works. Previously there was no default value and libraries were expected to complete a complex IT setup before even getting a library into their circulation manager. More commonly, libraries put an address in this field which didn't actually do the job, leading to privacy problems.

This default value is good enough for most purposes, and libraries that have or are able to set up their own 'black hole' email address can still do so.

I wasn't able to find a good way to unit test this, but here's a screenshot:

![image](https://user-images.githubusercontent.com/662474/71845931-602d5500-3097-11ea-8a46-1986257665c9.png)
