### PR TITLE
Overdrive production or testing

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -349,9 +349,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
         # The only case where this is likely to work is when the
         # loan exists but has not been locked to a delivery mechanism.
         overdrive_id = licensepool.identifier.identifier
-        url = self.CHECKOUT_ENDPOINT % self.url_args(
-            overdrive_id=overdrive_id
-        )
+        url = self.endpoint(self.CHECKOUT_ENDPOINT, overdrive_id=overdrive_id)
         return self.patron_request(patron, pin, url, method='DELETE')
 
     def perform_early_return(self, patron, pin, loan, http_get=None):
@@ -436,8 +434,8 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
         return data
 
     def get_hold(self, patron, pin, overdrive_id):
-        url = self.HOLD_ENDPOINT % self.url_args(
-            product_id=overdrive_id.upper()
+        url = self.endpoint(
+            self.HOLD_ENDPOINT, product_id=overdrive_id.upper()
         )
         data = self.patron_request(patron, pin, url).json()
         self.raise_exception_on_error(data)
@@ -556,7 +554,9 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
         overdrive_id = overdrive_id.upper()
         headers, document = self.fill_out_form(
             reserveId=overdrive_id, formatType=format_type)
-        url = self.FORMATS_ENDPOINT % self.url_args(overdrive_id=overdrive_id)
+        url = self.endpoint(
+            self.FORMATS_ENDPOINT, overdrive_id=overdrive_id
+        )
         return self.patron_request(patron, pin, url, headers, document)
 
     @classmethod
@@ -859,7 +859,8 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
             with Overdrive, or Overdrive refuses to release the hold for
             any reason.
         """
-        url = self.HOLD_ENDPOINT % self.url_args(
+        url = self.endpoint(
+            self.HOLD_ENDPOINT,
             product_id=licensepool.identifier.identifier
         )
         response = self.patron_request(patron, pin, url, method='DELETE')
@@ -878,7 +879,8 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
     def circulation_lookup(self, book):
         if isinstance(book, basestring):
             book_id = book
-            circulation_link = self.AVAILABILITY_ENDPOINT % self.url_args(
+            circulation_link = self.endpoint(
+                self.AVAILABILITY_ENDPOINT,
                 collection_token=self.collection_token,
                 product_id=book_id
             )

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -67,14 +67,18 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
         { "key": ExternalIntegration.PASSWORD, "label": _("Client Secret"), "required": True },
         {
             "key": BaseOverdriveAPI.SERVER_NICKNAME,
-            "label": _("Server endpoints"),
+            "label": _("Server family"),
             "description": _("Unless you hear otherwise from Overdrive, your integration should use their production servers."),
             "type": "select",
             "options": [
-                dict(key=BaseOverdriveAPI.PRODUCTION_SERVERS,
-                     value="Production"),
-                dict(key=BaseOverdriveAPI.TESTING_SERVERS,
-                     value="Testing")
+                dict(
+                    label=_("Production"), 
+                    key=BaseOverdriveAPI.PRODUCTION_SERVERS
+                ),
+                dict(
+                    label=_("Testing"),
+                    key=BaseOverdriveAPI.TESTING_SERVERS,
+                )
             ],
             "default": BaseOverdriveAPI.PRODUCTION_SERVERS,
         },

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -72,7 +72,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
             "type": "select",
             "options": [
                 dict(
-                    label=_("Production"), 
+                    label=_("Production"),
                     key=BaseOverdriveAPI.PRODUCTION_SERVERS
                 ),
                 dict(

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -459,7 +459,8 @@ class TestOverdriveAPI(OverdriveAPITest):
         pool = self._licensepool(None)
         patron = self._patron()
         pin = object()
-        expect_url = overdrive.CHECKOUT_ENDPOINT % overdrive.url_args(
+        expect_url = overdrive.endpoint(
+            overdrive.CHECKOUT_ENDPOINT,
             overdrive_id=pool.identifier.identifier
         )
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -459,7 +459,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         pool = self._licensepool(None)
         patron = self._patron()
         pin = object()
-        expect_url = overdrive.CHECKOUT_ENDPOINT % dict(
+        expect_url = overdrive.CHECKOUT_ENDPOINT % overdrive.url_args(
             overdrive_id=pool.identifier.identifier
         )
 


### PR DESCRIPTION
This is the circulation portion of https://jira.nypl.org/browse/SIMPLY-2486. It goes with https://github.com/NYPL-Simplified/server_core/pull/1148.

This branch adds a few more calls to endpoint(), and adds the GUI for choosing whether a given Overdrive integration hits the production or testing servers. I've tested this GUI manually.