### PR TITLE
Add a missing endpoint() call.

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -193,6 +193,7 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
                 method = 'post'
             else:
                 method = 'get'
+        url = self.endpoint(url)
         response = HTTP.request_with_timeout(
             method, url, headers=headers, data=data
         )
@@ -381,6 +382,9 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
             patron, pin, loan.license_pool.identifier.identifier,
             internal_format
         )
+        # The URL comes from Overdrive, so it probably doesn't need
+        # interpolation, but just in case.
+        url = self.endpoint(url)
 
         # Make a regular, non-authenticated request to the fulfillment link.
         http_get = http_get or HTTP.get_with_timeout


### PR DESCRIPTION
This branch fixes a pretty bad bug caused by the fix to https://jira.nypl.org/browse/SIMPLY-2486. Requests to Overdrive that act on behalf of a patron won't actually go through. I didn't catch this before because `patron_request` makes live HTTP requests and isn't tested.

I don't understand why this bug didn't show up when I ran QA. It looks like I released 3.0.3 without updating the submodule, which was its own mistake, but I wouldn't expect this to mean everything works.

At any rate, I'm going to release a 3.0.4 ASAP with this fix.