### PR TITLE
Bring our ODL implementation up to date with how Feedbooks serves audiobooks

### DIFF
--- a/api/odl.py
+++ b/api/odl.py
@@ -32,6 +32,7 @@ from core.model import (
     Credential,
     DataSource,
     DeliveryMechanism,
+    Edition,
     ExternalIntegration,
     Hold,
     Hyperlink,
@@ -447,7 +448,13 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI):
         content_link = None
         content_type = None
         for link in links:
-            if link.get("rel") == "license":
+            # Depending on the format being served, the crucial information
+            # may be in 'manifest' or in 'license'.
+            #
+            # TODO: when both links are present, access to the
+            # DeliveryMechanism would be great for figuring out which
+            # one to use.
+            if link.get("rel") in ("manifest", "license"):
                 content_link = link.get("href")
                 content_type = link.get("type")
                 break
@@ -796,28 +803,44 @@ class ODLImporter(OPDSImporter):
         odl_license_tags = parser._xpath(entry_tag, 'odl:license') or []
         for odl_license_tag in odl_license_tags:
             identifier = subtag(odl_license_tag, 'dcterms:identifier')
-            content_type = subtag(odl_license_tag, 'dcterms:format')
+            full_content_type = subtag(odl_license_tag, 'dcterms:format')
+
+            # By default, dcterms:format includes the media type of a
+            # DRM-free resource.
+            content_type = full_content_type
             drm_schemes = []
-            protection_tags = parser._xpath(odl_license_tag, 'odl:protection') or []
+
+            # But it may instead describe an audiobook protected with
+            # the Feedbooks access-control scheme.
+            feedbooks_audio = "%s; protection=%s"  % (
+                MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
+                DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM
+            )
+            if full_content_type == feedbooks_audio:
+                content_type = MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE
+                drm_schemes.append(DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM)
+
+            # Additional DRM schemes may be described in <odl:protection>
+            # tags.
+            protection_tags = parser._xpath(
+                odl_license_tag, 'odl:protection'
+            ) or []
             for protection_tag in protection_tags:
                 drm_scheme = subtag(protection_tag, 'dcterms:format')
+                if drm_scheme:
+                    drm_schemes.append(drm_scheme)
 
-                if MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE in drm_scheme and DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM in drm_scheme:
-                    drm_scheme = DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM
-                
-                drm_schemes.append(drm_scheme)
-            if not drm_schemes:
-                formats.append(FormatData(
-                    content_type=content_type,
-                    drm_scheme=None,
-                    rights_uri=RightsStatus.IN_COPYRIGHT,
-                ))
-            for drm_scheme in drm_schemes:
-                formats.append(FormatData(
-                    content_type=content_type,
-                    drm_scheme=drm_scheme,
-                    rights_uri=RightsStatus.IN_COPYRIGHT,
-                ))
+            for drm_scheme in (drm_schemes or [None]):
+                formats.append(
+                    FormatData(
+                        content_type=content_type,
+                        drm_scheme=drm_scheme,
+                        rights_uri=RightsStatus.IN_COPYRIGHT,
+                    )
+                )
+
+            if content_type == MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE:
+                data['medium'] = Edition.AUDIO_MEDIUM
 
             expires = None
             remaining_checkouts = None
@@ -837,12 +860,19 @@ class ODLImporter(OPDSImporter):
                 if rel == "self":
                     odl_status_link = link_tag.attrib.get("href")
                     break
+            if not odl_status_link:
+                # TODO: This is a hack necessary because Feedbooks
+                # doesn't provide the status link yet. Once that's fixed,
+                # this link will be present with rel="self", just like
+                # in the unit tests.
+                odl_status_link = "https://license.feedbooks.net/copy/status/?uuid=" + identifier.replace("urn:uuid:", "")
 
             if odl_status_link:
                 ignore, ignore, response = do_get(odl_status_link, headers={})
                 status = json.loads(response)
-                remaining_checkouts = status.get("checkouts", {}).get("left")
-                available_checkouts = status.get("checkouts", {}).get("available")
+                checkouts = status.get("checkouts", {})
+                remaining_checkouts = checkouts.get("left")
+                available_checkouts = checkouts.get("available")
 
             terms = parser._xpath(odl_license_tag, "odl:terms")
             if terms:

--- a/tests/files/odl/feedbooks_bibliographic.atom
+++ b/tests/files/odl/feedbooks_bibliographic.atom
@@ -254,46 +254,54 @@
   <category term="florida everglades" label="florida everglades"/>
   <category term="united states department of the interior" label="united states department of the interior"/>
 </entry>
-<entry>
-  <title>Short Poetry Collection 087</title>
-  <id>urn:uuid:92f9da47-f0fd-4cef-aa11-639f79d23847</id>
-  <updated>2010-04-08T23:23:44Z</updated>
-  <link href="https://api.archivelab.org/books/short_poetry_087_1004_librivox/opds_audio_manifest" type="application/audiobook+json" rel="http://opds-spec.org/acquisition" />
-  <link href="https://archive.org/services/img/short_poetry_087_1004_librivox" type="image/jpeg" rel="http://opds-spec.org/image"/>
-  <link href="https://archive.org/services/img/short_poetry_087_1004_librivox" type="image/jpeg" rel="http://opds-spec.org/image/thumbnail"/>
-  <dcterms:issued>2010</dcterms:issued>
-  <dcterms:language>en</dcterms:language>
-  <published>2010-04-08T00:00:00Z</published>
-  <author>
-  <name>Various</name>
-  </author>
-  <category term="librivox" label="librivox"/>
-  <category term="short poetry" label="short poetry"/>
-  <category term="short poems" label="short poems"/>
-  <summary type="html">
-  This is a collection of poems read by LibriVox volunteers for the month of March 2010. LibriVox project page: Short Poetry Collection 087 For more information, or to volunteer, please visit LibriVox.org M4B Audiobook (17MB)
-  </summary>
-  <odl:license>
-    <dcterms:identifier xsi:type="dcterms:URI">6</dcterms:identifier>
-    <dcterms:format>application/audiobook+json</dcterms:format>
-    <dcterms:source>http://www.feedbooks.com</dcterms:source>
-    <opds:price currencycode="USD">60.00</opds:price>
-    <dcterms:source xsi:type="dcterms:URI">urn:ISBN:9781250100771</dcterms:source>
-    <created>2010-04-08T23:23:44Z</created>
-    <odl:terms>
-      <odl:total_checkouts>10</odl:total_checkouts>
-      <odl:concurrent_checkouts>5</odl:concurrent_checkouts>
-      <odl:maximum_checkout_length>5097600</odl:maximum_checkout_length>
-    </odl:terms>
-    <odl:protection>
-      <dcterms:format>application/application/audiobook+json;profile=http://www.feedbooks.com/audiobooks/access-restriction</dcterms:format>
-      <odl:max_devices>6</odl:max_devices>
-      <odl:copy>false</odl:copy>
-      <odl:print>false</odl:print>
-      <odl:tts>false</odl:tts>
-    </odl:protection>
-  </odl:license>
-  <odl:tlink type="application/vnd.readium.lcp.status.1-0+json" href="https://loan.feedbooks.net/loan/get/{?id,checkout_id,expires,patron_id,notification_url}" rel="http://opds-spec.org/acquisition/borrow"/>
-  <link type="application/vnd.odl.status.1-0+json" href="https://license.feedbooks.net/license/status/?uuid=6" rel="self"/>
+<entry xmlns="http://www.w3.org/2005/Atom" xmlns:schema="http://schema.org/" xmlns:odl="http://opds-spec.org/odl" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:thr="http://purl.org/syndication/thread/1.0" xmlns:app="http://www.w3.org/2007/app" xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/" schema:additionalType="http://schema.org/Audiobook">
+<title>Rise of the Dragons, Book 1</title>
+<id>http://www.feedbooks.com/item/3264308</id>
+<dcterms:identifier xsi:type="dcterms:URI">urn:ISBN:9781338331042</dcterms:identifier>
+<author>
+  <name>Angie Sage</name>
+  <uri>https://www.feedbooks.com/search?query=contributor%3A%22Angie+Sage%22</uri>
+</author>
+<published>2020-01-23T15:43:59Z</published>
+<updated>2020-01-23T15:48:46Z</updated>
+<dcterms:language>en</dcterms:language>
+<dcterms:publisher>Scholastic Inc. Audio</dcterms:publisher>
+<dcterms:issued>2019-07-31</dcterms:issued>
+<summary>Mega bestselling author Angie Sage takes flight with an epic adventure that imagines dragons in the modern world.
+
+Once our world was full of dragons who lived in harmony with humans. Dragons counseled kings and queens. They fought in human battle...</summary>
+<dcterms:extent>517 MB</dcterms:extent>
+<category scheme="http://www.feedbooks.com/categories" term="FBFIC000000" label="Fiction"/>
+<category scheme="http://www.feedbooks.com/categories" term="FBJUV000000" label="Juvenile &amp; Young Adult"/>
+<category scheme="http://www.feedbooks.com/categories" term="FBJUV037000" label="Fantasy, Magic"/>
+<schema:duration>1080</schema:duration>
+<schema:abridged>false</schema:abridged>
+<link type="text/html" title="View on Feedbooks" rel="alternate" href="https://www.feedbooks.com/item/3264308"/>
+<link type="image/jpeg" rel="http://opds-spec.org/image" href="http://covers.feedbooks.net/item/3264308.jpg?size=large&amp;t=1579794526"/>
+<link type="image/jpeg" rel="http://opds-spec.org/image/thumbnail" href="http://covers.feedbooks.net/item/3264308.jpg?size=large&amp;t=1579794526"/>
+<content type="html">&lt;p&gt;Mega bestselling author Angie Sage takes flight with an epic adventure that imagines dragons in the modern world.&lt;/p&gt;
+
+&lt;p&gt;Once our world was full of dragons who lived in harmony with humans. Dragons counseled kings and queens. They fought in human battles. And they gave humans the most precious gift of all: magic.&lt;/p&gt;
+
+&lt;p&gt;But after a group of rogue dragons, the Raptors, tried to take over Earth, all dragons were banished to another realm.&lt;/p&gt;
+
+&lt;p&gt;Most humans forgot about the dragons, claiming they never existed. Eleven-year-old Sirin knows the truth -- she grew up with stories passed down through the generations. However, when her mother falls ill, even Sirin has trouble believing in magic . . . until she sees a mysterious streak of silver in the night sky.&lt;/p&gt;
+
+&lt;p&gt;Sirin becomes the first child to "lock" with a dragon in centuries -- forming a deep friendship unlike anything she's ever imagined. But Sirin learns that not all dragons returned with good intentions, and soon she finds herself at the center of a battle between the dragons who want to protect the humans . . . and those who want to destroy them.&lt;/p&gt;</content>
+<odl:license>
+  <dcterms:identifier xsi:type="dcterms:URI">urn:uuid:01234567-890a-bcde-f012-3456789abcde</dcterms:identifier>
+  <dcterms:format>application/audiobook+json; protection=http://www.feedbooks.com/audiobooks/access-restriction</dcterms:format>
+  <dcterms:format>text/html</dcterms:format>
+  <dcterms:source>http://www.entrepotnumerique.com/</dcterms:source>
+  <opds:price currencycode="USD">74.99</opds:price>
+  <dcterms:source xsi:type="dcterms:URI">urn:ISBN:cant-2434138-24161087916422216-libraries</dcterms:source>
+  <created>2020-01-24T01:03:29+01:00</created>
+  <odl:terms>
+    <odl:total_checkouts>15</odl:total_checkouts>
+    <odl:concurrent_checkouts>5</odl:concurrent_checkouts>
+    <odl:maximum_checkout_length>5097600</odl:maximum_checkout_length>
+  </odl:terms>
+  <odl:tlink type="application/vnd.readium.lcp.status.1-0+json" href="https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url}" rel="http://opds-spec.org/acquisition/borrow"/>
+</odl:license>
 </entry>
 </feed>

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -19,11 +19,13 @@ from core.model import (
     Credential,
     DataSource,
     DeliveryMechanism,
+    Edition,
     ExternalIntegration,
     Hold,
     Hyperlink,
     Identifier,
     Loan,
+    MediaTypes,
     Representation,
     RightsStatus,
     get_one,
@@ -477,7 +479,8 @@ class TestODLAPI(DatabaseTest, BaseODLTest):
 
         eq_(0, self._db.query(Loan).count())
 
-    def test_fulfill_success(self):
+    def test_fulfill_success_license(self):
+        # Fulfill a loan in a way that gives access to a license file.
         loan, ignore = self.license.loan_to(self.patron)
         loan.external_identifier = self._str
         loan.end = datetime.datetime.utcnow() + datetime.timedelta(days=3)
@@ -489,7 +492,7 @@ class TestODLAPI(DatabaseTest, BaseODLTest):
             },
             "links": [{
                 "rel": "license",
-                "href": "http://license",
+                "href": "http://acsm",
                 "type": DeliveryMechanism.ADOBE_DRM,
             }],
         })
@@ -501,8 +504,40 @@ class TestODLAPI(DatabaseTest, BaseODLTest):
         eq_(self.pool.identifier.type, fulfillment.identifier_type)
         eq_(self.pool.identifier.identifier, fulfillment.identifier)
         eq_(datetime.datetime(2017, 10, 21, 11, 12, 13), fulfillment.content_expires)
-        eq_("http://license", fulfillment.content_link)
+        eq_("http://acsm", fulfillment.content_link)
         eq_(DeliveryMechanism.ADOBE_DRM, fulfillment.content_type)
+
+    def test_fulfill_success_manifest(self):
+        # Fulfill a loan in a way that gives access to a manifest
+        # file.
+        loan, ignore = self.license.loan_to(self.patron)
+        loan.external_identifier = self._str
+        loan.end = datetime.datetime.utcnow() + datetime.timedelta(days=3)
+
+        audiobook = MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE
+
+        lsd = json.dumps({
+            "status": "ready",
+            "potential_rights": {
+                "end": "2017-10-21T11:12:13Z"
+            },
+            "links": [{
+                "rel": "manifest",
+                "href": "http://manifest",
+                "type": audiobook,
+            }],
+        })
+
+        self.api.queue_response(200, content=lsd)
+        fulfillment = self.api.fulfill(self.patron, "pin", self.pool, audiobook)
+        eq_(self.collection, fulfillment.collection(self._db))
+        eq_(self.pool.data_source.name, fulfillment.data_source_name)
+        eq_(self.pool.identifier.type, fulfillment.identifier_type)
+        eq_(self.pool.identifier.identifier, fulfillment.identifier)
+        eq_(datetime.datetime(2017, 10, 21, 11, 12, 13), fulfillment.content_expires)
+        eq_("http://manifest", fulfillment.content_link)
+        eq_(audiobook, fulfillment.content_type)
+
 
     def test_fulfill_cannot_fulfill(self):
         self.pool.licenses_owned = 7
@@ -1177,7 +1212,7 @@ class TestODLAPI(DatabaseTest, BaseODLTest):
             },
             "links": [{
                 "rel": "license",
-                "href": "http://license",
+                "href": "http://acsm",
                 "type": DeliveryMechanism.ADOBE_DRM,
             }],
         })
@@ -1189,7 +1224,7 @@ class TestODLAPI(DatabaseTest, BaseODLTest):
         eq_(self.pool.identifier.type, fulfillment.identifier_type)
         eq_(self.pool.identifier.identifier, fulfillment.identifier)
         eq_(datetime.datetime(2017, 10, 21, 11, 12, 13), fulfillment.content_expires)
-        eq_("http://license", fulfillment.content_link)
+        eq_("http://acsm", fulfillment.content_link)
         eq_(DeliveryMechanism.ADOBE_DRM, fulfillment.content_type)
 
     def test_release_hold_from_external_library(self):
@@ -1274,22 +1309,22 @@ class TestODLImporter(DatabaseTest, BaseODLTest):
         eq_(6, len(imported_pools))
         eq_(6, len(imported_works))
 
-        [canadianity, everglades, poetry, warrior, blazing, midnight,] = sorted(imported_editions, key=lambda x: x.title)
+        [canadianity, everglades, dragons, warrior, blazing, midnight,] = sorted(imported_editions, key=lambda x: x.title)
         eq_("The Blazing World", blazing.title)
         eq_("Sun Warrior", warrior.title)
         eq_("Canadianity", canadianity.title)
         eq_("The Midnight Dance", midnight.title)
         eq_("Everglades Wildguide", everglades.title)
-        eq_("Short Poetry Collection 087", poetry.title)
+        eq_("Rise of the Dragons, Book 1", dragons.title)
 
-        # This book is open access and has no 'odl:license' tag.
+        # This book is open access and has no applicable DRM
         [blazing_pool] = [p for p in imported_pools if p.identifier == blazing.primary_identifier]
         eq_(True, blazing_pool.open_access)
         [lpdm] = blazing_pool.delivery_mechanisms
         eq_(Representation.EPUB_MEDIA_TYPE, lpdm.delivery_mechanism.content_type)
         eq_(DeliveryMechanism.NO_DRM, lpdm.delivery_mechanism.drm_scheme)
 
-        # This book has a single 'odl:license' tag.
+        # # This book has a single 'odl:license' tag.
         [warrior_pool] = [p for p in imported_pools if p.identifier == warrior.primary_identifier]
         eq_(False, warrior_pool.open_access)
         [lpdm] = warrior_pool.delivery_mechanisms
@@ -1308,18 +1343,25 @@ class TestODLImporter(DatabaseTest, BaseODLTest):
         eq_(None, license.remaining_checkouts)
         eq_(1, license.concurrent_checkouts)
 
-        # This item is open access audiobook.
+        # This item is an open access audiobook.
         [everglades_pool] = [p for p in imported_pools if p.identifier == everglades.primary_identifier]
         eq_(True, everglades_pool.open_access)
         [lpdm] = everglades_pool.delivery_mechanisms
+        eq_(Edition.AUDIO_MEDIUM, everglades_pool.presentation_edition.medium)
 
         eq_(Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE, lpdm.delivery_mechanism.content_type)
         eq_(DeliveryMechanism.NO_DRM, lpdm.delivery_mechanism.drm_scheme)
 
-        # This is not an open access audiobook and the drm scheme is found in the `odl:protection` tag
-        [poetry_pool] = [p for p in imported_pools if p.identifier == poetry.primary_identifier]
-        eq_(False, poetry_pool.open_access)
-        [lpdm] = poetry_pool.delivery_mechanisms
+        # This is a non-open access audiobook. There is no
+        # <odl:protection> tag; the drm_scheme is implied by the value
+        # of <dcterms:format>.
+        [dragons_pool] = [
+            p for p in imported_pools
+            if p.identifier == dragons.primary_identifier
+        ]
+        eq_(Edition.AUDIO_MEDIUM, dragons_pool.presentation_edition.medium)
+        eq_(False, dragons_pool.open_access)
+        [lpdm] = dragons_pool.delivery_mechanisms
 
         eq_(Representation.AUDIOBOOK_MANIFEST_MEDIA_TYPE, lpdm.delivery_mechanism.content_type)
         eq_(DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM, lpdm.delivery_mechanism.drm_scheme)


### PR DESCRIPTION
This branch makes some tweaks to ODL import and fulfillment to support audiobooks protected with the Feedbooks access-control scheme, because the representation of such audiobooks has changed slightly, The behavior is unchanged for other formats or DRM schemes. These changes were validated on a live integration.

This fixes https://jira.nypl.org/browse/SIMPLY-2526.