### PR TITLE
Eliminate the status link hack.

### DIFF
--- a/api/odl.py
+++ b/api/odl.py
@@ -863,8 +863,9 @@ class ODLImporter(OPDSImporter):
             for link_tag in parser._xpath(odl_license_tag, 'atom:link') or []:
                 attrib = link_tag.attrib
                 rel = attrib.get("rel")
-                type = attrib.get("type")
-                if rel == 'self' and type == cls.LICENSE_INFO_DOCUMENT_MEDIA_TYPE:
+                type = attrib.get("type", "")
+                if (rel == 'self'
+                    and type.startswith(cls.LICENSE_INFO_DOCUMENT_MEDIA_TYPE)):
                     odl_status_link = attrib.get("href")
                     break
 

--- a/api/odl.py
+++ b/api/odl.py
@@ -788,6 +788,10 @@ class ODLImporter(OPDSImporter):
     NAME = ODLAPI.NAME
     PARSER_CLASS = ODLXMLParser
 
+    # The media type for an ODL Info document, used to get information
+    # about the license.
+    ODL_INFO_MEDIA_TYPE = 'application/vnd.odl.info+json'
+
     @classmethod
     def _detail_for_elementtree_entry(cls, parser, entry_tag, feed_url=None, do_get=None):
         do_get = do_get or Representation.cautious_http_get
@@ -854,19 +858,17 @@ class ODLImporter(OPDSImporter):
                     checkout_link = link_tag.attrib.get("href")
                     break
 
+            # Look for a link to the ODL status document for this license.
             odl_status_link = None
             for link_tag in parser._xpath(odl_license_tag, 'atom:link') or []:
-                rel = link_tag.attrib.get("rel")
-                if rel == "self":
-                    odl_status_link = link_tag.attrib.get("href")
+                attrib = link_tag.attrib
+                rel = attrib.get("rel")
+                type = attrib.get("type")
+                if rel == 'self' and type == cls.ODL_INFO_MEDIA_TYPE:
+                    odl_status_link = attrib.get("href")
                     break
-            if not odl_status_link:
-                # TODO: This is a hack necessary because Feedbooks
-                # doesn't provide the status link yet. Once that's fixed,
-                # this link will be present with rel="self", just like
-                # in the unit tests.
-                odl_status_link = "https://license.feedbooks.net/copy/status/?uuid=" + identifier.replace("urn:uuid:", "")
 
+            # If we found one, retrieve it and get licensing information about this book.
             if odl_status_link:
                 ignore, ignore, response = do_get(odl_status_link, headers={})
                 status = json.loads(response)

--- a/api/odl.py
+++ b/api/odl.py
@@ -788,9 +788,9 @@ class ODLImporter(OPDSImporter):
     NAME = ODLAPI.NAME
     PARSER_CLASS = ODLXMLParser
 
-    # The media type for an ODL Info document, used to get information
+    # The media type for a License Info Docuemnt, used to get information
     # about the license.
-    ODL_INFO_MEDIA_TYPE = 'application/vnd.odl.info+json'
+    LICENSE_INFO_DOCUMENT_MEDIA_TYPE = 'application/vnd.odl.info+json'
 
     @classmethod
     def _detail_for_elementtree_entry(cls, parser, entry_tag, feed_url=None, do_get=None):
@@ -858,13 +858,13 @@ class ODLImporter(OPDSImporter):
                     checkout_link = link_tag.attrib.get("href")
                     break
 
-            # Look for a link to the ODL status document for this license.
+            # Look for a link to the License Info Document for this license.
             odl_status_link = None
             for link_tag in parser._xpath(odl_license_tag, 'atom:link') or []:
                 attrib = link_tag.attrib
                 rel = attrib.get("rel")
                 type = attrib.get("type")
-                if rel == 'self' and type == cls.ODL_INFO_MEDIA_TYPE:
+                if rel == 'self' and type == cls.LICENSE_INFO_DOCUMENT_MEDIA_TYPE:
                     odl_status_link = attrib.get("href")
                     break
 

--- a/tests/files/odl/feedbooks_bibliographic.atom
+++ b/tests/files/odl/feedbooks_bibliographic.atom
@@ -81,7 +81,7 @@
     <odl:tts>false</odl:tts>
   </odl:protection>
   <odl:tlink type="application/vnd.readium.lcp.status.1-0+json" href="https://loan.feedbooks.net/loan/get/{?id,checkout_id,expires,patron_id,notification_url}" rel="http://opds-spec.org/acquisition/borrow"/>
-  <link type="application/vnd.odl.status.1-0+json" href="https://license.feedbooks.net/license/status/?uuid=1" rel="self"/>
+  <link type="application/vnd.odl.info+json" href="https://license.feedbooks.net/license/status/?uuid=1" rel="self"/>
 </odl:license>
 </entry>
 <entry>
@@ -138,7 +138,7 @@
     <odl:tts>false</odl:tts>
   </odl:protection>
   <odl:tlink type="application/vnd.readium.lcp.status.1-0+json" href="https://loan.feedbooks.net/loan/get/{?id,checkout_id,expires,patron_id,notification_url}" rel="http://opds-spec.org/acquisition/borrow"/>
-  <link type="application/vnd.odl.status.1-0+json" href="https://license.feedbooks.net/license/status/?uuid=2" rel="self"/>
+  <link type="application/vnd.odl.info+json" href="https://license.feedbooks.net/license/status/?uuid=2" rel="self"/>
 </odl:license>
 <odl:license>
   <dcterms:identifier xsi:type="dcterms:URI">3</dcterms:identifier>
@@ -159,7 +159,7 @@
     <odl:tts>false</odl:tts>
   </odl:protection>
   <odl:tlink type="application/vnd.readium.lcp.status.1-0+json" href="https://loan.feedbooks.net/loan/get/{?id,checkout_id,expires,patron_id,notification_url}" rel="http://opds-spec.org/acquisition/borrow"/>
-  <link type="application/vnd.odl.status.1-0+json" href="https://license.feedbooks.net/license/status/?uuid=3" rel="self"/>
+  <link type="application/vnd.odl.info+json" href="https://license.feedbooks.net/license/status/?uuid=3" rel="self"/>
 </odl:license>
 </entry>
 <entry>
@@ -207,7 +207,7 @@
     <odl:tts>false</odl:tts>
   </odl:protection>
   <odl:tlink type="application/vnd.readium.lcp.status.1-0+json" href="https://loan.feedbooks.net/loan/get/{?id,checkout_id,expires,patron_id,notification_url}" rel="http://opds-spec.org/acquisition/borrow"/>
-  <link type="application/vnd.odl.status.1-0+json" href="https://license.feedbooks.net/license/status/?uuid=4" rel="self"/>
+  <link type="application/vnd.odl.info+json" href="https://license.feedbooks.net/license/status/?uuid=4" rel="self"/>
 </odl:license>
 <odl:license>
   <dcterms:identifier xsi:type="dcterms:URI">5</dcterms:identifier>
@@ -229,7 +229,7 @@
     <odl:tts>false</odl:tts>
   </odl:protection>
   <odl:tlink type="application/vnd.readium.lcp.status.1-0+json" href="https://loan.feedbooks.net/loan/get/{?id,checkout_id,expires,patron_id,notification_url}" rel="http://opds-spec.org/acquisition/borrow"/>
-  <link type="application/vnd.odl.status.1-0+json" href="https://license.feedbooks.net/license/status/?uuid=5" rel="self"/>
+  <link type="application/vnd.odl.info+json" href="https://license.feedbooks.net/license/status/?uuid=5" rel="self"/>
 </odl:license>
 </entry>
 <entry>
@@ -302,6 +302,7 @@ Once our world was full of dragons who lived in harmony with humans. Dragons cou
     <odl:maximum_checkout_length>5097600</odl:maximum_checkout_length>
   </odl:terms>
   <odl:tlink type="application/vnd.readium.lcp.status.1-0+json" href="https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url}" rel="http://opds-spec.org/acquisition/borrow"/>
+  <link type="application/vnd.odl.info+json" href="https://license.feedbooks.net/copy/status/?uuid=5" rel="self"/>
 </odl:license>
 </entry>
 </feed>


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2533 and updates the sample ODL to be in sync with what the Feedbooks ODL server now serves. Specifically, the media type of the License Info Document has been finalized, and we now check for a link of that type, not just any link with rel="self".

The only changes to the tests are changes in the data, which trigger the modified code paths. The audiobook ("Rise of the Dragons, Part 1") gets a brand new License Info Document link. Previously, it didn't have that link, and relied on the now-removed hack. The other books have the media type of their License Info Document links corrected; otherwise the new code will think they're of the wrong type and ignore them.