### PR TITLE
Add ability to ignore SIP2 patron status block

### DIFF
--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -145,9 +145,9 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         self.client = client
         patron_status_block = integration.setting(self.PATRON_STATUS_BLOCK).json_value
         if patron_status_block is None or patron_status_block:
-            self.patron_status_fields_that_deny_borrowing = SIPClient.PATRON_STATUS_FIELDS_THAT_DENY_BORROWING_PRIVILEGES
+            self.fields_that_deny_borrowing = SIPClient.PATRON_STATUS_FIELDS_THAT_DENY_BORROWING_PRIVILEGES
         else:
-            self.patron_status_fields_that_deny_borrowing = []
+            self.fields_that_deny_borrowing = []
 
     def patron_information(self, username, password):
         try:
@@ -177,7 +177,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         info = self.patron_information(
             patron_or_patrondata.authorization_identifier, None
         )
-        return self.info_to_patrondata(info, False, fields_deny_borrowing=self.patron_status_fields_that_deny_borrowing)
+        return self.info_to_patrondata(info, False, fields_deny_borrowing=self.fields_that_deny_borrowing)
 
     def remote_authenticate(self, username, password):
         """Authenticate a patron with the SIP2 server.
@@ -191,7 +191,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             # passing it on.
             password = None
         info = self.patron_information(username, password)
-        return self.info_to_patrondata(info, fields_deny_borrowing=self.patron_status_fields_that_deny_borrowing)
+        return self.info_to_patrondata(info, fields_deny_borrowing=self.fields_that_deny_borrowing)
 
     def _run_self_tests(self, _db):
         def makeConnection(sip):

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -360,7 +360,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
 
         # Test with blocked patron, block should be set
         info = client.patron_information_parser(TestSIP2AuthenticationProvider.evergreen_expired_card)
-        patron = provider.info_to_patrondata(info, patron_blocks=True)
+        patron = provider.info_to_patrondata(info)
         eq_(patron.__class__, PatronData)
         eq_("12345", patron.authorization_identifier)
         eq_("863716", patron.permanent_id)
@@ -371,7 +371,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
 
         # Test with blocked patron, block should not be set
         info = client.patron_information_parser(TestSIP2AuthenticationProvider.evergreen_expired_card)
-        patron = provider.info_to_patrondata(info, patron_blocks=False)
+        patron = provider.info_to_patrondata(info, fields_deny_borrowing=[])
         eq_(patron.__class__, PatronData)
         eq_("12345", patron.authorization_identifier)
         eq_("863716", patron.permanent_id)


### PR DESCRIPTION
In some cases the library may want to ignore the patron status block message sent from the ILS and let the patron borrow anyway. This adds an optional setting that allows the configuration of:
 - the current blocking behaviour
 - not set the block based on the patron status message. 

I would have liked to make this more configurable, I was envisioning a set of check boxes where you could toggle each patron block reason, but this would require some UI changes in circulation-web which I wasn't comfortable with. This setting meets the use case of the hosting client I'm working with at LYRASIS, so I'm hoping this is a good improvement for now. 

Tagging @leonardr  