### PR TITLE
Make sure admins don't have spaces after email address

### DIFF
--- a/api/admin/controller/individual_admin_settings.py
+++ b/api/admin/controller/individual_admin_settings.py
@@ -48,6 +48,9 @@ class IndividualAdminSettingsController(SettingsController):
         if error:
             return error
 
+        # Strip whitespace from email
+        email = email.strip()
+
         # If there are no admins yet, anyone can create the first system admin.
         settingUp = (self._db.query(Admin).count() == 0)
         if settingUp and not flask.request.form.get("password"):


### PR DESCRIPTION
One of our hosting clients reported an issue when they created a new admin user. The user could not be deleted through the UI and when showing its details it did not show any possible roles. In the logs we were seeing: 
```
{"name": "root", "level": "ERROR", "timestamp": "2020-02-25T21:14:05.539783", "app": "simplified", "traceback": "Traceback (most recent call last):
  File \"/circulation/env/lib/python2.7/site-packages/flask/app.py\", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File \"/circulation/env/lib/python2.7/site-packages/flask/app.py\", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File \"/circulation/api/admin/routes.py\", line 101, in decorated
    v = f(*args, **kwargs)
  File \"/circulation/api/admin/routes.py\", line 80, in decorated
    return f(*args, **kwargs)
  File \"/circulation/api/admin/routes.py\", line 95, in decorated
    return f(*args, **kwargs)
  File \"/circulation/api/admin/routes.py\", line 373, in individual_admin
    return app.manager.admin_individual_admin_settings_controller.process_delete(email)
  File \"/Users/jgreen/projects/libsimple/circulation/api/admin/controller/individual_admin_settings.py\", line 237, in process_delete
    if admin.is_system_admin():
AttributeError: 'NoneType' object has no attribute 'is_system_admin'", "message": "Exception in web app: 'NoneType' object has no attribute 'is_system_admin'", "filename": "app_server.py"}
```

Turns out you can create a user with a space after the email, but this space isn't used when querying for the user in the future, so you cannot modify or delete them through the UI.

Tagging: @leonardr 