### PR TITLE
Use the new, more sophisticated Representation caching system when sending requests to the NoveList API.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -714,8 +714,8 @@ class OPDSFeedController(CirculationManagerController):
         if isinstance(lane, ProblemDetail):
             return lane
 
-        if not lane.sublanes:
-            # This lane has no sublanes. Although we can technically
+        if not lane.children:
+            # This lane has no children. Although we can technically
             # create a grouped feed, it would be an unsatisfying
             # gateway to a paginated feed. We should just serve the
             # paginated feed.

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -303,9 +303,10 @@ class OdiloRepresentationExtractor(object):
         metadata.circulation = OdiloRepresentationExtractor.record_info_to_circulation(availability)
         # 'active' --> means that the book exists but it's no longer in the collection
         # (it could be available again in the future)
-        if not active:
-            metadata.circulation.licenses_owned = 0
-        metadata.circulation.formats = formats
+        if metadata.circulation:
+            if not active:
+                metadata.circulation.licenses_owned = 0
+            metadata.circulation.formats = formats
 
         return metadata, active
 

--- a/api/odilo.py
+++ b/api/odilo.py
@@ -191,8 +191,8 @@ class OdiloRepresentationExtractor(object):
 
         title = book.get('title')
         subtitle = book.get('subtitle')
-        series = book.get('series')
-        series_position = book.get('seriesPosition')
+        series = book.get('series').strip() or None
+        series_position = book.get('seriesPosition').strip() or None
 
         contributors = []
         sort_author = book.get('author')
@@ -478,7 +478,6 @@ class OdiloAPI(BaseCirculationAPI, HasSelfTests):
             data = response.json()
         except ValueError:
             raise generic_exception
-
         if response.status_code == 200:
             self._update_credential(credential, data)
             self.token = credential.credential
@@ -515,6 +514,9 @@ class OdiloAPI(BaseCirculationAPI, HasSelfTests):
             method, url, headers=headers, data=data,
             timeout=60
         )
+
+        # TODO: If Odilo doesn't recognize the patron it will send
+        # 404 in this case.
         if response.status_code == 401:
             if exception_on_401:
                 # This is our second try. Give up.

--- a/tests/test_novelist.py
+++ b/tests/test_novelist.py
@@ -192,7 +192,7 @@ class TestNoveListAPI(DatabaseTest):
         # Test the lookup() method.
         h = DummyHTTPClient()
         h.queue_response(200, "text/html", content="yay")
-        
+
         class Mock(NoveListAPI):
             def build_query_url(self, params):
                 self.build_query_url_called_with = params
@@ -509,7 +509,7 @@ class TestNoveListAPI(DatabaseTest):
             self.novelist.create_item_object(book1_narrator_from_query, currentIdentifier, existingItem)
         )
         eq_(currentIdentifier, book1_narrator_from_query[2])
-        eq_(existingItem, 
+        eq_(existingItem,
             {"isbn": "23456",
             "mediaType": "EBook",
             "title": "Title 1",

--- a/tests/test_odilo.py
+++ b/tests/test_odilo.py
@@ -800,6 +800,20 @@ class TestOdiloRepresentationExtractor(OdiloAPITest):
 
         self.api.log.info('Testing book info with metadata finished ok !!')
 
+    def test_book_info_missing_metadata(self):
+        # Verify that we properly handle missing metadata from Odilo.
+        raw, book_json = self.sample_json("odilo_metadata.json")
+
+        # This was seen in real data.
+        book_json['series'] = ' '
+        book_json['seriesPosition'] = ' '
+
+        metadata, active = OdiloRepresentationExtractor.record_info_to_metadata(
+            book_json, {}
+        )
+        eq_(None, metadata.series)
+        eq_(None, metadata.series_position)
+
     def test_default_language_spanish(self):
         """Since Odilo primarily distributes Spanish-language titles, if a
         title comes in with no specified language, we assume it's


### PR DESCRIPTION
This branch should complete https://jira.nypl.org/browse/SIMPLY-2532. It also includes a couple very small unrelated fixes I made while investigating a couple other problems.

The NoveListAPI no longer has its own rules for checking the `representations` table for cached representations. Instead, it uses the standard `Representation.post` method, but passes in different versions of the URL for making the actual HTTP request, versus for caching the Representation in the database.

I ran my "five people simultaneously trying to get the same feed" script and got no more errors.