### PR TITLE
OPDSFeedController.navigation should create a NavigationFacets object for its navigation feed, not a FeaturedFacets.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -83,6 +83,7 @@ from core.model import (
 )
 from core.opds import (
     AcquisitionFeed,
+    NavigationFacets,
     NavigationFeed,
 )
 from core.util.opds_writer import (
@@ -800,7 +801,7 @@ class OPDSFeedController(CirculationManagerController):
             minimum_featured_quality=library.minimum_featured_quality,
         )
         facets = load_facets_from_request(
-            worklist=lane, base_class=FeaturedFacets,
+            worklist=lane, base_class=NavigationFacets,
             base_class_constructor_kwargs=facet_class_kwargs
         )
         annotator = self.manager.annotator(lane, facets)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -150,6 +150,7 @@ import base64
 import feedparser
 from core.opds import (
     AcquisitionFeed,
+    NavigationFacets,
     NavigationFeed,
 )
 from core.util.opds_writer import (
@@ -3273,13 +3274,11 @@ class TestOPDSFeedController(CirculationControllerTest):
             # sublanes for English, Spanish, Chinese, and French.
             eq_(len(lane.sublanes), len(entries))
 
-        # A FeaturedFacets object was created from a combination of
-        # library configuration and lane configuration, and passed in
-        # to NavigationFeed.navigation().
+        # A NavigationFacets object was created and passed in to
+        # NavigationFeed.navigation().
         args, kwargs = self.called_with
         facets = kwargs['facets']
-        assert isinstance(facets, FeaturedFacets)
-        eq_(library.minimum_featured_quality, facets.minimum_featured_quality)
+        assert isinstance(facets, NavigationFacets)
         NavigationFeed.navigation = old_navigation
 
     def _set_update_times(self):


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2622.

Here's the piece not tested here: https://github.com/NYPL-Simplified/server_core/blob/a8cee796a7c6ba09b459a9b6ef99a7ecc8e7a4a3/tests/test_opds.py#L2271

NavigationFacets gives any CachedFeed generated using it the "navigation" type.