### PR TITLE
Mention NoveList in the _other_ NoveList feed

### DIFF
--- a/api/lanes.py
+++ b/api/lanes.py
@@ -857,7 +857,7 @@ class WorkBasedLane(DynamicLane):
 class RecommendationLane(WorkBasedLane):
     """A lane of recommended Works based on a particular Work"""
 
-    DISPLAY_NAME = "Recommended Books"
+    DISPLAY_NAME = "Titles recommended by NoveList"
     ROUTE = "recommendations"
 
     # Cache for 24 hours -- would ideally be much longer but availability

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2472,7 +2472,7 @@ class TestWorkController(CirculationControllerTest):
         # ExternalSearchIndex.
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
-        eq_('Recommended Books', feed['feed']['title'])
+        eq_('Titles recommended by NoveList', feed['feed']['title'])
         [entry] = feed.entries
         eq_(self.english_1.title, entry['title'])
         author = self.edition.author_contributors[0]
@@ -2496,7 +2496,7 @@ class TestWorkController(CirculationControllerTest):
 
         kwargs = Mock.called_with
         eq_(self._db, kwargs.pop('_db'))
-        eq_('Recommended Books', kwargs.pop('title'))
+        eq_('Titles recommended by NoveList', kwargs.pop('title'))
 
         # The RecommendationLane is set up to ask for recommendations
         # for this book.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2472,7 +2472,7 @@ class TestWorkController(CirculationControllerTest):
         # ExternalSearchIndex.
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
-        eq_('Titles recommended by NoveList', feed['feed']['title'])
+        eq_('Recommended Books', feed['feed']['title'])
         [entry] = feed.entries
         eq_(self.english_1.title, entry['title'])
         author = self.edition.author_contributors[0]

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2472,7 +2472,7 @@ class TestWorkController(CirculationControllerTest):
         # ExternalSearchIndex.
         eq_(200, response.status_code)
         feed = feedparser.parse(response.data)
-        eq_('Recommended Books', feed['feed']['title'])
+        eq_('Titles recommended by NoveList', feed['feed']['title'])
         [entry] = feed.entries
         eq_(self.english_1.title, entry['title'])
         author = self.edition.author_contributors[0]


### PR DESCRIPTION
Follow-up for https://jira.nypl.org/browse/SIMPLY-1483. For the grouped feed containing different types of recommendations, my earlier branch changed one of the group names to mention NoveList. That's what SimplyE shows, so we're basically covered. But it's also possible to get a feed that _only_ contains NoveList recommendations, and the title of that feed should also mention NoveList, even though I don't think SimplyE ever shows it -- another client might.
