### PR TITLE
Avoid a situation where Elasticsearch is told to look for audience=None

### DIFF
--- a/api/lanes.py
+++ b/api/lanes.py
@@ -955,7 +955,7 @@ class SeriesLane(DynamicLane):
         self.series = series_name
         if parent:
             parent.append_child(self)
-            if isinstance(parent, WorkBasedLane):
+            if isinstance(parent, WorkBasedLane) and parent.source_audience:
                 # WorkBasedLane forces self.audiences to values
                 # compatible with the work in the WorkBasedLane, but
                 # that's not enough for us. We want to force

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -642,6 +642,15 @@ class TestSeriesLane(LaneTest):
         eq_([work_based_lane.source_audience], child.audiences)
         eq_(work_based_lane.languages, child.languages)
 
+        # If for some reason there's no audience for the work used as
+        # a basis for the parent lane, the parent lane's audience
+        # filter is used as a basis for the child lane's audience filter.
+        work_based_lane.source_audience = None
+        child = SeriesLane(
+            self._default_library, "No Audience", parent=work_based_lane
+        )
+        eq_(work_based_lane.audiences, child.audiences)
+
     def test_modify_search_filter_hook(self):
         lane = SeriesLane(self._default_library, "So That Happened")
         filter = Filter()


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2644.