### PR TITLE
Specific limit numbers

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -769,7 +769,7 @@ class CirculationAPI(object):
             # This patron can neither take out a loan or place a hold.
             # Raise PatronLoanLimitReached for the most understandable
             # error message.
-            raise PatronLoanLimitReached()
+            raise PatronLoanLimitReached(library=patron.library)
 
         # At this point it's important that we get up-to-date
         # availability information about this LicensePool, to reduce
@@ -780,9 +780,9 @@ class CirculationAPI(object):
 
         currently_available = pool.licenses_available > 0
         if currently_available and at_loan_limit:
-             raise PatronLoanLimitReached()
+             raise PatronLoanLimitReached(library=patron.library)
         if not currently_available and at_hold_limit:
-            raise PatronHoldLimitReached()
+            raise PatronHoldLimitReached(library=patron.library)
 
     def patron_at_loan_limit(self, patron):
         """Is the given patron at their loan limit?

--- a/api/circulation_exceptions.py
+++ b/api/circulation_exceptions.py
@@ -122,16 +122,20 @@ class LimitReached(CirculationException):
     SETTING_NAME = None
     MESSAGE_WITH_LIMIT = None
 
-    def as_problem_detail_document(self, debug=False, library=None):
+    def __init__(self, message=None, debug_info=None, library=None):
+        super(LimitReached, self).__init__(message=message, debug_info=debug_info)
+        if library:
+            self.limit = library.setting(self.SETTING_NAME).int_value
+        else:
+            self.limit = None
+
+    def as_problem_detail_document(self, debug=False):
         """Return a suitable problem detail document."""
         doc = self.BASE_DOC
-        if not library:
+        if not self.limit:
             return doc
-        limit = library.setting(self.SETTING_NAME).int_value
-        if limit:
-            detail = self.MESSAGE_WITH_LIMIT % dict(limit=limit)
-            return doc.detailed(detail=detail)
-        return doc
+        detail = self.MESSAGE_WITH_LIMIT % dict(limit=self.limit)
+        return doc.detailed(detail=detail)
 
 class PatronLoanLimitReached(CannotLoan, LimitReached):
     BASE_DOC = LOAN_LIMIT_REACHED

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -66,7 +66,7 @@ ALREADY_CHECKED_OUT = pd(
 )
 
 GENERIC_LOAN_LIMIT_MESSAGE = _("You have reached your loan limit. You cannot borrow anything further until you return something.")
-SPECIFIC_LOAN_LIMIT_MESSAGE = _("You have reached your loan limit of %(limit)d items. You cannot borrow anything further until you return something.")
+SPECIFIC_LOAN_LIMIT_MESSAGE = _("You have reached your loan limit of %(limit)d. You cannot borrow anything further until you return something.")
 LOAN_LIMIT_REACHED = pd(
       "http://librarysimplified.org/terms/problem/loan-limit-reached",
       403,
@@ -75,7 +75,7 @@ LOAN_LIMIT_REACHED = pd(
 )
 
 GENERIC_HOLD_LIMIT_MESSAGE = _("You have reached your hold limit. You cannot place another item on hold until you borrow something or remove a hold.")
-SPECIFIC_HOLD_LIMIT_MESSAGE = _("You have reached your hold limit of %(limit)d items. You cannot place another item on hold until you borrow something or remove a hold.")
+SPECIFIC_HOLD_LIMIT_MESSAGE = _("You have reached your hold limit of %(limit)d. You cannot place another item on hold until you borrow something or remove a hold.")
 HOLD_LIMIT_REACHED = pd(
       "http://librarysimplified.org/terms/problem/hold-limit-reached",
       403,

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -65,22 +65,22 @@ ALREADY_CHECKED_OUT = pd(
       _("You have already checked out this book."),
 )
 
-# TODO: This is only used in situations where the _ebook vendor_ has imposed a loan
-# limit. It should also be used in situations where the _library_ has imposed a loan
-# limit. That's tricky because it means keeping track of whether the patron's likely
-# intent was to borrow or place a hold.
+GENERIC_LOAN_LIMIT_MESSAGE = _("You have reached your loan limit. You cannot borrow anything further until you return something.")
+SPECIFIC_LOAN_LIMIT_MESSAGE = _("You have reached your loan limit of %(limit)d items. You cannot borrow anything further until you return something.")
 LOAN_LIMIT_REACHED = pd(
       "http://librarysimplified.org/terms/problem/loan-limit-reached",
       403,
       _("Loan limit reached."),
-      _("You have reached your loan limit. You cannot borrow anything further until you return something."),
+      GENERIC_LOAN_LIMIT_MESSAGE
 )
 
+GENERIC_HOLD_LIMIT_MESSAGE = _("You have reached your hold limit. You cannot place another item on hold until you borrow something or remove a hold.")
+SPECIFIC_HOLD_LIMIT_MESSAGE = _("You have reached your hold limit of %(limit)d items. You cannot place another item on hold until you borrow something or remove a hold.")
 HOLD_LIMIT_REACHED = pd(
       "http://librarysimplified.org/terms/problem/hold-limit-reached",
       403,
       _("Limit reached."),
-      _("You have reached your hold limit. You cannot place another item on hold until you borrow something or remove a hold."),
+      GENERIC_HOLD_LIMIT_MESSAGE
 )
 
 OUTSTANDING_FINES = pd(

--- a/tests/test_circulation_exceptions.py
+++ b/tests/test_circulation_exceptions.py
@@ -54,18 +54,22 @@ class TestLimitReached(DatabaseTest):
             MESSAGE_WITH_LIMIT = _("The limit was %(limit)d.")
 
         # No limit -> generic message.
-        ex = Mock()
-        library = self._default_library
-        pd = ex.as_problem_detail_document(library=library)
+        ex = Mock(library=self._default_library)
+        pd = ex.as_problem_detail_document()
+        eq_(None, ex.limit)
         eq_(generic_message, pd.detail)
 
         # Limit but no library -> generic message.
         self._default_library.setting(setting).value = 14
+        ex = Mock()
+        eq_(None, ex.limit)
         pd = ex.as_problem_detail_document()
         eq_(generic_message, pd.detail)
 
         # Limit and library -> specific message.
-        pd = ex.as_problem_detail_document(library=library)
+        ex = Mock(library=self._default_library)
+        eq_(14, ex.limit)
+        pd = ex.as_problem_detail_document()
         eq_("The limit was 14.", pd.detail)
 
     def test_subclasses(self):
@@ -74,11 +78,11 @@ class TestLimitReached(DatabaseTest):
         library = self._default_library
 
         library.setting(Configuration.LOAN_LIMIT).value = 2
-        pd = PatronLoanLimitReached().as_problem_detail_document(library=library)
+        pd = PatronLoanLimitReached(library=library).as_problem_detail_document()
         eq_("You have reached your loan limit of 2. You cannot borrow anything further until you return something.",
             pd.detail)
 
         library.setting(Configuration.HOLD_LIMIT).value = 3
-        pd = PatronHoldLimitReached().as_problem_detail_document(library=library)
+        pd = PatronHoldLimitReached(library=library).as_problem_detail_document()
         eq_("You have reached your hold limit of 3. You cannot place another item on hold until you borrow something or remove a hold.",
             pd.detail)

--- a/tests/test_circulation_exceptions.py
+++ b/tests/test_circulation_exceptions.py
@@ -1,9 +1,14 @@
+from flask_babel import lazy_gettext as _
 from nose.tools import (
     eq_,
     set_trace,
 )
+from core.util.problem_detail import ProblemDetail
+from api.config import Configuration
 from api.circulation_exceptions import *
 from api.problem_details import *
+from . import DatabaseTest
+
 
 class TestCirculationExceptions(object):
     def test_as_problem_detail_document(self):
@@ -26,3 +31,54 @@ class TestCirculationExceptions(object):
 
         e = NoLicenses()
         eq_(NO_LICENSES, e.as_problem_detail_document())
+
+
+class TestLimitReached(DatabaseTest):
+    """Test LimitReached, which may send different messages depending on the value of a
+    library ConfigurationSetting.
+    """
+
+    def test_as_problem_detail_document(self):
+        generic_message = _("You exceeded the limit, but I don't know what the limit was.")
+        pd = ProblemDetail(
+            "http://uri/",
+            403,
+            _("Limit exceeded."),
+            generic_message
+        )
+        setting = "some setting"
+
+        class Mock(LimitReached):
+            BASE_DOC = pd
+            SETTING_NAME = setting
+            MESSAGE_WITH_LIMIT = _("The limit was %(limit)d.")
+
+        # No limit -> generic message.
+        ex = Mock()
+        library = self._default_library
+        pd = ex.as_problem_detail_document(library=library)
+        eq_(generic_message, pd.detail)
+
+        # Limit but no library -> generic message.
+        self._default_library.setting(setting).value = 14
+        pd = ex.as_problem_detail_document()
+        eq_(generic_message, pd.detail)
+
+        # Limit and library -> specific message.
+        pd = ex.as_problem_detail_document(library=library)
+        eq_("The limit was 14.", pd.detail)
+
+    def test_subclasses(self):
+        # Use end-to-end tests to verify that the subclasses of
+        # LimitReached define the right constants.
+        library = self._default_library
+
+        library.setting(Configuration.LOAN_LIMIT).value = 2
+        pd = PatronLoanLimitReached().as_problem_detail_document(library=library)
+        eq_("You have reached your loan limit of 2. You cannot borrow anything further until you return something.",
+            pd.detail)
+
+        library.setting(Configuration.HOLD_LIMIT).value = 3
+        pd = PatronHoldLimitReached().as_problem_detail_document(library=library)
+        eq_("You have reached your hold limit of 3. You cannot place another item on hold until you borrow something or remove a hold.",
+            pd.detail)


### PR DESCRIPTION
This should be the last branch for https://jira.nypl.org/browse/SIMPLY-2657. When specific numbers are available for the exceeded loan and hold limits, those numbers are grabbed by the `PatronLoanLimitReached` and `PatronHoldLimitReached` constructors, and stored so that a more detailed error message can be used when the exception is converted to a problem detail document. This is the error message that (I hope) is displayed to patrons, and this will give patrons a better idea of what these limits actually are.