### PR TITLE
Add compressible to all route functions that only take GET and that return OPDS feeds or other potentially large documents.

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -18,6 +18,7 @@ from app import app, babel
 from config import Configuration
 from core.app_server import (
     ErrorHandler,
+    compressible,
     returns_problem_detail,
 )
 from core.model import ConfigurationSetting
@@ -208,17 +209,20 @@ def library_dir_route(path, *args, **kwargs):
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def index():
     return app.manager.index_controller()
 
 @library_route('/authentication_document')
 @has_library
 @returns_problem_detail
+@compressible
 def authentication_document():
     return app.manager.index_controller.authentication_document()
 
 @library_route('/public_key_document')
 @returns_problem_detail
+@compressible
 def public_key_document():
     return app.manager.index_controller.public_key_document()
 
@@ -227,6 +231,7 @@ def public_key_document():
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def acquisition_groups(lane_identifier):
     return app.manager.opds_feeds.groups(lane_identifier)
 
@@ -235,6 +240,7 @@ def acquisition_groups(lane_identifier):
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def feed(lane_identifier):
     return app.manager.opds_feeds.feed(lane_identifier)
 
@@ -243,6 +249,7 @@ def feed(lane_identifier):
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def navigation_feed(lane_identifier):
     return app.manager.opds_feeds.navigation(lane_identifier)
 
@@ -250,6 +257,7 @@ def navigation_feed(lane_identifier):
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def crawlable_library_feed():
     return app.manager.opds_feeds.crawlable_library_feed()
 
@@ -257,12 +265,14 @@ def crawlable_library_feed():
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def crawlable_list_feed(list_name):
     return app.manager.opds_feeds.crawlable_list_feed(list_name)
 
 @app.route('/collections/<collection_name>/crawlable')
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def crawlable_collection_feed(collection_name):
     return app.manager.opds_feeds.crawlable_collection_feed(collection_name)
 
@@ -313,6 +323,7 @@ def shared_collection_revoke_hold(collection_name, hold_id):
 @library_route('/marc')
 @has_library
 @returns_problem_detail
+@compressible
 def marc_page():
     return app.manager.marc_records.download_page()
 
@@ -321,6 +332,7 @@ def marc_page():
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def lane_search(lane_identifier):
     return app.manager.opds_feeds.search(lane_identifier)
 
@@ -337,6 +349,7 @@ def patron_profile():
 @allows_patron_web
 @requires_auth
 @returns_problem_detail
+@compressible
 def active_loans():
     return app.manager.loans.sync()
 
@@ -345,6 +358,7 @@ def active_loans():
 @allows_patron_web
 @requires_auth
 @returns_problem_detail
+@compressible
 def annotations():
     return app.manager.annotations.container()
 
@@ -353,6 +367,7 @@ def annotations():
 @allows_patron_web
 @requires_auth
 @returns_problem_detail
+@compressible
 def annotation_detail(annotation_id):
     return app.manager.annotations.detail(annotation_id)
 
@@ -361,6 +376,7 @@ def annotation_detail(annotation_id):
 @allows_patron_web
 @requires_auth
 @returns_problem_detail
+@compressible
 def annotations_for_work(identifier_type, identifier):
     return app.manager.annotations.container_for_work(identifier_type, identifier)
 
@@ -403,6 +419,7 @@ def loan_or_hold_detail(identifier_type, identifier):
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def work():
     return app.manager.urn_lookup.work_lookup('work')
 
@@ -412,6 +429,7 @@ def work():
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def contributor(contributor_name, languages, audiences):
     return app.manager.work_controller.contributor(contributor_name, languages, audiences)
 
@@ -421,6 +439,7 @@ def contributor(contributor_name, languages, audiences):
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def series(series_name, languages, audiences):
     return app.manager.work_controller.series(series_name, languages, audiences)
 
@@ -428,6 +447,7 @@ def series(series_name, languages, audiences):
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def permalink(identifier_type, identifier):
     return app.manager.work_controller.permalink(identifier_type, identifier)
 
@@ -435,6 +455,7 @@ def permalink(identifier_type, identifier):
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def recommendations(identifier_type, identifier):
     return app.manager.work_controller.recommendations(identifier_type, identifier)
 
@@ -442,6 +463,7 @@ def recommendations(identifier_type, identifier):
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@compressible
 def related_books(identifier_type, identifier):
     return app.manager.work_controller.related(identifier_type, identifier)
 


### PR DESCRIPTION
This branch adds the `compressible` annotator to a bunch of route functions. This enables transparent gzip encoding on the Content-Encoding level _if_ the client asks for it. Clients that don't ask for compression will still get uncompressed data. I don't see a way to test this as part of test_routes.py, but I've run spot checks on a local circ manager.

This addresses https://jira.nypl.org/browse/SIMPLY-2667.

Here's the rationale for which functions I annotated:

These functions return OPDS feeds, so making them compressible is a very good idea:

* index
* acquisition_groups
* navigation
* crawlable_library_feed
* crawlable_collection_feed
* crawlable_list_feed
* lane_search
* loans
* work
* contributor
* series
* permalink
* recommendations
* related_books

These functions can serve large non-OPDS documents that would benefit from `compressible`:

* annotations
* annotations_for_work

These functions don't really need `compressible` because they serve very small documents, but it doesn't hurt:

* public_key_document
* marc_page

I made these functions `compressible because they are _currently_ always small, but they might become bigger in the future:

* authentication_document
* annotation_detail

To be safe, I left some things alone even though they could potentially benefit from `compressible` and I don't think it would hurt to add it:

* All the shared ODL collection stuff.
* All the Adobe Vendor ID stuff -- this is supposed to implement a specific spec and compression is not part of the spec.
* Any route that takes a method other than GET or HEAD. `patron_profile` is the only one of these I see where `compressible` might be useful.