### PR TITLE
Handle PatronLoanLimitReached and PatronHoldLimitReached the same way.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1136,10 +1136,8 @@ class LoanController(CirculationManagerController):
             )
         except PatronAuthorizationFailedException, e:
             problem_doc = INVALID_CREDENTIALS
-        except PatronLoanLimitReached, e:
-            problem_doc = LOAN_LIMIT_REACHED.with_debug(unicode(e))
-        except PatronHoldLimitReached, e:
-            problem_doc = e.as_problem_detail_document()
+        except (PatronLoanLimitReached, PatronHoldLimitReached), e:
+            problem_doc = e.as_problem_detail_document().with_debug(unicode(e))
         except DeliveryMechanismError, e:
             return BAD_DELIVERY_MECHANISM.with_debug(
                 unicode(e), status_code=e.status_code


### PR DESCRIPTION
This branch fixes a small bug I discovered in the QA phase of https://jira.nypl.org/browse/SIMPLY-2657. For the "hold limit reached" error we were calling as_problem_detail properly, but for the "loan limit reached" error we were going off on our own and making our own problem detail document that didn't have the necessary context. I changed `borrow` to treat both exceptions the same way.

The right solution is to remove almost all of this code from `borrow` and just call `as_problem_detail` on any kind of exception we get here. This will put all the necessary logic in the exceptions (and whatever code raised the exceptions). It'll also simplify `borrow`, a method that's haphazardly tested. I started down this path and quickly discovered it was a lot more work than I want to do to fix a small bug like this. So I've just tested it locally against the QA server.