### PR TITLE
Send appropriate Cache-Control headers for all OPDS feeds

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -75,6 +75,7 @@ from core.util.http import HTTP
 from api.problem_details import *
 from api.admin.exceptions import *
 from core.util import LanguageCodes
+from core.util.flask_util import OPDSFeedResponse
 
 from api.config import (
     Configuration,
@@ -87,8 +88,6 @@ from api.admin.password_admin_authentication_provider import PasswordAdminAuthen
 from api.controller import CirculationManagerController
 from api.metadata_wrangler import MetadataWranglerCollectionRegistrar
 from core.app_server import (
-    entry_response,
-    feed_response,
     load_pagination_from_request,
 )
 from core.opds import AcquisitionFeed
@@ -669,7 +668,7 @@ class FeedController(AdminCirculationManagerController):
             url=this_url, annotator=annotator,
             pagination=pagination
         )
-        return feed_response(opds_feed, cache_for=0)
+        return OPDSFeedResponse(opds_feed, cache_for=0)
 
     def suppressed(self):
         self.require_librarian(flask.request.library)
@@ -684,7 +683,7 @@ class FeedController(AdminCirculationManagerController):
             url=this_url, annotator=annotator,
             pagination=pagination
         )
-        return feed_response(opds_feed, cache_for=0)
+        return OPDSFeedResponse(opds_feed, cache_for=0)
 
     def genres(self):
         data = dict({

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -683,7 +683,7 @@ class FeedController(AdminCirculationManagerController):
             url=this_url, annotator=annotator,
             pagination=pagination
         )
-        return OPDSFeedResponse(opds_feed, cache_for=0)
+        return OPDSFeedResponse(opds_feed, max_age=0)
 
     def genres(self):
         data = dict({
@@ -855,7 +855,7 @@ class CustomListsController(AdminCirculationManagerController):
             )
             annotator.annotate_feed(feed, worklist)
 
-            return feed_response(unicode(feed), cache_for=0)
+            return OPDSFeedResponse(unicode(feed), max_age=0)
 
         elif flask.request.method == "POST":
             name = flask.request.form.get("name")

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -668,7 +668,7 @@ class FeedController(AdminCirculationManagerController):
             url=this_url, annotator=annotator,
             pagination=pagination
         )
-        return OPDSFeedResponse(opds_feed, cache_for=0)
+        return OPDSFeedResponse(opds_feed, max_age=0)
 
     def suppressed(self):
         self.require_librarian(flask.request.library)

--- a/api/admin/controller/work_editor.py
+++ b/api/admin/controller/work_editor.py
@@ -69,6 +69,8 @@ class WorkController(AdminCirculationManagerController):
         """Return an OPDS entry with detailed information for admins.
 
         This includes relevant links for editing the book.
+
+        :return: An OPDSEntryResponse
         """
         self.require_librarian(flask.request.library)
 
@@ -77,11 +79,11 @@ class WorkController(AdminCirculationManagerController):
             return work
 
         annotator = AdminAnnotator(self.circulation, flask.request.library)
-        # Don't cache these OPDS entries - they should update immediately
-        # in the admin interface when an admin makes a change.
-        return AcquisitionFeed.single_entry(
-            self._db, work, annotator, max_age=0
-        )
+
+        # single_entry returns an OPDSEntryResponse that will not be
+        # cached, which is perfect. We want the admin interface
+        # to update immediately when an admin makes a change.
+        return AcquisitionFeed.single_entry(self._db, work, annotator)
 
     def complaints(self, identifier_type, identifier):
         """Return detailed complaint information for admins."""

--- a/api/admin/controller/work_editor.py
+++ b/api/admin/controller/work_editor.py
@@ -14,8 +14,6 @@ from api.config import (
 from api.metadata_wrangler import MetadataWranglerCollectionRegistrar
 from api.admin.validator import Validator
 from core.app_server import (
-    entry_response,
-    feed_response,
     load_pagination_from_request,
 )
 from core.classifier import (
@@ -81,8 +79,8 @@ class WorkController(AdminCirculationManagerController):
         annotator = AdminAnnotator(self.circulation, flask.request.library)
         # Don't cache these OPDS entries - they should update immediately
         # in the admin interface when an admin makes a change.
-        return entry_response(
-            AcquisitionFeed.single_entry(self._db, work, annotator), cache_for=0,
+        return AcquisitionFeed.single_entry(
+            self._db, work, annotator, max_age=0
         )
 
     def complaints(self, identifier_type, identifier):

--- a/api/config.py
+++ b/api/config.py
@@ -170,6 +170,11 @@ class Configuration(CoreConfiguration):
     #
     KEY_PAIR = "key-pair"
 
+    # Availability information can change pretty quickly, but it's
+    # generally okay for a client to cache any kind of OPDS document
+    # for ten minutes.
+    DEFAULT_OPDS_CACHE_TIME = 60 * 10
+
     SITEWIDE_SETTINGS = CoreConfiguration.SITEWIDE_SETTINGS + [
         {
             "key": BEARER_TOKEN_SIGNING_SECRET,

--- a/api/config.py
+++ b/api/config.py
@@ -170,11 +170,6 @@ class Configuration(CoreConfiguration):
     #
     KEY_PAIR = "key-pair"
 
-    # Availability information can change pretty quickly, but it's
-    # generally okay for a client to cache any kind of OPDS document
-    # for ten minutes.
-    DEFAULT_OPDS_CACHE_TIME = 60 * 10
-
     SITEWIDE_SETTINGS = CoreConfiguration.SITEWIDE_SETTINGS + [
         {
             "key": BEARER_TOKEN_SIGNING_SECRET,

--- a/api/controller.py
+++ b/api/controller.py
@@ -1172,17 +1172,13 @@ class LoanController(CirculationManagerController):
             status_code = 201
         else:
             status_code = 200
-        response_kwargs = dict(
-            cache_for=30*60
-            private=True
-        )
         if loan:
             return LibraryLoanAndHoldAnnotator.single_loan_feed(
-                self.circulation, loan, **response_kwargs
+                self.circulation, loan, status_code=status_code
             )
         elif hold:
             return LibraryLoanAndHoldAnnotator.single_hold_feed(
-                self.circulation, hold, **response_kwargs
+                self.circulation, hold, status_code=status_code
             )
         else:
             # This should never happen -- we should have sent a more specific

--- a/api/controller.py
+++ b/api/controller.py
@@ -1490,6 +1490,8 @@ class LoanController(CirculationManagerController):
 
         work = pool.work
         annotator = self.manager.annotator(None)
+        # Since this OPDS document is in a response to an unsafe operation,
+        # we don't want the client to cache it.
         return entry_response(
             AcquisitionFeed.single_entry(self._db, work, annotator)
         )
@@ -1683,7 +1685,8 @@ class WorkController(CirculationManagerController):
 
         annotator = self.manager.annotator(None)
         return entry_response(
-            AcquisitionFeed.single_entry(self._db, work, annotator)
+            AcquisitionFeed.single_entry(self._db, work, annotator),
+            cache_for=Configuration.DEFAULT_OPDS_CACHE_TIME
         )
 
     def related(self, identifier_type, identifier, novelist_api=None,

--- a/api/controller.py
+++ b/api/controller.py
@@ -742,11 +742,10 @@ class OPDSFeedController(CirculationManagerController):
         )
 
         annotator = self.manager.annotator(lane, facets)
-        feed = feed_class.groups(
+        return feed_class.groups(
             _db=self._db, title=lane.display_name, url=url, worklist=lane,
             annotator=annotator, facets=facets, search_engine=search_engine
-        )
-        return feed_response(feed)
+        ).response
 
     def feed(self, lane_identifier, feed_class=AcquisitionFeed):
         """Build or retrieve a paginated acquisition feed.
@@ -776,13 +775,12 @@ class OPDSFeedController(CirculationManagerController):
         )
 
         annotator = self.manager.annotator(lane, facets=facets)
-        feed = feed_class.page(
+        return feed_class.page(
             _db=self._db, title=lane.display_name,
             url=url, worklist=lane, annotator=annotator,
             facets=facets, pagination=pagination,
             search_engine=search_engine
-        )
-        return feed_response(feed)
+        ).response
 
     def navigation(self, lane_identifier):
         """Build or retrieve a navigation feed, for clients that do not support groups."""
@@ -896,13 +894,12 @@ class OPDSFeedController(CirculationManagerController):
         # so library settings are irrelevant.
         facets = CrawlableFacets.default(None)
 
-        feed = feed_class.page(
+        return feed_class.page(
             _db=self._db, title=title, url=url, worklist=worklist,
             annotator=annotator,
             facets=facets, pagination=pagination,
             search_engine=search_engine
-        )
-        return feed_response(feed)
+        ).response
 
     def _load_search_facets(self, lane):
         entrypoints = list(flask.request.library.entrypoints)
@@ -976,7 +973,7 @@ class OPDSFeedController(CirculationManagerController):
             _db=self._db, title=info['name'],
             url=make_url(), lane=lane, search_engine=search_engine,
             query=query, annotator=annotator, pagination=pagination,
-            facets=facets,
+            facets=facets
         )
         return feed_response(opds_feed)
 
@@ -1663,12 +1660,11 @@ class WorkController(CirculationManagerController):
             pagination=pagination,
         )
 
-        feed = feed_class.page(
+        return feed_class.page(
             _db=self._db, title=lane.display_name, url=url, worklist=lane,
             facets=facets, pagination=pagination,
             annotator=annotator, search_engine=search_engine
-        )
-        return feed_response(unicode(feed))
+        ).response
 
     def permalink(self, identifier_type, identifier):
         """Serve an entry for a single book.
@@ -1730,12 +1726,11 @@ class WorkController(CirculationManagerController):
             facets=facets,
         )
 
-        feed = feed_class.groups(
+        return feed_class.groups(
             _db=self._db, title=lane.DISPLAY_NAME,
             url=url, worklist=lane, annotator=annotator,
-            facets=facets, search_engine=search_engine,
-        )
-        return feed_response(unicode(feed))
+            facets=facets, search_engine=search_engine
+        ).response
 
     def recommendations(self, identifier_type, identifier, novelist_api=None,
                         feed_class=AcquisitionFeed):
@@ -1778,12 +1773,11 @@ class WorkController(CirculationManagerController):
             pagination=pagination,
         )
 
-        feed = feed_class.page(
+        return feed_class.page(
             _db=self._db, title=lane.DISPLAY_NAME, url=url, worklist=lane,
             facets=facets, pagination=pagination,
             annotator=annotator, search_engine=search_engine
-        )
-        return feed_response(unicode(feed))
+        ).response
 
     def report(self, identifier_type, identifier):
         """Report a problem with a book."""
@@ -1838,12 +1832,12 @@ class WorkController(CirculationManagerController):
         annotator = self.manager.annotator(lane)
 
         url = annotator.feed_url(lane, facets=facets, pagination=pagination)
-        feed = feed_class.page(
+        obj = feed_class.page(
             _db=self._db, title=lane.display_name, url=url, worklist=lane,
             facets=facets, pagination=pagination,
             annotator=annotator, search_engine=search_engine
         )
-        return feed_response(unicode(feed))
+        return obj.response
 
 
 class ProfileController(CirculationManagerController):

--- a/api/controller.py
+++ b/api/controller.py
@@ -2033,11 +2033,11 @@ class SharedCollectionController(CirculationManagerController):
             return e.as_problem_detail_document(debug=False)
         if loan and isinstance(loan, Loan):
             return SharedCollectionLoanAndHoldAnnotator.single_loan_feed(
-                collection, loan
+                collection, loan, status=201
             )
         elif loan and isinstance(loan, Hold):
             return SharedCollectionLoanAndHoldAnnotator.single_hold_feed(
-                collection, loan
+                collection, loan, status=201
             )
 
     def revoke_loan(self, collection_name, loan_id):

--- a/api/controller.py
+++ b/api/controller.py
@@ -1168,17 +1168,18 @@ class LoanController(CirculationManagerController):
         # At this point we have either a loan or a hold. If a loan, serve
         # a feed that tells the patron how to fulfill the loan. If a hold,
         # serve a feed that talks about the hold.
+        response_kwargs = {}
         if is_new:
-            status_code = 201
+            response_kwargs['status'] = 201
         else:
-            status_code = 200
+            response_kwargs['status'] = 200
         if loan:
             return LibraryLoanAndHoldAnnotator.single_loan_feed(
-                self.circulation, loan, status_code=status_code
+                self.circulation, loan, **response_kwargs
             )
         elif hold:
             return LibraryLoanAndHoldAnnotator.single_hold_feed(
-                self.circulation, hold, status_code=status_code
+                self.circulation, hold, **response_kwargs
             )
         else:
             # This should never happen -- we should have sent a more specific
@@ -2031,15 +2032,13 @@ class SharedCollectionController(CirculationManagerController):
         except RemoteIntegrationException, e:
             return e.as_problem_detail_document(debug=False)
         if loan and isinstance(loan, Loan):
-            response = SharedCollectionLoanAndHoldAnnotator.single_loan_feed(
+            return SharedCollectionLoanAndHoldAnnotator.single_loan_feed(
                 collection, loan
             )
-            return response.modified(status=201, max_age=0)
         elif loan and isinstance(loan, Hold):
-            response = SharedCollectionLoanAndHoldAnnotator.single_hold_feed(
+            return SharedCollectionLoanAndHoldAnnotator.single_hold_feed(
                 collection, loan
             )
-            return response.modified(status=201, max_age=0)
 
     def revoke_loan(self, collection_name, loan_id):
         collection = self.load_collection(collection_name)

--- a/api/controller.py
+++ b/api/controller.py
@@ -1837,12 +1837,11 @@ class WorkController(CirculationManagerController):
         annotator = self.manager.annotator(lane)
 
         url = annotator.feed_url(lane, facets=facets, pagination=pagination)
-        obj = feed_class.page(
+        return feed_class.page(
             _db=self._db, title=lane.display_name, url=url, worklist=lane,
             facets=facets, pagination=pagination,
             annotator=annotator, search_engine=search_engine
         )
-        return obj.response
 
 
 class ProfileController(CirculationManagerController):

--- a/api/controller.py
+++ b/api/controller.py
@@ -803,10 +803,9 @@ class OPDSFeedController(CirculationManagerController):
             base_class_constructor_kwargs=facet_class_kwargs
         )
         annotator = self.manager.annotator(lane, facets)
-        feed = NavigationFeed.navigation(
+        return NavigationFeed.navigation(
             self._db, title, url, lane, annotator, facets=facets
-        )
-        return feed_response(feed)
+        ).response
 
     def crawlable_library_feed(self):
         """Build or retrieve a crawlable acquisition feed for the

--- a/api/controller.py
+++ b/api/controller.py
@@ -23,7 +23,6 @@ from flask import (
 )
 from flask_babel import lazy_gettext as _
 
-from core.flask_util import Responselike
 from core.app_server import (
     cdn_url_for,
     url_for,
@@ -744,7 +743,7 @@ class OPDSFeedController(CirculationManagerController):
         return feed_class.groups(
             _db=self._db, title=lane.display_name, url=url, worklist=lane,
             annotator=annotator, facets=facets, search_engine=search_engine
-        ).response
+        )
 
     def feed(self, lane_identifier, feed_class=AcquisitionFeed):
         """Build or retrieve a paginated acquisition feed.
@@ -779,7 +778,7 @@ class OPDSFeedController(CirculationManagerController):
             url=url, worklist=lane, annotator=annotator,
             facets=facets, pagination=pagination,
             search_engine=search_engine
-        ).response
+        )
 
     def navigation(self, lane_identifier):
         """Build or retrieve a navigation feed, for clients that do not support groups."""
@@ -804,7 +803,7 @@ class OPDSFeedController(CirculationManagerController):
         annotator = self.manager.annotator(lane, facets)
         return NavigationFeed.navigation(
             self._db, title, url, lane, annotator, facets=facets
-        ).response
+        )
 
     def crawlable_library_feed(self):
         """Build or retrieve a crawlable acquisition feed for the
@@ -897,7 +896,7 @@ class OPDSFeedController(CirculationManagerController):
             annotator=annotator,
             facets=facets, pagination=pagination,
             search_engine=search_engine
-        ).response
+        )
 
     def _load_search_facets(self, lane):
         entrypoints = list(flask.request.library.entrypoints)
@@ -1090,8 +1089,9 @@ class LoanController(CirculationManagerController):
 
         # Then make the feed.
         feed = LibraryLoanAndHoldAnnotator.active_loans_for(
-            self.circulation, patron)
-        return Responselike(feed, max_age=60*30).response
+            self.circulation, patron
+        )
+        return feed.response
 
     def borrow(self, identifier_type, identifier, mechanism_id=None):
         """Create a new loan or hold for a book.
@@ -1519,8 +1519,7 @@ class LoanController(CirculationManagerController):
             else:
                 feed = LibraryLoanAndHoldAnnotator.single_hold_feed(
                     self.circulation, hold)
-            feed = unicode(feed)
-            return Responselike(feed).response
+            return feed
 
 class AnnotationController(CirculationManagerController):
 
@@ -1659,7 +1658,7 @@ class WorkController(CirculationManagerController):
             _db=self._db, title=lane.display_name, url=url, worklist=lane,
             facets=facets, pagination=pagination,
             annotator=annotator, search_engine=search_engine
-        ).response
+        )
 
     def permalink(self, identifier_type, identifier):
         """Serve an entry for a single book.
@@ -1679,7 +1678,7 @@ class WorkController(CirculationManagerController):
 
         annotator = self.manager.annotator(None)
         return AcquisitionFeed.single_entry(
-            self._db, work, annotator
+            self._db, work, annotator,
             max_age=OPDSFeed.DEFAULT_MAX_AGE
         )
 
@@ -1726,7 +1725,7 @@ class WorkController(CirculationManagerController):
             _db=self._db, title=lane.DISPLAY_NAME,
             url=url, worklist=lane, annotator=annotator,
             facets=facets, search_engine=search_engine
-        ).response
+        )
 
     def recommendations(self, identifier_type, identifier, novelist_api=None,
                         feed_class=AcquisitionFeed):
@@ -1773,7 +1772,7 @@ class WorkController(CirculationManagerController):
             _db=self._db, title=lane.DISPLAY_NAME, url=url, worklist=lane,
             facets=facets, pagination=pagination,
             annotator=annotator, search_engine=search_engine
-        ).response
+        )
 
     def report(self, identifier_type, identifier):
         """Report a problem with a book."""
@@ -1985,10 +1984,9 @@ class SharedCollectionController(CirculationManagerController):
         if not loan or loan.license_pool.collection != collection:
             return LOAN_NOT_FOUND
 
-        feed = SharedCollectionLoanAndHoldAnnotator.single_loan_feed(
-            collection, loan)
-        headers = { "Content-Type" : OPDSFeed.ACQUISITION_FEED_TYPE }
-        return Response(etree.tostring(feed), 200, headers)
+        return SharedCollectionLoanAndHoldAnnotator.single_loan_feed(
+            collection, loan
+        )
 
     def borrow(self, collection_name, identifier_type, identifier, hold_id):
         collection = self.load_collection(collection_name)
@@ -2127,10 +2125,9 @@ class SharedCollectionController(CirculationManagerController):
         if not hold or not hold.license_pool.collection == collection:
             return HOLD_NOT_FOUND
 
-        feed = SharedCollectionLoanAndHoldAnnotator.single_hold_feed(
-            collection, hold)
-        headers = { "Content-Type" : OPDSFeed.ACQUISITION_FEED_TYPE }
-        return Response(etree.tostring(feed), 200, headers)
+        return SharedCollectionLoanAndHoldAnnotator.single_hold_feed(
+            collection, hold
+        )
 
     def revoke_hold(self, collection_name, hold_id):
         collection = self.load_collection(collection_name)

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -198,7 +198,6 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
             valid, a PatronData that serves only to indicate which
             authorization identifier the patron prefers.
         """
-        return PatronData(authorization_identifier="23333094313069", complete=False)
         if not self.collects_password:
             # We don't even look at the password. If the patron exists, they
             # are authenticated.

--- a/api/opds.py
+++ b/api/opds.py
@@ -442,7 +442,10 @@ class CirculationManagerAnnotator(Annotator):
             containing an error message.
         """
         if not work:
-            return AcquisitionFeed(db, "Unknown work", url, [], annotator).as_error_response()
+            return AcquisitionFeed(
+                _db, title="Unknown work", url=url, works=[], 
+                annotator=annotator
+            ).as_error_response()
 
         # This method is generally used for reporting the results of
         # authenticated transactions such as borrowing and hold

--- a/api/opds.py
+++ b/api/opds.py
@@ -1429,13 +1429,13 @@ class LibraryLoanAndHoldAnnotator(LibraryAnnotator):
         active_holds_by_work = {}
         active_fulfillments_by_work = {}
         if fulfillment:
-            d = active_fulfillments_by_work
+            active_fulfillments_by_work[work] = fulfillment
         else:
             if isinstance(item, Loan):
                 d = active_loans_by_work
             elif isinstance(item, Hold):
                 d = active_holds_by_work
-        d[work] = item
+            d[work] = item
 
         annotator = cls(
             circulation, None, library,
@@ -1515,7 +1515,7 @@ class SharedCollectionLoanAndHoldAnnotator(SharedCollectionAnnotator):
         active_holds_by_work = {}
         active_fulfillments_by_work = {}
         if fulfillment:
-            d = active_fulfillments_by_work
+            active_fulfillments_by_work[work] = fulfillment
             route = 'shared_collection_loan_info'
             route_kwargs = dict(loan_id=item.id)
         else:
@@ -1527,7 +1527,7 @@ class SharedCollectionLoanAndHoldAnnotator(SharedCollectionAnnotator):
                 d = active_holds_by_work
                 route = 'shared_collection_hold_info'
                 route_kwargs = dict(hold_id=item.id)
-        d[work] = item
+            d[work] = item
         annotator = cls(
             collection, None,
             active_loans_by_work=active_loans_by_work,

--- a/api/opds.py
+++ b/api/opds.py
@@ -1382,7 +1382,8 @@ class LibraryLoanAndHoldAnnotator(LibraryAnnotator):
 
         feed_obj = AcquisitionFeed(db, "Active loans and holds", url, works, annotator)
         annotator.annotate_feed(feed_obj, None)
-        return OPDSFeedResponse(feed_obj, max_age=60*30)
+
+        return OPDSFeedResponse(feed_obj, max_age=60*30, private=True)
 
     @classmethod
     def single_loan_feed(cls, circulation, loan, test_mode=False):

--- a/api/opds.py
+++ b/api/opds.py
@@ -1454,10 +1454,6 @@ class LibraryLoanAndHoldAnnotator(LibraryAnnotator):
         )
         return cls._single_entry_response(_db, work, annotator, url, **response_kwargs)
 
-    single_loan_feed = single_item_feed
-    single_hold_feed = single_item_feed
-    single_fulfillment_feed = single_item_feed
-
     def drm_device_registration_feed_tags(self, patron):
         """Return tags that provide information on DRM device deregistration
         independent of any particular loan. These tags will go under
@@ -1541,7 +1537,3 @@ class SharedCollectionLoanAndHoldAnnotator(SharedCollectionAnnotator):
             **route_kwargs
         )
         return cls._single_entry_response(_db, work, annotator, url, **response_kwargs)
-
-    single_loan_feed = single_item_feed
-    single_hold_feed = single_item_feed
-    single_fulfillment_feed = single_item_feed

--- a/api/opds.py
+++ b/api/opds.py
@@ -1381,7 +1381,7 @@ class LibraryLoanAndHoldAnnotator(LibraryAnnotator):
 
         feed_obj = AcquisitionFeed(db, "Active loans and holds", url, works, annotator)
         annotator.annotate_feed(feed_obj, None)
-        return feed_obj
+        return OPDSFeedResponse(feed_obj, max_age=60*30)
 
     @classmethod
     def single_loan_feed(cls, circulation, loan, test_mode=False):

--- a/api/opds.py
+++ b/api/opds.py
@@ -21,6 +21,7 @@ from core.opds import (
     AcquisitionFeed,
     UnfulfillableWork,
 )
+from core.util.flask_util import OPDSFeedResponse
 from core.util.opds_writer import (
     OPDSFeed,
 )

--- a/scripts.py
+++ b/scripts.py
@@ -461,9 +461,9 @@ class CacheRepresentationPerLane(TimestampScript, LaneSweeperScript):
                     cached_feeds.append(feed)
                     self.log.info(
                         "Took %.2f sec to make %d bytes.", (b-a),
-                        len(feed._response)
+                        len(feed.data)
                     )
-        total_size = sum(len(x._response) for x in cached_feeds)
+        total_size = sum(len(x.data) for x in cached_feeds)
         return cached_feeds
 
     def facets(self, lane):

--- a/scripts.py
+++ b/scripts.py
@@ -460,9 +460,10 @@ class CacheRepresentationPerLane(TimestampScript, LaneSweeperScript):
                 if feed:
                     cached_feeds.append(feed)
                     self.log.info(
-                        "Took %.2f sec to make %d bytes.", (b-a), len(feed)
+                        "Took %.2f sec to make %d bytes.", (b-a),
+                        len(feed._response)
                     )
-        total_size = sum(len(x) for x in cached_feeds)
+        total_size = sum(len(x._response) for x in cached_feeds)
         return cached_feeds
 
     def facets(self, lane):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2366,8 +2366,8 @@ class TestWorkController(CirculationControllerTest):
         ):
             response = m(contributor, languages, audiences, feed_class=Mock)
 
-        # The Response served by Mock.page is converted into a real
-        # Flask response
+        # The Response served by Mock.page becomes the response to the
+        # incoming request.
         eq_(200, response.status_code)
         eq_("An OPDS feed", response.data)
 
@@ -2530,8 +2530,8 @@ class TestWorkController(CirculationControllerTest):
                 *args, **kwargs
             )
 
-        # The return value of Mock.page was converted into a Flask
-        # response.
+        # The return value of Mock.page was used as the response
+        # to the incoming request.
         eq_(200, response.status_code)
         eq_("A bunch of titles", response.data)
 
@@ -2714,8 +2714,8 @@ class TestWorkController(CirculationControllerTest):
                 novelist_api=mock_api, feed_class=Mock
             )
 
-        # The return value of Mock.groups() has been converted into a
-        # Flask response.
+        # The return value of Mock.groups was used as the response
+        # to the incoming request.
         eq_(200, response.status_code)
         eq_("An OPDS feed", response.data)
 
@@ -2898,7 +2898,8 @@ class TestWorkController(CirculationControllerTest):
                 feed_class=Mock
             )
 
-        # We got the return value of Mock.page(), converted to a Response.
+        # The return value of Mock.page() is the response to the
+        # incoming request.
         eq_(200, response.status_code)
         eq_("An OPDS feed", response.data)
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2437,7 +2437,7 @@ class TestWorkController(CirculationControllerTest):
             annotator = LibraryAnnotator(None, None, self._default_library)
             expect = AcquisitionFeed.single_entry(
                 self._db, self.english_1, annotator
-            )._response
+            ).data
 
         eq_(200, response.status_code)
         eq_(expect, response.data)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -15,7 +15,7 @@ from decimal import Decimal
 import flask
 from flask import (
     url_for,
-    FlaskResponse,
+    Response as FlaskResponse,
 )
 from flask_sqlalchemy_session import (
     current_session,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3104,7 +3104,7 @@ class TestOPDSFeedController(CirculationControllerTest):
             @classmethod
             def page(cls, **kwargs):
                 self.called_with = kwargs
-                return "An OPDS feed"
+                return Responselike("An OPDS feed")
 
         sort_key = ["sort", "pagination", "key"]
         with self.request_context_with_library(
@@ -3123,8 +3123,10 @@ class TestOPDSFeedController(CirculationControllerTest):
                 library_short_name=self._default_library.short_name,
             )
 
-        # We got the return value of Mock.groups()
-        eq_("An OPDS feed", response)
+        # The Responselike returned from Mock.groups() was converted
+        # to a real Response object.
+        assert isinstance(response, Response)
+        eq_("An OPDS feed", response.data)
 
         # Now check all the keyword arguments that were passed into
         # page().

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -273,7 +273,7 @@ class TestCirculationManagerAnnotator(DatabaseTest):
         response = m(self._db, work, annotator, url)
         assert isinstance(response, OPDSEntryResponse)
         assert '<title>%s</title>' % work.title in response.data
-        
+
         # By default, the representation is private but can be cached
         # by the recipient.
         eq_(True, response.private)
@@ -283,7 +283,7 @@ class TestCirculationManagerAnnotator(DatabaseTest):
         response = m(self._db, work, annotator, url, max_age=12, private=False)
         eq_(False, response.private)
         eq_(12, response.max_age)
-        
+
         # Test the case where the Work we thought we were providing is missing.
         work = None
         response = m(self._db, work, annotator, url)
@@ -394,7 +394,7 @@ class TestLibraryAnnotator(VendorIDTest):
             # Check that the configuration value made it into the link.
             eq_(href, link_config[rel])
             eq_("text/html", link.attrib['type'])
-                
+
         # There are three help links using different protocols.
         help_links = [x.attrib['href'] for x in mock_feed
                       if x.attrib['rel'] == 'help']
@@ -1595,7 +1595,111 @@ class TestLibraryAnnotator(VendorIDTest):
 class TestLibraryLoanAndHoldAnnotator(DatabaseTest):
 
     def test_single_item_feed(self):
-        pass
+        # Test the generation of single-item OPDS feeds for loans (with and
+        # without fulfillment) and holds.
+        class MockAnnotator(LibraryLoanAndHoldAnnotator):
+
+            def url_for(self, controller, **kwargs):
+                self.url_for_called_with = (controller, kwargs)
+                return "a URL"
+
+            def _single_entry_response(self, *args, **kwargs):
+                self._single_entry_response_called_with = (args, kwargs)
+                # Return the annotator itself so we can look at it.
+                return self
+
+        def test_annotator(item, fulfillment=None):
+            # Call MockAnnotator.single_item_feed with certain arguments
+            # and make some general assertions about the return value.
+            circulation = object()
+            test_mode = object()
+            feed_class = object()
+            result = MockAnnotator.single_item_feed(
+                circulation, item, fulfillment, test_mode, feed_class,
+                extra_arg="value"
+            )
+
+            # The final result is a MockAnnotator object. This isn't
+            # normal; it's because
+            # MockAnnotator._single_entry_response returns the
+            # MockAnnotator it creates, for us to examine.
+            assert isinstance(result, MockAnnotator)
+
+            # Let's examine the MockAnnotator itself.
+            eq_(circulation, result.circulation)
+            eq_(self._default_library, result.library)
+            eq_(test_mode, result.test_mode)
+
+            # Now let's see what we did with it after calling its
+            # constructor.
+
+            # First, we generated a URL to the "loan_or_hold_detail"
+            # controller for the license pool's identifier.
+            url_call = result.url_for_called_with
+            controller_name, kwargs = url_call
+            eq_("loan_or_hold_detail", controller_name)
+            eq_(self._default_library.short_name,
+                kwargs.pop('library_short_name'))
+            eq_(pool.identifier.type, kwargs.pop('identifier_type'))
+            eq_(pool.identifier.identifier, kwargs.pop('identifier'))
+            eq_(True, kwargs.pop('_external'))
+            eq_({}, kwargs)
+
+            # The return value of that was the string "a URL". We then
+            # passed that into _single_entry_response, along with
+            # `item` and a number of arguments that we made up.
+            response_call = result._single_entry_response_called_with
+            (_db, _work, annotator, url, _feed_class), kwargs = (
+                response_call
+            )
+            eq_(self._db, _db)
+            eq_(work, _work)
+            eq_(result, annotator)
+            eq_("a URL", url)
+            eq_(feed_class, _feed_class)
+
+            # The only keyword argument is an extra argument propagated from
+            # the single_item_feed call.
+            eq_('value', kwargs.pop('extra_arg'))
+
+            # Return the MockAnnotator for further examination.
+            return result
+
+        # Now we're going to call test_annotator a couple times in
+        # different situations.
+        work = self._work(with_license_pool=True)
+        [pool] = work.license_pools
+        patron = self._patron()
+        loan, ignore = pool.loan_to(patron)
+
+        # First, let's ask for a single-item feed for a loan.
+        annotator = test_annotator(loan)
+
+        # Everything tested by test_annotator happened, but _also_,
+        # when the annotator was created, the Loan was stored in
+        # active_loans_by_work.
+        eq_({work : loan}, annotator.active_loans_by_work)
+
+        # Since we passed in a loan rather than a hold,
+        # active_holds_by_work is empty.
+        eq_({}, annotator.active_holds_by_work)
+
+        # Since we didn't pass in a fulfillment for the loan,
+        # active_fulfillments_by_work is empty.
+        eq_({}, annotator.active_fulfillments_by_work)
+
+        # Now try it again, but give the loan a fulfillment.
+        fulfillment = object()
+        annotator = test_annotator(loan, fulfillment)
+        eq_({work : loan}, annotator.active_loans_by_work)
+        eq_({work : fulfillment}, annotator.active_fulfillments_by_work)
+
+        # Finally, try it with a hold.
+        hold, ignore = pool.on_hold_to(patron)
+        annotator = test_annotator(hold)
+        eq_({work : hold}, annotator.active_holds_by_work)
+        eq_({}, annotator.active_loans_by_work)
+        eq_({}, annotator.active_fulfillments_by_work)
 
 
 class TestSharedCollectionAnnotator(DatabaseTest):
@@ -1784,3 +1888,121 @@ class TestSharedCollectionAnnotator(DatabaseTest):
         [borrow] = work4_links
         assert "shared_collection_borrow" in borrow.attrib.get("href")
         eq_('http://opds-spec.org/acquisition/borrow', borrow.attrib.get("rel"))
+
+    def test_single_item_feed(self):
+        # Test the generation of single-item OPDS feeds for loans (with and
+        # without fulfillment) and holds.
+        class MockAnnotator(SharedCollectionLoanAndHoldAnnotator):
+
+            def url_for(self, controller, **kwargs):
+                self.url_for_called_with = (controller, kwargs)
+                return "a URL"
+
+            def _single_entry_response(self, *args, **kwargs):
+                self._single_entry_response_called_with = (args, kwargs)
+                # Return the annotator itself so we can look at it.
+                return self
+
+        def test_annotator(item, fulfillment, expect_route,
+                           expect_route_kwargs):
+            # Call MockAnnotator.single_item_feed with certain arguments
+            # and make some general assertions about the return value.
+            test_mode = object()
+            feed_class = object()
+            result = MockAnnotator.single_item_feed(
+                self.collection, item, fulfillment, test_mode, feed_class,
+                extra_arg="value"
+            )
+
+            # The final result is a MockAnnotator object. This isn't
+            # normal; it's because
+            # MockAnnotator._single_entry_response returns the
+            # MockAnnotator it creates, for us to examine.
+            assert isinstance(result, MockAnnotator)
+
+            # Let's examine the MockAnnotator itself.
+            eq_(self.collection, result.collection)
+            eq_(test_mode, result.test_mode)
+
+            # Now let's see what we did with it after calling its
+            # constructor.
+
+            # First, we generated a URL to a controller controller for
+            # the license pool's identifier. _Which_ controller we
+            # used depends on what `item` is.
+            url_call = result.url_for_called_with
+            route, route_kwargs = url_call
+
+            # The route is the one we expect.
+            eq_(expect_route, route)
+
+            # Apart from a few keyword arguments that are always the same,
+            # the keyword arguments are the ones we expect.
+            eq_(self.collection.name, route_kwargs.pop('collection_name'))
+            eq_(True, route_kwargs.pop('_external'))
+            eq_(expect_route_kwargs, route_kwargs)
+
+            # The return value of that was the string "a URL". We then
+            # passed that into _single_entry_response, along with
+            # `item` and a number of arguments that we made up.
+            response_call = result._single_entry_response_called_with
+            (_db, _work, annotator, url, _feed_class), kwargs = (
+                response_call
+            )
+            eq_(self._db, _db)
+            eq_(work, _work)
+            eq_(result, annotator)
+            eq_("a URL", url)
+            eq_(feed_class, _feed_class)
+
+            # The only keyword argument is an extra argument propagated from
+            # the single_item_feed call.
+            eq_('value', kwargs.pop('extra_arg'))
+
+            # Return the MockAnnotator for further examination.
+            return result
+
+        # Now we're going to call test_annotator a couple times in
+        # different situations.
+        work = self.work
+        [pool] = work.license_pools
+        patron = self._patron()
+        loan, ignore = pool.loan_to(patron)
+
+        # First, let's ask for a single-item feed for a loan.
+        annotator = test_annotator(
+            loan, None, expect_route="shared_collection_loan_info",
+            expect_route_kwargs=dict(loan_id=loan.id)
+        )
+
+        # Everything tested by test_annotator happened, but _also_,
+        # when the annotator was created, the Loan was stored in
+        # active_loans_by_work.
+        eq_({work : loan}, annotator.active_loans_by_work)
+
+        # Since we passed in a loan rather than a hold,
+        # active_holds_by_work is empty.
+        eq_({}, annotator.active_holds_by_work)
+
+        # Since we didn't pass in a fulfillment for the loan,
+        # active_fulfillments_by_work is empty.
+        eq_({}, annotator.active_fulfillments_by_work)
+
+        # Now try it again, but give the loan a fulfillment.
+        fulfillment = object()
+        annotator = test_annotator(
+            loan, fulfillment, expect_route="shared_collection_loan_info",
+            expect_route_kwargs=dict(loan_id=loan.id)
+        )
+        eq_({work : loan}, annotator.active_loans_by_work)
+        eq_({work : fulfillment}, annotator.active_fulfillments_by_work)
+
+        # Finally, try it with a hold.
+        hold, ignore = pool.on_hold_to(patron)
+        annotator = test_annotator(
+            hold, None, expect_route="shared_collection_hold_info",
+            expect_route_kwargs=dict(hold_id=hold.id)
+        )
+        eq_({work : hold}, annotator.active_holds_by_work)
+        eq_({}, annotator.active_loans_by_work)
+        eq_({}, annotator.active_fulfillments_by_work)

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1592,6 +1592,12 @@ class TestLibraryAnnotator(VendorIDTest):
         eq_(mech2.delivery_mechanism.content_type, indirect.attrib['type'])
 
 
+class TestLibraryLoanAndHoldAnnotator(DatabaseTest):
+
+    def test_single_item_feed(self):
+        pass
+
+
 class TestSharedCollectionAnnotator(DatabaseTest):
     def setup(self):
         super(TestSharedCollectionAnnotator, self).setup()
@@ -1610,6 +1616,9 @@ class TestSharedCollectionAnnotator(DatabaseTest):
         assert "feed" in feed_url_fantasy
         assert str(self.lane.id) in feed_url_fantasy
         assert self.collection.name in feed_url_fantasy
+
+    def test_single_item_feed(self):
+        pass
 
     def get_parsed_feed(self, works, lane=None):
         if not lane:

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1934,9 +1934,9 @@ class TestSharedCollectionAnnotator(DatabaseTest):
             # Now let's see what we did with it after calling its
             # constructor.
 
-            # First, we generated a URL to a controller controller for
-            # the license pool's identifier. _Which_ controller we
-            # used depends on what `item` is.
+            # First, we generated a URL to a controller for the
+            # license pool's identifier. _Which_ controller we used
+            # depends on what `item` is.
             url_call = result.url_for_called_with
             route, route_kwargs = url_call
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -999,9 +999,16 @@ class TestLibraryAnnotator(VendorIDTest):
         self.initialize_adobe(self._default_library)
         patron = self._patron()
         cls = LibraryLoanAndHoldAnnotator
-        raw = cls.active_loans_for(None, patron, test_mode=True)
+
+        response = cls.active_loans_for(None, patron, test_mode=True)
+
+        # The feed is cacheable but private.
+        assert isinstance(OPDSFeedResponse, raw)
+        eq_(60*30, response.max_age)
+        eq_(True, response.private)
+
         # No entries in the feed...
-        raw = unicode(raw)
+        raw = unicode(response)
         feed = feedparser.parse(raw)
         eq_(0, len(feed['entries']))
 
@@ -1019,7 +1026,7 @@ class TestLibraryAnnotator(VendorIDTest):
         eq_(expect_url, upmp_link['href'])
 
         # ... and we have DRM licensing information.
-        tree = etree.fromstring(raw)
+        tree = etree.fromstring(response)
         parser = OPDSXMLParser()
         licensor = parser._xpath1(tree, "//atom:feed/drm:licensor")
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1216,9 +1216,10 @@ class TestLibraryAnnotator(VendorIDTest):
             Representation.TEXT_HTML_MEDIA_TYPE + DeliveryMechanism.STREAMING_PROFILE,
             None, None)
 
-        feed_obj = LibraryLoanAndHoldAnnotator.single_fulfillment_feed(
-            None, loan, fulfillment, test_mode=True)
-        raw = etree.tostring(feed_obj)
+        response = LibraryLoanAndHoldAnnotator.single_fulfillment_feed(
+            None, loan, fulfillment, test_mode=True
+        )
+        raw = response.data
 
         entries = feedparser.parse(raw)['entries']
         eq_(1, len(entries))

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1003,7 +1003,7 @@ class TestLibraryAnnotator(VendorIDTest):
         response = cls.active_loans_for(None, patron, test_mode=True)
 
         # The feed is cacheable but private.
-        assert isinstance(OPDSFeedResponse, raw)
+        assert isinstance(response, OPDSFeedResponse)
         eq_(60*30, response.max_age)
         eq_(True, response.private)
 
@@ -1026,7 +1026,7 @@ class TestLibraryAnnotator(VendorIDTest):
         eq_(expect_url, upmp_link['href'])
 
         # ... and we have DRM licensing information.
-        tree = etree.fromstring(response)
+        tree = etree.fromstring(response.data)
         parser = OPDSXMLParser()
         licensor = parser._xpath1(tree, "//atom:feed/drm:licensor")
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1216,7 +1216,7 @@ class TestLibraryAnnotator(VendorIDTest):
             Representation.TEXT_HTML_MEDIA_TYPE + DeliveryMechanism.STREAMING_PROFILE,
             None, None)
 
-        response = LibraryLoanAndHoldAnnotator.single_fulfillment_feed(
+        response = LibraryLoanAndHoldAnnotator.single_item_feed(
             None, loan, fulfillment, test_mode=True
         )
         raw = response.data

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -78,7 +78,10 @@ from core.mirror import MirrorUploader
 
 from core.marc import MARCExporter
 
-from core.util.flask_util import Response
+from core.util.flask_util import (
+    Response,
+    OPDSFeedResponse
+)
 
 from api.marc import LibraryAnnotator as  MARCLibraryAnnotator
 
@@ -398,10 +401,10 @@ class TestCacheFacetListsPerLane(TestLaneScript):
                 annotator.feed_url(lane, facets=facets, pagination=pagination)
             )
 
-            # Try again without mocking AcquisitionFeed to verify that
-            # we get something a Flask Response containing an OPDS
-            # feed.
+            # Try again without mocking AcquisitionFeed, to verify that
+            # we get a Flask Response containing an OPDS feed.
             response = script.do_generate(lane, facets, pagination)
+            assert isinstance(response, OPDSFeedResponse)
             eq_(AcquisitionFeed.ACQUISITION_FEED_TYPE, response.content_type)
             assert response.data.startswith('<feed')
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -394,9 +394,11 @@ class TestCacheFacetListsPerLane(TestLaneScript):
             )
 
             # Try again without mocking AcquisitionFeed to verify that
-            # we get something that looks like an OPDS feed.
-            result = script.do_generate(lane, facets, pagination)
-            assert result.startswith('<feed')
+            # we get something that looks like a Flask Response
+            # containing an OPDS feed.
+            response = script.do_generate(lane, facets, pagination)
+            eq_(AcquisitionFeed.ACQUISITION_FEED_TYPE, response.mimetype)
+            assert response._response.startswith('<feed')
 
 
 class TestCacheOPDSGroupFeedPerLane(TestLaneScript):


### PR DESCRIPTION
 to https://github.com/NYPL-Simplified/server_core/pull/1170, circulation portion of https://jira.nypl.org/browse/SIMPLY-2633.

In this branch, all controllers that serve OPDS feeds expect to get OPDSFeedResponse or OPDSEntryResponse objects from the methods they call, rather than getting OPDS feeds/entries and converting them into Response objects. This change was necessary because the logic that generates the OPDS feed itself is also the bit that knows how long the feed should be cached -- an important piece of information for generating the response as a whole.

As far as the controllers themselves are concerned, this means only that methods which used to call `feed_response` and `entry_response` don't need to do that anymore. Whatever method they call now returns an appropriate Response.

Inside the methods called by the controllers, things are a little more complicated. Some of these methods are covered in the core branch, but I had to change the methods that are circulation-specific -- the bookshelf feed, entries for individual loans or holds, etc.

To make this easier, I unified a bunch of methods whose job was to create a response containing a single OPDS entry for a loan or hold. These became `LibraryLoanAndHoldAnnotator.single_item_feed` and `SharedCollectionLoanAndHoldAnnotator.single_item_feed`. These methods were previously tested only indirectly, through controller tests. These both call the same helper method (`CirculationManagerAnnotator._single_entry_response`), which gives me three methods to test instead of six.