### PR TITLE
Remove {errorpageurl} from the URL for an Overdrive manifest document, rather than filling it in

### DIFF
--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -1246,9 +1246,9 @@ class TestExtractData(OverdriveAPITest):
             json, "ebook-overdrive-manifest", "http://bar.com/"
         )
         
-        # The {errorpageurl} has been filed in, the {odreadauthurl} parameter
-        # has been removed, and contentfile=true has been appended.
-        eq_(base_url + '?errorpageurl=http://bar.com/&contentfile=true', link)
+        # The {errorpageurl} and {odreadauthurl} parameters
+        # have been removed, and contentfile=true has been appended.
+        eq_(base_url + '?contentfile=true', link)
 
     def test_extract_download_link(self):
         # Verify that extract_download_link can or cannot find a 
@@ -1323,9 +1323,9 @@ class TestExtractData(OverdriveAPITest):
             do_not_fetch_manifest)
 
         # If we do want a manifest, make_direct_download_link is called
-        # after the template is filled in.
+        # without errorpageurl being affected.
         do_fetch_manifest = m(working, error_url, fetch_manifest=True)
-        eq_("http://download/?errorpageurl=http://error/",
+        eq_("http://download/?errorpageurl={errorpageurl}",
             Mock.called_with)
         eq_("http://manifest/", do_fetch_manifest)
 


### PR DESCRIPTION
This is a server support branch for https://jira.nypl.org/browse/SIMPLY-2547.

Previously we converted an Overdrive Listen URL to an Overdrive manifest document URL by filling in a value for the {errorpageurl} template and stripping out the {odreadauthurl} template. This didn't match what the Overdrive API was expecting, and the presence of {errorpageurl} was causing a 500 error on the Overdrive side. This branch changes the conversion process so we strip out both the {errorpageurl} and {odreadauthurl} templates. In standalone tests this change  is sufficient to get a manifest document out of the Overdrive API.