### PR TITLE
Peg nltk to the final Python 2 release.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,9 @@ ndg-httpsclient
 # In circ, feedparser is only used in tests.
 feedparser
 
+# nltk is a textblob dependency, and this is the last release that supports Python 2
+nltk==3.4.5
+
 # TODO: This is only used for summary evaluation, which I think should
 # only happen in the metadata wrangler, so it should be possible to move
 # it out of core.


### PR DESCRIPTION
Circulation version of https://github.com/NYPL-Simplified/server_core/pull/1173.

NLTK 3.4.5 was [the final release to support Python 2](https://www.nltk.org/news.html). A Python 3-only release was put out early this week, and now anyone who tries to set up a circ manager will get a release of NLTK that won't work, installed as a dependency on textblob. This branch pegs the version of NLTK in use to the final Python 2 release.

Ticket: https://jira.nypl.org/browse/SIMPLY-2705