### PR TITLE
Disable the merge_slashes feature

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -15,6 +15,10 @@ from werkzeug.exceptions import HTTPException
 
 from app import app, babel
 
+# We use URIs as identifiers throughout the application, meaning that
+# we never want werkzeug's merge_slashes feature.
+app.url_map.merge_slashes = False
+
 from config import Configuration
 from core.app_server import (
     ErrorHandler,
@@ -371,7 +375,7 @@ def annotations():
 def annotation_detail(annotation_id):
     return app.manager.annotations.detail(annotation_id)
 
-@library_route('/annotations/<identifier_type>/<path:identifier>/', methods=['GET'])
+@library_route('/annotations/<identifier_type>/<path:identifier>', methods=['GET'])
 @has_library
 @allows_patron_web
 @requires_auth

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -213,6 +213,10 @@ class RouteTest(ControllerTest):
         # Call an assertion method several times, using different
         # types of identifier in the URL, to make sure the identifier
         # is always passed through correctly.
+        #
+        # The url must contain the string '<identifier>' standing in
+        # for the place where an identifier should be plugged in, and
+        # the *args list must include the string '<identifier>'.
         authenticated = kwargs.pop('authenticated', False)
         if authenticated:
             assertion_method = self.assert_authenticated_request_calls


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-2707 by disabling [werkzeug's `merge_slashes` feature](https://werkzeug.palletsprojects.com/en/1.0.x/routing/#rule-format), introduced in February with the release of werkzeug 1.0.

When this feature is enabled, certain identifiers aren't passed through correctly. In particular, the ending slashes on URIs like `https://unglue.it/api/id/work/129511/` are stripped.

I added a direct test to verify that `merge_slashes` is disabled globally, but that's just the easiest way to do it. If we want to, we could leave `merge_slashes` on globally, so long as we turn it off for any path that contains an identifier. So I also changed the existing routing test for every path that contains an identifier. The new tests call a helper method that makes a set of similar assertions using four different identifiers.

The new testing revealed an additional bug: the `/annotations` path has an extra slash at the end which isn't necessary. I don't know how serious this bug is, because the `merge_slashes` problem means basically nothing about unglue.it books works, but it's possible that bookmarks and last reading position for unglue.it titles won't work even if the `merge_slashes` problem were to be fixed.