### PR TITLE
Fix RBDigital catalog delta sync

### DIFF
--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -1448,7 +1448,7 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
                 return None
             else:
                 # something more serious went wrong
-                error_message = "get_metadata_by_isbn(%s) in library #%s catalog ran into problems: %s" % (identifier_string, str(self.library_id), error_message)
+                error_message = "get_metadata_by_isbn(%s) in library #%s catalog ran into problems: %s" % (identifier_string, str(self.library_id), message)
                 raise BadResponseException(url, message)
 
         return respdict
@@ -1544,8 +1544,9 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
                 # generate a CoverageFailure to let the system know to revisit this book
                 # TODO:  if did not create a Work, but have a CoverageFailure for the isbn,
                 # check that re-processing that coverage would generate the work.
-                e = "Could not extract metadata from RBDigital data: %r" % catalog_item
-                make_note = CoverageFailure(identifier, e, data_source=self.data_source, transient=True)
+                # e = "Could not extract metadata from RBDigital data: %r" % catalog_item
+                # make_note = CoverageFailure(identifier, e, data_source=self.data_source, transient=True)
+                continue
 
             # convert IdentifierData into Identifier, if can
             identifier, made_new = metadata.primary_identifier.load(_db=self._db)

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -1316,8 +1316,8 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
         response = self.request(url)
         try:
             snapshots = response.json()
-        except Exception as e:
-            raise BadResponseException(url, "RBDigital available-dates response not parseable.")
+        except ValueError as e:
+            raise BadResponseException(url, "RBDigital available-dates response not parsable.")
 
         if len(snapshots) < 1:
             raise BadResponseException(url, "RBDigital available-dates response contains no snapshots.")
@@ -1411,7 +1411,7 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
         try:
             resplist = response.json()
         except Exception, e:
-            raise BadResponseException(url, "RBDigital availability response not parseable.")
+            raise BadResponseException(url, "RBDigital availability response not parsable.")
         return resplist
 
     def get_metadata_by_isbn(self, identifier):

--- a/tests/files/rbdigital/response_catalog_availability_dates_multi.json
+++ b/tests/files/rbdigital/response_catalog_availability_dates_multi.json
@@ -1,0 +1,793 @@
+[
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-14",
+    "eBookCount": 1646,
+    "eAudioCount": 13468,
+    "totalCount": 15114
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-13",
+    "eBookCount": 1646,
+    "eAudioCount": 13468,
+    "totalCount": 15114
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-12",
+    "eBookCount": 1646,
+    "eAudioCount": 13468,
+    "totalCount": 15114
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-11",
+    "eBookCount": 1646,
+    "eAudioCount": 13468,
+    "totalCount": 15114
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-10",
+    "eBookCount": 1646,
+    "eAudioCount": 13468,
+    "totalCount": 15114
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-09",
+    "eBookCount": 1640,
+    "eAudioCount": 13468,
+    "totalCount": 15108
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-08",
+    "eBookCount": 1635,
+    "eAudioCount": 13430,
+    "totalCount": 15065
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-07",
+    "eBookCount": 1630,
+    "eAudioCount": 13414,
+    "totalCount": 15044
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-06",
+    "eBookCount": 1631,
+    "eAudioCount": 13414,
+    "totalCount": 15045
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-05",
+    "eBookCount": 1631,
+    "eAudioCount": 13414,
+    "totalCount": 15045
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-04",
+    "eBookCount": 1631,
+    "eAudioCount": 13414,
+    "totalCount": 15045
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-03",
+    "eBookCount": 1631,
+    "eAudioCount": 13414,
+    "totalCount": 15045
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-02",
+    "eBookCount": 1631,
+    "eAudioCount": 13413,
+    "totalCount": 15044
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-04-01",
+    "eBookCount": 1631,
+    "eAudioCount": 13404,
+    "totalCount": 15035
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-31",
+    "eBookCount": 1633,
+    "eAudioCount": 13386,
+    "totalCount": 15019
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-30",
+    "eBookCount": 1633,
+    "eAudioCount": 13386,
+    "totalCount": 15019
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-29",
+    "eBookCount": 1633,
+    "eAudioCount": 13386,
+    "totalCount": 15019
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-28",
+    "eBookCount": 1634,
+    "eAudioCount": 13386,
+    "totalCount": 15020
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-27",
+    "eBookCount": 1634,
+    "eAudioCount": 13378,
+    "totalCount": 15012
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-26",
+    "eBookCount": 1634,
+    "eAudioCount": 13378,
+    "totalCount": 15012
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-25",
+    "eBookCount": 1571,
+    "eAudioCount": 13325,
+    "totalCount": 14896
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-24",
+    "eBookCount": 1571,
+    "eAudioCount": 13325,
+    "totalCount": 14896
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-23",
+    "eBookCount": 1571,
+    "eAudioCount": 13325,
+    "totalCount": 14896
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-22",
+    "eBookCount": 1571,
+    "eAudioCount": 13308,
+    "totalCount": 14879
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-20",
+    "eBookCount": 1571,
+    "eAudioCount": 13308,
+    "totalCount": 14879
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-19",
+    "eBookCount": 1571,
+    "eAudioCount": 13308,
+    "totalCount": 14879
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-18",
+    "eBookCount": 1571,
+    "eAudioCount": 13308,
+    "totalCount": 14879
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-17",
+    "eBookCount": 1571,
+    "eAudioCount": 13308,
+    "totalCount": 14879
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-16",
+    "eBookCount": 1571,
+    "eAudioCount": 13300,
+    "totalCount": 14871
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-15",
+    "eBookCount": 1571,
+    "eAudioCount": 13300,
+    "totalCount": 14871
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-14",
+    "eBookCount": 1571,
+    "eAudioCount": 13300,
+    "totalCount": 14871
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-13",
+    "eBookCount": 1572,
+    "eAudioCount": 13309,
+    "totalCount": 14881
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-12",
+    "eBookCount": 1572,
+    "eAudioCount": 13311,
+    "totalCount": 14883
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-11",
+    "eBookCount": 1572,
+    "eAudioCount": 13311,
+    "totalCount": 14883
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-10",
+    "eBookCount": 1572,
+    "eAudioCount": 13311,
+    "totalCount": 14883
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-09",
+    "eBookCount": 1572,
+    "eAudioCount": 13311,
+    "totalCount": 14883
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-08",
+    "eBookCount": 1572,
+    "eAudioCount": 13311,
+    "totalCount": 14883
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-07",
+    "eBookCount": 1572,
+    "eAudioCount": 13311,
+    "totalCount": 14883
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-06",
+    "eBookCount": 1572,
+    "eAudioCount": 13311,
+    "totalCount": 14883
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-05",
+    "eBookCount": 1572,
+    "eAudioCount": 13311,
+    "totalCount": 14883
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-04",
+    "eBookCount": 1569,
+    "eAudioCount": 13307,
+    "totalCount": 14876
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-03",
+    "eBookCount": 1570,
+    "eAudioCount": 13307,
+    "totalCount": 14877
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-02",
+    "eBookCount": 1571,
+    "eAudioCount": 13300,
+    "totalCount": 14871
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-03-01",
+    "eBookCount": 1571,
+    "eAudioCount": 13299,
+    "totalCount": 14870
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-29",
+    "eBookCount": 1571,
+    "eAudioCount": 13217,
+    "totalCount": 14788
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-28",
+    "eBookCount": 1570,
+    "eAudioCount": 13202,
+    "totalCount": 14772
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-27",
+    "eBookCount": 1570,
+    "eAudioCount": 13202,
+    "totalCount": 14772
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-26",
+    "eBookCount": 1570,
+    "eAudioCount": 13202,
+    "totalCount": 14772
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-25",
+    "eBookCount": 1570,
+    "eAudioCount": 13202,
+    "totalCount": 14772
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-24",
+    "eBookCount": 1570,
+    "eAudioCount": 13202,
+    "totalCount": 14772
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-23",
+    "eBookCount": 1570,
+    "eAudioCount": 13202,
+    "totalCount": 14772
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-22",
+    "eBookCount": 1570,
+    "eAudioCount": 13202,
+    "totalCount": 14772
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-21",
+    "eBookCount": 1570,
+    "eAudioCount": 13202,
+    "totalCount": 14772
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-20",
+    "eBookCount": 1570,
+    "eAudioCount": 13202,
+    "totalCount": 14772
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-18",
+    "eBookCount": 1570,
+    "eAudioCount": 13202,
+    "totalCount": 14772
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-17",
+    "eBookCount": 1570,
+    "eAudioCount": 13202,
+    "totalCount": 14772
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-16",
+    "eBookCount": 1570,
+    "eAudioCount": 13202,
+    "totalCount": 14772
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-15",
+    "eBookCount": 1570,
+    "eAudioCount": 13202,
+    "totalCount": 14772
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-14",
+    "eBookCount": 1570,
+    "eAudioCount": 13155,
+    "totalCount": 14725
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-13",
+    "eBookCount": 1570,
+    "eAudioCount": 13155,
+    "totalCount": 14725
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-12",
+    "eBookCount": 1570,
+    "eAudioCount": 13156,
+    "totalCount": 14726
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-11",
+    "eBookCount": 1570,
+    "eAudioCount": 13156,
+    "totalCount": 14726
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-10",
+    "eBookCount": 1570,
+    "eAudioCount": 13156,
+    "totalCount": 14726
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-09",
+    "eBookCount": 1572,
+    "eAudioCount": 13156,
+    "totalCount": 14728
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-08",
+    "eBookCount": 1572,
+    "eAudioCount": 13156,
+    "totalCount": 14728
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-07",
+    "eBookCount": 1572,
+    "eAudioCount": 13156,
+    "totalCount": 14728
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-06",
+    "eBookCount": 1572,
+    "eAudioCount": 13156,
+    "totalCount": 14728
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-05",
+    "eBookCount": 1572,
+    "eAudioCount": 13156,
+    "totalCount": 14728
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-04",
+    "eBookCount": 1572,
+    "eAudioCount": 13156,
+    "totalCount": 14728
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-03",
+    "eBookCount": 1572,
+    "eAudioCount": 13156,
+    "totalCount": 14728
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-02",
+    "eBookCount": 1572,
+    "eAudioCount": 13156,
+    "totalCount": 14728
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-02-01",
+    "eBookCount": 1572,
+    "eAudioCount": 13344,
+    "totalCount": 14916
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-31",
+    "eBookCount": 1572,
+    "eAudioCount": 13279,
+    "totalCount": 14851
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-30",
+    "eBookCount": 1572,
+    "eAudioCount": 13279,
+    "totalCount": 14851
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-29",
+    "eBookCount": 1572,
+    "eAudioCount": 13279,
+    "totalCount": 14851
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-28",
+    "eBookCount": 1572,
+    "eAudioCount": 13279,
+    "totalCount": 14851
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-27",
+    "eBookCount": 1572,
+    "eAudioCount": 13279,
+    "totalCount": 14851
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-26",
+    "eBookCount": 1572,
+    "eAudioCount": 13281,
+    "totalCount": 14853
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-25",
+    "eBookCount": 1572,
+    "eAudioCount": 13281,
+    "totalCount": 14853
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-24",
+    "eBookCount": 1572,
+    "eAudioCount": 13281,
+    "totalCount": 14853
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-23",
+    "eBookCount": 1572,
+    "eAudioCount": 13270,
+    "totalCount": 14842
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-22",
+    "eBookCount": 1572,
+    "eAudioCount": 13270,
+    "totalCount": 14842
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-21",
+    "eBookCount": 1539,
+    "eAudioCount": 13248,
+    "totalCount": 14787
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-20",
+    "eBookCount": 1539,
+    "eAudioCount": 13248,
+    "totalCount": 14787
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-19",
+    "eBookCount": 1539,
+    "eAudioCount": 13248,
+    "totalCount": 14787
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-18",
+    "eBookCount": 1539,
+    "eAudioCount": 13248,
+    "totalCount": 14787
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-17",
+    "eBookCount": 1539,
+    "eAudioCount": 13248,
+    "totalCount": 14787
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-16",
+    "eBookCount": 1505,
+    "eAudioCount": 13211,
+    "totalCount": 14716
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-15",
+    "eBookCount": 1505,
+    "eAudioCount": 13211,
+    "totalCount": 14716
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2020-01-01",
+    "eBookCount": 1510,
+    "eAudioCount": 13026,
+    "totalCount": 14536
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2019-12-01",
+    "eBookCount": 1510,
+    "eAudioCount": 12974,
+    "totalCount": 14484
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-17",
+    "eBookCount": 1513,
+    "eAudioCount": 12919,
+    "totalCount": 14432
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-16",
+    "eBookCount": 1517,
+    "eAudioCount": 12766,
+    "totalCount": 14283
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-15",
+    "eBookCount": 1489,
+    "eAudioCount": 12670,
+    "totalCount": 14159
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-14",
+    "eBookCount": 1313,
+    "eAudioCount": 12502,
+    "totalCount": 13815
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-13",
+    "eBookCount": 1313,
+    "eAudioCount": 12502,
+    "totalCount": 13815
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-12",
+    "eBookCount": 1481,
+    "eAudioCount": 12345,
+    "totalCount": 13826
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-11",
+    "eBookCount": 1482,
+    "eAudioCount": 12264,
+    "totalCount": 13746
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-09",
+    "eBookCount": 1458,
+    "eAudioCount": 12157,
+    "totalCount": 13615
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-08",
+    "eBookCount": 1461,
+    "eAudioCount": 12115,
+    "totalCount": 13576
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-07",
+    "eBookCount": 1362,
+    "eAudioCount": 12069,
+    "totalCount": 13431
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-06",
+    "eBookCount": 1374,
+    "eAudioCount": 12022,
+    "totalCount": 13396
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-05",
+    "eBookCount": 1380,
+    "eAudioCount": 12106,
+    "totalCount": 13486
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-04",
+    "eBookCount": 1385,
+    "eAudioCount": 11969,
+    "totalCount": 13354
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2018-10-03",
+    "eBookCount": 1364,
+    "eAudioCount": 11836,
+    "totalCount": 13200
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-02",
+    "eBookCount": 1349,
+    "eAudioCount": 11757,
+    "totalCount": 13106
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-10-01",
+    "eBookCount": 1355,
+    "eAudioCount": 11710,
+    "totalCount": 13065
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-09-01",
+    "eBookCount": 1367,
+    "eAudioCount": 11679,
+    "totalCount": 13046
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-08-01",
+    "eBookCount": 1542,
+    "eAudioCount": 11596,
+    "totalCount": 13138
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-07-01",
+    "eBookCount": 1514,
+    "eAudioCount": 11471,
+    "totalCount": 12985
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-06-01",
+    "eBookCount": 1514,
+    "eAudioCount": 11471,
+    "totalCount": 12985
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-05-01",
+    "eBookCount": 1514,
+    "eAudioCount": 11471,
+    "totalCount": 12985
+  },
+  {
+    "tenantId": 1931,
+    "asOf": "2016-04-01",
+    "eBookCount": 1511,
+    "eAudioCount": 11424,
+    "totalCount": 12935
+  }
+]

--- a/tests/files/rbdigital/response_catalog_availability_dates_only_one.json
+++ b/tests/files/rbdigital/response_catalog_availability_dates_only_one.json
@@ -1,0 +1,9 @@
+[
+  {
+    "tenantId": 1931,
+    "asOf": "2016-04-01",
+    "eBookCount": 1511,
+    "eAudioCount": 11424,
+    "totalCount": 12935
+  }
+]

--- a/tests/files/rbdigital/response_catalog_delta.json
+++ b/tests/files/rbdigital/response_catalog_delta.json
@@ -1,73 +1,21 @@
-[
-  {
-    "libraryId": 1931,
-    "libraryName": "Wethersfield Public Library",
-    "beginDate": "2016-10-17",
-    "endDate": "2016-10-18",
-    "addedTitles": [
-      {
-        "publisher": "Recorded Books, Inc.",
-        "narrators": "Jackson, J.D.",
-        "audience": "Childrens",
-        "genres": "JUVENILE NONFICTION / Biography & Autobiography / Sports & Recreation",
-        "primaryGenre": "biography-autobiography-memoir,history,juvenile-nonfiction,sports",
-        "isbn": "9781934180723",
-        "mediaType": "eAudio",
-        "title": "Emperor Mage: The Immortals",
-        "authors": "Myers, Walter Dean",
-        "language": "English",
-        "images": [
-          {
-            "name": "small",
-            "url": "http://images.oneclickdigital.com/78226/78226_image_71x108.jpg"
-          },
-          {
-            "name": "medium",
-            "url": "http://images.oneclickdigital.com/78226/78226_image_95x140.jpg"
-          },
-          {
-            "name": "large",
-            "url": "http://images.oneclickdigital.com/78226/78226_image_128x192.jpg"
-          }
-        ],
-        "titleId": 226
-      }
-    ],
-    "removedTitles": [
-      {
-        "description": "\"Float like a butterfly, sting like a bee.\" This was one of the most famous catch-phrases of boxing legend Muhammad Ali. Rising from poverty-stricken Louisville in the 1950s he became one of the world's greatest athletes. Beginning life as Cassius Clay, Ali would struggle against opponents both in and out of the ring. Segregation and racism stood as obstacles in his path, but as he climbed the boxing ranks, his social conscience grew. He refused to be pigeonholed as a stereotypical black athlete in the 1960s and changed his name to Muhammad Ali after converting to Islam. Fighting for social justice even as his brutal profession took its toll on his body and mind, his spirit was never defeated. Best-selling author of the Coretta Scott King Honor book Monster (RB# 96335), Walter Dean Myers pens this inspirational biography of a true champion. Acclaimed narrator JD Jackson adds the perfect voice to this triumphant true story. \"... the kind of universal story that needs a writer as talented as Myers to retell it for every generation.\"-Booklist",
-        "publisher": "Recorded Books, Inc.",
-        "narrators": "Jackson, J.D.",
-        "audience": "Childrens",
-        "genres": "JUVENILE NONFICTION / Biography & Autobiography / Sports & Recreation",
-        "primaryGenre": "biography-autobiography-memoir,history,juvenile-nonfiction,sports",
-        "isbn": "9780590543439",
-        "mediaType": "eAudio",
-        "title": "Greatest: Muhammad Ali, The",
-        "authors": "Myers, Walter Dean",
-        "language": "English",
-        "images": [
-          {
-            "name": "small",
-            "url": "http://images.oneclickdigital.com/78226/78226_image_71x108.jpg"
-          },
-          {
-            "name": "medium",
-            "url": "http://images.oneclickdigital.com/78226/78226_image_95x140.jpg"
-          },
-          {
-            "name": "large",
-            "url": "http://images.oneclickdigital.com/78226/78226_image_128x192.jpg"
-          }
-        ],
-        "titleId": 226
-      }
-    ],
-    "eBookAddedCount": 0,
-    "eBookRemovedCount": 0,
-    "eAudioAddedCount": 1,
-    "eAudioRemovedCount": 1,
-    "titleAddedCount": 1,
-    "titleRemovedCount": 1
-  }
-]
+{
+  "tenantId": 1931,
+  "beginDate": "2020-03-14",
+  "endDate": "2020-04-14",
+  "addedBooks": [
+    {
+      "id": 1301944,
+      "isbn": "9781934180723",
+      "mediaType": "eAudio"
+    }
+  ],
+  "removedBooks": [
+    {
+      "id": 1031919,
+      "isbn": "9780590543439",
+      "mediaType": "eAudio"
+    }
+  ],
+  "booksAddedCount": 1,
+  "booksRemovedCount": 1
+}

--- a/tests/files/rbdigital/response_catalog_media_isbn.json
+++ b/tests/files/rbdigital/response_catalog_media_isbn.json
@@ -1,0 +1,33 @@
+{
+  "seriesName": "Immortals (Pierce)",
+  "seriesPosition": 3,
+  "seriesTotal": 4,
+  "publicationDate": "2008-10-01T00:00:00Z",
+  "hasDigitalRights": false,
+  "description": "In this third volume of the popular Immortals Quartet, Daine enters a glittering world laced with danger and treachery, a world that grows more intense when the gods themselves push her to use her wild magic for their own ends.",
+  "publisher": "Full Cast Audio",
+  "narrators": "Tamora Pierce; A Full Cast",
+  "audience": "Childrens",
+  "genres": "JUVENILE FICTION / Fantasy & Magic",
+  "primaryGenre": "fantasy,juvenile-fiction",
+  "isbn": "9781934180723",
+  "mediaType": "eAudio",
+  "title": "Emperor Mage",
+  "authors": "Tamora Pierce",
+  "language": "English",
+  "images": [
+    {
+      "name": "small",
+      "url": "https://d2cv0ie6dlin9h.cloudfront.net/1748797/1748797_image_71x108.jpg"
+    },
+    {
+      "name": "medium",
+      "url": "https://d2cv0ie6dlin9h.cloudfront.net/1748797/1748797_image_95x140.jpg"
+    },
+    {
+      "name": "large",
+      "url": "https://d2cv0ie6dlin9h.cloudfront.net/1748797/1748797_image_128x192.jpg"
+    }
+  ],
+  "titleId": 10167
+}

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -305,35 +305,114 @@ class TestRBDigitalAPI(RBDigitalAPITest):
             [x['title'] for x in catalog]
         )
 
+    def test_align_delta_dates_to_available_snapshots(self):
+        datastr, datadict = self.api.get_data("response_catalog_availability_dates_multi.json")
+        # The following are the earliest and latest dates in the snapshot test file.
+        first_snapshot = "2016-04-01"
+        last_snapshot = "2020-04-14"
+
+        # A missing begin date should be assigned the date of the earliest
+        # snapshot; a missing end date, should get the date of the latest.
+        self.api.queue_response(status_code=200, content=datastr)
+        from_date, to_date = self.api.align_dates_to_available_snapshots()
+        eq_(first_snapshot, from_date)
+        eq_(last_snapshot, to_date)
+
+        # Items at the temporal beginning and end of
+        # the snapshot list should match when specified
+        self.api.queue_response(status_code=200, content=datastr)
+        from_date, to_date = self.api.align_dates_to_available_snapshots(from_date=first_snapshot, to_date=last_snapshot)
+        eq_(first_snapshot, from_date)
+        eq_(last_snapshot, to_date)
+
+        # A unmatched from_date should be assigned the date of the previous
+        # snapshot (or the first snapshot, if there is not an earlier one).
+        # An unmatched to_date should be assigned the date of the next
+        # snapshot (or the last snapshot, if there is not a later one).
+        self.api.queue_response(status_code=200, content=datastr)
+        from_date, to_date = self.api.align_dates_to_available_snapshots(from_date="2016-06-15", to_date="2020-03-22")
+        eq_("2016-06-01", from_date)
+        eq_("2020-03-22", to_date)
+
+        self.api.queue_response(status_code=200, content=datastr)
+        from_date, to_date = self.api.align_dates_to_available_snapshots(from_date="2016-05-31", to_date="2016-09-02")
+        eq_("2016-05-01", from_date)
+        eq_("2016-10-01", to_date)
+
+        self.api.queue_response(status_code=200, content=datastr)
+        from_date, to_date = self.api.align_dates_to_available_snapshots(from_date="1960-01-01", to_date="2999-12-31")
+        eq_(first_snapshot, from_date)
+        eq_(last_snapshot, to_date)
+
+        # date alignment cannot work without at least one snapshot
+        self.api.queue_response(status_code=200, content=u"[]")
+        assert_raises_regexp(
+            BadResponseException, ".*RBDigital available-dates response contains no snapshots.",
+            self.api.align_dates_to_available_snapshots, from_date="2000-02-02", to_date="2000-01-01"
+        )
+        self.api.queue_response(status_code=200, content=u"[]")
+        assert_raises_regexp(
+            BadResponseException, ".*RBDigital available-dates response contains no snapshots.",
+            self.api.align_dates_to_available_snapshots
+        )
+
     def test_get_delta(self):
+        assert_raises_regexp(
+            ValueError, 'from_date 2000-02-02 cannot be after to_date 2000-01-01.',
+            self.api.get_delta, from_date="2000-02-02", to_date="2000-01-01"
+        )
+
+        # The effective begin and end snapshot dates (after availability alignment)
+        # cannot be the same.
+        # This can happen when from_date and to_date from the call were the same
+        # and there is an exact snapshot date match, ...
+        available_dates_string, datadict = self.api.get_data("response_catalog_availability_dates_multi.json")
+        self.api.queue_response(status_code=200, content=available_dates_string)
+        assert_raises_regexp(
+            ValueError, 'The effective begin and end RBDigital catalog snapshot dates cannot be the same.',
+            self.api.get_delta, from_date="2020-04-01", to_date="2020-04-01"
+        )
+        # but can also occur when:
+        # - both dates are less than the date of the first snapshot, ...
+        self.api.queue_response(status_code=200, content=available_dates_string)
+        assert_raises_regexp(
+            ValueError, 'The effective begin and end RBDigital catalog snapshot dates cannot be the same.',
+            self.api.get_delta, from_date="1960-01-01", to_date="1960-01-02"
+        )
+        # - both dates are greater than the date of the last snapshot, or ...
+        self.api.queue_response(status_code=200, content=available_dates_string)
+        assert_raises_regexp(
+            ValueError, 'The effective begin and end RBDigital catalog snapshot dates cannot be the same.',
+            self.api.get_delta, from_date="2999-12-31", to_date="2999-12-31"
+        )
+        # - only a single snapshot is available
+        datastr, datadict = self.api.get_data("response_catalog_availability_dates_only_one.json")
+        self.api.queue_response(status_code=200, content=datastr)
+        assert_raises_regexp(
+            ValueError, 'The effective begin and end RBDigital catalog snapshot dates cannot be the same.',
+            self.api.get_delta, from_date="1960-01-01", to_date="2999-12-31"
+        )
+        self.api.queue_response(status_code=200, content=datastr)
+        assert_raises_regexp(
+            ValueError, 'The effective begin and end RBDigital catalog snapshot dates cannot be the same.',
+            self.api.get_delta
+        )
+
+        # Retrieving a delta requires first retrieving a list of dated
+        # snapshots, then retrieving the changes between those dates.
+        datastr, datadict = self.api.get_data("response_catalog_availability_dates_multi.json")
+        self.api.queue_response(status_code=200, content=datastr)
         datastr, datadict = self.api.get_data("response_catalog_delta.json")
         self.api.queue_response(status_code=200, content=datastr)
 
-        assert_raises_regexp(
-            ValueError, 'from_date 2000-01-01 00:00:00 must be real, in the past, and less than 6 months ago.',
-            self.api.get_delta, from_date="2000-01-01", to_date="2000-02-01"
-        )
-
-        today = datetime.datetime.now()
-        three_months = relativedelta(months=3)
-        assert_raises_regexp(
-            ValueError, "from_date .* - to_date .* asks for too-wide date range.",
-            self.api.get_delta, from_date=(today - three_months), to_date=today
-        )
-
         delta = self.api.get_delta()
-        eq_(1931, delta[0]["libraryId"])
-        eq_("Wethersfield Public Library", delta[0]["libraryName"])
-        eq_("2016-10-17", delta[0]["beginDate"])
-        eq_("2016-10-18", delta[0]["endDate"])
-        eq_(0, delta[0]["eBookAddedCount"])
-        eq_(0, delta[0]["eBookRemovedCount"])
-        eq_(1, delta[0]["eAudioAddedCount"])
-        eq_(1, delta[0]["eAudioRemovedCount"])
-        eq_(1, delta[0]["titleAddedCount"])
-        eq_(1, delta[0]["titleRemovedCount"])
-        eq_(1, len(delta[0]["addedTitles"]))
-        eq_(1, len(delta[0]["removedTitles"]))
+        eq_(1931, delta["tenantId"])
+        eq_("2020-03-14", delta["beginDate"])
+        eq_("2020-04-14", delta["endDate"])
+        eq_(1, delta["booksAddedCount"])
+        eq_(1, delta["booksRemovedCount"])
+        eq_([{u'isbn': u'9781934180723', u'id': 1301944, u'mediaType': u'eAudio'}], delta["addedBooks"])
+        eq_([{u'isbn': u'9780590543439', u'id': 1031919, u'mediaType': u'eAudio'}], delta["removedBooks"])
 
     def test_patron_remote_identifier_new_patron(self):
         # End-to-end test of patron_remote_identifier, in the case
@@ -821,7 +900,15 @@ class TestRBDigitalAPI(RBDigitalAPITest):
         tricks.licenses_owned = 10
         tricks.licenses_available = 5
 
+        # Retrieving a delta requires first retrieving a list of dated
+        # snapshots, then retrieving the changes between those dates.
+        datastr, datadict = self.get_data("response_catalog_availability_dates_multi.json")
+        self.api.queue_response(status_code=200, content=datastr)
         datastr, datadict = self.get_data("response_catalog_delta.json")
+        self.api.queue_response(status_code=200, content=datastr)
+        # RBDigitalAPI.populate_delta then retrieves a complete media entry
+        # for the ISBN of each added item. This is not needed for removals.
+        datastr, datadict = self.get_data("response_catalog_media_isbn.json")
         self.api.queue_response(status_code=200, content=datastr)
         result = self.api.populate_delta()
 
@@ -847,7 +934,7 @@ class TestRBDigitalAPI(RBDigitalAPITest):
             "9781934180723", collection=self.collection
         )
         work = emperor.work
-        eq_("Emperor Mage: The Immortals", work.title)
+        eq_("Emperor Mage", work.title)
         eq_(True, work.presentation_ready)
 
         # However, we have not set availability information on this

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -356,6 +356,14 @@ class TestRBDigitalAPI(RBDigitalAPITest):
             self.api.align_dates_to_available_snapshots
         )
 
+        # exception for invalid json
+        self.api.queue_response(status_code=200, content="this is not JSON")
+        assert_raises_regexp(
+            BadResponseException, ".*RBDigital available-dates response not parsable.",
+            self.api.align_dates_to_available_snapshots
+        )
+
+
     def test_get_delta(self):
         assert_raises_regexp(
             ValueError, 'from_date 2000-02-02 cannot be after to_date 2000-01-01.',


### PR DESCRIPTION
## JIRA Ticket

https://jira.nypl.org/browse/SIMPLY-2747

## What does this PR do?

This PR addresses an issue caused by changes to the RBDigital API.

Specifically, the `/v1/libraries/:libraryId/media/delta` endpoint, has been deprecated. It previously worked by accepting `begin` and `end` date query parameters, from which it would calculate and return the delta between those dates and return cataloging metadata for the items involved.

In the new version,
- the `begin` and `end` dates are selected from a list of snapshots from the `/v1/libraries/:libraryId/book-holdings/delta/available-dates` endpoint,
- those dates are then given as query parameters to the `/v1/libraries/:libraryId/book-holdings/delta` endpoint (the format of this response has changed, as well), and finally
- the ISBN for each added item is used as the `:token` for the `/v1/libraries/:libraryId/media/:token` endpoint to retrieve the catalog metadata in the correct format.

The PR also fixes a couple of bugs on apparently seldomly traversed paths.

## How should this be tested?

Run the `bin/rbdigital_collection_delta` script in QA, test, and/or dev environment and ensure that it completes successfully.

Run test suite, which has been updated with new tests, assertions, and content that reflect added and changed methods and new API endpoint responses.

## Who has tested?
@tdilauro - In two dev environments from dumps of different Circulation Manager instances.