### PR TITLE
All Overdrive formats except streaming and manifest-based formats must be locked in before use.

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -134,15 +134,19 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
         (overdrive_audiobook_manifest, libby_drm): 'audiobook-overdrive-manifest'
     }
 
-    # Once you choose an Adobe format you're locked into it and can't
-    # use other formats.
-    LOCK_IN_FORMATS = [ x for x in BaseOverdriveAPI.FORMATS if 'adobe' in x ]
-
     # These formats can be delivered either as manifest files or as
     # links to websites that stream the content.
     STREAMING_FORMATS = [
         'ebook-overdrive',
         'audiobook-overdrive',
+    ]
+
+    # Once you choose a non-streaming format you're locked into it and can't
+    # use other formats.
+    LOCK_IN_FORMATS = [
+        x for x in BaseOverdriveAPI.FORMATS
+        if x not in STREAMING_FORMATS
+        and x not in MANIFEST_INTERNAL_FORMATS
     ]
 
     # TODO: This is a terrible choice but this URL should never be

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -93,6 +93,23 @@ class TestOverdriveAPI(OverdriveAPITest):
         eq_(self.collection.external_integration,
             self.api.external_integration(self._db))
 
+    def test_lock_in_format(self):
+        # Verify which formats do or don't need to be locked in before
+        # fulfillment.
+        needs_lock_in = self.api.LOCK_IN_FORMATS
+
+        # Streaming and manifest-based formats are exempt; all
+        # other formats need lock-in.
+        exempt = (
+            list(self.api.STREAMING_FORMATS) +
+            list(self.api.MANIFEST_INTERNAL_FORMATS)
+        )
+        for i in self.api.FORMATS:
+            if i not in exempt:
+                assert i in needs_lock_in
+        for i in exempt:
+            assert i not in needs_lock_in
+
     def test__run_self_tests(self):
         """Verify that OverdriveAPI._run_self_tests() calls the right
         methods.
@@ -1245,13 +1262,13 @@ class TestExtractData(OverdriveAPITest):
         link = MockOverdriveAPI.get_download_link(
             json, "ebook-overdrive-manifest", "http://bar.com/"
         )
-        
+
         # The {errorpageurl} and {odreadauthurl} parameters
         # have been removed, and contentfile=true has been appended.
         eq_(base_url + '?contentfile=true', link)
 
     def test_extract_download_link(self):
-        # Verify that extract_download_link can or cannot find a 
+        # Verify that extract_download_link can or cannot find a
         # download link for a given format subdocument.
 
         class Mock(OverdriveAPI):


### PR DESCRIPTION
## Description

This branch fixes https://jira.nypl.org/browse/SIMPLY-2755.

## How Has This Been Tested?

Used a local circulation manager install against NYPL's QA database to check out an affected book

https://localhost:6500/NYNYPL/works/Overdrive%20ID/d246264b-1a10-44dd-b273-b96c676da3b7/borrow

and then fulfill its DRM-free offering.

https://localhost:6500/NYNYPL/works/248488/fulfill/1

## Checklist:

- [x] All new and existing tests passed.
