### PR TITLE
Fix marc record generator

### DIFF
--- a/api/admin/controller/catalog_services.py
+++ b/api/admin/controller/catalog_services.py
@@ -106,7 +106,7 @@ class CatalogServicesController(SettingsController):
             self._db, ExternalIntegrationLink,
             library_id=None,
             external_integration_id=service.id,
-            purpose="MARC"
+            purpose=ExternalIntegrationLink.MARC
         )
 
         if mirror_integration_id == self.NO_MIRROR_INTEGRATION:

--- a/scripts.py
+++ b/scripts.py
@@ -795,21 +795,21 @@ class CacheMARCFiles(LaneSweeperScript):
         # integration.
         integration_link = get_one(
             self._db, ExternalIntegrationLink,
-            other_integration_id=exporter.integration.id,
+            external_integration_id=exporter.integration.id,
             purpose=ExternalIntegrationLink.MARC
         )
         # Then use the "other" integration value to find the storage integration.
-        integration = get_one(self._db, ExternalIntegration,
+        storage_integration = get_one(self._db, ExternalIntegration,
             id=integration_link.other_integration_id
         )
 
-        if not integration:
+        if not storage_integration:
             self.log.info("No storage External Integration was found.")
             return
 
         # First update the file with ALL the records.
         records = exporter.records(
-            lane, annotator, integration
+            lane, annotator, storage_integration
         )
 
         # Then create a new file with changes since the last update.
@@ -819,7 +819,7 @@ class CacheMARCFiles(LaneSweeperScript):
             start_time = last_update - timedelta(days=1)
 
             records = exporter.records(
-                lane, annotator, integration, start_time=start_time
+                lane, annotator, storage_integration, start_time=start_time
             )
 
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -596,9 +596,18 @@ class TestCacheMARCFiles(TestLaneScript):
                 self.called_with += [(lane, annotator, mirror_integration, start_time)]
 
         exporter = MockMARCExporter(None, None, integration)
+
+        # This just needs to be an ExternalIntegration, but a storage integration
+        # makes the most sense in this context.
+        the_linked_integration, ignore = create(
+            self._db, ExternalIntegration,
+            protocol=ExternalIntegration.S3,
+            goal=ExternalIntegration.STORAGE_GOAL,
+        )
+
         integration_link = self._external_integration_link(
             integration=integration,
-            other_integration=exporter.integration,
+            other_integration=the_linked_integration,
             purpose=ExternalIntegrationLink.MARC
         )
 
@@ -611,7 +620,7 @@ class TestCacheMARCFiles(TestLaneScript):
 
         eq_(lane, exporter.called_with[0][0])
         assert isinstance(exporter.called_with[0][1], MARCLibraryAnnotator)
-        eq_(exporter.integration, exporter.called_with[0][2])
+        eq_(the_linked_integration, exporter.called_with[0][2])
         eq_(None, exporter.called_with[0][3])
 
         # If we have a cached file already, and it's old enough, the script will
@@ -635,12 +644,12 @@ class TestCacheMARCFiles(TestLaneScript):
 
         eq_(lane, exporter.called_with[0][0])
         assert isinstance(exporter.called_with[0][1], MARCLibraryAnnotator)
-        eq_(exporter.integration, exporter.called_with[0][2])
+        eq_(the_linked_integration, exporter.called_with[0][2])
         eq_(None, exporter.called_with[0][3])
 
         eq_(lane, exporter.called_with[1][0])
         assert isinstance(exporter.called_with[1][1], MARCLibraryAnnotator)
-        eq_(exporter.integration, exporter.called_with[1][2])
+        eq_(the_linked_integration, exporter.called_with[1][2])
         assert exporter.called_with[1][3] < last_week
 
         # If we already have a recent cached file, the script won't do anything.
@@ -657,12 +666,12 @@ class TestCacheMARCFiles(TestLaneScript):
 
         eq_(lane, exporter.called_with[0][0])
         assert isinstance(exporter.called_with[0][1], MARCLibraryAnnotator)
-        eq_(exporter.integration, exporter.called_with[0][2])
+        eq_(the_linked_integration, exporter.called_with[0][2])
         eq_(None, exporter.called_with[0][3])
 
         eq_(lane, exporter.called_with[1][0])
         assert isinstance(exporter.called_with[1][1], MARCLibraryAnnotator)
-        eq_(exporter.integration, exporter.called_with[1][2])
+        eq_(the_linked_integration, exporter.called_with[1][2])
         assert exporter.called_with[1][3] < yesterday
         assert exporter.called_with[1][3] > last_week
 
@@ -678,12 +687,12 @@ class TestCacheMARCFiles(TestLaneScript):
 
         eq_(lane, exporter.called_with[0][0])
         assert isinstance(exporter.called_with[0][1], MARCLibraryAnnotator)
-        eq_(exporter.integration, exporter.called_with[0][2])
+        eq_(the_linked_integration, exporter.called_with[0][2])
         eq_(None, exporter.called_with[0][3])
 
         eq_(lane, exporter.called_with[1][0])
         assert isinstance(exporter.called_with[1][1], MARCLibraryAnnotator)
-        eq_(exporter.integration, exporter.called_with[1][2])
+        eq_(the_linked_integration, exporter.called_with[1][2])
         assert exporter.called_with[1][3] < yesterday
         assert exporter.called_with[1][3] > last_week
 


### PR DESCRIPTION
## Description

This PR fixes some issues related to MARC export:
- completes some changes started on [SIMPLY-2296](https://jira.nypl.org/browse/SIMPLY-2296) in [3.0.2cm](https://github.com/NYPL-Simplified/circulation/releases/tag/3.0.2):
  - switches from literal "MARC" to constant `ExternalIntegrationLink.MARC` for `ExternalIntegrationLink`'s purpose,
  - drops use of `MARC_Exporter.STORAGE_PROTOCOL`, and
  - fixes some tests; and
- fixes an error that occurs when attempting to lookup the storage integration for a MARC Export and renames a variable for clarity.
  - The query for the MARC Export integration's `ExternalIntegrationLink` was malformed, resulting in a None, rather than an `ExternalIntegrationLink`.

## Prerequisite

Complete fix depends on changes in [server_core PR #1176](https://github.com/NYPL-Simplified/server_core/pull/1176).

## Motivation and Context

See JIRA issue https://jira.nypl.org/browse/SIMPLY-2759

MARC record export/mirroring was not working.

## How Has This Been Tested?

Set a breakpoint at the `ExternalIntegrationLink` and stepped through the code. Once the error was corrected, stepping through revealed a correct `ExternalIntegrationLink`.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
