### PR TITLE
Fix an os-specific tmpfile test.

### DIFF
--- a/tests/sip/test_client.py
+++ b/tests/sip/test_client.py
@@ -104,7 +104,8 @@ class TestSIPClient(object):
             assert isinstance(connection, MockSocket)
             eq_(set(['keyfile', 'certfile']), set(kwargs.keys()))
             for tmpfile in kwargs.values():
-                assert tmpfile.startswith("/tmp")
+                tmpfile = os.path.abspath(tmpfile)
+                assert os.path.basename(tmpfile).startswith("tmp")
                 # By the time the SSL socket has been wrapped, the
                 # temporary file has already been removed.  Because of
                 # that we can't verify from within a unit test that the


### PR DESCRIPTION
## Description

Fixes a test of temp file names so that it does not depend on the OS and/or OS version on which the test is run.

## Motivation and Context

Current versions of MacOS use `/var/folders` instead of `/tmp` when creating files with `tempfile.mkstemp`. I would expect that particular test to fail on non-Unixy platforms, as well.

## How Has This Been Tested?

I tested by running the test (and all the other tests, for that matter) in a MacOS Catalina environment. I'm counting on Travis to perform the test in a Linux environment.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X ] All new and existing tests passed.
