### PR TITLE
Allow some OPDS feed controllers to turn off caching by user request

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -297,9 +297,11 @@ class CirculationManager(object):
         """Generate a URL for a view that (probably) passes through a CDN.
 
         :param view: Name of the view.
-        :param facets: The faceting object used to generate the document that's calling
+        :param _facets: The faceting object used to generate the document that's calling
            this method. This may change which function is actually used to generate the
-           URL; in particular, it may disable a CDN that would otherwise be used.
+           URL; in particular, it may disable a CDN that would otherwise be used. This is
+           called _facets just in case there's ever a view that takes 'facets' as a real
+           keyword argument.
         :param args: Positional arguments to the view function.
         :param kwargs: Keyword arguments to the view function.
         """
@@ -765,7 +767,7 @@ class OPDSFeedController(CirculationManagerController):
 
         url = self.cdn_url_for(
             "acquisition_groups", lane_identifier=lane_identifier,
-            library_short_name=library.short_name, facets=facets
+            library_short_name=library.short_name, _facets=facets
         )
 
         annotator = self.manager.annotator(lane, facets)
@@ -798,7 +800,7 @@ class OPDSFeedController(CirculationManagerController):
         library_short_name = flask.request.library.short_name
         url = self.cdn_url_for(
             "feed", lane_identifier=lane_identifier,
-            library_short_name=library_short_name, facets=facets
+            library_short_name=library_short_name, _facets=facets
         )
 
         annotator = self.manager.annotator(lane, facets=facets)

--- a/api/controller.py
+++ b/api/controller.py
@@ -201,7 +201,7 @@ class CirculationManager(object):
             authenticated = False
             controller = getattr(self, 'admin_sign_in_controller', None)
             if controller:
-                admin = self.admin_sign_in_controller.authenticated_admin_from_request()
+                admin = controller.authenticated_admin_from_request()
                 # If authenticated_admin_from_request returns anything other than an admin (probably
                 # a ProblemDetail), the user is not an authenticated admin.
                 if isinstance(admin, Admin):

--- a/api/controller.py
+++ b/api/controller.py
@@ -155,6 +155,7 @@ from novelist import (
 from base_controller import BaseCirculationManagerController
 from testing import MockCirculationAPI, MockSharedCollectionAPI
 from core.analytics import Analytics
+from core.lane import BaseFacets
 from core.marc import MARCExporter
 
 class CirculationManager(object):
@@ -186,7 +187,7 @@ class CirculationManager(object):
         caching rules unless you're an authenticated administrator.
         """
         facets = load_facets_from_request(*args, **kwargs)
-        if facets and facets.max_cache_age is not None:
+        if isinstance(facets, BaseFacets) and getattr(facets, 'max_cache_age', None) is not None:
             # A faceting object was loaded, and it tried to do something nonstandard
             # with caching.
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -178,6 +178,12 @@ class CirculationManager(object):
         self.setup_one_time_controllers()
         self.load_settings()
 
+    def load_facets_from_request(self):
+        facets = core_load_facets_from_request
+        if facets.max_cache_age is not None:
+        app.manager.admin_sign_in_controller.authenticated_admin_from_request()
+
+
     def reload_settings_if_changed(self):
         """If the site configuration has been updated, reload the
         CirculationManager's configuration from the database.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3179,6 +3179,7 @@ class TestOPDSFeedController(CirculationControllerTest):
             expect_url = self.controller.cdn_url_for(
                 "feed", lane_identifier=lane_id,
                 library_short_name=self._default_library.short_name,
+                _facets=load_facets_from_request()
             )
 
         assert isinstance(response, Response)
@@ -3285,6 +3286,7 @@ class TestOPDSFeedController(CirculationControllerTest):
             expect_url = self.manager.opds_feeds.cdn_url_for(
                 "acquisition_groups", lane_identifier=None,
                 library_short_name=library.short_name,
+                _facets=load_facets_from_request()
             )
 
         kwargs = self.groups_called_with
@@ -3322,6 +3324,7 @@ class TestOPDSFeedController(CirculationControllerTest):
             expect_url = self.manager.opds_feeds.cdn_url_for(
                 "feed", lane_identifier=self.english_adult_fiction.id,
                 library_short_name=library.short_name,
+                _facets=load_facets_from_request()
             )
 
         eq_(self.english_adult_fiction, self.page_called_with.pop('worklist'))

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -173,6 +173,7 @@ import random
 import json
 import urllib
 from core.analytics import Analytics
+from core.lane import BaseFacets
 from core.util.authentication_for_opds import AuthenticationForOPDSDocument
 from api.registry import Registration
 
@@ -744,7 +745,7 @@ class TestCirculationManager(CirculationControllerTest):
 
         # But if a faceting object is passed in as _facets, it's checked
         # to see if it wants to disable caching.
-        class MockFacets(object):
+        class MockFacets(BaseFacets):
             max_cache_age = None
         kwargs_with_facets = dict(kwargs)
         kwargs_with_facets.update(_facets=MockFacets)


### PR DESCRIPTION
## Description

This branch makes it possible for a client to signal to the circulation manager that it wants a brand-new OPDS feed, not one based on a potentially out-of-date cache. You do this by sticking `max_age=0` onto the URL. This only works if the client is authenticated with the admin interface as an administrator; a random OPDS client can't use this functionality.

There are no links to feeds with this capability -- you have to know to add it -- but once you're in "no cache" mode, OPDS feeds will propagate "no cache mode", whenver possible, to the OPDS feeds they link to.

## Motivation and Context

This is the last part of the backend work for https://jira.nypl.org/browse/SIMPLY-2582. 

## How Has This Been Tested?

Reproduction steps are given in the JIRA ticket. I added test coverage for most of `CirculationManager.cdn_url_for`, which previously fell into the "too difficult and too small to bother testing" category.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [] All new and existing tests passed.
