### PR TITLE
Treat an empty list of circulation events from Bibliotheca as an error condition, just to be safe.

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1137,9 +1137,22 @@ class EventParser(BibliothecaParser):
     }
 
     def process_all(self, string):
+        has_events = False
         for i in super(EventParser, self).process_all(
                 string, "//CloudLibraryEvent"):
             yield i
+            has_events = True
+
+        if not has_events:
+            # An empty list of events may mean nothing happened, or it
+            # may indicate an unreported server-side error. To be
+            # safe, we'll treat this as a server-initiated error
+            # condition. If this is just a slow day, normal behavior
+            # will resume as soon as something happens.
+            raise RemoteInitiatedServerError(
+                "No events returned from server. This may not be an error, but treating it as one to be safe.",
+                BibliothecaAPI.SERVICE_NAME
+            )
 
     def process_one(self, tag, namespaces):
         isbn = self.text_of_subtag(tag, "ISBN")

--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -1526,11 +1526,13 @@ class RBDigitalAPI(BaseCirculationAPI, HasSelfTests):
 
         return items_transmitted, items_created
 
-    def populate_delta(self, months=1):
+    def populate_delta(self, months=1, today=None):
         """ Call get_delta for the last month to get all of the library's book info changes
         from RBDigital.  Update Work, Edition, LicensePool objects in our database.
+
+        :param today: A date to use instead of the current date, for use in tests.
         """
-        today = datetime.datetime.utcnow()
+        today = today or datetime.datetime.utcnow()
         time_ago = relativedelta(months=months)
 
         delta = self.get_delta(from_date=(today - time_ago), to_date=today)

--- a/tests/files/bibliotheca/empty_event_list.xml
+++ b/tests/files/bibliotheca/empty_event_list.xml
@@ -1,0 +1,1 @@
+<LibraryEventBatch xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>

--- a/tests/files/bibliotheca/empty_event_list.xml
+++ b/tests/files/bibliotheca/empty_event_list.xml
@@ -1,1 +1,0 @@
-<LibraryEventBatch xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -679,6 +679,14 @@ class TestBibliothecaParser(BibliothecaAPITest):
 
 class TestEventParser(BibliothecaAPITest):
 
+    def test_parse_empty_list(self):
+        data = self.sample_data("empty_event_list.xml")
+        assert_raises_regexp(
+            RemoteInitiatedServerError,
+            "No events returned from server. This may not be an error, but treating it as one to be safe.",
+            list, EventParser().process_all(data)
+        )
+
     def test_parse_empty_end_date_event(self):
         data = self.sample_data("empty_end_date_event.xml")
         [event] = list(EventParser().process_all(data))

--- a/tests/test_rbdigital.py
+++ b/tests/test_rbdigital.py
@@ -980,7 +980,9 @@ class TestRBDigitalAPI(RBDigitalAPITest):
         # for the ISBN of each added item. This is not needed for removals.
         datastr, datadict = self.get_data("response_catalog_media_isbn.json")
         self.api.queue_response(status_code=200, content=datastr)
-        result = self.api.populate_delta()
+        result = self.api.populate_delta(
+            today=datetime.datetime(2020,04,30)
+        )
 
         # populate_delta returns two numbers, as required by
         # RBDigitalSyncMonitor.


### PR DESCRIPTION
## Description

If the "cloudevents" endpoint of the Bibliotheca API returns an empty list, this branch treats that as a temporary error condition, which will stop the `BibliothecaEventMonitor` from running. Once the API returns a list of events with at least one thing in it, the `BibliothecaEventMonitor` will be able to resume.

This branch incidentally fixes a problem in the RBDigital test code which only became apparent one month after the last date mentioned in one of the test files.

## Motivation and Context

This fixes https://jira.nypl.org/browse/SIMPLY-2750. There are some server-side error conditions which cause the Bibliotheca API to send empty documents instead of error messages. This one is quite serious because it can cause a library to permanently miss out on data, including books added to a collection.

Raising an exception on an empty document will solve this problem. The downside is that on a slow day it may look like the API isn't working, even if it's working fine.

## How Has This Been Tested?

Using the NYPL QA server, I bumped down `BibliothecaMonitor.OVERLAP` to five seconds and ran bin/bibliotheca_monitor several times in succession until I encountered a five-second period where nothing happened. Let's say that happened at 4:10:00.

At that point bibliotheca_monitor started erroring out. Every time I ran it, it tried to get a list of events from 4:09:55 to the present time, and when the list came back empty, it errored out.

At some point someone borrowed a Bibliotheca book. Let's say that happened at 4:10:29.

The next time I ran bibliotheca_monitor, it grabbed the list of events from 4:09:55 to 4:10:35, processed one event from 4:10:29, and updated the monitor's start date from 4:09:55 to the current time -- 4:10:35.

The next time I ran bibliotheca_monitor after _that_, it grabbed a list of events starting at 4:10:30. At this point it had completely recovered from the temporary "API failure".

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
