### PR TITLE
Use the AnnouncementListValidator to validate incoming data of the appropriate type

### DIFF
--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -261,6 +261,9 @@ class LibrarySettingsController(SettingsController):
         #   geographic areas), but not settings that are a single value of that type
         #   (_one_ language code or geographic area). Sometimes there's even an implication
         #   that a certain data type ('geographic') _must_ mean a list.
+        # * A list value is returned as a JSON-encoded string. It
+        #   would be better to keep that as a list for longer in case
+        #   controller code needs to look at it.
         format = setting.get('format')
         type = setting.get('type')
 

--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -279,7 +279,7 @@ class LibrarySettingsController(SettingsController):
             value = self.list_setting(setting)
             value = validator.validate_geographic_areas(value, self._db)
         elif format == "announcements":
-            value = self.list_setting(setting)
+            value = self.list_setting(setting, json_objects=True)
             value = validator.validate(value)
         elif type == "list":
             value = self.list_setting(setting)
@@ -296,8 +296,15 @@ class LibrarySettingsController(SettingsController):
         """Retrieve the single value of the given setting from the current HTTP request."""
         return flask.request.form.get(setting['key'])
 
-    def list_setting(self, setting):
-        """Retrieve the list of values for the given setting from the current HTTP request."""
+    def list_setting(self, setting, json_objects=False):
+        """Retrieve the list of values for the given setting from the current HTTP request.
+
+        :param json_objects: If this is True, the incoming settings are JSON-encoded objects and not
+           regular strings.
+
+        :return: A JSON-encoded string encoding the list of values set for the given setting in the
+           current request.
+        """
         if setting.get('options'):
             # Restrict to the values in 'options'.
             value = []
@@ -309,7 +316,11 @@ class LibrarySettingsController(SettingsController):
             value = []
             inputs = flask.request.form.getlist(setting.get("key"))
             for i in inputs:
-                value.extend(i) if isinstance(i, list) else value.append(i)
+                if not isinstance(i, list):
+                    i = [i]
+                if json_objects:
+                    i = [json.loads(s) for x in i]
+                value.extend(i)
         return json.dumps(filter(None, value))
 
     def image_setting(self, setting):

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -255,7 +255,8 @@ class TestLibrarySettings(SettingsControllerTest):
                 (Configuration.LOGO, TestFileUpload(image_data)),
             ])
             validator = MockValidator()
-            response = self.manager.admin_library_settings_controller.process_post(validator)
+            validators = dict(geographic=validator)
+            response = self.manager.admin_library_settings_controller.process_post(validators)
             eq_(response.status_code, 201)
 
         library = get_one(self._db, Library, short_name="nypl")


### PR DESCRIPTION
## Description

This branch changes library_configuration_settings to take a dictionary of validator objects instead of just one validator (assumed to be a GeographicValidator). This makes it possible to use different validation rules for fields of different types. Specifically, fields of type `announcements` are validated using an `AnnouncementListValidator`.

There are still no actual fields of type `announcements` in LIBRARY_SETTINGS, so this code won't ever be triggered in real life. I'm assuming the branch that adds the front-end editor for fields of this type will add an appropriate field.

I refactored library_configuration_settings to make it easier to test, and added a lot of unit tests for code that was already covered at a higher level by test_libraries_post_edit and test_libraries_post_create.

## Motivation and Context

This is back-end work towards tickets like https://jira.nypl.org/browse/SIMPLY-2736.

I'm trying to clear a path towards a more general framework for data validation, without going all out and writing that framework when that's not the point of the work we're doing. I'm doing just enough refactoring to be confident that my additions didn't break anything,.

## How Has This Been Tested?

Still not exposed through the UI, so the automated tests should be enough.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] All new and existing tests passed.
