### PR TITLE
Fix odl expired raises nolicense

### DIFF
--- a/api/odl.py
+++ b/api/odl.py
@@ -345,8 +345,8 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI):
     def _checkout(self, patron_or_client, licensepool, hold=None):
         _db = Session.object_session(patron_or_client)
 
-        unexpired_licenses_owned = len([license for license in licensepool.licenses if not license.is_expired])
-        if unexpired_licenses_owned < 1:
+        unexpired_licenses = (l for l in licensepool.licenses if not l.is_expired)
+        if not any(unexpired_licenses):
             raise NoLicenses()
 
         # Make sure pool info is updated.

--- a/api/odl.py
+++ b/api/odl.py
@@ -344,7 +344,8 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI):
     def _checkout(self, patron_or_client, licensepool, hold=None):
         _db = Session.object_session(patron_or_client)
 
-        if licensepool.licenses_owned < 1:
+        unexpired_licenses_owned = len([license for license in licensepool.licenses if not license.is_expired])
+        if unexpired_licenses_owned < 1:
             raise NoLicenses()
 
         # Make sure pool info is updated.

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -1590,6 +1590,17 @@ class TestSharedODLAPI(DatabaseTest, BaseODLTest):
         eq_([self.pool.identifier.links[0].resource.url],
              self.api.requests)
 
+    def test_checkout_no_licenses(self):
+        self.api.queue_response(
+            NO_LICENSES.response[1],
+            headers=NO_LICENSES.response[2],
+            content=NO_LICENSES.response[0],
+        )
+        assert_raises(NoLicenses, self.api.checkout, self.patron, "pin",
+                      self.pool, Representation.EPUB_MEDIA_TYPE)
+        eq_([self.pool.identifier.links[0].resource.url],
+             self.api.requests)
+
     def test_checkout_from_hold_not_available(self):
         hold, ignore = self.pool.on_hold_to(self.patron)
         hold_info_response = self.get_data("shared_collection_hold_info_reserved.opds")


### PR DESCRIPTION
## Description

This branch fixes an issue that led to an unhandled exception when ODL checkout encountered a licensepool in which all available licenses were expired. It checks for this condition and raises `NoLicenses`

## Motivation and Context

During checkout of an ODL edition, if all the licenses in the associated licensepool were expired, checkout would raise `NoAvailableCopies`, rather than `NoLicenses`.

This triggered a hold (`ODLAPI._place_hold`), which in turn triggered an addition check to ensure that there truly were no licenses available. Because there were "available" licenses (albeit expired ones) that check failed, raising an unhandled `CurrentlyAvailable` exception, which Flask handled.

Fixes [SIMPLY-2779](https://jira.nypl.org/browse/SIMPLY-2779).

## How Has This Been Tested?

This was tested end-to-end using two CM instances, one configured as a SharedODL server, the other as a client.

New tests were added to cover the underlying condition on the server and verify the expected response in the client.

## Checklist:

- [X] All new and existing tests passed.
