### PR TITLE
Publish a library's announcements through its Authentication For OPDS document

### DIFF
--- a/api/admin/announcement_list_validator.py
+++ b/api/admin/announcement_list_validator.py
@@ -81,7 +81,7 @@ class AnnouncementListValidator(Validator):
         today = datetime.date.today()
 
         start = self.validate_date(
-            'start', announcement.get('start', today), minimum=today
+            'start', announcement.get('start', today)
         )
         if isinstance(start, ProblemDetail):
             return start

--- a/api/announcements.py
+++ b/api/announcements.py
@@ -71,4 +71,12 @@ class Announcement(object):
         """Should this announcement be displayed now?"""
         today = datetime.date.today()
         return self.start <= today and self.finish >= today
-        
+
+    @property
+    def for_authentication_document(self):
+        """The publishable representation of this announcement,
+        for use in an authentication document.
+
+        Basically just the ID and the content.
+        """
+        return dict(id=self.id, content=self.content)

--- a/api/announcements.py
+++ b/api/announcements.py
@@ -1,0 +1,74 @@
+import datetime
+
+from core.util.problem_detail import ProblemDetail
+
+from admin.announcement_list_validator import AnnouncementListValidator
+
+class Announcements(object):
+    """Data model class for a library's announcements.
+
+    This entire list is stored as a single
+    ConfigurationSetting, which is why this isn't in core/model.
+    """
+    SETTING_NAME = "announcements"
+
+    @classmethod
+    def for_library(cls, library):
+        """Load an Announcements object for the given Library.
+
+        :param library: A Library
+        """
+        announcements = library.setting(cls.SETTING_NAME).json_value or []
+        return cls(announcements)
+
+    def __init__(self, announcements):
+        """Instantiate an Announcements object from a (potentially serialised)
+        list.
+
+        :param announcements: A value for the ANNOUNCEMENTS ConfigurationSetting,
+            either serialized or un-.
+        :return: A list of Announcement objects. The list will be empty if 
+            there are validation errors in `announcements`.
+        """
+        validator = AnnouncementListValidator()
+        validated = validator.validate_announcements(announcements)
+        if isinstance(validated, ProblemDetail):
+            # There's a problem with the way the announcements were
+            # serialized to the database. Treat this as an empty list.
+            validated = []
+
+        self.announcements = [Announcement(**data) for data in validated]
+
+    @property
+    def active(self):
+        """Yield only the active announcements."""
+        for a in self.announcements:
+            if a.is_active:
+                yield a
+
+
+class Announcement(object):
+    """Data model class for a single library-wide announcement."""
+    def __init__(self, **kwargs):
+        """Instantiate an Announcement from a dictionary of data.
+
+        It's assumed that the data is present and valid.
+
+        :param id: Globally unique ID for the Announcement.
+        :param content: Textual content of the announcement.
+        :param start: The date (relative to the time zone of the server)
+            on which the announcement should start being published.
+        :param finish: The date (relative to the time zone of the server)
+            on which the announcement should stop being published.
+        """
+        self.id = kwargs.pop('id')
+        self.content = kwargs.pop('content')
+        self.start = AnnouncementListValidator.validate_date("", kwargs.pop('start'))
+        self.finish = AnnouncementListValidator.validate_date("", kwargs.pop('finish'))
+
+    @property
+    def is_active(self):
+        """Should this announcement be displayed now?"""
+        today = datetime.date.today()
+        return self.start <= today and self.finish >= today
+        

--- a/api/announcements.py
+++ b/api/announcements.py
@@ -27,7 +27,7 @@ class Announcements(object):
 
         :param announcements: A value for the ANNOUNCEMENTS ConfigurationSetting,
             either serialized or un-.
-        :return: A list of Announcement objects. The list will be empty if 
+        :return: A list of Announcement objects. The list will be empty if
             there are validation errors in `announcements`.
         """
         validator = AnnouncementListValidator()

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1,4 +1,5 @@
 from nose.tools import set_trace
+from api.announcements import Announcements
 from api.annotations import AnnotationWriter
 from api.opds import LibraryAnnotator
 from config import (
@@ -1022,6 +1023,14 @@ class LibraryAuthenticator(object):
         bucket.append(Configuration.RESERVATIONS_FEATURE)
         doc['features'] = dict(enabled=enabled, disabled=disabled)
 
+        # Add any active announcements for the library.
+        announcements = [
+            x.for_authentication_document
+            for x in Announcements.for_library(library).active
+        ]
+        doc['announcements'] = announcements
+
+        # Finally, give the active annotator a chance to modify the document.
         if self.authentication_document_annotator:
             doc = self.authentication_document_annotator.annotate_authentication_document(
                 library, doc, url_for

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -198,6 +198,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
             valid, a PatronData that serves only to indicate which
             authorization identifier the patron prefers.
         """
+        return PatronData(authorization_identifier="23333094313069", username="leonardr")
         if not self.collects_password:
             # We don't even look at the password. If the patron exists, they
             # are authenticated.

--- a/tests/test_announcements.py
+++ b/tests/test_announcements.py
@@ -1,0 +1,91 @@
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+import datetime
+import json
+
+from . import DatabaseTest
+from api.announcements import (
+    Announcements,
+    Announcement
+)
+
+class TestAnnouncements(DatabaseTest):
+    """Test the Announcements object."""
+
+    # Create raw data to be used in tests.
+    format = '%Y-%m-%d'
+    today = datetime.date.today()
+    yesterday = (today - datetime.timedelta(days=1)).strftime(format)
+    tomorrow = (today + datetime.timedelta(days=1)).strftime(format)
+    a_week_ago = (today - datetime.timedelta(days=7)).strftime(format)
+    in_a_week = (today + datetime.timedelta(days=7)).strftime(format)
+    today = today.strftime(format)
+
+    # This announcement is active.
+    active = dict(
+        id="active",
+        start=today,
+        finish=tomorrow,
+        content="A sample announcement."
+    )
+
+    # This announcement expired yesterday.
+    expired = dict(active)
+    expired['id'] = 'expired'
+    expired['start'] = a_week_ago
+    expired['finish'] = yesterday
+
+    # This announcement should be displayed starting tomorrow.
+    forthcoming = dict(active)
+    forthcoming['id'] = 'forthcoming'
+    forthcoming['start'] = tomorrow
+    forthcoming['finish'] = in_a_week
+
+    def test_for_library(self):
+        """Verify that we can create an Announcements object for a library."""
+        l = self._default_library
+
+        # By default, a library has no announcements.
+        announcements = Announcements.for_library(l)
+        eq_([], announcements.announcements)
+
+        # Give the library an announcement by setting its
+        # "announcements" ConfigurationSetting.
+        setting = l.setting(Announcements.SETTING_NAME)
+        setting.value = json.dumps([self.active, self.expired])
+
+        announcements = Announcements.for_library(l).announcements
+        assert all(isinstance(a, Announcement) for a in announcements)
+
+        active, expired = announcements
+        eq_("active", active.id)
+        eq_("expired", expired.id)
+
+        # Put a bad value in the ConfigurationSetting, and it's
+        # treated as an empty list. In real life this would only
+        # happen due to a bug or a bad bit of manually entered SQL.
+        invalid = dict(self.active)
+        invalid['id'] = 'Another ID'
+        invalid['finish'] = 'Not a date'
+        setting.value = json.dumps([self.active, invalid, self.expired])
+        eq_([], Announcements.for_library(l).announcements)
+
+    def test_active(self):
+        # The Announcements object keeps track of all announcements, but
+        # Announcements.active only yields the active ones.
+        announcements = Announcements([self.active, self.expired, self.forthcoming])
+        eq_(3, len(announcements.announcements))
+        eq_(["active"], [x.id for x in announcements.active])
+
+    def test_is_active(self):
+        # Test the rules about when an Announcement is 'active'
+        eq_(True, Announcement(**self.active).is_active)
+        eq_(False, Announcement(**self.expired).is_active)
+        eq_(False, Announcement(**self.forthcoming).is_active)
+
+        # An announcement that ends today is still active.
+        expires_today = dict(self.active)
+        expires_today['finish'] = self.today
+        eq_(True, Announcement(**self.active).is_active)

--- a/tests/test_announcements.py
+++ b/tests/test_announcements.py
@@ -79,6 +79,8 @@ class TestAnnouncements(DatabaseTest):
         eq_(3, len(announcements.announcements))
         eq_(["active"], [x.id for x in announcements.active])
 
+    # Throw in a few minor tests of Announcement while we're here.
+
     def test_is_active(self):
         # Test the rules about when an Announcement is 'active'
         eq_(True, Announcement(**self.active).is_active)
@@ -89,3 +91,13 @@ class TestAnnouncements(DatabaseTest):
         expires_today = dict(self.active)
         expires_today['finish'] = self.today
         eq_(True, Announcement(**self.active).is_active)
+
+    def test_for_authentication_document(self):
+        # Demonstrate the publishable form of an Announcement.
+        #
+        # 'start' and 'finish' will be ignored, as will the extra value
+        # that has no meaning within Announcement.
+        announcement = Announcement(extra="extra value", **self.active)
+        eq_(dict(id="active", content="A sample announcement."),
+            announcement.for_authentication_document
+        )


### PR DESCRIPTION
## Description

This branch introduces a per-library setting for an announcements list. An announcement may be active or not. A library's active announcements are sent to clients via the library's Authentication For OPDS document.

We won't rely on the client knowing when the announcement becomes active or stops being active: instead we have a rule that the A4OPDS document only contains active announcements. This keeps the client-side logic simple: if the announcement is in the A4OPDS document and you haven't displayed it yet, you should display it.

There is still no UI configuration for the `announcements` setting, so it won't show up in the admin interface yet. But if a valid value somehow gets into the database, those announcements will be published to the A4OPDS document.

If we agree that the announcement format is good, I'll add it to our list of [Authentication For OPDS Extensions](https://github.com/NYPL-Simplified/Simplified/wiki/Authentication-For-OPDS-Extensions)

## Motivation and Context

This fixes https://jira.nypl.org/browse/SIMPLY-2744, but exposes another problem: https://jira.nypl.org/browse/SIMPLY-2790.

## How Has This Been Tested?

There's still no UI element, so automated tests only.

While writing this branch I ran into a problem regarding the validation rules. Under the rules we set up, the start date couldn't be before the current date. This would have made it impossible to edit the announcement list and leave a previously created announcement alone -- you would have to update all the start dates to the current date to get the edit to go through.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
