### PR TITLE
Fix patron expiration test

### DIFF
--- a/api/util/patron.py
+++ b/api/util/patron.py
@@ -59,7 +59,6 @@ class PatronUtility(object):
         :raises OutstandingFines: If the patron has too many outstanding fines.
 
         """
-        now = datetime.datetime.utcnow()
         if not cls.authorization_is_active(patron):
             # The patron's card has expired.
             raise AuthorizationExpired()

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,9 @@ feedparser
 # nltk is a textblob dependency, and this is the last release that supports Python 2
 nltk==3.4.5
 
+# rsa is an oauth2client dependency. Version 4.1 silently drops Python 2 support.
+rsa<4.1
+
 # TODO: This is only used for summary evaluation, which I think should
 # only happen in the metadata wrangler, so it should be possible to move
 # it out of core.

--- a/tests/test_patron_utility.py
+++ b/tests/test_patron_utility.py
@@ -24,40 +24,46 @@ class TestPatronUtility(DatabaseTest):
         of whether or not a patron needs to have their account
         synced with the remote.
         """
+
+        # Control for borrowing privileges
+        class MockPatronUtility(PatronUtility):
+            mock_has_borrowing_privileges = True
+
+            @classmethod
+            def authorization_is_active(cls, patron):
+                return cls.mock_has_borrowing_privileges
+
         now = datetime.datetime.utcnow()
         one_hour_ago = now - datetime.timedelta(hours=1)
         six_seconds_ago = now - datetime.timedelta(seconds=6)
         three_seconds_ago = now - datetime.timedelta(seconds=3)
         yesterday = now - datetime.timedelta(days=1)
 
-        # Patron expirations checks are done against localtime, rather than
-        # UTC; so `patron.authorization_expires` needs datetimes relative to
-        # `datetime.datetime.now()`, rather than `...utcnow()`.
-        localtime_now = datetime.datetime.now()
-        localtime_yesterday = localtime_now - datetime.timedelta(days=1)
-
         patron = self._patron()
+
+        # Patron has borrowing privileges. For now.
+        MockPatronUtility.mock_has_borrowing_privileges = True
 
         # Patron has never been synced.
         patron.last_external_sync = None
-        eq_(True, PatronUtility.needs_external_sync(patron))
+        eq_(True, MockPatronUtility.needs_external_sync(patron))
 
         # Patron was synced recently.
         patron.last_external_sync = one_hour_ago
-        eq_(False, PatronUtility.needs_external_sync(patron))
+        eq_(False, MockPatronUtility.needs_external_sync(patron))
 
         # Patron was synced more than 12 hours ago.
         patron.last_external_sync = yesterday
-        eq_(True, PatronUtility.needs_external_sync(patron))
+        eq_(True, MockPatronUtility.needs_external_sync(patron))
 
         # Patron was synced recently but has no borrowing
         # privileges. Timeout is five seconds instead of 12 hours.
-        patron.authorization_expires = localtime_yesterday
+        MockPatronUtility.mock_has_borrowing_privileges = False
         patron.last_external_sync = three_seconds_ago
-        eq_(False, PatronUtility.needs_external_sync(patron))
+        eq_(False, MockPatronUtility.needs_external_sync(patron))
 
         patron.last_external_sync = six_seconds_ago
-        eq_(True, PatronUtility.needs_external_sync(patron))
+        eq_(True, MockPatronUtility.needs_external_sync(patron))
 
     def test_has_borrowing_privileges(self):
         """Test the methods that encapsulate the determination

--- a/tests/test_patron_utility.py
+++ b/tests/test_patron_utility.py
@@ -30,6 +30,12 @@ class TestPatronUtility(DatabaseTest):
         three_seconds_ago = now - datetime.timedelta(seconds=3)
         yesterday = now - datetime.timedelta(days=1)
 
+        # Patron expirations checks are done against localtime, rather than
+        # UTC; so `patron.authorization_expires` needs datetimes relative to
+        # `datetime.datetime.now()`, rather than `...utcnow()`.
+        localtime_now = datetime.datetime.now()
+        localtime_yesterday = localtime_now - datetime.timedelta(days=1)
+
         patron = self._patron()
 
         # Patron has never been synced.
@@ -46,7 +52,7 @@ class TestPatronUtility(DatabaseTest):
 
         # Patron was synced recently but has no borrowing
         # privileges. Timeout is five seconds instead of 12 hours.
-        patron.authorization_expires = yesterday
+        patron.authorization_expires = localtime_yesterday
         patron.last_external_sync = three_seconds_ago
         eq_(False, PatronUtility.needs_external_sync(patron))
 
@@ -57,7 +63,11 @@ class TestPatronUtility(DatabaseTest):
         """Test the methods that encapsulate the determination
         of whether or not a patron can borrow books.
         """
-        now = datetime.datetime.utcnow()
+
+        # Patron expirations checks are done against localtime, rather than
+        # UTC; so `patron.authorization_expires` needs datetimes relative to
+        # `datetime.datetime.now()`, rather than `...utcnow()`.
+        now = datetime.datetime.now()
         one_day_ago = now - datetime.timedelta(days=1)
         patron = self._patron()
 


### PR DESCRIPTION
## Description

This branch fixes a couple of tests that used the wrong time zone for patron expiration date/time values.

## Motivation and Context

Depending on local time zone and time of day when run, the affected tests might or might not fail. The tests in question were using UTC time for patron expiration, but the `PatronUtility.authorization_is_active` uses server local time.

Fixes #741  

## How Has This Been Tested?

Successfully ran the remediated tests late night EDT, when they were originally failing, and mid-morning EDT when they previously were NOT failing.
  ```
  TESTING=true PYTHONWARNINGS=ignore nosetests -w tests \
    test_patron_utility.py:TestPatronUtility.test_has_borrowing_privileges \
    test_patron_utility.py:TestPatronUtility.test_needs_external_sync
  ```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.