### PR TITLE
Peg rsa to Python 2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,8 +38,8 @@ feedparser
 # nltk is a textblob dependency, and this is the last release that supports Python 2
 nltk==3.4.5
 
-# rsa is an oauth2client dependency. Version 4.1 silently drops Python 2 support.
-rsa<4.1
+# rsa is an oauth2client dependency. This is the last version to support Python 2.
+rsa==4.3
 
 # TODO: This is only used for summary evaluation, which I think should
 # only happen in the metadata wrangler, so it should be possible to move


### PR DESCRIPTION
## Description

Pegs `rsa` version at 4.3, the official final version that supports Python 2.

## Motivation and Context

The Python `rsa` package has reached end of support for Python 2 and a final release has been designated.

Here's the relevant comment on the `rsa` github issue:
- https://github.com/sybrenstuvel/python-rsa/issues/152#issuecomment-643408638
> 4.3 is a re-tagged version 4.0, but I also took the opportunity to back-port two security fixes to Python 2.7.

## How Has This Been Tested?

Ran full circulation manager test suite.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
