### PR TITLE
Catalog url pattern

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -183,11 +183,11 @@ class Configuration(CoreConfiguration):
         },
         {
             "key": PATRON_WEB_CLIENT_URL,
-            "label": _("URL of the web catalog for patrons"),
+            "label": _("Hostnames for web application access"),
             "required": True,
             "format": "string",
             "allowed": ["*"],
-            "description": _("You can set this to '*' in development, but you must a real case-sensitive URL or regular expression in production in order to prevent unauthorized CORS requests.")
+            "description": _("Only web applications from these hosts can access this circulation manager. This can be a single hostname ('catalog.library.org'), or a regular expression that matches many hostnames ('.*\.libraryvendor\.com'). You can also set this to '*' to allow access from any host, but you must not do this in a production environment -- only during development.")
         },
         {
             "key": STATIC_FILE_CACHE_TIME,

--- a/api/config.py
+++ b/api/config.py
@@ -187,7 +187,7 @@ class Configuration(CoreConfiguration):
             "required": True,
             "format": "string",
             "allowed": ["*"],
-            "description": _("You can set this to '*' in development, but you must use a real URL in production in order to prevent unauthorized CORS requests.")
+            "description": _("You can set this to '*' in development, but you must a real case-sensitive URL or regular expression in production in order to prevent unauthorized CORS requests.")
         },
         {
             "key": STATIC_FILE_CACHE_TIME,

--- a/api/config.py
+++ b/api/config.py
@@ -185,7 +185,7 @@ class Configuration(CoreConfiguration):
             "key": PATRON_WEB_CLIENT_URL,
             "label": _("URL of the web catalog for patrons"),
             "required": True,
-            "format": "url",
+            "format": "string",
             "allowed": ["*"],
             "description": _("You can set this to '*' in development, but you must use a real URL in production in order to prevent unauthorized CORS requests.")
         },


### PR DESCRIPTION
## Description

I changed the admin interface input validation for the `PATRON_WEB_CLIENT_URL` setting, and updated the setting description as well.

## Motivation and Context

This will allow users to set a regular expression for their allowed CORS domains, which in turn enables them to set up multiple frontends accessing the same circulation-manager. This will be used by Lyrasis to have both a production and a beta instance of `circulation-patron-web`.

## How Has This Been Tested?

`nosetests tests/admin/ tests/test_controller.py`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

I only ran the admin tests.
Is there documentation somewhere I need to update beyond the setting description?
