### PR TITLE
Patron Web Hostnames

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -27,7 +27,7 @@ class Configuration(CoreConfiguration):
     DEFAULT_OPDS_FORMAT = "simple_opds_entry"
 
     # The name of the sitewide url that points to the patron web catalog.
-    PATRON_WEB_CLIENT_URL = u"Patron Web Client"
+    PATRON_WEB_HOSTNAMES = u"Patron Web Client"
 
     # The name of the sitewide secret used to sign cookies for admin login.
     SECRET_KEY = u"secret_key"
@@ -182,12 +182,11 @@ class Configuration(CoreConfiguration):
             "required": True,
         },
         {
-            "key": PATRON_WEB_CLIENT_URL,
+            "key": PATRON_WEB_HOSTNAMES,
             "label": _("Hostnames for web application access"),
             "required": True,
-            "format": "string",
-            "allowed": ["*"],
-            "description": _("Only web applications from these hosts can access this circulation manager. This can be a single hostname ('catalog.library.org'), or a regular expression that matches many hostnames ('.*\.libraryvendor\.com'). You can also set this to '*' to allow access from any host, but you must not do this in a production environment -- only during development.")
+            "format": "list",
+            "description": _("Only web applications from these hosts can access this circulation manager. This can be a single hostname ('catalog.library.org') or a comma-separated list of hostnames ('catalog.library.org','beta.library.org'). You can also set this to '*' to allow access from any host, but you must not do this in a production environment -- only during development.")
         },
         {
             "key": STATIC_FILE_CACHE_TIME,

--- a/api/config.py
+++ b/api/config.py
@@ -26,8 +26,8 @@ class Configuration(CoreConfiguration):
 
     DEFAULT_OPDS_FORMAT = "simple_opds_entry"
 
-    # The name of the sitewide url that points to the patron web catalog.
-    PATRON_WEB_HOSTNAMES = u"Patron Web Client"
+    # The list of patron web urls allowed to access this CM
+    PATRON_WEB_HOSTNAMES = u"patron_web_hostnames"
 
     # The name of the sitewide secret used to sign cookies for admin login.
     SECRET_KEY = u"secret_key"

--- a/api/config.py
+++ b/api/config.py
@@ -185,7 +185,7 @@ class Configuration(CoreConfiguration):
             "key": PATRON_WEB_HOSTNAMES,
             "label": _("Hostnames for web application access"),
             "required": True,
-            "format": "list",
+            "type": "list",
             "description": _("Only web applications from these hosts can access this circulation manager. This can be a single hostname ('catalog.library.org') or a comma-separated list of hostnames ('catalog.library.org','beta.library.org'). You can also set this to '*' to allow access from any host, but you must not do this in a production environment -- only during development.")
         },
         {

--- a/api/controller.py
+++ b/api/controller.py
@@ -288,10 +288,11 @@ class CirculationManager(object):
             scheme, netloc, path, parameters, query, fragment = urlparse.urlparse(url)
             return scheme + "://" + netloc
 
-        sitewide_patron_web_client_url = ConfigurationSetting.sitewide(
-            self._db, Configuration.PATRON_WEB_CLIENT_URL).value
-        if sitewide_patron_web_client_url:
-            patron_web_domains.add(get_domain(sitewide_patron_web_client_url))
+        sitewide_patron_web_client_urls = ConfigurationSetting.sitewide(
+            self._db, Configuration.PATRON_WEB_HOSTNAMES).value
+        if sitewide_patron_web_client_urls:
+            for url in sitewide_patron_web_client_urls:
+                patron_web_domains.add(get_domain(url))
 
         from registry import Registration
         for setting in self._db.query(

--- a/api/controller.py
+++ b/api/controller.py
@@ -289,7 +289,7 @@ class CirculationManager(object):
             return scheme + "://" + netloc
 
         sitewide_patron_web_client_urls = ConfigurationSetting.sitewide(
-            self._db, Configuration.PATRON_WEB_HOSTNAMES).value
+            self._db, Configuration.PATRON_WEB_HOSTNAMES).json_value
         if sitewide_patron_web_client_urls:
             for url in sitewide_patron_web_client_urls:
                 patron_web_domains.add(get_domain(url))

--- a/migration/20200622-patron-web-client-is-a-list.sql
+++ b/migration/20200622-patron-web-client-is-a-list.sql
@@ -1,0 +1,1 @@
+update configurationsettings set value=concat('["', value, '"]') where key='Patron Web Client' and value is not null;

--- a/migration/20200622-patron-web-client-is-a-list.sql
+++ b/migration/20200622-patron-web-client-is-a-list.sql
@@ -1,1 +1,2 @@
 update configurationsettings set value=concat('["', value, '"]') where key='Patron Web Client' and value is not null;
+update configurationsettings set key='patron_web_hostnames' where key='Patron Web Url';

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -445,13 +445,13 @@ class TestCirculationManager(CirculationControllerTest):
         # We also set up some patron web client settings that will
         # be loaded.
         ConfigurationSetting.sitewide(
-            self._db, Configuration.PATRON_WEB_HOSTNAMES).value = json.dumps(list("http://sitewide/1234"))
+            self._db, Configuration.PATRON_WEB_HOSTNAMES).value = json.dumps(["http://sitewide/1234"])
         registry = self._external_integration(
             protocol="some protocol", goal=ExternalIntegration.DISCOVERY_GOAL
         )
         ConfigurationSetting.for_library_and_externalintegration(
             self._db, Registration.LIBRARY_REGISTRATION_WEB_CLIENT,
-            library, registry).value = json.dumps(list("http://registration"))
+            library, registry).value = "http://registration"
 
         # Then reload the CirculationManager...
         self.manager.load_settings()
@@ -500,7 +500,7 @@ class TestCirculationManager(CirculationControllerTest):
 
         # The sitewide patron web domain can also be set to *.
         ConfigurationSetting.sitewide(
-            self._db, Configuration.PATRON_WEB_HOSTNAMES).value = list("*")
+            self._db, Configuration.PATRON_WEB_HOSTNAMES).value = json.dumps(["*"])
         self.manager.load_settings()
         eq_(set(["*", "http://registration"]), manager.patron_web_domains)
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -445,13 +445,13 @@ class TestCirculationManager(CirculationControllerTest):
         # We also set up some patron web client settings that will
         # be loaded.
         ConfigurationSetting.sitewide(
-            self._db, Configuration.PATRON_WEB_HOSTNAMES).value = list("http://sitewide/1234")
+            self._db, Configuration.PATRON_WEB_HOSTNAMES).value = json.dumps(list("http://sitewide/1234"))
         registry = self._external_integration(
             protocol="some protocol", goal=ExternalIntegration.DISCOVERY_GOAL
         )
         ConfigurationSetting.for_library_and_externalintegration(
             self._db, Registration.LIBRARY_REGISTRATION_WEB_CLIENT,
-            library, registry).value = "http://registration"
+            library, registry).value = json.dumps(list("http://registration"))
 
         # Then reload the CirculationManager...
         self.manager.load_settings()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -445,7 +445,7 @@ class TestCirculationManager(CirculationControllerTest):
         # We also set up some patron web client settings that will
         # be loaded.
         ConfigurationSetting.sitewide(
-            self._db, Configuration.PATRON_WEB_CLIENT_URL).value = "http://sitewide/1234"
+            self._db, Configuration.PATRON_WEB_HOSTNAMES).value = list("http://sitewide/1234")
         registry = self._external_integration(
             protocol="some protocol", goal=ExternalIntegration.DISCOVERY_GOAL
         )
@@ -500,7 +500,7 @@ class TestCirculationManager(CirculationControllerTest):
 
         # The sitewide patron web domain can also be set to *.
         ConfigurationSetting.sitewide(
-            self._db, Configuration.PATRON_WEB_CLIENT_URL).value = "*"
+            self._db, Configuration.PATRON_WEB_HOSTNAMES).value = list("*")
         self.manager.load_settings()
         eq_(set(["*", "http://registration"]), manager.patron_web_domains)
 


### PR DESCRIPTION
## Description

This update allows users to pass a list of urls that will be allowed CORS access to the CM. This is a change from the previous single-value setting, and from the attempted regex-based approach. 

To accomplish this properly, I also renamed the setting from `PATRON_WEB_CLIENT` to `PATRON_WEB_HOSTNAMES`, and the DB key from `Patron Web Url` to `patron_web_hostnames`. There is a migration script included in the PR to change the key and update from single string to list of strings.

## Motivation and Context

- To allow multiple web front ends to access the same CM backend. 

## How Has This Been Tested?

`nosetests tests/admin/ tests/test_controller.py`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
