### PR TITLE
Make announcement configuration compatible with frontend code

### DIFF
--- a/api/admin/announcement_list_validator.py
+++ b/api/admin/announcement_list_validator.py
@@ -40,7 +40,7 @@ class AnnouncementListValidator(Validator):
                 _("Too many announcements: maximum is %(maximum)d",
                   maximum=self.maximum_announcements)
             )
-            
+
         seen_ids = set()
         for announcement in announcements:
             validated = self.validate_announcement(announcement)
@@ -158,4 +158,3 @@ class AnnouncementListValidator(Validator):
         """Format the output of validate_announcements for storage in ConfigurationSetting.value"""
         from ..announcements import Announcements
         return json.dumps([x.json_ready for x in Announcements(value).announcements])
-

--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -321,13 +321,14 @@ class LibrarySettingsController(SettingsController):
             # Allow any entered values.
             value = []
             inputs = flask.request.form.getlist(setting.get("key")) if setting.get("type") == "list" else flask.request.form.get(setting.get("key"))
-            if json_objects:
+            if json_objects and inputs:
                 inputs = json.loads(inputs)
-            for i in inputs:
-                if not isinstance(i, list):
-                    i = [i]
-                value.extend(i)
-        
+            if inputs:
+                for i in inputs:
+                    if not isinstance(i, list):
+                        i = [i]
+                    value.extend(i)
+
         return json.dumps(filter(None, value))
 
     def image_setting(self, setting):

--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -58,8 +58,6 @@ class LibrarySettingsController(SettingsController):
                     value = ConfigurationSetting.for_library(setting.get("key"), library).json_value
                     if value and setting.get("format") == "geographic":
                         value = self.get_extra_geographic_information(value)
-                    # if value and setting.get("format") == "announcements":
-                    #     value = AnnouncementListValidator().validate_announcements(value)
                 else:
                     value = self.current_value(setting, library)
 
@@ -320,7 +318,11 @@ class LibrarySettingsController(SettingsController):
         else:
             # Allow any entered values.
             value = []
-            inputs = flask.request.form.getlist(setting.get("key")) if setting.get("type") == "list" else flask.request.form.get(setting.get("key"))
+            if setting.get("type") == "list":
+                inputs = flask.request.form.getlist(setting.get("key"))
+            else:
+                inputs = flask.request.form.get(setting.get("key"))
+
             if json_objects and inputs:
                 inputs = json.loads(inputs)
             if inputs:

--- a/api/config.py
+++ b/api/config.py
@@ -224,8 +224,7 @@ class Configuration(CoreConfiguration):
             "key": Announcements.SETTING_NAME,
             "label": _("Scheduled announcements"),
             "description": _("Announcements will be displayed to authenticated patrons."),
-            "category": "Basic Information",
-            "type": "list",
+            "category": "Announcements",
             "format": "announcements"
         },
         {

--- a/api/config.py
+++ b/api/config.py
@@ -225,7 +225,7 @@ class Configuration(CoreConfiguration):
             "label": _("Scheduled announcements"),
             "description": _("Announcements will be displayed to authenticated patrons."),
             "category": "Announcements",
-            "format": "announcements"
+            "type": "announcements"
         },
         {
             "key": HELP_EMAIL,

--- a/api/config.py
+++ b/api/config.py
@@ -225,7 +225,7 @@ class Configuration(CoreConfiguration):
             "label": _("Scheduled announcements"),
             "description": _("Announcements will be displayed to authenticated patrons."),
             "category": "Announcements",
-            "type": "announcements"
+            "format": "announcements"
         },
         {
             "key": HELP_EMAIL,

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -105,7 +105,7 @@ class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
             announcements = library_settings.get(Announcements.SETTING_NAME)
             eq_(
                 [self.active['id'], self.expired['id'], self.forthcoming['id']],
-                [x.get('id') for x in announcements]
+                [json.loads(x).get('id') for x in announcements]
             )
 
             # The objects found in `library_settings` aren't exactly

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -288,7 +288,6 @@ class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
                 (Configuration.LIBRARY_SERVICE_AREA, ['06759', 'everywhere', 'MD', 'Boston, MA']),
                 (Configuration.LIBRARY_FOCUS_AREA, ['Manitoba', 'Broward County, FL', 'QC']),
                 (Announcements.SETTING_NAME, json.dumps([self.active, self.forthcoming])),
-                # (Announcements.SETTING_NAME, [json.dumps(x) for x in [self.active, self.forthcoming]]),
                 (Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, "email@example.com"),
                 (Configuration.HELP_EMAIL, "help@example.com"),
                 (Configuration.FEATURED_LANE_SIZE, "5"),
@@ -639,7 +638,7 @@ class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
 
         eq_(
             'validated value',
-            m(library, dict(key="announcement_list", type="announcements"), validator)
+            m(library, dict(key="announcement_list", format="announcements"), validator)
         )
         eq_(json.dumps(controller.announcement_list), validator.called_with)
 

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -639,7 +639,7 @@ class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
 
         eq_(
             'validated value',
-            m(library, dict(key="announcement_list", format="announcements"), validator)
+            m(library, dict(key="announcement_list", type="announcements"), validator)
         )
         eq_(json.dumps(controller.announcement_list), validator.called_with)
 

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -105,15 +105,15 @@ class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
             announcements = library_settings.get(Announcements.SETTING_NAME)
             eq_(
                 [self.active['id'], self.expired['id'], self.forthcoming['id']],
-                [json.loads(x).get('id') for x in announcements]
+                [x.get('id') for x in json.loads(announcements)]
             )
 
             # The objects found in `library_settings` aren't exactly
             # the same as what is stored in the database: string dates
-            # have been parsed into datetime.date objects.
-            for i in announcements:
-                assert isinstance(i['start'], datetime.date)
-                assert isinstance(i['finish'], datetime.date)
+            # can be parsed into datetime.date objects.
+            for i in json.loads(announcements):
+                assert isinstance(datetime.datetime.strptime(i.get('start'), "%Y-%m-%d"), datetime.date)
+                assert isinstance(datetime.datetime.strptime(i.get('finish'), "%Y-%m-%d"), datetime.date)
 
     def test_libraries_get_with_multiple_libraries(self):
         # Delete any existing library created by the controller test setup.

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -105,7 +105,7 @@ class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
             announcements = library_settings.get(Announcements.SETTING_NAME)
             eq_(
                 [self.active['id'], self.expired['id'], self.forthcoming['id']],
-                [x['id'] for x in announcements]
+                [x.get('id') for x in announcements]
             )
 
             # The objects found in `library_settings` aren't exactly

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -287,7 +287,8 @@ class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
                 (Configuration.TINY_COLLECTION_LANGUAGES, ['ger']),
                 (Configuration.LIBRARY_SERVICE_AREA, ['06759', 'everywhere', 'MD', 'Boston, MA']),
                 (Configuration.LIBRARY_FOCUS_AREA, ['Manitoba', 'Broward County, FL', 'QC']),
-                (Announcements.SETTING_NAME, [json.dumps(x) for x in [self.active, self.forthcoming]]),
+                (Announcements.SETTING_NAME, json.dumps([self.active, self.forthcoming])),
+                # (Announcements.SETTING_NAME, [json.dumps(x) for x in [self.active, self.forthcoming]]),
                 (Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, "email@example.com"),
                 (Configuration.HELP_EMAIL, "help@example.com"),
                 (Configuration.FEATURED_LANE_SIZE, "5"),
@@ -643,7 +644,7 @@ class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
         eq_(json.dumps(controller.announcement_list), validator.called_with)
 
     def test__format_validated_value(self):
-        
+
         m = LibrarySettingsController._format_validated_value
 
         # When there is no validator, the incoming value is used as the formatted value,


### PR DESCRIPTION
I needed to make a few changes to make this work with the frontend code (I think we were initially expecting the front end to send the announcements in a different format, which turned out not to be compatible with the JavaScript FormData API?)--does this seem okay?