### PR TITLE
Change web color theme settings to primary and secondary

### DIFF
--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -163,8 +163,10 @@ class LibrarySettingsController(SettingsController):
             )
 
     def check_web_color_contrast(self, settings):
-        """Verify that the web primary color and web secondary
-        color go together.
+        """
+        Verify that the web primary and secondary color both contrast
+        well on white, as these colors will serve as button backgrounds with
+        white test, as well as text color on white backgrounds.
         """
         primary = flask.request.form.get(Configuration.WEB_PRIMARY_COLOR, Configuration.DEFAULT_WEB_PRIMARY_COLOR)
         secondary = flask.request.form.get(Configuration.WEB_SECONDARY_COLOR, Configuration.DEFAULT_WEB_SECONDARY_COLOR)

--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -175,7 +175,7 @@ class LibrarySettingsController(SettingsController):
             return tuple(int(hex[i:i+2], 16)/255.0 for i in (0, 2 ,4))
         primary_passes = wcag_contrast_ratio.passes_AA(wcag_contrast_ratio.rgb(hex_to_rgb(primary), hex_to_rgb("#ffffff")))
         secondary_passes = wcag_contrast_ratio.passes_AA(wcag_contrast_ratio.rgb(hex_to_rgb(secondary), hex_to_rgb("#ffffff")))
-        if not primary_passes and secondary_passes:
+        if not (primary_passes and secondary_passes):
             primary_check_url = "https://contrast-ratio.com/#%23" + secondary[1:] + "-on-%23" + "#ffffff"[1:] 
             secondary_check_url = "https://contrast-ratio.com/#%23" + secondary[1:] + "-on-%23" + "#ffffff"[1:]
             return INVALID_CONFIGURATION_OPTION.detailed(

--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -163,19 +163,22 @@ class LibrarySettingsController(SettingsController):
             )
 
     def check_web_color_contrast(self, settings):
-        """Verify that the web background color and web foreground
+        """Verify that the web primary color and web secondary
         color go together.
         """
-        background = flask.request.form.get(Configuration.WEB_BACKGROUND_COLOR, Configuration.DEFAULT_WEB_BACKGROUND_COLOR)
-        foreground = flask.request.form.get(Configuration.WEB_FOREGROUND_COLOR, Configuration.DEFAULT_WEB_FOREGROUND_COLOR)
+        primary = flask.request.form.get(Configuration.WEB_PRIMARY_COLOR, Configuration.DEFAULT_WEB_PRIMARY_COLOR)
+        secondary = flask.request.form.get(Configuration.WEB_SECONDARY_COLOR, Configuration.DEFAULT_WEB_SECONDARY_COLOR)
         def hex_to_rgb(hex):
             hex = hex.lstrip("#")
             return tuple(int(hex[i:i+2], 16)/255.0 for i in (0, 2 ,4))
-        if not wcag_contrast_ratio.passes_AA(wcag_contrast_ratio.rgb(hex_to_rgb(background), hex_to_rgb(foreground))):
-            contrast_check_url = "https://contrast-ratio.com/#%23" + foreground[1:] + "-on-%23" + background[1:]
+        primary_passes = wcag_contrast_ratio.passes_AA(wcag_contrast_ratio.rgb(hex_to_rgb(primary), hex_to_rgb("#ffffff")))
+        secondary_passes = wcag_contrast_ratio.passes_AA(wcag_contrast_ratio.rgb(hex_to_rgb(secondary), hex_to_rgb("#ffffff")))
+        if not primary_passes and secondary_passes:
+            primary_check_url = "https://contrast-ratio.com/#%23" + secondary[1:] + "-on-%23" + "#ffffff"[1:] 
+            secondary_check_url = "https://contrast-ratio.com/#%23" + secondary[1:] + "-on-%23" + "#ffffff"[1:]
             return INVALID_CONFIGURATION_OPTION.detailed(
-                _("The web background and foreground colors don't have enough contrast to pass the WCAG 2.0 AA guidelines and will be difficult for some patrons to read. Check contrast <a href='%(contrast_check_url)s' target='_blank'>here</a>.",
-                  contrast_check_url=contrast_check_url))
+                _("The web primary and secondary colors don't have enough contrast to pass the WCAG 2.0 AA guidelines and will be difficult for some patrons to read. Check contrast for primary <a href='%(primary_check_url)s' target='_blank'>here</a> and secondary <a href='%(primary_check_url)s' target='_blank'>here</a>.",
+                  primary_check_url=primary_check_url, secondary_check_url=secondary_check_url))
 
     def check_header_links(self, settings):
         """Verify that header links and labels are the same length."""

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1096,7 +1096,7 @@ class LibraryAuthenticator(object):
             Configuration.WEB_PRIMARY_COLOR, library).value
         secondary = ConfigurationSetting.for_library(
             Configuration.WEB_SECONDARY_COLOR, library).value
-        if background or foreground:
+        if primary or secondary:
             doc["web_color_scheme"] = dict(primary=primary, secondary=secondary)
 
         # Add the description of the library as the OPDS feed's

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1097,7 +1097,7 @@ class LibraryAuthenticator(object):
         secondary = ConfigurationSetting.for_library(
             Configuration.WEB_SECONDARY_COLOR, library).value
         if primary or secondary:
-            doc["web_color_scheme"] = dict(primary=primary, secondary=secondary)
+            doc["web_color_scheme"] = dict(primary=primary, secondary=secondary, background=primary, foreground=secondary)
 
         # Add the description of the library as the OPDS feed's
         # service_description.

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1092,12 +1092,12 @@ class LibraryAuthenticator(object):
             doc['color_scheme'] = description
 
         # Add the library's web colors, if it has any.
-        background = ConfigurationSetting.for_library(
-            Configuration.WEB_BACKGROUND_COLOR, library).value
-        foreground = ConfigurationSetting.for_library(
-            Configuration.WEB_FOREGROUND_COLOR, library).value
+        primary = ConfigurationSetting.for_library(
+            Configuration.WEB_PRIMARY_COLOR, library).value
+        secondary = ConfigurationSetting.for_library(
+            Configuration.WEB_SECONDARY_COLOR, library).value
         if background or foreground:
-            doc["web_color_scheme"] = dict(background=background, foreground=foreground)
+            doc["web_color_scheme"] = dict(primary=primary, secondary=secondary)
 
         # Add the description of the library as the OPDS feed's
         # service_description.

--- a/api/config.py
+++ b/api/config.py
@@ -101,10 +101,10 @@ class Configuration(CoreConfiguration):
     DEFAULT_COLOR_SCHEME = "blue"
 
     # The color options for web applications to use for this library.
-    WEB_BACKGROUND_COLOR = "web-background-color"
-    WEB_FOREGROUND_COLOR = "web-foreground-color"
-    DEFAULT_WEB_BACKGROUND_COLOR = "#000000"
-    DEFAULT_WEB_FOREGROUND_COLOR = "#ffffff"
+    WEB_PRIMARY_COLOR = "web-primary-color"
+    WEB_SECONDARY_COLOR = "web-secondary-color"
+    DEFAULT_WEB_PRIMARY_COLOR = "#377F8B"
+    DEFAULT_WEB_SECONDARY_COLOR = "#D53F34"
 
     # A link to a CSS file for customizing the catalog display in web applications.
     WEB_CSS_FILE = "web-css-file"
@@ -286,19 +286,19 @@ class Configuration(CoreConfiguration):
             "category": "Client Interface Customization",
         },
         {
-            "key": WEB_BACKGROUND_COLOR,
-            "label": _("Web background color"),
-            "description": _("This tells web applications what background color to use. Must have sufficient contrast with the foreground color."),
+            "key": WEB_PRIMARY_COLOR,
+            "label": _("Web primary color"),
+            "description": _("This is the brand primary color for the web application. Must have sufficient contrast with white."),
             "type": "color-picker",
-            "default": DEFAULT_WEB_BACKGROUND_COLOR,
+            "default": DEFAULT_WEB_PRIMARY_COLOR,
             "category": "Client Interface Customization",
         },
         {
-            "key": WEB_FOREGROUND_COLOR,
-            "label": _("Web foreground color"),
-            "description": _("This tells web applications what foreground color to use. Must have sufficient contrast with the background color."),
+            "key": WEB_SECONDARY_COLOR,
+            "label": _("Web secondary color"),
+            "description": _("This is the brand secondary color for the web application. Must have sufficient contrast with white."),
             "type": "color-picker",
-            "default": DEFAULT_WEB_FOREGROUND_COLOR,
+            "default": DEFAULT_WEB_SECONDARY_COLOR,
             "category": "Client Interface Customization",
         },
         {

--- a/migration/20200630-update-web-colorscheme.sql
+++ b/migration/20200630-update-web-colorscheme.sql
@@ -1,0 +1,2 @@
+update configurationsettings set key='web-primary-color' where key='web-background-color';
+update configurationsettings set key='web-secondary-color' where key='web-foreground-color';

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -190,12 +190,12 @@ class TestLibrarySettings(SettingsControllerTest):
             response = self.manager.admin_library_settings_controller.process_post()
             eq_(response.uri, INCOMPLETE_CONFIGURATION.uri)
 
-        # Test a bad contrast ratio between the web foreground and
-        # web background colors.
+        # Test a web primary and secondary color that doesn't contrast
+        # well on white. Here primary will, secondary should not.
         with self.request_context_with_admin("/", method="POST"):
             flask.request.form = self.library_form(
-                library, {Configuration.WEB_BACKGROUND_COLOR: "#000000",
-                Configuration.WEB_FOREGROUND_COLOR: "#010101"}
+                library, {Configuration.WEB_PRIMARY_COLOR: "#000000",
+                Configuration.WEB_SECONDARY_COLOR: "#e0e0e0"}
             )
             response = self.manager.admin_library_settings_controller.process_post()
             eq_(response.uri, INVALID_CONFIGURATION_OPTION.uri)

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -199,7 +199,8 @@ class TestLibrarySettings(SettingsControllerTest):
             )
             response = self.manager.admin_library_settings_controller.process_post()
             eq_(response.uri, INVALID_CONFIGURATION_OPTION.uri)
-            assert "contrast-ratio.com/#%23010101-on-%23000000" in response.detail
+            assert "contrast-ratio.com/#%23e0e0e0-on-%23ffffff" in response.detail
+            assert "contrast-ratio.com/#%23e0e0e0-on-%23ffffff" in response.detail
 
         # Test a list of web header links and a list of labels that
         # aren't the same length.

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1207,9 +1207,9 @@ class TestLibraryAuthenticator(AuthenticatorTest):
 
         # Set the colors a web client should use.
         ConfigurationSetting.for_library(
-            Configuration.WEB_BACKGROUND_COLOR, library).value = "#012345"
+            Configuration.WEB_PRIMARY_COLOR, library).value = "#012345"
         ConfigurationSetting.for_library(
-            Configuration.WEB_FOREGROUND_COLOR, library).value = "#abcdef"
+            Configuration.WEB_SECONDARY_COLOR, library).value = "#abcdef"
 
         # Configure the various ways a patron can get help.
         ConfigurationSetting.for_library(

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1276,7 +1276,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
 
             # The mobile color scheme and web colors are correctly reported.
             eq_("plaid", doc['color_scheme'])
-            eq_("#377F8B", doc['web_color_scheme']['primaru'])
+            eq_("#377F8B", doc['web_color_scheme']['primary'])
             eq_("#D53F34", doc['web_color_scheme']['secondary'])
 
             # _geographic_areas was called and provided the library's

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1276,8 +1276,8 @@ class TestLibraryAuthenticator(AuthenticatorTest):
 
             # The mobile color scheme and web colors are correctly reported.
             eq_("plaid", doc['color_scheme'])
-            eq_("#377F8B", doc['web_color_scheme']['primary'])
-            eq_("#D53F34", doc['web_color_scheme']['secondary'])
+            eq_("#012345", doc['web_color_scheme']['primary'])
+            eq_("#abcdef", doc['web_color_scheme']['secondary'])
 
             # _geographic_areas was called and provided the library's
             # focus area and service area.

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1276,8 +1276,8 @@ class TestLibraryAuthenticator(AuthenticatorTest):
 
             # The mobile color scheme and web colors are correctly reported.
             eq_("plaid", doc['color_scheme'])
-            eq_("#012345", doc['web_color_scheme']['background'])
-            eq_("#abcdef", doc['web_color_scheme']['foreground'])
+            eq_("#377F8B", doc['web_color_scheme']['primaru'])
+            eq_("#D53F34", doc['web_color_scheme']['secondary'])
 
             # _geographic_areas was called and provided the library's
             # focus area and service area.


### PR DESCRIPTION
## Description

The new web interface uses "primary" and "secondary" colors instead of "background" and "foreground". These colors must now both contrast well on white. This PR updates the settings, along with their DB keys. It also configures the default settings to be a teal for primary and a red for secondary.

### Breaking Change

This is a breaking change. It deprecates the `web_foreground_color` and `web_background_color`, which will break any instances of circulation-patron-web currently running that update to the new circulation manager code. I have reached out to Micah at DPLA on slack but have not heard back from him RE if they are using CPW at all. This change will break the NYPL OpenEbooks, but NYPL is hopefully planning to migrate that to the new CPW code soon.

## Motivation and Context

The new version of CPW uses "primary" and "secondary" colors instead of "background" and "foreground". 

## How Has This Been Tested?

Just ran tests via travis.

## To Do:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Update documentation (can someone point me to where?).
- [x] All new and existing tests passed.
- [x] Check with NYPL and DPLA if this breaking change is acceptable
- [x] Write a DB migration script
