### PR TITLE
Add support for choosing arbitrary S3 regions and using virtual hosted-style S3 URLs

### DIFF
--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -291,8 +291,9 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         # into a LicensePoolDeliveryMechanism. The other formats were
         # ignored.
         [mechanism] = pool.delivery_mechanisms
-        eq_('https://s3.amazonaws.com/test.content.bucket/FeedBooks/URI/http%3A%2F%2Fwww.feedbooks.com%2Fbook%2F677/Discourse+on+the+Method.epub',
-            mechanism.resource.representation.mirror_url
+        eq_(
+            mechanism.resource.representation.mirror_url,
+            'https://test-content-bucket.s3.amazonaws.com/FeedBooks/URI/http%3A//www.feedbooks.com/book/677/Discourse%20on%20the%20Method.epub'
         )
         eq_(u'application/epub+zip', mechanism.delivery_mechanism.content_type)
 

--- a/tests/test_odilo.py
+++ b/tests/test_odilo.py
@@ -169,7 +169,7 @@ class TestOdiloAPI(OdiloAPITest):
         self.api.refresh_creds(credential)
         eq_("new bearer token 2", credential.credential)
         eq_(self.api.token, credential.credential)
-        assert credential.expires > datetime.datetime.now()
+        assert credential.expires > datetime.datetime.utcnow()
 
     def test_credential_refresh_failure(self):
         """Verify that a useful error message results when the Odilo bearer

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1075,17 +1075,19 @@ class TestDirectoryImportScript(DatabaseTest):
         # We have created a book. It has a cover image, which has a
         # thumbnail.
         eq_("A book", work.title)
-        assert work.cover_full_url.endswith(
-            '/test.cover.bucket/Gutenberg/Gutenberg+ID/1003/1003.jpg'
+        eq_(
+            work.cover_full_url,
+            u'https://test-cover-bucket.s3.amazonaws.com/Gutenberg/Gutenberg%20ID/1003/1003.jpg'
         )
-        assert work.cover_thumbnail_url.endswith(
-            '/test.cover.bucket/scaled/300/Gutenberg/Gutenberg+ID/1003/1003.png'
+        eq_(
+            work.cover_thumbnail_url,
+            u'https://test-cover-bucket.s3.amazonaws.com/scaled/300/Gutenberg/Gutenberg%20ID/1003/1003.png'
         )
         [pool] = work.license_pools
-        assert pool.open_access_download_url.endswith(
-            '/test.content.bucket/Gutenberg/Gutenberg+ID/1003/A+book.epub'
+        eq_(
+            pool.open_access_download_url,
+            u'https://test-content-bucket.s3.amazonaws.com/Gutenberg/Gutenberg%20ID/1003/A%20book.epub'
         )
-
         eq_(RightsStatus.CC0,
             pool.delivery_mechanisms[0].rights_status.uri)
 
@@ -1237,8 +1239,9 @@ class TestDirectoryImportScript(DatabaseTest):
         # The CirculationData has an open-access link associated with it.
         [link] = circulation.links
         eq_(Hyperlink.OPEN_ACCESS_DOWNLOAD, link.rel)
-        assert link.href.endswith(
-            '/test.content.bucket/Gutenberg/Gutenberg+ID/2345/Name+of+book.epub'
+        eq_(
+            link.href,
+            u'https://test-content-bucket.s3.amazonaws.com/Gutenberg/Gutenberg%20ID/2345/Name%20of%20book.epub'
         )
         eq_(Representation.EPUB_MEDIA_TYPE, link.media_type)
         eq_("I'm an EPUB.", link.content)
@@ -1279,8 +1282,9 @@ class TestDirectoryImportScript(DatabaseTest):
         script = MockDirectoryImportScript(self._db, mock_filesystem)
         link = script.load_cover_link(*args)
         eq_(Hyperlink.IMAGE, link.rel)
-        assert link.href.endswith(
-            '/test.cover.bucket/Gutenberg/Gutenberg+ID/2345/2345.jpg'
+        eq_(
+            link.href,
+            u'https://test-cover-bucket.s3.amazonaws.com/Gutenberg/Gutenberg%20ID/2345/2345.jpg'
         )
         eq_(Representation.JPEG_MEDIA_TYPE, link.media_type)
         eq_("I'm an image.", link.content)


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR updates the core submodule to the latest version containing [PR 1179](https://github.com/NYPL-Simplified/server_core/pull/1179) adding support for choosing arbitrary S3 regions and using virtual hosted-style S3 URLs.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Buckets created after September 30, 2020, will support only virtual hosted-style requests. Path-style requests will continue to be supported for buckets created on or before this date. For more information, see Amazon S3 Path Deprecation Plan – The Rest of the Story.

Please refer to [PR 1179](https://github.com/NYPL-Simplified/server_core/pull/1179) for more information.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I updated tests accordingly by changing S3 URLs from using path-style to using virtual hosted-style requests.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
