### PR TITLE
DB Migration fix

### DIFF
--- a/migration/20200625-patron-web-hostnames-is-a-list.sql
+++ b/migration/20200625-patron-web-hostnames-is-a-list.sql
@@ -1,0 +1,1 @@
+update configurationsettings set value=concat('["', value, '"]') where key='patron_web_hostnames' and value is not null;


### PR DESCRIPTION
## Description

This is a new migration to fix a typo in the #1447 migration script. Previously, we updated the value where key is `Patron Web Client` to a list, and then renamed the value of `Patron Web Url` to `patron_web_hostnames`. The first piece of this migration should have said `Patron Web Url` not `Patron Web Client`, so we ended up with `patron_web_hostnames` holding the original non-list value. This migration updates that value to a list.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have run the migration locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
