### PR TITLE
Deprecate Header Links and CSS File

### DIFF
--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -137,7 +137,6 @@ class LibrarySettingsController(SettingsController):
         validations = [
             self.check_for_missing_fields,
             self.check_web_color_contrast,
-            self.check_header_links,
             self.validate_formats
         ]
         for validation in validations:
@@ -176,14 +175,6 @@ class LibrarySettingsController(SettingsController):
             return INVALID_CONFIGURATION_OPTION.detailed(
                 _("The web background and foreground colors don't have enough contrast to pass the WCAG 2.0 AA guidelines and will be difficult for some patrons to read. Check contrast <a href='%(contrast_check_url)s' target='_blank'>here</a>.",
                   contrast_check_url=contrast_check_url))
-
-    def check_header_links(self, settings):
-        """Verify that header links and labels are the same length."""
-        header_links = flask.request.form.getlist(Configuration.WEB_HEADER_LINKS)
-        header_labels = flask.request.form.getlist(Configuration.WEB_HEADER_LABELS)
-        if len(header_links) != len(header_labels):
-            return INVALID_CONFIGURATION_OPTION.detailed(
-                _("There must be the same number of web header links and web header labels."))
 
     def get_library_from_uuid(self, library_uuid):
         if library_uuid:

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1071,12 +1071,6 @@ class LibraryAuthenticator(object):
         if logo:
             links.append(dict(rel="logo", type="image/png", href=logo))
 
-        # Add the library's custom CSS file, if it has one.
-        css_file = ConfigurationSetting.for_library(
-            Configuration.WEB_CSS_FILE, library).value
-        if css_file:
-            links.append(dict(rel="stylesheet", type="text/css", href=css_file))
-
         library_name = self.library_name or unicode(_("Library"))
         auth_doc_url = self.authentication_document_url(library)
         doc = AuthenticationForOPDSDocument(

--- a/api/config.py
+++ b/api/config.py
@@ -106,9 +106,6 @@ class Configuration(CoreConfiguration):
     DEFAULT_WEB_BACKGROUND_COLOR = "#000000"
     DEFAULT_WEB_FOREGROUND_COLOR = "#ffffff"
 
-    # A link to a CSS file for customizing the catalog display in web applications.
-    WEB_CSS_FILE = "web-css-file"
-
     # Header links and labels for web applications to display for this library.
     # TODO: It's very awkward to have these as separate settings, and separate
     # lists of inputs in the UI.
@@ -299,13 +296,6 @@ class Configuration(CoreConfiguration):
             "description": _("This tells web applications what foreground color to use. Must have sufficient contrast with the background color."),
             "type": "color-picker",
             "default": DEFAULT_WEB_FOREGROUND_COLOR,
-            "category": "Client Interface Customization",
-        },
-        {
-            "key": WEB_CSS_FILE,
-            "label": _("Custom CSS file for web"),
-            "description": _("Give web applications a CSS file to customize the catalog display."),
-            "format": "url",
             "category": "Client Interface Customization",
         },
         {

--- a/api/config.py
+++ b/api/config.py
@@ -106,12 +106,6 @@ class Configuration(CoreConfiguration):
     DEFAULT_WEB_BACKGROUND_COLOR = "#000000"
     DEFAULT_WEB_FOREGROUND_COLOR = "#ffffff"
 
-    # Header links and labels for web applications to display for this library.
-    # TODO: It's very awkward to have these as separate settings, and separate
-    # lists of inputs in the UI.
-    WEB_HEADER_LINKS = "web-header-links"
-    WEB_HEADER_LABELS = "web-header-labels"
-
     # The library-wide logo setting.
     LOGO = "logo"
 
@@ -296,20 +290,6 @@ class Configuration(CoreConfiguration):
             "description": _("This tells web applications what foreground color to use. Must have sufficient contrast with the background color."),
             "type": "color-picker",
             "default": DEFAULT_WEB_FOREGROUND_COLOR,
-            "category": "Client Interface Customization",
-        },
-        {
-            "key": WEB_HEADER_LINKS,
-            "label": _("Web header links"),
-            "description": _("This gives web applications a list of links to display in the header. Specify labels for each link in the same order under 'Web header labels'."),
-            "type": "list",
-            "category": "Client Interface Customization",
-        },
-        {
-            "key": WEB_HEADER_LABELS,
-            "label": _("Web header labels"),
-            "description": _("Labels for each link under 'Web header links'."),
-            "type": "list",
             "category": "Client Interface Customization",
         },
         {

--- a/api/opds.py
+++ b/api/opds.py
@@ -946,15 +946,6 @@ class LibraryAnnotator(CirculationManagerAnnotator):
                 d = dict(href=setting.value, type="text/html", rel=rel)
                 _add_link(d)
 
-        navigation_urls = ConfigurationSetting.for_library(
-            Configuration.WEB_HEADER_LINKS, self.library).json_value
-        if navigation_urls:
-            navigation_labels = ConfigurationSetting.for_library(
-                Configuration.WEB_HEADER_LABELS, self.library).json_value
-            for (url, label) in zip(navigation_urls, navigation_labels):
-                d = dict(href=url, title=label, type="text/html", rel="related", role="navigation")
-                _add_link(d)
-
         for type, value in Configuration.help_uris(self.library):
             d = dict(href=value, rel="help")
             if type:

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -212,9 +212,6 @@ class TestLibrarySettings(SettingsControllerTest):
                 (Configuration.WEBSITE_URL, "https://library.library/"),
                 (Configuration.DEFAULT_NOTIFICATION_EMAIL_ADDRESS, "email@example.com"),
                 (Configuration.HELP_EMAIL, "help@example.com"),
-                (Configuration.WEB_HEADER_LINKS, "http://library.com/1"),
-                (Configuration.WEB_HEADER_LINKS, "http://library.com/2"),
-                (Configuration.WEB_HEADER_LABELS, "One"),
             ])
             response = self.manager.admin_library_settings_controller.process_post()
             eq_(response.uri, INVALID_CONFIGURATION_OPTION.uri)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1187,7 +1187,6 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             LibraryAnnotator.LICENSE: "http://license/",
             LibraryAnnotator.REGISTER: "custom-registration-hook://library/",
             Configuration.LOGO: "image data",
-            Configuration.WEB_CSS_FILE: "http://style.css",
         }
 
         for rel, value in link_config.iteritems():

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -371,14 +371,6 @@ class TestLibraryAnnotator(VendorIDTest):
         for rel, value in link_config.iteritems():
             ConfigurationSetting.for_library(rel, self._default_library).value = value
 
-        # Set up settings for navigation links.
-        ConfigurationSetting.for_library(
-            Configuration.WEB_HEADER_LINKS, self._default_library
-        ).value = json.dumps(["http://example.com/1", "http://example.com/2"])
-        ConfigurationSetting.for_library(
-            Configuration.WEB_HEADER_LABELS, self._default_library
-        ).value = json.dumps(["one", "two"])
-
         self.annotator.add_configuration_links(mock_feed)
 
         # Ten links were added to the "feed"


### PR DESCRIPTION
## Description

Circulation Patron Web is about to be launched into production at NYPL and Lyrasis as well as other organizations such as Amigos. At the moment the only other known production version is OpenEbooks at NYPL. Once CPW is in production, it will be very difficult to make breaking changes, so we should consider making them now. This PR is an attempt to clean up the settings that relate to CPW by deprecating two settings that no longer map properly to the current version of CPW.

This PR:
1. Removes support for custom CSS files for the web catalog.
2. Removes support for custom header links in the web catalog.

### CSS file motivation

With the new version of CPW, the CSS file route of style updates will no longer work. For those types of style changes, we will need to expose the them object from CPW in the circulation manager so that theme settings can be overridden. If more style changes are necessary than that allows, we will want to provide a path for libraries to wrap the application and override desired components in the file system. 

### Header links motivation

The Header links setting for circulation-patron-web was implemented for a previous version, seemingly with the intent of letting patrons navigate the main library website from the header of circulation-patron-web. This is no longer a goal of CPW, and instead we provide a link _back_ to the main library website where that navigation can be done natively. Thus, CPW is a separate app, still associated with the main library website, but not intending to mirror its functionality or appear to be the same system.

If we want to keep this functionality and allow libraries to add links to their catalog header, we will need to make significant UX considerations, as this quickly becomes messy. One possibly way to accommodate these extra links would be a dropdown in the header.

## How Has This Been Tested?

Only via Travis

## To Do:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Get community approval
- [ ] Write DB migration script
- [ ] Update documentation
- [ ] Make sure tests pass