### PR TITLE
Don't set lane.media when creating or editing a lane.

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -955,7 +955,6 @@ class LanesController(AdminCirculationManagerController):
                 lane, is_new = create(
                     self._db, Lane, display_name=display_name,
                     parent=parent, library=library)
-                lane.media = [Edition.BOOK_MEDIUM]
 
                 # Make a new lane the first child of its parent and bump all the siblings down in priority.
                 siblings = self._db.query(Lane).filter(Lane.library==library).filter(Lane.parent==lane.parent).filter(Lane.id!=lane.id)

--- a/migration/20200701-no-medium-in-lanes.sql
+++ b/migration/20200701-no-medium-in-lanes.sql
@@ -1,0 +1,2 @@
+-- As of 2020-07 the lanes.media field is not and should not be used for anything.
+update lanes set media=null;

--- a/tests/admin/controller/test_controller.py
+++ b/tests/admin/controller/test_controller.py
@@ -1528,7 +1528,7 @@ class TestLanesController(AdminControllerTest):
             eq_(self._default_library, lane.library)
             eq_("lane", lane.display_name)
             eq_(parent, lane.parent)
-            eq_([Edition.BOOK_MEDIUM], lane.media)
+            eq_(None, lane.media)
             eq_(1, len(lane.customlists))
             eq_(list, lane.customlists[0])
             eq_(False, lane.inherit_parent_restrictions)
@@ -1571,6 +1571,7 @@ class TestLanesController(AdminControllerTest):
             eq_("new name", lane.display_name)
             eq_([list2], lane.customlists)
             eq_(True, lane.inherit_parent_restrictions)
+            eq_(None, lane.media)
             eq_(2, lane.size)
 
     def test_lane_delete_success(self):


### PR DESCRIPTION
## Description

This branch changes the admin interface so that it no longer sets `lanes.media` to a value that excludes audiobooks.

## Motivation and Context

We don't actually use `lanes.media` for anything currently -- lanes are expected to hold all types of media, and we use entry points to control which subset of a lane a user sees.

Setting `lanes.media` leads to inaccurate counts of lane size: see https://jira.nypl.org/browse/SIMPLY-2850 for details.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Automated tests. Ran migration script against local database to make sure the syntax is valid.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
