### PR TITLE
Don't represent loans and holds for books that can't actually be delivered

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -1402,13 +1402,20 @@ class LibraryLoanAndHoldAnnotator(LibraryAnnotator):
             cls, circulation, patron, test_mode=False, **response_kwargs
     ):
         db = Session.object_session(patron)
+
+        excluded_audio_sources = ConfigurationSetting.excluded_audio_data_sources(_db)
+
         active_loans_by_work = {}
         for loan in patron.loans:
+            if cls._exclude_from_feeds(excluded_audio_sources, loan):
+                continue
             work = loan.work
             if work:
                 active_loans_by_work[work] = loan
         active_holds_by_work = {}
         for hold in patron.holds:
+            if cls._exclude_from_feeds(excluded_audio_sources, hold):
+                continue
             work = hold.work
             if work:
                 active_holds_by_work[work] = hold
@@ -1423,6 +1430,22 @@ class LibraryLoanAndHoldAnnotator(LibraryAnnotator):
         feed_obj = AcquisitionFeed(db, "Active loans and holds", url, works, annotator)
         annotator.annotate_feed(feed_obj, None)
         return feed_obj.as_response(max_age=60*30, private=True)
+
+    @classmethod
+    def _exclude_from_feeds(cls, excluded_sources, loan):
+        pool = loan.license_pool
+        if not pool:
+            # Shouldn't happen
+            return False
+        edition = pool.presentation_edition
+        if not edition:
+            # Shouldn't happen
+            return False
+        if edition.medium != Edition.AUDIO_MEDIUM:
+            return False
+        if pool.data_source.name in excluded_sources:
+            return True
+        return False
 
     @classmethod
     def single_item_feed(cls, circulation, item, fulfillment=None, test_mode=False,


### PR DESCRIPTION
## Description

For a while now we've given Overdrive audiobooks special treatment, controlled by a sitewide setting. This branch adds another bit of special treatment: loans and holds for Overdrive audiobooks will not be represented in the `loans` and `holds` tables. This will stop them from showing up in patrons' bookshelf feeds, where new versions of SimplyE might incorrectly believe that they are fulfillable through the SimplyE/circulation manager system. (How do they get into bookshelf feeds in the first place? Patrons take out loans for them using the Overdrive web site.)

This solution should work in the short term, while we're certifying that Overdrive audiobooks work with NYPL's collection, but other libraries should continue to treat Overdrive audiobooks as unfulfillable. It should also work in the long term, since the expectation is that every library with an Overdrive collection should have audiobooks enabled -- the existing sitewide setting will go away rather than become a per-library setting.

Since Overdrive is the source of truth regarding these loans, once the sitewide setting is removed, they'll immediately start showing up in the `loans` and `holds` tables, and in bookshelf feeds.

## Motivation and Context

This fixes https://jira.nypl.org/browse/SIMPLY-2869.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I borrowed an Overdrive audiobook with my NYPL card. The audiobook shows up in my bookshelf feed on NYPL's production server, but not on my local installation using NYPL's Overdrive credentials.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
