### PR TITLE
Refactor the Overdrive checkout process, unit-test it, and add one new bit of error checking.

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -153,6 +153,13 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
     # displayed to a patron, so it doesn't matter much.
     DEFAULT_ERROR_URL = "http://librarysimplified.org/"
 
+    # Map Overdrive's error messages to standard circulation manager
+    # exceptions.
+    ERROR_MESSAGE_TO_EXCEPTION = {
+        "PatronHasExceededCheckoutLimit": PatronLoanLimitReached,
+        "PatronHasExceededCheckoutLimit_ForCPC": PatronLoanLimitReached,
+    }
+
     def __init__(self, _db, collection):
         super(OverdriveAPI, self).__init__(_db, collection)
         self.overdrive_bibliographic_coverage_provider = (
@@ -325,37 +332,16 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
 
         response = self.patron_request(
             patron, pin, self.CHECKOUTS_ENDPOINT, extra_headers=headers,
-            data=payload)
+            data=payload
+        )
+        data = response.json()
         if response.status_code == 400:
-            error = response.json()
-            code = error['errorCode']
-            if code == 'NoCopiesAvailable':
-                # Clearly our info is out of date.
-                self.update_licensepool(identifier.identifier)
-                raise NoAvailableCopies()
-            elif code == 'TitleAlreadyCheckedOut':
-                # Client should have used a fulfill link instead, but
-                # we can handle it.
-                loan = self.get_loan(patron, pin, identifier.identifier)
-                expires = self.extract_expiration_date(loan)
-                return LoanInfo(
-                    licensepool.collection,
-                    licensepool.data_source.name,
-                    licensepool.identifier.type,
-                    licensepool.identifier.identifier,
-                    None,
-                    expires,
-                    None
-                )
-            elif code == 'PatronHasExceededCheckoutLimit':
-                raise PatronLoanLimitReached()
-            else:
-                raise CannotLoan(code)
+            return self._process_checkout_error(patron, pin, licensepool, data)
         else:
             # Try to extract the expiration date from the response.
-            expires = self.extract_expiration_date(response.json())
+            expires = self.extract_expiration_date(data)
 
-        # Create the loan info. We don't know the expiration
+        # Create the loan info.
         loan = LoanInfo(
             licensepool.collection,
             licensepool.data_source.name,
@@ -366,6 +352,50 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
             None,
         )
         return loan
+
+    def _process_checkout_error(self, patron, pin, licensepool, error):
+        """Handle an error received by the API checkout endpoint.
+
+        :param patron: The Patron who tried to check out the book.
+        :param pin: The Patron's PIN; used in case follow-up
+            API requests are necessary.
+        :param licensepool: LicensePool for the book that was to be borrowed.
+        :param error: A dictionary representing the error response, parsed as JSON.
+        """
+        code = "Unknown Error"
+        identifier = licensepool.identifier
+        if isinstance(error, dict):
+            code = error.get('errorCode', code)
+        if code == 'NoCopiesAvailable':
+            # Clearly our info is out of date.
+            self.update_licensepool(identifier.identifier)
+            raise NoAvailableCopies()
+
+        if code == 'TitleAlreadyCheckedOut':
+            # Client should have used a fulfill link instead, but
+            # we can handle it.
+            #
+            # NOTE: It's very unlikely this will happen, but it could
+            # happen if the patron borrows a book through Libby and
+            # then immediately borrows the same book through SimplyE.
+            loan = self.get_loan(patron, pin, identifier.identifier)
+            expires = self.extract_expiration_date(loan)
+            return LoanInfo(
+                licensepool.collection,
+                licensepool.data_source.name,
+                identifier.type,
+                identifier.identifier,
+                None,
+                expires,
+                None
+            )
+
+        if code in self.ERROR_MESSAGE_TO_EXCEPTION:
+            exc_class = self.ERROR_MESSAGE_TO_EXCEPTION[code]
+            raise exc_class()
+
+        # All-purpose fallback
+        raise CannotLoan(code)
 
     def checkin(self, patron, pin, licensepool):
 
@@ -644,12 +674,17 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
 
     @classmethod
     def _extract_date(cls, data, field_name):
+        if not isinstance(data, dict):
+            return None
         if not field_name in data:
-            d = None
-        else:
-            d = datetime.datetime.strptime(
-                data[field_name], cls.TIME_FORMAT)
-        return d
+            return None
+        try:
+            return datetime.datetime.strptime(
+                data[field_name], cls.TIME_FORMAT
+            )
+        except ValueError, e:
+            # Wrong format
+            return None
 
     def get_patron_information(self, patron, pin):
         data = self.patron_request(patron, pin, self.ME_ENDPOINT).json()

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -311,7 +311,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         # First, test the successful path.
         api = Mock(self._db, self.collection)
         api_response = json.dumps("some data")
-        api.queue_response(200, content=api_response)
+        api.queue_response(201, content=api_response)
         loan = api.checkout(patron, pin, pool, "internal format is ignored")
 
         # Verify that a good-looking patron request went out.
@@ -329,7 +329,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         # The API response was passed into extract_expiration_date.
         #
         # The most important thing here is not the content of the response but the
-        # fact that the response code was 200.
+        # fact that the response code was not 400.
         eq_("some data", api.extract_expiration_date_called_with.pop())
 
         # The return value is a LoanInfo object with all relevant info.

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -27,6 +27,7 @@ from api.circulation import (
     CirculationAPI,
     FulfillmentInfo,
     HoldInfo,
+    LoanInfo,
 )
 from api.circulation_exceptions import *
 from api.config import Configuration
@@ -275,6 +276,205 @@ class TestOverdriveAPI(OverdriveAPITest):
             self.api.website_id, self.api.ils_name(self._default_library)
         )
         eq_(expect, self.api.scope_string(self._default_library))
+
+    def test_checkout(self):
+        # Verify the process of checking out a book.
+        patron = object()
+        pin = object()
+        pool = self._licensepool(edition=None, collection=self.collection)
+        identifier = pool.identifier
+
+        class Mock(MockOverdriveAPI):
+            MOCK_EXPIRATION_DATE = object()
+            PROCESS_CHECKOUT_ERROR_RESULT = Exception(
+                "exception in _process_checkout_error"
+            )
+
+            def __init__(self, *args, **kwargs):
+                super(Mock, self).__init__(*args, **kwargs)
+                self.extract_expiration_date_called_with = []
+                self._process_checkout_error_called_with = []
+
+            def extract_expiration_date(self, loan):
+                self.extract_expiration_date_called_with.append(loan)
+                return self.MOCK_EXPIRATION_DATE
+
+            def _process_checkout_error(self, patron, pin, licensepool, data):
+                self._process_checkout_error_called_with.append(
+                    (patron, pin, licensepool, data)
+                )
+                result = self.PROCESS_CHECKOUT_ERROR_RESULT
+                if isinstance(result, Exception):
+                    raise result
+                return result
+
+        # First, test the successful path.
+        api = Mock(self._db, self.collection)
+        api_response = json.dumps("some data")
+        api.queue_response(200, content=api_response)
+        loan = api.checkout(patron, pin, pool, "internal format is ignored")
+
+        # Verify that a good-looking patron request went out.
+        endpoint, ignore, kwargs = api.requests.pop()
+        assert endpoint.endswith("/me/checkouts")
+        eq_(patron, kwargs.pop('_patron'))
+        extra_headers = kwargs.pop('extra_headers')
+        eq_({"Content-Type": "application/json"}, extra_headers)
+        data = json.loads(kwargs.pop('data'))
+        eq_(
+            {'fields': [{'name': 'reserveId', 'value': pool.identifier.identifier}]},
+            data
+        )
+
+        # The API response was passed into extract_expiration_date.
+        #
+        # The most important thing here is not the content of the response but the
+        # fact that the response code was 200.
+        eq_("some data", api.extract_expiration_date_called_with.pop())
+
+        # The return value is a LoanInfo object with all relevant info.
+        assert isinstance(loan, LoanInfo)
+        eq_(pool.collection.id, loan.collection_id)
+        eq_(pool.data_source.name, loan.data_source_name)
+        eq_(identifier.type, loan.identifier_type)
+        eq_(identifier.identifier, loan.identifier)
+        eq_(None, loan.start_date)
+        eq_(api.MOCK_EXPIRATION_DATE, loan.end_date)
+
+        # _process_checkout_error was not called
+        eq_([], api._process_checkout_error_called_with)
+
+        # Now let's test error conditions.
+
+        # Most of the time, an error simply results in an exception.
+        api.queue_response(400, content=api_response)
+        assert_raises_regexp(
+            Exception, "exception in _process_checkout_error",
+            api.checkout, patron, pin, pool, "internal format is ignored"
+        )
+        eq_((patron, pin, pool, "some data"), api._process_checkout_error_called_with.pop())
+
+        # However, if _process_checkout_error is able to recover from
+        # the error and ends up returning something, the return value
+        # is propagated from checkout().
+        api.PROCESS_CHECKOUT_ERROR_RESULT = "Actually, I was able to recover"
+        api.queue_response(400, content=api_response)
+        eq_(
+            "Actually, I was able to recover",
+            api.checkout(
+                patron, pin, pool, "internal format is ignored"
+            )
+        )
+        eq_((patron, pin, pool, "some data"), api._process_checkout_error_called_with.pop())
+
+    def test__process_checkout_error(self):
+        # Verify that _process_checkout_error handles common API-side errors,
+        # making follow-up API calls if necessary.
+
+        class Mock(MockOverdriveAPI):
+            MOCK_LOAN = object()
+            MOCK_EXPIRATION_DATE = object()
+
+            def __init__(self, *args, **kwargs):
+                super(Mock, self).__init__(*args, **kwargs)
+                self.update_licensepool_called_with = []
+                self.get_loan_called_with = []
+                self.extract_expiration_date_called_with = []
+
+            def update_licensepool(self, identifier):
+                self.update_licensepool_called_with.append(identifier)
+
+            def get_loan(self, patron, pin, identifier):
+                self.get_loan_called_with.append((patron, pin, identifier))
+                return self.MOCK_LOAN
+
+            def extract_expiration_date(self, loan):
+                self.extract_expiration_date_called_with.append(loan)
+                return self.MOCK_EXPIRATION_DATE
+
+        patron = object()
+        pin = object()
+        pool = self._licensepool(edition=None, collection=self.collection)
+        identifier = pool.identifier
+        api = Mock(self._db, self.collection)
+        m = api._process_checkout_error
+
+        # Most of the error handling is pretty straightforward.
+        def with_error_code(code):
+            # Simulate the response of the Overdrive API with a given error code.
+            error = dict(errorCode=code)
+
+            # Handle the error.
+            return m(patron, pin, pool, error)
+
+        # Errors not specifically known become generic CannotLoan exceptions.
+        assert_raises_regexp(
+            CannotLoan, "WeirdError", with_error_code, "WeirdError"
+        )
+
+        # If the data passed in to _process_checkout_error is not what
+        # the real Overdrive API would send, the error is even more
+        # generic.
+        assert_raises_regexp(
+            CannotLoan, "Unknown Error",
+            m, patron, pin, pool, "Not a dict"
+        )
+        assert_raises_regexp(
+            CannotLoan, "Unknown Error",
+            m, patron, pin, pool, dict(errorCodePresent=False)
+        )
+
+        # Some known errors become specific subclasses of CannotLoan.
+        assert_raises(PatronLoanLimitReached, with_error_code,
+                      "PatronHasExceededCheckoutLimit")
+        assert_raises(PatronLoanLimitReached, with_error_code,
+                      "PatronHasExceededCheckoutLimit_ForCPC")
+
+        # There are two cases where we need to make follow-up API
+        # requests as the result of a failure during the loan process.
+
+        # First, if the error is "NoCopiesAvailable", we know we have
+        # out-of-date availability information and we need to call
+        # update_licensepool before raising NoAvailbleCopies().
+        assert_raises(NoAvailableCopies, with_error_code,
+                      "NoCopiesAvailable")
+        eq_(identifier.identifier, api.update_licensepool_called_with.pop())
+
+        # If the error is "TitleAlreadyCheckedOut", then the problem
+        # is that the patron tried to take out a new loan instead of
+        # fulfilling an existing loan. In this case we don't raise an
+        # exception at all; we fulfill the loan and return a LoanInfo
+        # object.
+        loan = with_error_code("TitleAlreadyCheckedOut")
+
+        # get_loan was called with the patron's details.
+        eq_((patron, pin, identifier.identifier),
+            api.get_loan_called_with.pop())
+
+        # extract_expiration_date was called on the return value of get_loan.
+        eq_(api.MOCK_LOAN, api.extract_expiration_date_called_with.pop())
+
+        # And a LoanInfo was created with all relevant information.
+        assert isinstance(loan, LoanInfo)
+        eq_(pool.collection.id, loan.collection_id)
+        eq_(pool.data_source.name, loan.data_source_name)
+        eq_(identifier.type, loan.identifier_type)
+        eq_(identifier.identifier, loan.identifier)
+        eq_(None, loan.start_date)
+        eq_(api.MOCK_EXPIRATION_DATE, loan.end_date)
+
+    def test_extract_expiration_date(self):
+        # Test the code that finds and parses a loan expiration date.
+        m = OverdriveAPI.extract_expiration_date
+
+        # Success
+        eq_(datetime(2020, 1, 2, 3, 4, 5), m(dict(expires="2020-01-02T03:04:05Z")))
+
+        # Various failure cases.
+        eq_(None, m(dict(expiresPresent=False)))
+        eq_(None, m(dict(expires="Wrong date format")))
+        eq_(None, m("Not a dict"))
+        eq_(None, m(None))
 
     def test_place_hold(self):
         # Verify that an appropriate request is made to HOLDS_ENDPOINT


### PR DESCRIPTION
## Description

This branch makes a really simple change, made more complicated by the fact that it touches a really important method -- the method that borrows books through Overdrive -- that didn't have test coverage. I refactored the method and added test coverage.

## Motivation and Context

We don't have a complete list of all the error messages Overdrive might send. Recently we discovered a new one which is affecting a lot of our patrons. A problem the patron could fix (they're at their loan limit and need to return something) is reported as a general "Loan failed" error that there's no indication how to fix.

This branch fixes https://jira.nypl.org/browse/SIMPLY-2791.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

To make sure that my refactoring didn't break anything, I used a live Overdrive integration in the following test cases:

* Borrow a book
* Hit the same URL just used to borrow the book, trying to borrow it again. (To get this to work I had to comment out some code in controller.py, since we usually catch this case before going into Overdrive code.) This tests the most complicated part of the code: where we get an error from the Overdrive API but we're able to recover from it and act as though everything's normal.
* Try to borrow a book when at the patron loan limit. (I wasn't able to get the exact error message described in 2791, but I got `PatronHasExceededCheckoutLimit`, and they're now handled the same way, by using a dictionary to map the Overdrive message to an exception class.)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
