### PR TITLE
SAML: remove redundant library settings

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2683,3 +2683,5 @@ class BaseSAMLAuthenticationProvider(AuthenticationProvider, BearerTokenSigner):
            'required': True
        }
     ] + AuthenticationProvider.SETTINGS
+
+    LIBRARY_SETTINGS = []


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR removes redundant library settings from the `Libraries` section:

![image](https://user-images.githubusercontent.com/6442436/87464038-e1a80600-c62b-11ea-8ac1-1cdd4988b1cb.png)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This settings are not required for SAML authentication providers.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
