### PR TITLE
SAML: load SP's private key

### DIFF
--- a/api/saml/configuration.py
+++ b/api/saml/configuration.py
@@ -174,6 +174,9 @@ class SAMLConfiguration(object):
         if not isinstance(sp_provider, ServiceProviderMetadata):
             raise SAMLConfigurationError(_('SAML SP configuration is not correct'))
 
+        sp_provider_private_key = self._configuration_storage.load(db, self.SP_PRIVATE_KEY)
+        sp_provider.private_key = sp_provider_private_key
+
         return sp_provider
 
     def get_debug(self, db):

--- a/api/saml/metadata.py
+++ b/api/saml/metadata.py
@@ -577,6 +577,18 @@ class ServiceProviderMetadata(ProviderMetadata):
         """
         return self._private_key
 
+    @private_key.setter
+    def private_key(self, value):
+        """Returns the private key used for encrypting SAML requests
+
+        :param value: New private key
+        :type value: string
+
+        :return: Private key used for encrypting SAML requests
+        :rtype: string
+        """
+        self._private_key = value
+
 
 class NameID(object):
     """Represents saml2:NameID"""

--- a/api/saml/parser.py
+++ b/api/saml/parser.py
@@ -323,6 +323,12 @@ class SAMLMetadataParser(object):
             './md:KeyDescriptor/ds:KeyInfo/ds:X509Data/ds:X509Certificate')
         certificates = self._parse_certificates(certificate_nodes)
 
+        if len(certificates) > 1:
+            raise SAMLMetadataParsingError(
+                _('There are more than 1 SP certificates'.format(required_acs_binding.value)))
+
+        certificate = next(iter(certificates))
+
         sp = ServiceProviderMetadata(
             entity_id,
             ui_info,
@@ -330,7 +336,7 @@ class SAMLMetadataParser(object):
             acs_service,
             authn_requests_signed,
             want_assertions_signed,
-            certificates)
+            certificate)
 
         return sp
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR fixes the issue related to not loading SP's private key by CM.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

CM has to load an SP's private key if it was set up by an administrator.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
