### PR TITLE
SAML: Add a fallback for the case when IdP metadata does not contain display names

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2681,16 +2681,6 @@ class BaseSAMLAuthenticationProvider(AuthenticationProvider, BearerTokenSigner):
                             'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'),
            'category': 'IDP',
            'required': True
-       },
-       {
-           'key': SAMLConfiguration.IDP_DISPLAY_NAME_TEMPLATE,
-           'label': _('Identity Provider\'s display name template'),
-           'type': 'text',
-           'description': _('Template used to generate IdP display name shown in the UI in the case when '
-                            'IdP metadata does not contain neither mduid:DisplayName nor md:OrganizationDisplayName'),
-           'category': 'IDP',
-           'required': False,
-           'default': SAMLConfiguration.IDP_DISPLAY_NAME_DEFAULT_TEMPLATE
        }
     ] + AuthenticationProvider.SETTINGS
 

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2681,6 +2681,16 @@ class BaseSAMLAuthenticationProvider(AuthenticationProvider, BearerTokenSigner):
                             'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'),
            'category': 'IDP',
            'required': True
+       },
+       {
+           'key': SAMLConfiguration.IDP_DISPLAY_NAME_TEMPLATE,
+           'label': _('Identity Provider\'s display name template'),
+           'type': 'text',
+           'description': _('Template used to generate IdP display name shown in the UI in the case when '
+                            'IdP metadata does not contain neither mduid:DisplayName nor md:OrganizationDisplayName'),
+           'category': 'IDP',
+           'required': False,
+           'default': SAMLConfiguration.IDP_DISPLAY_NAME_DEFAULT_TEMPLATE
        }
     ] + AuthenticationProvider.SETTINGS
 

--- a/api/saml/configuration.py
+++ b/api/saml/configuration.py
@@ -92,6 +92,9 @@ class SAMLConfiguration(object):
 
     IDP_XML_METADATA = 'idp_xml_metadata'
 
+    IDP_DISPLAY_NAME_TEMPLATE = 'idp_display_name_template'
+    IDP_DISPLAY_NAME_DEFAULT_TEMPLATE = 'Identity Provider # {0}'
+
     def __init__(self, configuration_storage, metadata_parser):
         """Initializes a new instance of SAMLConfiguration class
 

--- a/api/saml/configuration.py
+++ b/api/saml/configuration.py
@@ -92,8 +92,7 @@ class SAMLConfiguration(object):
 
     IDP_XML_METADATA = 'idp_xml_metadata'
 
-    IDP_DISPLAY_NAME_TEMPLATE = 'idp_display_name_template'
-    IDP_DISPLAY_NAME_DEFAULT_TEMPLATE = 'Identity Provider # {0}'
+    IDP_DISPLAY_NAME_DEFAULT_TEMPLATE = 'Identity Provider #{0}'
 
     def __init__(self, configuration_storage, metadata_parser):
         """Initializes a new instance of SAMLConfiguration class

--- a/api/saml/controller.py
+++ b/api/saml/controller.py
@@ -258,6 +258,8 @@ class SAMLController(object):
             }
         )
         redirect_uri = authentication_manager.start_authentication(db, idp_entity_id, relay_state)
+        if isinstance(redirect_uri, ProblemDetail):
+            return redirect_uri
 
         return redirect(redirect_uri)
 

--- a/api/saml/metadata.py
+++ b/api/saml/metadata.py
@@ -56,6 +56,93 @@ class LocalizableMetadataItem(object):
         return self._language
 
 
+class Organization(object):
+    """Represents md:Organization and contains basic information about an organization
+    responsible for a SAML entity or role
+    """
+    def __init__(self, organization_names=None, organization_display_names=None, organization_urls=None):
+        """Initializes a new instance of Organization class
+
+        :param organization_names: (Optional) List of localized organization names that may or may not be
+            suitable for human consumption
+        :type organization_names: Optional[List[LocalizableMetadataItem]]
+
+        :param organization_display_names: (Optional) List of localized organization names that
+            suitable for human consumption
+        :type organization_display_names: Optional[List[LocalizableMetadataItem]]
+
+        :param organization_urls: (Optional) List of localized organization URIs that
+            specify a location to which to direct a user for additional information
+        :type organization_urls: Optional[List[LocalizableMetadataItem]]
+        """
+        if organization_names:
+            for organization_name in organization_names:
+                if not isinstance(organization_name, LocalizableMetadataItem):
+                    raise ValueError('organization_name must have type LocalizableMetadataItem')
+
+        if organization_display_names:
+            for organization_display_name in organization_display_names:
+                if not isinstance(organization_display_name, LocalizableMetadataItem):
+                    raise ValueError('organization_display_name must have type LocalizableMetadataItem')
+
+        if organization_urls:
+            for organization_url in organization_urls:
+                if not isinstance(organization_url, LocalizableMetadataItem):
+                    raise ValueError('organization_url must have type LocalizableMetadataItem')
+
+        self._organization_names = organization_names
+        self._organization_display_names = organization_display_names
+        self._organization_urls = organization_urls
+
+    def __eq__(self, other):
+        """Compares two Organization objects
+
+        :param other: Organization object
+        :type other: Organization
+
+        :return: Boolean value indicating whether two items are equal
+        :rtype: bool
+        """
+        if not isinstance(other, Organization):
+            return False
+
+        return \
+            self.organization_names == other.organization_names and \
+            self.organization_display_names == other.organization_display_names and \
+            self.organization_urls == other.organization_urls
+
+    @property
+    def organization_names(self):
+        """Returns a list of localized organization names that may or may not be
+        suitable for human consumption
+
+        :return: List of localized organization names that may or may not be
+            suitable for human consumption
+        :rtype: Optional[List[LocalizableMetadataItem]]
+        """
+        return self._organization_names
+
+    @property
+    def organization_display_names(self):
+        """Returns a list of localized organization names that suitable for human consumption
+
+        :return: List of localized organization names that suitable for human consumption
+        :rtype: Optional[List[LocalizableMetadataItem]]
+        """
+        return self._organization_display_names
+
+    @property
+    def organization_urls(self):
+        """Returns a list of localized organization URIs that specify a location to which to direct a user for
+        additional information
+
+        :return: List of localized organization URIs that
+            specify a location to which to direct a user for additional information
+        :rtype: Optional[List[LocalizableMetadataItem]]
+        """
+        return self._organization_urls
+
+
 class UIInfo(object):
     """Represents mdui:UIInfoType and contains values that can be shown in the UI to describe IdPs/SPs"""
 
@@ -261,7 +348,7 @@ class Service(object):
 class ProviderMetadata(object):
     """Base class for IdentityProvider and ServiceProvider classes"""
 
-    def __init__(self, entity_id, ui_info, name_id_format=NameIDFormat.UNSPECIFIED):
+    def __init__(self, entity_id, ui_info, organization, name_id_format=NameIDFormat.UNSPECIFIED):
         """Initializes a new instance of ProviderMetadata class
 
         :param entity_id: Provider's entityID
@@ -270,17 +357,25 @@ class ProviderMetadata(object):
         :param ui_info: UIInfo object containing "UI" metadata of the provider
         :type ui_info: UIInfo
 
+        :param organization: Organization object containing basic information about an organization
+            responsible for a SAML entity or role
+        :type organization: Organization
+
         :param name_id_format: String defining the name identifier formats supported by the identity provider
         :type name_id_format: string
         """
         if not isinstance(ui_info, UIInfo):
             raise ValueError('ui_info must have type UIInfo')
 
+        if not isinstance(organization, Organization):
+            raise ValueError('organization must have type UIInfo')
+
         if not isinstance(name_id_format, str):
             raise ValueError('name_id_format must be a string')
 
         self._entity_id = entity_id
         self._ui_info = ui_info
+        self._organization = organization
         self._name_id_format = name_id_format
 
     def __eq__(self, other):
@@ -298,6 +393,7 @@ class ProviderMetadata(object):
         return \
             self.entity_id == other.entity_id and \
             self.ui_info == other.ui_info and \
+            self.organization == other.organization and \
             self.name_id_format == other.name_id_format
 
     @property
@@ -318,6 +414,14 @@ class ProviderMetadata(object):
         return self._ui_info
 
     @property
+    def organization(self):
+        """Returns the provider's Organization object
+        :return: Provider's Organization object
+        :rtype: Organization
+        """
+        return self._organization
+
+    @property
     def name_id_format(self):
         """Returns the name ID format
 
@@ -334,6 +438,7 @@ class IdentityProviderMetadata(ProviderMetadata):
             self,
             entity_id,
             ui_info,
+            organization,
             name_id_format,
             sso_service,
             slo_service=None,
@@ -347,6 +452,10 @@ class IdentityProviderMetadata(ProviderMetadata):
 
         :param ui_info: UIInfo object containing this IdP's description which can be shown the UI
         :type ui_info: UIInfo
+
+        :param organization: Organization object containing basic information about an organization
+            responsible for a SAML entity or role
+        :type organization: Organization
 
         :param name_id_format: String defining the name identifier formats supported by the identity provider
         :type name_id_format: string
@@ -367,7 +476,7 @@ class IdentityProviderMetadata(ProviderMetadata):
         :param encryption_certificates: (Optional) Certificate in X.509 format used for encrypting <AuthnResponse>
         :type encryption_certificates: Optional[List[string]]
         """
-        super(IdentityProviderMetadata, self).__init__(entity_id, ui_info, name_id_format)
+        super(IdentityProviderMetadata, self).__init__(entity_id, ui_info, organization, name_id_format)
 
         if not isinstance(sso_service, Service):
             raise ValueError('sso_service must have type Service')
@@ -459,6 +568,7 @@ class ServiceProviderMetadata(ProviderMetadata):
             self,
             entity_id,
             ui_info,
+            organization,
             name_id_format,
             acs_service,
             authn_requests_signed=False,
@@ -472,6 +582,10 @@ class ServiceProviderMetadata(ProviderMetadata):
 
         :param ui_info: UIInfo object containing this IdP's description which can be shown the UI
         :type ui_info: UIInfo
+
+        :param organization: Organization object containing basic information about an organization
+            responsible for a SAML entity or role
+        :type organization: Organization
 
         :param name_id_format: String defining the name identifier formats supported by the identity provider
         :type name_id_format: string
@@ -494,7 +608,7 @@ class ServiceProviderMetadata(ProviderMetadata):
         :param private_key: (Optional) Private key used for encrypting SAML requests
         :type private_key: string
         """
-        super(ServiceProviderMetadata, self).__init__(entity_id, ui_info, name_id_format)
+        super(ServiceProviderMetadata, self).__init__(entity_id, ui_info, organization, name_id_format)
 
         if not isinstance(acs_service, Service):
             raise ValueError('acs_service must have type Service')

--- a/api/saml/parser.py
+++ b/api/saml/parser.py
@@ -368,7 +368,7 @@ class SAMLMetadataParser(object):
             raise SAMLMetadataParsingError(
                 _('There are more than 1 SP certificates'.format(required_acs_binding.value)))
 
-        certificate = next(iter(certificates))
+        certificate = next(iter(certificates)) if certificates else None
 
         sp = ServiceProviderMetadata(
             entity_id,

--- a/api/saml/parser.py
+++ b/api/saml/parser.py
@@ -8,7 +8,7 @@ from onelogin.saml2.utils import OneLogin_Saml2_Utils
 
 from api.saml.exceptions import SAMLError
 from api.saml.metadata import IdentityProviderMetadata, LocalizableMetadataItem, UIInfo, ServiceProviderMetadata, \
-    Binding, Service, NameIDFormat
+    Binding, Service, NameIDFormat, Organization
 
 
 class SAMLMetadataParsingError(SAMLError):
@@ -101,50 +101,54 @@ class SAMLMetadataParser(object):
         for provider_node in provider_nodes:
             entity_id = entity_descriptor_node.get('entityID', None)
             ui_info = self._parse_ui_info(provider_node)
-            provider = parse_function(provider_node, entity_id, ui_info)
+            organization = self._parse_organization_metadata(entity_descriptor_node)
+            provider = parse_function(provider_node, entity_id, ui_info, organization)
 
             providers.append(provider)
 
         return providers
 
-    def _parse_ui_info_item(self, provider_descriptor_node, xpath, required=False):
+    def _parse_localizable_metadata_items(self, provider_descriptor_node, xpath, required=False):
         """Parses IDPSSODescriptor/SPSSODescriptor's mdui:UIInfo child elements (for example, mdui:DisplayName)
 
         :param provider_descriptor_node: Parent IDPSSODescriptor/SPSSODescriptor XML node
         :type provider_descriptor_node: defusedxml.lxml.RestrictedElement
 
-        :param xpath: XPath expression for a particular mdui:UIInfo child element (for example, mdui:DisplayName)
+        :param xpath: XPath expression for a particular md:localizedNameType child element
+            (for example, mdui:DisplayName)
         :type xpath: string
 
-        :param required: Boolean value indicating whether particular mdui:UIInfo child element is required or not
+        :param required: Boolean value indicating whether particular md:localizedNameType child element
+            is required or not
         :type required: bool
 
-        :return: List of mdui:UIInfo child elements
-        :rtype: List[LocalizableMetadataItem]
+        :return: List of md:localizedNameType child elements
+        :rtype: Optional[List[LocalizableMetadataItem]]
 
         :raise: MetadataParsingError
         """
-        ui_info_item_nodes = OneLogin_Saml2_Utils.query(provider_descriptor_node, xpath)
+        localizable_metadata_nodes = OneLogin_Saml2_Utils.query(provider_descriptor_node, xpath)
 
-        if not ui_info_item_nodes and required:
+        if not localizable_metadata_nodes and required:
             last_slash_index = xpath.rfind('/')
-            ui_info_item_name = xpath[last_slash_index + 1:]
+            localizable_metadata_tag_name = xpath[last_slash_index + 1:]
 
-            raise SAMLMetadataParsingError(_('{0} tag is missing'.format(ui_info_item_name)))
+            raise SAMLMetadataParsingError(_('{0} tag is missing'.format(localizable_metadata_tag_name)))
 
-        ui_info_items = None
+        localizable_items = None
 
-        if ui_info_item_nodes:
-            ui_info_items = []
+        if localizable_metadata_nodes:
+            localizable_items = []
 
-            for ui_info_item_node in ui_info_item_nodes:
-                ui_info_item_text = ui_info_item_node.text
-                ui_info_item_language = ui_info_item_node.get('{http://www.w3.org/XML/1998/namespace}lang', None)
-                ui_info_item = LocalizableMetadataItem(ui_info_item_text, ui_info_item_language)
+            for localizable_metadata_node in localizable_metadata_nodes:
+                localizable_item_text = localizable_metadata_node.text
+                localizable_item_language = localizable_metadata_node.get(
+                    '{http://www.w3.org/XML/1998/namespace}lang', None)
+                localizable_item = LocalizableMetadataItem(localizable_item_text, localizable_item_language)
 
-                ui_info_items.append(ui_info_item)
+                localizable_items.append(localizable_item)
 
-        return ui_info_items
+        return localizable_items
 
     def _parse_ui_info(self, provider_node):
         """Parses IDPSSODescriptor/SPSSODescriptor's mdui:UIInfo and translates it into UIInfo object
@@ -157,15 +161,15 @@ class SAMLMetadataParser(object):
 
         :raise: MetadataParsingError
         """
-        display_names = self._parse_ui_info_item(
+        display_names = self._parse_localizable_metadata_items(
             provider_node, './md:Extensions/mdui:UIInfo/mdui:DisplayName')
-        descriptions = self._parse_ui_info_item(
+        descriptions = self._parse_localizable_metadata_items(
             provider_node, './md:Extensions/mdui:UIInfo/mdui:Description')
-        information_urls = self._parse_ui_info_item(
+        information_urls = self._parse_localizable_metadata_items(
             provider_node, './md:Extensions/mdui:UIInfo/mdui:InformationURL')
-        privacy_statement_urls = self._parse_ui_info_item(
+        privacy_statement_urls = self._parse_localizable_metadata_items(
             provider_node, './md:Extensions/mdui:UIInfo/mdui:PrivacyStatementURL')
-        logos = self._parse_ui_info_item(
+        logos = self._parse_localizable_metadata_items(
             provider_node, './md:Extensions/mdui:UIInfo/mdui:Logo')
 
         ui_info = UIInfo(
@@ -177,6 +181,32 @@ class SAMLMetadataParser(object):
         )
 
         return ui_info
+
+    def _parse_organization_metadata(self, entity_descriptor_node):
+        """Parses IDPSSODescriptor/SPSSODescriptor's mdui:Organization and translates it into Organization object
+
+        :param entity_descriptor_node: Parent EntityDescriptor node
+        :type entity_descriptor_node: defusedxml.lxml.RestrictedElement
+
+        :return: Organization object
+        :rtype: Organization
+
+        :raise: MetadataParsingError
+        """
+        organization_names = self._parse_localizable_metadata_items(
+            entity_descriptor_node, './md:Organization/md:OrganizationName')
+        organization_display_names = self._parse_localizable_metadata_items(
+            entity_descriptor_node, './md:Organization/md:OrganizationDisplayName')
+        organization_urls = self._parse_localizable_metadata_items(
+            entity_descriptor_node, './md:Organization/md:OrganizationURL')
+
+        organization = Organization(
+            organization_names,
+            organization_display_names,
+            organization_urls
+        )
+
+        return organization
 
     def _parse_name_id_format(self, provider_node):
         """Parses a name ID format
@@ -203,6 +233,7 @@ class SAMLMetadataParser(object):
             provider_node,
             entity_id,
             ui_info,
+            organization,
             required_sso_binding=Binding.HTTP_REDIRECT,
             required_slo_binding=Binding.HTTP_REDIRECT):
         """Parses IDPSSODescriptor node and translates it into an IdentityProviderMetadata object
@@ -215,6 +246,10 @@ class SAMLMetadataParser(object):
 
         :param ui_info: UIInfo object containing IdP's description
         :type ui_info: UIInfo
+
+        :param organization: Organization object containing basic information about an organization
+            responsible for a SAML entity or role
+        :type organization: Organization
 
         :param required_sso_binding: Required binding for Single Sign-On profile (HTTP-Redirect by default)
         :type required_sso_binding: Binding
@@ -267,6 +302,7 @@ class SAMLMetadataParser(object):
         idp = IdentityProviderMetadata(
             entity_id,
             ui_info,
+            organization,
             name_id_format,
             sso_service,
             slo_service,
@@ -281,6 +317,7 @@ class SAMLMetadataParser(object):
             provider_node,
             entity_id,
             ui_info,
+            organization,
             required_acs_binding=Binding.HTTP_POST):
         """Parses SPSSODescriptor node and translates it into a ServiceProvider object
 
@@ -292,6 +329,10 @@ class SAMLMetadataParser(object):
 
         :param ui_info: UIInfo object containing IdP's description
         :type ui_info: UIInfo
+
+        :param organization: Organization object containing basic information about an organization
+            responsible for a SAML entity or role
+        :type organization: Organization
 
         :param required_acs_binding: Required binding for Assertion Consumer Service (HTTP-Redirect by default)
         :type required_acs_binding: Binding
@@ -332,6 +373,7 @@ class SAMLMetadataParser(object):
         sp = ServiceProviderMetadata(
             entity_id,
             ui_info,
+            organization,
             name_id_format,
             acs_service,
             authn_requests_signed,

--- a/api/saml/provider.py
+++ b/api/saml/provider.py
@@ -144,7 +144,9 @@ class SAMLWebSSOAuthenticationProvider(BaseSAMLAuthenticationProvider, ExternalI
             link = {
                 'rel': 'authenticate',
                 'href': self._create_authenticate_url(db, identity_provider.entity_id),
-                'display_names': self._join_ui_info_items(identity_provider.ui_info.display_names),
+                'display_names': self._join_ui_info_items(
+                    identity_provider.ui_info.display_names,
+                    identity_provider.organization.organization_display_names),
                 'descriptions': self._join_ui_info_items(identity_provider.ui_info.descriptions),
                 'information_urls': self._join_ui_info_items(identity_provider.ui_info.information_urls),
                 'privacy_statement_urls': self._join_ui_info_items(
@@ -233,10 +235,10 @@ class SAMLWebSSOAuthenticationProvider(BaseSAMLAuthenticationProvider, ExternalI
             db, DataSource, name=self.TOKEN_DATA_SOURCE_NAME
         )
 
-    def _join_ui_info_items(self, ui_info_items):
-        """Joins all UIInfo items (like, display names, descriptions, etc.) to a single list of dicts
+    def _join_ui_info_items(self, *ui_info_item_lists):
+        """Joins all UI info items (like, display names, descriptions, etc.) to a single list of dicts
 
-        :param ui_info_items: List of child UIInfo objects
+        :param ui_info_item_lists: List of child LocalizableMetadataInfo objects
         :type: List[LocalizableMetadataItem]
 
         :return: List of dicts containing UI information (display names, descriptions, etc.)
@@ -244,12 +246,14 @@ class SAMLWebSSOAuthenticationProvider(BaseSAMLAuthenticationProvider, ExternalI
         """
         result = []
 
-        if ui_info_items:
-            for ui_info_item in ui_info_items:
-                result.append({
-                    'value': ui_info_item.value,
-                    'language': ui_info_item.language
-                })
+        if ui_info_item_lists:
+            for ui_info_item_list in ui_info_item_lists:
+                if ui_info_item_list:
+                    for ui_info_item in ui_info_item_list:
+                        result.append({
+                            'value': ui_info_item.value,
+                            'language': ui_info_item.language
+                        })
 
         return result
 

--- a/api/saml/provider.py
+++ b/api/saml/provider.py
@@ -56,9 +56,6 @@ class SAMLWebSSOAuthenticationProvider(BaseSAMLAuthenticationProvider, ExternalI
 
         self._logger = logging.getLogger(__name__)
         self._authentication_manager = None
-        self._idp_display_name_template = integration.setting(
-            SAMLConfiguration.IDP_DISPLAY_NAME_TEMPLATE
-        ).value or SAMLConfiguration.IDP_DISPLAY_NAME_DEFAULT_TEMPLATE
 
     def _authentication_flow_document(self, db):
         """Creates a Authentication Flow object for use in an Authentication for OPDS document.
@@ -179,7 +176,7 @@ class SAMLWebSSOAuthenticationProvider(BaseSAMLAuthenticationProvider, ExternalI
         elif identity_provider.organization.organization_display_names:
             return identity_provider.organization.organization_display_names
         else:
-            display_name = self._idp_display_name_template.format(identity_provider_index)
+            display_name = SAMLConfiguration.IDP_DISPLAY_NAME_DEFAULT_TEMPLATE.format(identity_provider_index)
             return [
                 LocalizableMetadataItem(display_name, language='en')
             ]

--- a/tests/saml/fixtures.py
+++ b/tests/saml/fixtures.py
@@ -12,6 +12,13 @@ IDP_1_UI_INFO_INFORMATION_URL = 'http://idp1.hilbertteam.net'
 IDP_1_UI_INFO_PRIVACY_STATEMENT_URL = 'http://idp1.hilbertteam.net'
 IDP_1_UI_INFO_LOGO_URL = 'http://idp1.hilbertteam.net/logo.png'
 
+IDP_1_ORGANIZATION_EN_ORGANIZATION_NAME = IDP_1_UI_INFO_DISPLAY_NAME
+IDP_1_ORGANIZATION_ES_ORGANIZATION_NAME = IDP_1_ORGANIZATION_EN_ORGANIZATION_NAME
+IDP_1_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME = IDP_1_UI_INFO_DISPLAY_NAME
+IDP_1_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME = IDP_1_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME
+IDP_1_ORGANIZATION_EN_ORGANIZATION_URL = IDP_1_UI_INFO_INFORMATION_URL
+IDP_1_ORGANIZATION_ES_ORGANIZATION_URL = IDP_1_ORGANIZATION_EN_ORGANIZATION_URL
+
 IDP_1_SSO_URL = 'http://idp1.hilbertteam.net/idp/profile/SAML2/Redirect/SSO'
 IDP_1_SSO_BINDING = Binding.HTTP_REDIRECT
 
@@ -24,10 +31,31 @@ IDP_2_UI_INFO_INFORMATION_URL = 'http://idp2.hilbertteam.net'
 IDP_2_UI_INFO_PRIVACY_STATEMENT_URL = 'http://idp2.hilbertteam.net'
 IDP_2_UI_INFO_LOGO_URL = 'http://idp2.hilbertteam.net/logo.png'
 
+IDP_2_ORGANIZATION_EN_ORGANIZATION_NAME = IDP_2_UI_INFO_DISPLAY_NAME
+IDP_2_ORGANIZATION_ES_ORGANIZATION_NAME = IDP_2_ORGANIZATION_EN_ORGANIZATION_NAME
+IDP_2_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME = IDP_2_UI_INFO_DISPLAY_NAME
+IDP_2_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME = IDP_2_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME
+IDP_2_ORGANIZATION_EN_ORGANIZATION_URL = IDP_2_UI_INFO_INFORMATION_URL
+IDP_2_ORGANIZATION_ES_ORGANIZATION_URL = IDP_2_ORGANIZATION_EN_ORGANIZATION_URL
+
 IDP_2_SSO_URL = 'http://idp2.hilbertteam.net/idp/profile/SAML2/Redirect/SSO'
 IDP_2_SSO_BINDING = Binding.HTTP_REDIRECT
 
 SP_ENTITY_ID = 'http://sp.hilbertteam.net/idp/shibboleth'
+SP_UI_INFO_DISPLAY_NAME = 'Shibboleth Test SP'
+SP_UI_INFO_EN_DISPLAY_NAME = SP_UI_INFO_DISPLAY_NAME
+SP_UI_INFO_ES_DISPLAY_NAME = SP_UI_INFO_DISPLAY_NAME
+SP_UI_INFO_DESCRIPTION = 'Shibboleth Test SP'
+SP_UI_INFO_INFORMATION_URL = 'http://sp.hilbertteam.net'
+SP_UI_INFO_PRIVACY_STATEMENT_URL = 'http://sp.hilbertteam.net'
+SP_UI_INFO_LOGO_URL = 'http://sp.hilbertteam.net/logo.png'
+
+SP_ORGANIZATION_EN_ORGANIZATION_NAME = SP_UI_INFO_DISPLAY_NAME
+SP_ORGANIZATION_ES_ORGANIZATION_NAME = SP_ORGANIZATION_EN_ORGANIZATION_NAME
+SP_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME = SP_UI_INFO_DISPLAY_NAME
+SP_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME = SP_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME
+SP_ORGANIZATION_EN_ORGANIZATION_URL = SP_UI_INFO_INFORMATION_URL
+SP_ORGANIZATION_ES_ORGANIZATION_URL = SP_ORGANIZATION_EN_ORGANIZATION_URL
 
 SP_ACS_URL = 'http://sp.hilbertteam.net/idp/profile/SAML2/POST'
 SP_ACS_BINDING = Binding.HTTP_POST
@@ -88,56 +116,6 @@ kF7xgXphcsIlNUxJyp79q30fpwUCCwwTcfimCWBzRCAf
 '''
 
 INCORRECT_XML = ''
-
-INCORRECT_ONE_IDP_METADATA_WITHOUT_DISPLAY_NAME = \
-    '''<?xml version="1.0" encoding="UTF-8"?>
-<!--
-     This is example metadata only. Do *NOT* supply it as is without review,
-     and do *NOT* provide it in real time to your partners.
-
-     This metadata is not dynamic - it will not change as your configuration changes.
--->
-<EntityDescriptor
-  xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
-  xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-  xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
-  xmlns:xml="http://www.w3.org/XML/1998/namespace"
-  xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
-  entityID="{0}">
-    <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
-        <KeyDescriptor use="signing">
-            <ds:KeyInfo>
-                    <ds:X509Data>
-                        <ds:X509Certificate>
-{1}
-                        </ds:X509Certificate>
-                    </ds:X509Data>
-            </ds:KeyInfo>
-        </KeyDescriptor>
-        <KeyDescriptor use="encryption">
-            <ds:KeyInfo>
-                    <ds:X509Data>
-                        <ds:X509Certificate>
-{2}
-                        </ds:X509Certificate>
-                    </ds:X509Data>
-            </ds:KeyInfo>
-        </KeyDescriptor>
-        <NameIDFormat>{3}</NameIDFormat>
-        <NameIDFormat>{4}</NameIDFormat>
-        <SingleSignOnService 
-            Binding="{5}" 
-            Location="{6}"/>
-    </IDPSSODescriptor>
-</EntityDescriptor>
-'''.format(
-        IDP_1_ENTITY_ID,
-        SIGNING_CERTIFICATE,
-        ENCRYPTION_CERTIFICATE,
-        NAME_ID_FORMAT_1,
-        NAME_ID_FORMAT_2,
-        IDP_1_SSO_BINDING.value,
-        IDP_1_SSO_URL)
 
 INCORRECT_ONE_IDP_METADATA_WITHOUT_SSO_SERVICE = \
     '''<?xml version="1.0" encoding="UTF-8"?>
@@ -268,6 +246,56 @@ INCORRECT_ONE_IDP_METADATA_WITH_SSO_SERVICE_WITH_WRONG_BINDING = \
         Binding.HTTP_ARTIFACT.value,
         IDP_1_SSO_URL)
 
+CORRECT_ONE_IDP_METADATA_WITHOUT_DISPLAY_NAMES = \
+    '''<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     This is example metadata only. Do *NOT* supply it as is without review,
+     and do *NOT* provide it in real time to your partners.
+
+     This metadata is not dynamic - it will not change as your configuration changes.
+-->
+<EntityDescriptor
+  xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+  xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+  xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
+  xmlns:xml="http://www.w3.org/XML/1998/namespace"
+  xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+  entityID="{0}">
+    <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
+        <KeyDescriptor use="signing">
+            <ds:KeyInfo>
+                    <ds:X509Data>
+                        <ds:X509Certificate>
+{1}
+                        </ds:X509Certificate>
+                    </ds:X509Data>
+            </ds:KeyInfo>
+        </KeyDescriptor>
+        <KeyDescriptor use="encryption">
+            <ds:KeyInfo>
+                    <ds:X509Data>
+                        <ds:X509Certificate>
+{2}
+                        </ds:X509Certificate>
+                    </ds:X509Data>
+            </ds:KeyInfo>
+        </KeyDescriptor>
+        <NameIDFormat>{3}</NameIDFormat>
+        <NameIDFormat>{4}</NameIDFormat>
+        <SingleSignOnService 
+            Binding="{5}" 
+            Location="{6}"/>
+    </IDPSSODescriptor>
+</EntityDescriptor>
+'''.format(
+        IDP_1_ENTITY_ID,
+        SIGNING_CERTIFICATE,
+        ENCRYPTION_CERTIFICATE,
+        NAME_ID_FORMAT_1,
+        NAME_ID_FORMAT_2,
+        IDP_1_SSO_BINDING.value,
+        IDP_1_SSO_URL)
+
 CORRECT_ONE_IDP_METADATA = \
     '''<?xml version="1.0" encoding="UTF-8"?>
 <!--
@@ -322,6 +350,14 @@ CORRECT_ONE_IDP_METADATA = \
             Binding="{11}" 
             Location="{12}"/>
     </IDPSSODescriptor>
+    <Organization>
+      <OrganizationName xml:lang="en">{13}</OrganizationName>
+      <OrganizationName xml:lang="es">{14}</OrganizationName>
+      <OrganizationDisplayName xml:lang="en">{15}</OrganizationDisplayName>
+      <OrganizationDisplayName xml:lang="es">{16}</OrganizationDisplayName>
+      <OrganizationURL xml:lang="en">{17}</OrganizationURL>
+      <OrganizationURL xml:lang="es">{18}</OrganizationURL>
+    </Organization>
 </EntityDescriptor>
 '''.format(
         IDP_1_ENTITY_ID,
@@ -336,7 +372,14 @@ CORRECT_ONE_IDP_METADATA = \
         NAME_ID_FORMAT_1,
         NAME_ID_FORMAT_2,
         IDP_1_SSO_BINDING.value,
-        IDP_1_SSO_URL)
+        IDP_1_SSO_URL,
+        IDP_1_ORGANIZATION_EN_ORGANIZATION_NAME,
+        IDP_1_ORGANIZATION_ES_ORGANIZATION_NAME,
+        IDP_1_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME,
+        IDP_1_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME,
+        IDP_1_ORGANIZATION_EN_ORGANIZATION_URL,
+        IDP_1_ORGANIZATION_ES_ORGANIZATION_URL
+    )
 
 CORRECT_ONE_IDP_METADATA_WITHOUT_NAME_ID_FORMAT = \
     '''<?xml version="1.0" encoding="UTF-8"?>
@@ -390,6 +433,14 @@ CORRECT_ONE_IDP_METADATA_WITHOUT_NAME_ID_FORMAT = \
             Binding="{9}" 
             Location="{10}"/>
     </IDPSSODescriptor>
+    <Organization>
+      <OrganizationName xml:lang="en">{11}</OrganizationName>
+      <OrganizationName xml:lang="es">{12}</OrganizationName>
+      <OrganizationDisplayName xml:lang="en">{13}</OrganizationDisplayName>
+      <OrganizationDisplayName xml:lang="es">{14}</OrganizationDisplayName>
+      <OrganizationURL xml:lang="en">{15}</OrganizationURL>
+      <OrganizationURL xml:lang="es">{16}</OrganizationURL>
+    </Organization>
 </EntityDescriptor>
 '''.format(
         IDP_1_ENTITY_ID,
@@ -402,7 +453,14 @@ CORRECT_ONE_IDP_METADATA_WITHOUT_NAME_ID_FORMAT = \
         SIGNING_CERTIFICATE,
         ENCRYPTION_CERTIFICATE,
         IDP_1_SSO_BINDING.value,
-        IDP_1_SSO_URL)
+        IDP_1_SSO_URL,
+        IDP_1_ORGANIZATION_EN_ORGANIZATION_NAME,
+        IDP_1_ORGANIZATION_ES_ORGANIZATION_NAME,
+        IDP_1_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME,
+        IDP_1_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME,
+        IDP_1_ORGANIZATION_EN_ORGANIZATION_URL,
+        IDP_1_ORGANIZATION_ES_ORGANIZATION_URL
+    )
 
 CORRECT_ONE_IDP_METADATA_WITH_ONE_CERTIFICATE = \
     '''<?xml version="1.0" encoding="UTF-8"?>
@@ -449,6 +507,14 @@ CORRECT_ONE_IDP_METADATA_WITH_ONE_CERTIFICATE = \
             Binding="{10}" 
             Location="{11}"/>
     </IDPSSODescriptor>
+    <Organization>
+      <OrganizationName xml:lang="en">{12}</OrganizationName>
+      <OrganizationName xml:lang="es">{13}</OrganizationName>
+      <OrganizationDisplayName xml:lang="en">{14}</OrganizationDisplayName>
+      <OrganizationDisplayName xml:lang="es">{15}</OrganizationDisplayName>
+      <OrganizationURL xml:lang="en">{16}</OrganizationURL>
+      <OrganizationURL xml:lang="es">{17}</OrganizationURL>
+    </Organization>
 </EntityDescriptor>
 '''.format(
         IDP_1_ENTITY_ID,
@@ -462,7 +528,14 @@ CORRECT_ONE_IDP_METADATA_WITH_ONE_CERTIFICATE = \
         NAME_ID_FORMAT_1,
         NAME_ID_FORMAT_2,
         IDP_1_SSO_BINDING.value,
-        IDP_1_SSO_URL)
+        IDP_1_SSO_URL,
+        IDP_1_ORGANIZATION_EN_ORGANIZATION_NAME,
+        IDP_1_ORGANIZATION_ES_ORGANIZATION_NAME,
+        IDP_1_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME,
+        IDP_1_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME,
+        IDP_1_ORGANIZATION_EN_ORGANIZATION_URL,
+        IDP_1_ORGANIZATION_ES_ORGANIZATION_URL
+    )
 
 CORRECT_MULTIPLE_IDPS_METADATA = \
     '''<?xml version="1.0" encoding="UTF-8"?>
@@ -514,26 +587,34 @@ CORRECT_MULTIPLE_IDPS_METADATA = \
         Binding="{7}" 
         Location="{8}"/>
     </IDPSSODescriptor>
+    <Organization>
+      <OrganizationName xml:lang="en">{9}</OrganizationName>
+      <OrganizationName xml:lang="es">{10}</OrganizationName>
+      <OrganizationDisplayName xml:lang="en">{11}</OrganizationDisplayName>
+      <OrganizationDisplayName xml:lang="es">{12}</OrganizationDisplayName>
+      <OrganizationURL xml:lang="en">{13}</OrganizationURL>
+      <OrganizationURL xml:lang="es">{14}</OrganizationURL>
+    </Organization>
   </EntityDescriptor>
   <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" 
     xmlns:ds="http://www.w3.org/2000/09/xmldsig#" 
     xmlns:shibmd="urn:mace:shibboleth:metadata:1.0" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
     xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" 
-    entityID="{9}">
+    entityID="{15}">
     <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0">
       <Extensions>
         <shibmd:Scope regexp="false">example.org</shibmd:Scope>
         <mdui:UIInfo>
-          <mdui:DisplayName xml:lang="en">{10}</mdui:DisplayName>
-          <mdui:DisplayName xml:lang="es">{11}</mdui:DisplayName>
+          <mdui:DisplayName xml:lang="en">{16}</mdui:DisplayName>
+          <mdui:DisplayName xml:lang="es">{17}</mdui:DisplayName>
         </mdui:UIInfo>
       </Extensions>
       <KeyDescriptor use="signing">
         <ds:KeyInfo>
           <ds:X509Data>
             <ds:X509Certificate>
-{12}
+{18}
             </ds:X509Certificate>
           </ds:X509Data>
         </ds:KeyInfo>
@@ -542,20 +623,28 @@ CORRECT_MULTIPLE_IDPS_METADATA = \
         <ds:KeyInfo>
           <ds:X509Data>
             <ds:X509Certificate>
-{13}
+{19}
             </ds:X509Certificate>
           </ds:X509Data>
         </ds:KeyInfo>
       </KeyDescriptor>
-      <NameIDFormat>{14}</NameIDFormat>
-      <NameIDFormat>{15}</NameIDFormat>
+      <NameIDFormat>{20}</NameIDFormat>
+      <NameIDFormat>{21}</NameIDFormat>
       <SingleSignOnService 
         Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign" 
         Location="http://idp.hilbertteam.net/idp/profile/SAML2/POST-SimpleSign/SSO"/>
       <SingleSignOnService 
-        Binding="{16}" 
-        Location="{17}"/>
+        Binding="{22}" 
+        Location="{23}"/>
     </IDPSSODescriptor>
+    <Organization>
+      <OrganizationName xml:lang="en">{24}</OrganizationName>
+      <OrganizationName xml:lang="es">{25}</OrganizationName>
+      <OrganizationDisplayName xml:lang="en">{26}</OrganizationDisplayName>
+      <OrganizationDisplayName xml:lang="es">{27}</OrganizationDisplayName>
+      <OrganizationURL xml:lang="en">{28}</OrganizationURL>
+      <OrganizationURL xml:lang="es">{29}</OrganizationURL>
+    </Organization>
   </EntityDescriptor>
 </EntityDescriptors>
 '''.format(
@@ -568,6 +657,12 @@ CORRECT_MULTIPLE_IDPS_METADATA = \
         NAME_ID_FORMAT_2,
         IDP_1_SSO_BINDING.value,
         IDP_1_SSO_URL,
+        IDP_1_ORGANIZATION_EN_ORGANIZATION_NAME,
+        IDP_1_ORGANIZATION_ES_ORGANIZATION_NAME,
+        IDP_1_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME,
+        IDP_1_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME,
+        IDP_1_ORGANIZATION_EN_ORGANIZATION_URL,
+        IDP_1_ORGANIZATION_ES_ORGANIZATION_URL,
         IDP_2_ENTITY_ID,
         IDP_2_UI_INFO_EN_DISPLAY_NAME,
         IDP_2_UI_INFO_ES_DISPLAY_NAME,
@@ -576,7 +671,14 @@ CORRECT_MULTIPLE_IDPS_METADATA = \
         NAME_ID_FORMAT_1,
         NAME_ID_FORMAT_2,
         IDP_2_SSO_BINDING.value,
-        IDP_2_SSO_URL)
+        IDP_2_SSO_URL,
+        IDP_2_ORGANIZATION_EN_ORGANIZATION_NAME,
+        IDP_2_ORGANIZATION_ES_ORGANIZATION_NAME,
+        IDP_2_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME,
+        IDP_2_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME,
+        IDP_2_ORGANIZATION_EN_ORGANIZATION_URL,
+        IDP_2_ORGANIZATION_ES_ORGANIZATION_URL
+    )
 
 INCORRECT_ONE_SP_METADATA_WITHOUT_ACS_SERVICE = \
     '''<EntityDescriptor 
@@ -620,11 +722,22 @@ CORRECT_ONE_SP_METADATA = \
     xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
     entityID="{0}">
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:oasis:names:tc:SAML:1.0:protocol">
+    <Extensions>
+      <shibmd:Scope regexp="false">example.org</shibmd:Scope>
+      <mdui:UIInfo>
+          <mdui:DisplayName xml:lang="en">{1}</mdui:DisplayName>
+          <mdui:DisplayName xml:lang="es">{2}</mdui:DisplayName>
+          <mdui:Description xml:lang="en">{3}</mdui:Description>
+          <mdui:InformationURL xml:lang="en">{4}</mdui:InformationURL>
+          <mdui:PrivacyStatementURL xml:lang="en">{5}</mdui:PrivacyStatementURL>
+          <mdui:Logo height="10" width="10">{6}</mdui:Logo>
+        </mdui:UIInfo>
+      </Extensions>
     <KeyDescriptor>
       <ds:KeyInfo>
         <ds:X509Data>
           <ds:X509Certificate>
-{1}
+{7}
           </ds:X509Certificate>
         </ds:X509Data>
       </ds:KeyInfo>
@@ -639,17 +752,38 @@ CORRECT_ONE_SP_METADATA = \
       <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
     </KeyDescriptor>
     <AssertionConsumerService 
-        Binding="{2}" 
-        Location="{3}/" 
+        Binding="{8}" 
+        Location="{9}/" 
         index="1"/>
     <AssertionConsumerService 
-        Binding="{2}" 
-        Location="{3}" 
+        Binding="{8}" 
+        Location="{9}" 
         index="0"/>
   </SPSSODescriptor>
+  <Organization>
+      <OrganizationName xml:lang="en">{10}</OrganizationName>
+      <OrganizationName xml:lang="es">{11}</OrganizationName>
+      <OrganizationDisplayName xml:lang="en">{12}</OrganizationDisplayName>
+      <OrganizationDisplayName xml:lang="es">{13}</OrganizationDisplayName>
+      <OrganizationURL xml:lang="en">{14}</OrganizationURL>
+      <OrganizationURL xml:lang="es">{15}</OrganizationURL>
+    </Organization>
 </EntityDescriptor>
 '''.format(
         SP_ENTITY_ID,
+        SP_UI_INFO_EN_DISPLAY_NAME,
+        SP_UI_INFO_ES_DISPLAY_NAME,
+        SP_UI_INFO_DESCRIPTION,
+        SP_UI_INFO_INFORMATION_URL,
+        SP_UI_INFO_PRIVACY_STATEMENT_URL,
+        SP_UI_INFO_LOGO_URL,
         SIGNING_CERTIFICATE,
         SP_ACS_BINDING.value,
-        SP_ACS_URL)
+        SP_ACS_URL,
+        SP_ORGANIZATION_EN_ORGANIZATION_NAME,
+        SP_ORGANIZATION_ES_ORGANIZATION_NAME,
+        SP_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME,
+        SP_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME,
+        SP_ORGANIZATION_EN_ORGANIZATION_URL,
+        SP_ORGANIZATION_ES_ORGANIZATION_URL
+    )

--- a/tests/saml/fixtures.py
+++ b/tests/saml/fixtures.py
@@ -787,3 +787,20 @@ CORRECT_ONE_SP_METADATA = \
         SP_ORGANIZATION_EN_ORGANIZATION_URL,
         SP_ORGANIZATION_ES_ORGANIZATION_URL
     )
+
+
+def strip_certificate(certificate):
+    """
+    Converts certificate to a one-line format
+
+    :param certificate: Certificate in a multi-line format
+    :type certificate: string
+
+    :return: Certificate in a one-line format
+    :rtype: string
+    """
+
+    return certificate\
+        .replace('\n', '')\
+        .replace('-----BEGIN CERTIFICATE-----', '')\
+        .replace('-----END CERTIFICATE-----', '')

--- a/tests/saml/test_auth.py
+++ b/tests/saml/test_auth.py
@@ -10,7 +10,8 @@ from parameterized import parameterized
 
 from api.saml.auth import SAMLAuthenticationManager, SAMLAuthenticationManagerFactory
 from api.saml.configuration import SAMLOneLoginConfiguration, SAMLConfiguration, ExternalIntegrationOwner
-from api.saml.metadata import ServiceProviderMetadata, UIInfo, NameIDFormat, Service, IdentityProviderMetadata, Subject
+from api.saml.metadata import ServiceProviderMetadata, UIInfo, NameIDFormat, Service, IdentityProviderMetadata, Subject, \
+    Organization
 from tests.saml import fixtures
 from tests.saml.database_test import DatabaseTest
 from tests.test_controller import ControllerTest
@@ -18,6 +19,7 @@ from tests.test_controller import ControllerTest
 SERVICE_PROVIDER_WITH_UNSIGNED_REQUESTS = ServiceProviderMetadata(
     fixtures.SP_ENTITY_ID,
     UIInfo(),
+    Organization(),
     NameIDFormat.UNSPECIFIED.value,
     Service(fixtures.SP_ACS_URL, fixtures.SP_ACS_BINDING)
 )
@@ -25,6 +27,7 @@ SERVICE_PROVIDER_WITH_UNSIGNED_REQUESTS = ServiceProviderMetadata(
 SERVICE_PROVIDER_WITH_SIGNED_REQUESTS = ServiceProviderMetadata(
     fixtures.SP_ENTITY_ID,
     UIInfo(),
+    Organization(),
     NameIDFormat.UNSPECIFIED.value,
     Service(fixtures.SP_ACS_URL, fixtures.SP_ACS_BINDING),
     True,
@@ -37,6 +40,7 @@ IDENTITY_PROVIDERS = [
     IdentityProviderMetadata(
         fixtures.IDP_1_ENTITY_ID,
         UIInfo(),
+        Organization(),
         NameIDFormat.UNSPECIFIED.value,
         Service(fixtures.IDP_1_SSO_URL, fixtures.IDP_1_SSO_BINDING),
         signing_certificates=[
@@ -46,6 +50,7 @@ IDENTITY_PROVIDERS = [
     IdentityProviderMetadata(
         fixtures.IDP_2_ENTITY_ID,
         UIInfo(),
+        Organization(),
         NameIDFormat.UNSPECIFIED.value,
         Service(fixtures.IDP_2_SSO_URL, fixtures.IDP_2_SSO_BINDING)
     )

--- a/tests/saml/test_configuration.py
+++ b/tests/saml/test_configuration.py
@@ -3,13 +3,15 @@ from mock import MagicMock, create_autospec, call
 from nose.tools import eq_
 
 from api.saml.configuration import SAMLConfiguration, SAMLOneLoginConfiguration, SAMLConfigurationStorage
-from api.saml.metadata import ServiceProviderMetadata, UIInfo, Service, NameIDFormat, IdentityProviderMetadata
+from api.saml.metadata import ServiceProviderMetadata, UIInfo, Service, NameIDFormat, IdentityProviderMetadata, \
+    Organization
 from api.saml.parser import SAMLMetadataParser
 from tests.saml import fixtures
 
 SERVICE_PROVIDER = ServiceProviderMetadata(
     fixtures.SP_ENTITY_ID,
     UIInfo(),
+    Organization(),
     NameIDFormat.UNSPECIFIED.value,
     Service(fixtures.SP_ACS_URL, fixtures.SP_ACS_BINDING),
     private_key=fixtures.PRIVATE_KEY
@@ -19,12 +21,14 @@ IDENTITY_PROVIDERS = [
     IdentityProviderMetadata(
         fixtures.IDP_1_ENTITY_ID,
         UIInfo(),
+        Organization(),
         NameIDFormat.UNSPECIFIED.value,
         Service(fixtures.IDP_1_SSO_URL, fixtures.IDP_1_SSO_BINDING)
     ),
     IdentityProviderMetadata(
         fixtures.IDP_2_ENTITY_ID,
         UIInfo(),
+        Organization(),
         NameIDFormat.UNSPECIFIED.value,
         Service(fixtures.IDP_2_SSO_URL, fixtures.IDP_2_SSO_BINDING)
     )

--- a/tests/saml/test_controller.py
+++ b/tests/saml/test_controller.py
@@ -10,7 +10,8 @@ from parameterized import parameterized
 from api.authenticator import Authenticator, PatronData
 from api.saml.auth import SAMLAuthenticationManager, SAML_INCORRECT_RESPONSE
 from api.saml.controller import SAMLController, SAML_INVALID_REQUEST, SAML_INVALID_RESPONSE
-from api.saml.metadata import ServiceProviderMetadata, UIInfo, NameIDFormat, Service, IdentityProviderMetadata
+from api.saml.metadata import ServiceProviderMetadata, UIInfo, NameIDFormat, Service, IdentityProviderMetadata, \
+    Organization
 from api.saml.provider import SAMLWebSSOAuthenticationProvider, SAML_INVALID_SUBJECT
 from core.model import Credential, Patron
 from core.util.problem_detail import ProblemDetail
@@ -20,6 +21,7 @@ from tests.saml.controller_test import ControllerTest
 SERVICE_PROVIDER = ServiceProviderMetadata(
     fixtures.SP_ENTITY_ID,
     UIInfo(),
+    Organization(),
     NameIDFormat.UNSPECIFIED.value,
     Service(fixtures.SP_ACS_URL, fixtures.SP_ACS_BINDING)
 )
@@ -28,6 +30,7 @@ IDENTITY_PROVIDERS = [
     IdentityProviderMetadata(
         fixtures.IDP_1_ENTITY_ID,
         UIInfo(),
+        Organization(),
         NameIDFormat.UNSPECIFIED.value,
         Service(fixtures.IDP_1_SSO_URL, fixtures.IDP_1_SSO_BINDING),
         signing_certificates=[
@@ -37,6 +40,7 @@ IDENTITY_PROVIDERS = [
     IdentityProviderMetadata(
         fixtures.IDP_2_ENTITY_ID,
         UIInfo(),
+        Organization(),
         NameIDFormat.UNSPECIFIED.value,
         Service(fixtures.IDP_2_SSO_URL, fixtures.IDP_2_SSO_BINDING)
     )

--- a/tests/saml/test_parser.py
+++ b/tests/saml/test_parser.py
@@ -4,22 +4,10 @@ from api.saml.metadata import IdentityProviderMetadata, UIInfo, LocalizableMetad
     ServiceProviderMetadata, NameIDFormat, Organization
 from api.saml.parser import SAMLMetadataParsingError, SAMLMetadataParser
 from tests.saml import fixtures
+from tests.saml.fixtures import strip_certificate
 
 
 class SAMLMetadataParserTest(object):
-    def _strip_certificate(self, certificate):
-        """
-        Converts certificate to a one-line format
-
-        :param certificate: Certificate in a multi-line format
-        :type certificate: string
-
-        :return: Certificate in a one-line format
-        :rtype: string
-        """
-
-        return certificate.replace('\n', '')
-
     @raises(SAMLMetadataParsingError)
     def test_parse_raises_exception_when_xml_metadata_has_incorrect_format(self):
         # Arrange
@@ -69,8 +57,8 @@ class SAMLMetadataParserTest(object):
                     fixtures.IDP_1_SSO_BINDING
                 ),
                 want_authn_requests_signed=False,
-                signing_certificates=[self._strip_certificate(fixtures.SIGNING_CERTIFICATE)],
-                encryption_certificates=[self._strip_certificate(fixtures.ENCRYPTION_CERTIFICATE)]
+                signing_certificates=[strip_certificate(fixtures.SIGNING_CERTIFICATE)],
+                encryption_certificates=[strip_certificate(fixtures.ENCRYPTION_CERTIFICATE)]
             )
         )
 
@@ -129,8 +117,8 @@ class SAMLMetadataParserTest(object):
                     fixtures.IDP_1_SSO_BINDING
                 ),
                 want_authn_requests_signed=False,
-                signing_certificates=[self._strip_certificate(fixtures.SIGNING_CERTIFICATE)],
-                encryption_certificates=[self._strip_certificate(fixtures.ENCRYPTION_CERTIFICATE)]
+                signing_certificates=[strip_certificate(fixtures.SIGNING_CERTIFICATE)],
+                encryption_certificates=[strip_certificate(fixtures.ENCRYPTION_CERTIFICATE)]
             )
         )
 
@@ -187,8 +175,8 @@ class SAMLMetadataParserTest(object):
                     fixtures.IDP_1_SSO_BINDING
                 ),
                 want_authn_requests_signed=False,
-                signing_certificates=[self._strip_certificate(fixtures.SIGNING_CERTIFICATE)],
-                encryption_certificates=[self._strip_certificate(fixtures.ENCRYPTION_CERTIFICATE)]
+                signing_certificates=[strip_certificate(fixtures.SIGNING_CERTIFICATE)],
+                encryption_certificates=[strip_certificate(fixtures.ENCRYPTION_CERTIFICATE)]
             )
         )
 
@@ -242,8 +230,8 @@ class SAMLMetadataParserTest(object):
                     fixtures.IDP_1_SSO_BINDING
                 ),
                 want_authn_requests_signed=False,
-                signing_certificates=[self._strip_certificate(fixtures.SIGNING_CERTIFICATE)],
-                encryption_certificates=[self._strip_certificate(fixtures.SIGNING_CERTIFICATE)]
+                signing_certificates=[strip_certificate(fixtures.SIGNING_CERTIFICATE)],
+                encryption_certificates=[strip_certificate(fixtures.SIGNING_CERTIFICATE)]
             )
         )
 
@@ -288,8 +276,8 @@ class SAMLMetadataParserTest(object):
                     fixtures.IDP_1_SSO_BINDING
                 ),
                 want_authn_requests_signed=False,
-                signing_certificates=[self._strip_certificate(fixtures.SIGNING_CERTIFICATE)],
-                encryption_certificates=[self._strip_certificate(fixtures.ENCRYPTION_CERTIFICATE)]
+                signing_certificates=[strip_certificate(fixtures.SIGNING_CERTIFICATE)],
+                encryption_certificates=[strip_certificate(fixtures.ENCRYPTION_CERTIFICATE)]
             )
         )
 
@@ -323,8 +311,8 @@ class SAMLMetadataParserTest(object):
                     fixtures.IDP_2_SSO_BINDING
                 ),
                 want_authn_requests_signed=False,
-                signing_certificates=[self._strip_certificate(fixtures.SIGNING_CERTIFICATE)],
-                encryption_certificates=[self._strip_certificate(fixtures.ENCRYPTION_CERTIFICATE)]
+                signing_certificates=[strip_certificate(fixtures.SIGNING_CERTIFICATE)],
+                encryption_certificates=[strip_certificate(fixtures.ENCRYPTION_CERTIFICATE)]
             )
         )
 
@@ -392,6 +380,6 @@ class SAMLMetadataParserTest(object):
                 ),
                 authn_requests_signed=False,
                 want_assertions_signed=False,
-                certificate=self._strip_certificate(fixtures.SIGNING_CERTIFICATE)
+                certificate=strip_certificate(fixtures.SIGNING_CERTIFICATE)
             )
         )

--- a/tests/saml/test_parser.py
+++ b/tests/saml/test_parser.py
@@ -1,7 +1,7 @@
 from nose.tools import raises, eq_
 
 from api.saml.metadata import IdentityProviderMetadata, UIInfo, LocalizableMetadataItem, Service, \
-    ServiceProviderMetadata, NameIDFormat
+    ServiceProviderMetadata, NameIDFormat, Organization
 from api.saml.parser import SAMLMetadataParsingError, SAMLMetadataParser
 from tests.saml import fixtures
 
@@ -19,31 +19,6 @@ class SAMLMetadataParserTest(object):
         """
 
         return certificate.replace('\n', '')
-
-    def _check_idp_metadata(
-            self,
-            idp_metadata,
-            entity_id,
-            ui_info,
-            name_id_format,
-            sso_service,
-            want_authn_requests_signed,
-            signing_certificates,
-            encryption_certificates):
-        assert isinstance(idp_metadata, IdentityProviderMetadata)
-        assert idp_metadata.entity_id == entity_id
-
-        assert isinstance(idp_metadata.ui_info, UIInfo)
-        assert idp_metadata.ui_info == ui_info
-
-        assert idp_metadata.name_id_format == name_id_format
-
-        assert idp_metadata.sso_service == sso_service
-
-        assert idp_metadata.want_authn_requests_signed == want_authn_requests_signed
-
-        assert idp_metadata.signing_certificates == signing_certificates
-        assert idp_metadata.encryption_certificates == encryption_certificates
 
     @raises(SAMLMetadataParsingError)
     def test_parse_raises_exception_when_xml_metadata_has_incorrect_format(self):
@@ -68,6 +43,36 @@ class SAMLMetadataParserTest(object):
 
         # Act
         metadata_parser.parse(fixtures.INCORRECT_ONE_IDP_METADATA_WITH_SSO_SERVICE_WITH_WRONG_BINDING)
+
+    def test_parse_does_not_raise_exception_when_xml_metadata_does_not_have_display_names(self):
+        # Arrange
+        metadata_parser = SAMLMetadataParser()
+
+        # Act
+        result = metadata_parser.parse(fixtures.CORRECT_ONE_IDP_METADATA_WITHOUT_DISPLAY_NAMES)
+
+        # Assert
+        assert isinstance(result, list)
+        eq_(len(result), 1)
+
+        [result] = result
+
+        eq_(
+            result,
+            IdentityProviderMetadata(
+                entity_id=fixtures.IDP_1_ENTITY_ID,
+                ui_info=UIInfo(),
+                organization=Organization(),
+                name_id_format=fixtures.NAME_ID_FORMAT_1,
+                sso_service=Service(
+                    fixtures.IDP_1_SSO_URL,
+                    fixtures.IDP_1_SSO_BINDING
+                ),
+                want_authn_requests_signed=False,
+                signing_certificates=[self._strip_certificate(fixtures.SIGNING_CERTIFICATE)],
+                encryption_certificates=[self._strip_certificate(fixtures.ENCRYPTION_CERTIFICATE)]
+            )
+        )
 
     def test_parse_correctly_parses_one_idp_metadata(self):
         # Arrange
@@ -103,6 +108,20 @@ class SAMLMetadataParserTest(object):
                     [
                         LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_LOGO_URL)
                     ]
+                ),
+                organization=Organization(
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_NAME, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_NAME, 'es')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME, 'es')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_URL, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_URL, 'es')
+                    ],
                 ),
                 name_id_format=fixtures.NAME_ID_FORMAT_1,
                 sso_service=Service(
@@ -148,6 +167,20 @@ class SAMLMetadataParserTest(object):
                         LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_LOGO_URL, 'en')
                     ]
                 ),
+                organization=Organization(
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_NAME, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_NAME, 'es')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME, 'es')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_URL, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_URL, 'es')
+                    ],
+                ),
                 name_id_format=NameIDFormat.UNSPECIFIED.value,
                 sso_service=Service(
                     fixtures.IDP_1_SSO_URL,
@@ -189,6 +222,20 @@ class SAMLMetadataParserTest(object):
                         LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_LOGO_URL, 'en')
                     ]
                 ),
+                organization=Organization(
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_NAME, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_NAME, 'es')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME, 'es')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_URL, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_URL, 'es')
+                    ],
+                ),
                 name_id_format=fixtures.NAME_ID_FORMAT_1,
                 sso_service=Service(
                     fixtures.IDP_1_SSO_URL,
@@ -200,7 +247,7 @@ class SAMLMetadataParserTest(object):
             )
         )
 
-    def test_parse_correctly_parses_metadata_with_multiple_descriptors_(self):
+    def test_parse_correctly_parses_metadata_with_multiple_descriptors(self):
         # Arrange
         metadata_parser = SAMLMetadataParser()
 
@@ -220,6 +267,20 @@ class SAMLMetadataParserTest(object):
                         LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_EN_DISPLAY_NAME, 'en'),
                         LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_ES_DISPLAY_NAME, 'es')
                     ]
+                ),
+                organization=Organization(
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_NAME, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_NAME, 'es')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME, 'es')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_URL, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_URL, 'es')
+                    ],
                 ),
                 name_id_format=fixtures.NAME_ID_FORMAT_1,
                 sso_service=Service(
@@ -241,6 +302,20 @@ class SAMLMetadataParserTest(object):
                         LocalizableMetadataItem(fixtures.IDP_2_UI_INFO_EN_DISPLAY_NAME, 'en'),
                         LocalizableMetadataItem(fixtures.IDP_2_UI_INFO_ES_DISPLAY_NAME, 'es')
                     ]
+                ),
+                organization=Organization(
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_2_ORGANIZATION_EN_ORGANIZATION_NAME, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_2_ORGANIZATION_ES_ORGANIZATION_NAME, 'es')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_2_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_2_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME, 'es')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.IDP_2_ORGANIZATION_EN_ORGANIZATION_URL, 'en'),
+                        LocalizableMetadataItem(fixtures.IDP_2_ORGANIZATION_ES_ORGANIZATION_URL, 'es')
+                    ],
                 ),
                 name_id_format=fixtures.NAME_ID_FORMAT_1,
                 sso_service=Service(
@@ -278,7 +353,38 @@ class SAMLMetadataParserTest(object):
             result,
             ServiceProviderMetadata(
                 entity_id=fixtures.SP_ENTITY_ID,
-                ui_info=UIInfo(),
+                ui_info=UIInfo(
+                    [
+                        LocalizableMetadataItem(fixtures.SP_UI_INFO_EN_DISPLAY_NAME, 'en'),
+                        LocalizableMetadataItem(fixtures.SP_UI_INFO_ES_DISPLAY_NAME, 'es')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.SP_UI_INFO_DESCRIPTION, 'en')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.SP_UI_INFO_INFORMATION_URL, 'en')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.SP_UI_INFO_PRIVACY_STATEMENT_URL, 'en')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.SP_UI_INFO_LOGO_URL)
+                    ]
+                ),
+                organization=Organization(
+                    [
+                        LocalizableMetadataItem(fixtures.SP_ORGANIZATION_EN_ORGANIZATION_NAME, 'en'),
+                        LocalizableMetadataItem(fixtures.SP_ORGANIZATION_ES_ORGANIZATION_NAME, 'es')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.SP_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME, 'en'),
+                        LocalizableMetadataItem(fixtures.SP_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME, 'es')
+                    ],
+                    [
+                        LocalizableMetadataItem(fixtures.SP_ORGANIZATION_EN_ORGANIZATION_URL, 'en'),
+                        LocalizableMetadataItem(fixtures.SP_ORGANIZATION_ES_ORGANIZATION_URL, 'es')
+                    ],
+                ),
                 name_id_format=NameIDFormat.UNSPECIFIED.value,
                 acs_service=Service(
                     fixtures.SP_ACS_URL,
@@ -286,6 +392,6 @@ class SAMLMetadataParserTest(object):
                 ),
                 authn_requests_signed=False,
                 want_assertions_signed=False,
-                certificate=[self._strip_certificate(fixtures.SIGNING_CERTIFICATE)]
+                certificate=self._strip_certificate(fixtures.SIGNING_CERTIFICATE)
             )
         )

--- a/tests/saml/test_provider.py
+++ b/tests/saml/test_provider.py
@@ -10,7 +10,7 @@ from api.authenticator import PatronData
 from api.saml.auth import SAMLAuthenticationManager, SAMLAuthenticationManagerFactory
 from api.saml.configuration import SAMLConfiguration, SAMLOneLoginConfiguration
 from api.saml.metadata import ServiceProviderMetadata, NameIDFormat, UIInfo, Service, IdentityProviderMetadata, \
-    LocalizableMetadataItem, Subject, AttributeStatement, SAMLAttributes, SubjectJSONEncoder
+    LocalizableMetadataItem, Subject, AttributeStatement, SAMLAttributes, SubjectJSONEncoder, Organization
 from api.saml.provider import SAMLWebSSOAuthenticationProvider, SAML_INVALID_SUBJECT
 from core.util.problem_detail import ProblemDetail
 from tests.saml import fixtures
@@ -19,6 +19,7 @@ from tests.saml.controller_test import ControllerTest
 SERVICE_PROVIDER = ServiceProviderMetadata(
     fixtures.SP_ENTITY_ID,
     UIInfo(),
+    Organization(),
     NameIDFormat.UNSPECIFIED.value,
     Service(fixtures.SP_ACS_URL, fixtures.SP_ACS_BINDING)
 )
@@ -27,6 +28,7 @@ IDENTITY_PROVIDERS = [
     IdentityProviderMetadata(
         fixtures.IDP_1_ENTITY_ID,
         UIInfo(),
+        Organization(),
         NameIDFormat.UNSPECIFIED.value,
         Service(fixtures.IDP_1_SSO_URL, fixtures.IDP_1_SSO_BINDING)
     ),
@@ -42,6 +44,7 @@ IDENTITY_PROVIDERS = [
                 LocalizableMetadataItem('Test Shibboleth IdP', 'es')
             ]
         ),
+        Organization(),
         NameIDFormat.UNSPECIFIED.value,
         Service(fixtures.IDP_2_SSO_URL, fixtures.IDP_2_SSO_BINDING)
     )

--- a/tests/saml/test_provider.py
+++ b/tests/saml/test_provider.py
@@ -79,7 +79,9 @@ class SAMLWebSSOAuthenticationProviderTest(ControllerTest):
     @parameterized.expand([
         (
             'identity_provider_with_display_name',
-            IDENTITY_PROVIDER_WITH_DISPLAY_NAME,
+            [
+                IDENTITY_PROVIDER_WITH_DISPLAY_NAME
+            ],
             {
                 'type': SAMLWebSSOAuthenticationProvider.FLOW_TYPE,
                 'description': SAMLWebSSOAuthenticationProvider.NAME,
@@ -143,7 +145,9 @@ class SAMLWebSSOAuthenticationProviderTest(ControllerTest):
         ),
         (
             'identity_provider_with_organization_display_name',
-            IDENTITY_PROVIDER_WITH_ORGANIZATION_DISPLAY_NAME,
+            [
+                IDENTITY_PROVIDER_WITH_ORGANIZATION_DISPLAY_NAME
+            ],
             {
                 'type': SAMLWebSSOAuthenticationProvider.FLOW_TYPE,
                 'description': SAMLWebSSOAuthenticationProvider.NAME,
@@ -171,8 +175,11 @@ class SAMLWebSSOAuthenticationProviderTest(ControllerTest):
 
         ),
         (
-            'identity_provider_without_display_names',
-            IDENTITY_PROVIDER_WITHOUT_DISPLAY_NAMES,
+            'identity_provider_without_display_names_and_default_template',
+            [
+                IDENTITY_PROVIDER_WITHOUT_DISPLAY_NAMES,
+                IDENTITY_PROVIDER_WITHOUT_DISPLAY_NAMES
+            ],
             {
                 'type': SAMLWebSSOAuthenticationProvider.FLOW_TYPE,
                 'description': SAMLWebSSOAuthenticationProvider.NAME,
@@ -180,7 +187,26 @@ class SAMLWebSSOAuthenticationProviderTest(ControllerTest):
                     {
                         'rel': 'authenticate',
                         'href': 'http://localhost/default/saml_authenticate?idp_entity_id=http%3A%2F%2Fidp1.hilbertteam.net%2Fidp%2Fshibboleth&provider=SAML+2.0+Web+SSO',
-                        'display_names': [],
+                        'display_names': [
+                            {
+                                'value': SAMLConfiguration.IDP_DISPLAY_NAME_DEFAULT_TEMPLATE.format(1),
+                                'language': 'en'
+                            }
+                        ],
+                        'descriptions': [],
+                        'information_urls': [],
+                        'privacy_statement_urls': [],
+                        'logo_urls': []
+                    },
+                    {
+                        'rel': 'authenticate',
+                        'href': 'http://localhost/default/saml_authenticate?idp_entity_id=http%3A%2F%2Fidp1.hilbertteam.net%2Fidp%2Fshibboleth&provider=SAML+2.0+Web+SSO',
+                        'display_names': [
+                            {
+                                'value': SAMLConfiguration.IDP_DISPLAY_NAME_DEFAULT_TEMPLATE.format(2),
+                                'language': 'en'
+                            }
+                        ],
                         'descriptions': [],
                         'information_urls': [],
                         'privacy_statement_urls': [],
@@ -189,16 +215,67 @@ class SAMLWebSSOAuthenticationProviderTest(ControllerTest):
                 ]
             }
 
+        ),
+        (
+            'identity_provider_without_display_names_and_custom_template',
+            [
+                IDENTITY_PROVIDER_WITHOUT_DISPLAY_NAMES,
+                IDENTITY_PROVIDER_WITHOUT_DISPLAY_NAMES
+            ],
+            {
+                'type': SAMLWebSSOAuthenticationProvider.FLOW_TYPE,
+                'description': SAMLWebSSOAuthenticationProvider.NAME,
+                'links': [
+                    {
+                        'rel': 'authenticate',
+                        'href': 'http://localhost/default/saml_authenticate?idp_entity_id=http%3A%2F%2Fidp1.hilbertteam.net%2Fidp%2Fshibboleth&provider=SAML+2.0+Web+SSO',
+                        'display_names': [
+                            {
+                                'value': 'IdP # 1',
+                                'language': 'en'
+                            }
+                        ],
+                        'descriptions': [],
+                        'information_urls': [],
+                        'privacy_statement_urls': [],
+                        'logo_urls': []
+                    },
+                    {
+                        'rel': 'authenticate',
+                        'href': 'http://localhost/default/saml_authenticate?idp_entity_id=http%3A%2F%2Fidp1.hilbertteam.net%2Fidp%2Fshibboleth&provider=SAML+2.0+Web+SSO',
+                        'display_names': [
+                            {
+                                'value': 'IdP # 2',
+                                'language': 'en'
+                            }
+                        ],
+                        'descriptions': [],
+                        'information_urls': [],
+                        'privacy_statement_urls': [],
+                        'logo_urls': []
+                    }
+                ]
+            },
+            'IdP # {0}'
         )
     ])
-    def test_authentication_document(self, name, identity_provider, expected_result):
+    def test_authentication_document(
+            self,
+            name,
+            identity_providers,
+            expected_result,
+            identity_provider_display_name_template=None):
         # Arrange
+        if identity_provider_display_name_template:
+            self._integration.setting(SAMLConfiguration.IDP_DISPLAY_NAME_TEMPLATE).value = \
+                identity_provider_display_name_template
+
         provider = SAMLWebSSOAuthenticationProvider(self._default_library, self._integration)
         configuration = create_autospec(spec=SAMLConfiguration)
         configuration.get_debug = MagicMock(return_value=False)
         configuration.get_strict = MagicMock(return_value=False)
         configuration.get_service_provider = MagicMock(return_value=SERVICE_PROVIDER)
-        configuration.get_identity_providers = MagicMock(return_value=[identity_provider])
+        configuration.get_identity_providers = MagicMock(return_value=identity_providers)
         onelogin_configuration = SAMLOneLoginConfiguration(configuration)
         authentication_manager = SAMLAuthenticationManager(onelogin_configuration)
 

--- a/tests/saml/test_provider.py
+++ b/tests/saml/test_provider.py
@@ -24,84 +24,181 @@ SERVICE_PROVIDER = ServiceProviderMetadata(
     Service(fixtures.SP_ACS_URL, fixtures.SP_ACS_BINDING)
 )
 
-IDENTITY_PROVIDERS = [
-    IdentityProviderMetadata(
-        fixtures.IDP_1_ENTITY_ID,
-        UIInfo(),
-        Organization(),
-        NameIDFormat.UNSPECIFIED.value,
-        Service(fixtures.IDP_1_SSO_URL, fixtures.IDP_1_SSO_BINDING)
+IDENTITY_PROVIDER_WITH_DISPLAY_NAME = IdentityProviderMetadata(
+    fixtures.IDP_2_ENTITY_ID,
+    UIInfo(
+        display_names=[
+            LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_EN_DISPLAY_NAME, 'en'),
+            LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_ES_DISPLAY_NAME, 'es')
+        ],
+        descriptions=[
+            LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_DESCRIPTION, 'en'),
+            LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_DESCRIPTION, 'es')
+        ],
+        information_urls=[
+            LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_INFORMATION_URL, 'en'),
+            LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_INFORMATION_URL, 'es')
+        ],
+        privacy_statement_urls=[
+            LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_PRIVACY_STATEMENT_URL, 'en'),
+            LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_PRIVACY_STATEMENT_URL, 'es')
+        ],
+        logo_urls=[
+            LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_LOGO_URL, 'en'),
+            LocalizableMetadataItem(fixtures.IDP_1_UI_INFO_LOGO_URL, 'es')
+        ]
     ),
-    IdentityProviderMetadata(
-        fixtures.IDP_2_ENTITY_ID,
-        UIInfo(
-            display_names=[
-                LocalizableMetadataItem('Test Shibboleth IdP', 'en'),
-                LocalizableMetadataItem('Test Shibboleth IdP', 'es')
-            ],
-            descriptions=[
-                LocalizableMetadataItem('Test Shibboleth IdP', 'en'),
-                LocalizableMetadataItem('Test Shibboleth IdP', 'es')
-            ]
-        ),
-        Organization(),
-        NameIDFormat.UNSPECIFIED.value,
-        Service(fixtures.IDP_2_SSO_URL, fixtures.IDP_2_SSO_BINDING)
-    )
-]
+    Organization(),
+    NameIDFormat.UNSPECIFIED.value,
+    Service(fixtures.IDP_2_SSO_URL, fixtures.IDP_2_SSO_BINDING)
+)
+
+IDENTITY_PROVIDER_WITH_ORGANIZATION_DISPLAY_NAME = IdentityProviderMetadata(
+    fixtures.IDP_2_ENTITY_ID,
+    UIInfo(),
+    Organization(
+        organization_display_names=[
+            LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME, 'en'),
+            LocalizableMetadataItem(fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME, 'es')
+        ]
+    ),
+    NameIDFormat.UNSPECIFIED.value,
+    Service(fixtures.IDP_2_SSO_URL, fixtures.IDP_2_SSO_BINDING)
+)
+
+IDENTITY_PROVIDER_WITHOUT_DISPLAY_NAMES = IdentityProviderMetadata(
+    fixtures.IDP_1_ENTITY_ID,
+    UIInfo(),
+    Organization(),
+    NameIDFormat.UNSPECIFIED.value,
+    Service(fixtures.IDP_1_SSO_URL, fixtures.IDP_1_SSO_BINDING)
+)
 
 
 class SAMLWebSSOAuthenticationProviderTest(ControllerTest):
-    def test_authentication_document(self):
+    @parameterized.expand([
+        (
+            'identity_provider_with_display_name',
+            IDENTITY_PROVIDER_WITH_DISPLAY_NAME,
+            {
+                'type': SAMLWebSSOAuthenticationProvider.FLOW_TYPE,
+                'description': SAMLWebSSOAuthenticationProvider.NAME,
+                'links': [
+                    {
+                        'rel': 'authenticate',
+                        'href': 'http://localhost/default/saml_authenticate?idp_entity_id=http%3A%2F%2Fidp2.hilbertteam.net%2Fidp%2Fshibboleth&provider=SAML+2.0+Web+SSO',
+                        'display_names': [
+                            {
+                                'value': fixtures.IDP_1_UI_INFO_EN_DISPLAY_NAME,
+                                'language': 'en'
+                            },
+                            {
+                                'value': fixtures.IDP_1_UI_INFO_ES_DISPLAY_NAME,
+                                'language': 'es'
+                            }
+                        ],
+                        'descriptions': [
+                            {
+                                'value': fixtures.IDP_1_UI_INFO_DESCRIPTION,
+                                'language': 'en'
+                            },
+                            {
+                                'value': fixtures.IDP_1_UI_INFO_DESCRIPTION,
+                                'language': 'es'
+                            }
+                        ],
+                        'information_urls': [
+                            {
+                                'value': fixtures.IDP_1_UI_INFO_INFORMATION_URL,
+                                'language': 'en'
+                            },
+                            {
+                                'value': fixtures.IDP_1_UI_INFO_INFORMATION_URL,
+                                'language': 'es'
+                            }
+                        ],
+                        'privacy_statement_urls': [
+                            {
+                                'value': fixtures.IDP_1_UI_INFO_PRIVACY_STATEMENT_URL,
+                                'language': 'en'
+                            },
+                            {
+                                'value': fixtures.IDP_1_UI_INFO_PRIVACY_STATEMENT_URL,
+                                'language': 'es'
+                            }
+                        ],
+                        'logo_urls': [
+                            {
+                                'value': fixtures.IDP_1_UI_INFO_LOGO_URL,
+                                'language': 'en'
+                            },
+                            {
+                                'value': fixtures.IDP_1_UI_INFO_LOGO_URL,
+                                'language': 'es'
+                            }
+                        ]
+                    }
+                ]
+            }
+        ),
+        (
+            'identity_provider_with_organization_display_name',
+            IDENTITY_PROVIDER_WITH_ORGANIZATION_DISPLAY_NAME,
+            {
+                'type': SAMLWebSSOAuthenticationProvider.FLOW_TYPE,
+                'description': SAMLWebSSOAuthenticationProvider.NAME,
+                'links': [
+                    {
+                        'rel': 'authenticate',
+                        'href': 'http://localhost/default/saml_authenticate?idp_entity_id=http%3A%2F%2Fidp2.hilbertteam.net%2Fidp%2Fshibboleth&provider=SAML+2.0+Web+SSO',
+                        'display_names': [
+                            {
+                                'value': fixtures.IDP_1_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME,
+                                'language': 'en'
+                            },
+                            {
+                                'value': fixtures.IDP_1_ORGANIZATION_ES_ORGANIZATION_DISPLAY_NAME,
+                                'language': 'es'
+                            }
+                        ],
+                        'descriptions': [],
+                        'information_urls': [],
+                        'privacy_statement_urls': [],
+                        'logo_urls': []
+                    }
+                ]
+            }
+
+        ),
+        (
+            'identity_provider_without_display_names',
+            IDENTITY_PROVIDER_WITHOUT_DISPLAY_NAMES,
+            {
+                'type': SAMLWebSSOAuthenticationProvider.FLOW_TYPE,
+                'description': SAMLWebSSOAuthenticationProvider.NAME,
+                'links': [
+                    {
+                        'rel': 'authenticate',
+                        'href': 'http://localhost/default/saml_authenticate?idp_entity_id=http%3A%2F%2Fidp1.hilbertteam.net%2Fidp%2Fshibboleth&provider=SAML+2.0+Web+SSO',
+                        'display_names': [],
+                        'descriptions': [],
+                        'information_urls': [],
+                        'privacy_statement_urls': [],
+                        'logo_urls': []
+                    }
+                ]
+            }
+
+        )
+    ])
+    def test_authentication_document(self, name, identity_provider, expected_result):
         # Arrange
-        expected_result = {
-            'type': SAMLWebSSOAuthenticationProvider.FLOW_TYPE,
-            'description': SAMLWebSSOAuthenticationProvider.NAME,
-            'links': [
-                {
-                    'rel': 'authenticate',
-                    'href': 'http://localhost/default/saml_authenticate?idp_entity_id=http%3A%2F%2Fidp1.hilbertteam.net%2Fidp%2Fshibboleth&provider=SAML+2.0+Web+SSO',
-                    'display_names': [],
-                    'descriptions': [],
-                    'information_urls': [],
-                    'privacy_statement_urls': [],
-                    'logo_urls': []
-                },
-                {
-                    'rel': 'authenticate',
-                    'href': 'http://localhost/default/saml_authenticate?idp_entity_id=http%3A%2F%2Fidp2.hilbertteam.net%2Fidp%2Fshibboleth&provider=SAML+2.0+Web+SSO',
-                    'display_names': [
-                        {
-                            'value': 'Test Shibboleth IdP',
-                            'language': 'en'
-                        },
-                        {
-                            'value': 'Test Shibboleth IdP',
-                            'language': 'es'
-                        }
-                    ],
-                    'descriptions': [
-                        {
-                            'value': 'Test Shibboleth IdP',
-                            'language': 'en'
-                        },
-                        {
-                            'value': 'Test Shibboleth IdP',
-                            'language': 'es'
-                        }
-                    ],
-                    'information_urls': [],
-                    'privacy_statement_urls': [],
-                    'logo_urls': []
-                }
-            ]
-        }
         provider = SAMLWebSSOAuthenticationProvider(self._default_library, self._integration)
         configuration = create_autospec(spec=SAMLConfiguration)
         configuration.get_debug = MagicMock(return_value=False)
         configuration.get_strict = MagicMock(return_value=False)
         configuration.get_service_provider = MagicMock(return_value=SERVICE_PROVIDER)
-        configuration.get_identity_providers = MagicMock(return_value=IDENTITY_PROVIDERS)
+        configuration.get_identity_providers = MagicMock(return_value=[identity_provider])
         onelogin_configuration = SAMLOneLoginConfiguration(configuration)
         authentication_manager = SAMLAuthenticationManager(onelogin_configuration)
 

--- a/tests/saml/test_provider.py
+++ b/tests/saml/test_provider.py
@@ -215,61 +215,14 @@ class SAMLWebSSOAuthenticationProviderTest(ControllerTest):
                 ]
             }
 
-        ),
-        (
-            'identity_provider_without_display_names_and_custom_template',
-            [
-                IDENTITY_PROVIDER_WITHOUT_DISPLAY_NAMES,
-                IDENTITY_PROVIDER_WITHOUT_DISPLAY_NAMES
-            ],
-            {
-                'type': SAMLWebSSOAuthenticationProvider.FLOW_TYPE,
-                'description': SAMLWebSSOAuthenticationProvider.NAME,
-                'links': [
-                    {
-                        'rel': 'authenticate',
-                        'href': 'http://localhost/default/saml_authenticate?idp_entity_id=http%3A%2F%2Fidp1.hilbertteam.net%2Fidp%2Fshibboleth&provider=SAML+2.0+Web+SSO',
-                        'display_names': [
-                            {
-                                'value': 'IdP # 1',
-                                'language': 'en'
-                            }
-                        ],
-                        'descriptions': [],
-                        'information_urls': [],
-                        'privacy_statement_urls': [],
-                        'logo_urls': []
-                    },
-                    {
-                        'rel': 'authenticate',
-                        'href': 'http://localhost/default/saml_authenticate?idp_entity_id=http%3A%2F%2Fidp1.hilbertteam.net%2Fidp%2Fshibboleth&provider=SAML+2.0+Web+SSO',
-                        'display_names': [
-                            {
-                                'value': 'IdP # 2',
-                                'language': 'en'
-                            }
-                        ],
-                        'descriptions': [],
-                        'information_urls': [],
-                        'privacy_statement_urls': [],
-                        'logo_urls': []
-                    }
-                ]
-            },
-            'IdP # {0}'
         )
     ])
     def test_authentication_document(
             self,
             name,
             identity_providers,
-            expected_result,
-            identity_provider_display_name_template=None):
+            expected_result):
         # Arrange
-        if identity_provider_display_name_template:
-            self._integration.setting(SAMLConfiguration.IDP_DISPLAY_NAME_TEMPLATE).value = \
-                identity_provider_display_name_template
-
         provider = SAMLWebSSOAuthenticationProvider(self._default_library, self._integration)
         configuration = create_autospec(spec=SAMLConfiguration)
         configuration.get_debug = MagicMock(return_value=False)

--- a/tests/saml/test_validator.py
+++ b/tests/saml/test_validator.py
@@ -7,7 +7,7 @@ from api.admin.validator import PatronAuthenticationValidatorFactory
 from api.saml import configuration
 from api.saml.parser import SAMLMetadataParser
 from api.saml.provider import SAMLWebSSOAuthenticationProvider
-from api.saml.validator import SAMLSettingsValidator, INCORRECT_METADATA
+from api.saml.validator import SAMLSettingsValidator, SAML_INCORRECT_METADATA
 from core.util.problem_detail import ProblemDetail
 from tests.saml import fixtures
 from tests.saml.database_test import DatabaseTest
@@ -31,14 +31,14 @@ class SAMLSettingsValidatorTest(DatabaseTest):
             'incorrect_sp_metadata_and_incorrect_idp_metadata',
             fixtures.INCORRECT_ONE_SP_METADATA_WITHOUT_ACS_SERVICE,
             fixtures.INCORRECT_ONE_IDP_METADATA_WITHOUT_SSO_SERVICE,
-            INCORRECT_METADATA.detailed(
+            SAML_INCORRECT_METADATA.detailed(
                 'Missing urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST AssertionConsumerService')
         ),
         (
             'correct_sp_metadata_and_incorrect_idp_metadata',
             fixtures.CORRECT_ONE_SP_METADATA,
             fixtures.INCORRECT_ONE_IDP_METADATA_WITHOUT_SSO_SERVICE,
-            INCORRECT_METADATA.detailed(
+            SAML_INCORRECT_METADATA.detailed(
                 'Missing urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect SingleSignOnService service declaration')
         ),
         (


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR extends the algorithm used for generating SAML authentication documents:
1. Check whether `md:Extensions/mdui:UIInfo/mdui:DisplayName` tags exist. If yes, then populate `display_names` in the authentication document and stop.
2. Check whether `md:Organization/mdui:OrganizationDisplayName` tags exist. If yes, then populate `display_names` in the authentication document and stop.
3. Generate an IdP name using `SAMLConfiguration.IDP_DISPLAY_NAME_TEMPLATE` configuration setting

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Not all IdP conform with SAML best practices and don't include `mdui:DisplayName` tags inside their metadata. This PR adds several fallbacks for this case.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
