### PR TITLE
SAML: Fix attribute parsing

### DIFF
--- a/api/saml/metadata.py
+++ b/api/saml/metadata.py
@@ -729,6 +729,24 @@ class NameID(object):
         self._sp_name_qualifier = sp_name_qualifier
         self._name_id = name_id
 
+    def __eq__(self, other):
+        """Compares two NameID objects
+
+        :param other: NameID object
+        :type other: NameID
+
+        :return: Boolean value indicating whether two items are equal
+        :rtype: bool
+        """
+        if not isinstance(other, NameID):
+            return False
+
+        return \
+            self.name_format == other.name_format and \
+            self.name_qualifier == other.name_qualifier and \
+            self.sp_name_qualifier == other.sp_name_qualifier and \
+            self.name_id == other.name_id
+
     @property
     def name_format(self):
         """Returns name ID's format
@@ -778,6 +796,7 @@ class SAMLAttributes(Enum):
     givenName = 'urn:oid:2.5.4.42'
     surname = 'urn:oid:2.5.4.4'
     mail = 'urn:oid:0.9.2342.19200300.100.1.3'
+    displayName = 'urn:oid:2.16.840.1.113730.3.1.241'
 
     eduPersonUniqueId = 'urn:oid:1.3.6.1.4.1.5923.1.1.1.13'
     eduPersonTargetedID = 'urn:oid:1.3.6.1.4.1.5923.1.1.1.10'
@@ -872,31 +891,27 @@ class AttributeStatement(object):
         """Initializes a new instance of AttributeStatement class
 
         :param attributes: Attributes in a form of a list of a dictionary
-        :type attributes: Union[List[Attribute], Dict[string, List[Any]]]
+        :type attributes: List[Attribute]
         """
         self._attributes = {}
 
-        attribute_names = {attribute.value: attribute for attribute in SAMLAttributes}
+        for attribute in attributes:
+            self._attributes[attribute.name] = attribute
 
-        if isinstance(attributes, list):
-            for attribute in attributes:
-                if not isinstance(attribute, Attribute):
-                    raise ValueError('attribute must have type Attribute')
+    def __eq__(self, other):
+        """Compares two AttributeStatement objects
 
-                if attribute.name in attribute_names:
-                    predefined_name = attribute_names[attribute.name].name
-                    attribute = Attribute(predefined_name, attribute.values)
+        :param other: AttributeStatement object
+        :type other: AttributeStatement
 
-                self._attributes[attribute.name] = attribute
-        elif isinstance(attributes, dict):
-            for name, attribute_values in attributes.iteritems():
+        :return: Boolean value indicating whether two items are equal
+        :rtype: bool
+        """
+        if not isinstance(other, AttributeStatement):
+            return False
 
-                if name in attribute_names:
-                    name = attribute_names[name].name
-
-                attribute = Attribute(name=name, values=attribute_values)
-
-                self._attributes[attribute.name] = attribute
+        return \
+            self.attributes == other.attributes
 
     @property
     def attributes(self):
@@ -938,6 +953,23 @@ class Subject(object):
             self._valid_till = valid_till
         else:
             raise ValueError('valid_till is not valid')
+
+    def __eq__(self, other):
+        """Compares two Subject objects
+
+        :param other: Subject object
+        :type other: Subject
+
+        :return: Boolean value indicating whether two items are equal
+        :rtype: bool
+        """
+        if not isinstance(other, Subject):
+            return False
+
+        return \
+            self.name_id == other.name_id and \
+            self.attribute_statement == other.attribute_statement and \
+            self.valid_till == other.valid_till
 
     @property
     def name_id(self):

--- a/api/saml/parser.py
+++ b/api/saml/parser.py
@@ -8,7 +8,7 @@ from onelogin.saml2.utils import OneLogin_Saml2_Utils
 
 from api.saml.exceptions import SAMLError
 from api.saml.metadata import IdentityProviderMetadata, LocalizableMetadataItem, UIInfo, ServiceProviderMetadata, \
-    Binding, Service, NameIDFormat, Organization
+    Binding, Service, NameIDFormat, Organization, NameID, AttributeStatement, Subject, SAMLAttributes, Attribute
 
 
 class SAMLMetadataParsingError(SAMLError):
@@ -467,3 +467,89 @@ class SAMLMetadataParser(object):
         self._logger.info('Finished parsing an XML string containing SAML metadata')
 
         return providers
+
+
+class SAMLSubjectParser(object):
+    """Parses SAML response into Subject object"""
+
+    def _parse_name_id(self, name_id_attributes):
+        """Parses NameID attributes
+
+        :param name_id_attributes: Dictionary containing NameID attributes
+        :type name_id_attributes: Dict
+
+        :return: NameID object
+        :rtype: NameID
+        """
+        name_id = NameID(
+            name_id_attributes['Format'],
+            name_id_attributes['NameQualifier'],
+            None,
+            name_id_attributes['value']
+        )
+
+        return name_id
+
+    def _parse_attribute_values(self, attribute_values):
+        """Parses attribute values
+
+        :param attribute_values: List containing SAML attribute values
+        :type attribute_values: List[Union[str, Dict]]
+
+        :return: 2-tupple containing a NameID and a list of SAML attribute values
+        :rtype: Tuple[Optional[NameID], List[str]]
+        """
+        parsed_attribute_values = []
+
+        for attribute_value in attribute_values:
+            if isinstance(attribute_value, dict) and 'NameID' in attribute_value:
+                name_id = self._parse_name_id(attribute_value['NameID'])
+
+                parsed_attribute_values.append(name_id.name_id)
+            else:
+                parsed_attribute_values.append(attribute_value)
+
+        return parsed_attribute_values
+
+    def _parse_attribute_statement(self, attributes):
+        parsed_attributes = []
+        attribute_names = {attribute.value: attribute for attribute in SAMLAttributes}
+
+        for name, attribute_values in attributes.iteritems():
+            if name in attribute_names:
+                name = attribute_names[name].name
+
+            parsed_attribute_values = self._parse_attribute_values(attribute_values)
+            attribute = Attribute(name=name, values=parsed_attribute_values)
+
+            parsed_attributes.append(attribute)
+
+        attribute_statement = AttributeStatement(parsed_attributes)
+
+        return attribute_statement
+
+    def parse(self, auth):
+        """Parses OneLogin_Saml2_Auth object containing SAML response data into Subject
+
+        :param auth: OneLogin_Saml2_Auth object containing SAML response
+        :type auth: OneLogin_Saml2_Auth
+
+        :return: Subject object containing SAML attributes and NameID
+        :rtype: api.saml.metadata.Subject
+        """
+        name_id = NameID(
+            auth.get_nameid_format(),
+            auth.get_nameid_nq(),
+            auth.get_nameid_spnq(),
+            auth.get_nameid()
+        )
+        raw_attributes = auth.get_attributes()
+        attribute_statement = self._parse_attribute_statement(raw_attributes)
+        valid_till = auth.get_session_expiration()
+
+        if not valid_till:
+            valid_till = auth.get_last_assertion_not_on_or_after()
+
+        subject = Subject(name_id, attribute_statement, valid_till)
+
+        return subject

--- a/api/saml/parser.py
+++ b/api/saml/parser.py
@@ -496,8 +496,8 @@ class SAMLSubjectParser(object):
         :param attribute_values: List containing SAML attribute values
         :type attribute_values: List[Union[str, Dict]]
 
-        :return: 2-tupple containing a NameID and a list of SAML attribute values
-        :rtype: Tuple[Optional[NameID], List[str]]
+        :return: List of parsed SAML attribute values
+        :rtype: List[str]
         """
         parsed_attribute_values = []
 

--- a/tests/saml/test_auth.py
+++ b/tests/saml/test_auth.py
@@ -3,7 +3,7 @@ from base64 import b64encode
 from xml.dom.minidom import Document
 
 from defusedxml.lxml import fromstring
-from mock import create_autospec, MagicMock
+from mock import create_autospec, MagicMock, patch
 from nose.tools import eq_
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
 from parameterized import parameterized
@@ -12,6 +12,7 @@ from api.saml.auth import SAMLAuthenticationManager, SAMLAuthenticationManagerFa
 from api.saml.configuration import SAMLOneLoginConfiguration, SAMLConfiguration, ExternalIntegrationOwner
 from api.saml.metadata import ServiceProviderMetadata, UIInfo, NameIDFormat, Service, IdentityProviderMetadata, Subject, \
     Organization
+from api.saml.parser import SAMLSubjectParser
 from tests.saml import fixtures
 from tests.saml.database_test import DatabaseTest
 from tests.test_controller import ControllerTest
@@ -56,7 +57,6 @@ IDENTITY_PROVIDERS = [
     )
 ]
 
-
 SAML_RESPONSE = \
     '''<?xml version="1.0" encoding="UTF-8"?>
 <saml2p:Response Destination="http://opds.hilbertteam.net/SAML2/POST" ID="_fd5cf32afbc789778279262c12d36743" InResponseTo="ONELOGIN_7ad774603b0d8b79fd877628801734d3f6198843" IssueInstant="2020-06-07T23:39:43.836Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"><saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://idp.hilbertteam.net/idp/shibboleth</saml2:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><ds:Reference URI="#_fd5cf32afbc789778279262c12d36743"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><ds:DigestValue>lBpSPvuk06OY95wRllXIZnKJesBo4YxSLRXIobKTZ2A=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>dRXFZ96XRNR8fqnU7lbJ8LQO401i/HmVNgZJ9VS1/qycbwfYJdAsI0sm9fUw/Dh8NRjiJDaQL1k0MSozQiUtuB8wgnn5oo+F1jr2PipNMERuixVuXVMwxuQL81N8AEgdqSN2/RHNC7fbstE6svAIHaINh5fwldL7IzKhZ1KJr/k=</ds:SignatureValue><ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIICXDCCAcWgAwIBAgIBADANBgkqhkiG9w0BAQ0FADBLMQswCQYDVQQGEwJ1czENMAsGA1UECAwE
@@ -81,6 +81,70 @@ MAMBAf8wDQYJKoZIhvcNAQENBQADgYEAc/ddQRAswvrlYD8IOA9TCjyqkUJmyJBOj+d0PTzW7lF7
 NUyPSp0SunDq12RD8imVq15wNzuzsiIfUZ7F/sp1iFH8ASrBS4sk39stDgUcjFNcwekihUGw3Gfh
 GcniFvvia/F82fbPXBPajb9nXNyn3ZwlLsooeC06oIj8FlyHoR8=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></ds:Signature><saml2:Subject><saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" NameQualifier="http://idp.hilbertteam.net/idp/shibboleth" SPNameQualifier="http://opds.hilbertteam.net/metadata/">AAdzZWNyZXQxeAj5TZ2CQ6FkW//TigUE8kgDuJfVEw7mtnCAFq02hvot2hQzlCj5QqQOBRlsAs0dqp1oHoi/apPWmrC2G30BvrtXcDfZsCGQv9eTGSRDydTLVPEe+lfCc1yg3WlxTeiCbFazW6kcybVgUper</saml2:NameID><saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml2:SubjectConfirmationData Address="185.99.252.212" InResponseTo="ONELOGIN_7ad774603b0d8b79fd877628801734d3f6198843" NotOnOrAfter="2020-06-07T23:44:43.894Z" Recipient="http://opds.hilbertteam.net/SAML2/POST"/></saml2:SubjectConfirmation></saml2:Subject><saml2:Conditions NotBefore="2020-06-07T23:39:43.836Z" NotOnOrAfter="2020-06-07T23:44:43.836Z"><saml2:AudienceRestriction><saml2:Audience>http://opds.hilbertteam.net/metadata/</saml2:Audience></saml2:AudienceRestriction></saml2:Conditions><saml2:AuthnStatement AuthnInstant="2020-06-07T23:39:43.759Z" SessionIndex="_a91f42a8f3d848ee8f3a35912279b93b"><saml2:SubjectLocality Address="185.99.252.212"/><saml2:AuthnContext><saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef></saml2:AuthnContext></saml2:AuthnStatement><saml2:AttributeStatement><saml2:Attribute FriendlyName="uid" Name="urn:oid:0.9.2342.19200300.100.1.1" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"><saml2:AttributeValue>student1</saml2:AttributeValue></saml2:Attribute><saml2:Attribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"><saml2:AttributeValue>student1@idptestbed.edu</saml2:AttributeValue></saml2:Attribute><saml2:Attribute FriendlyName="sn" Name="urn:oid:2.5.4.4" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"><saml2:AttributeValue>Ent</saml2:AttributeValue></saml2:Attribute><saml2:Attribute FriendlyName="givenName" Name="urn:oid:2.5.4.42" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"><saml2:AttributeValue>Stud</saml2:AttributeValue></saml2:Attribute></saml2:AttributeStatement></saml2:Assertion></saml2p:Response>'''
 
+SAML_COLUMBIA_RESPONSE = \
+    '''<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema" Destination="https://demo.lyrasistechnology.org/saml_callback" ID="_4d5f4eee04306190d284ba4010221ca9" InResponseTo="ONELOGIN_f220116d21195b57167c482fe4712929624c4287" IssueInstant="2020-07-23T13:10:25.397Z" Version="2.0">
+  <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">https://shibboleth-dev.cc.columbia.edu/idp/shibboleth</saml2:Issuer>
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#_4d5f4eee04306190d284ba4010221ca9">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="xsd"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>RLVl7tZAmPlD2KTgzOU3bJ/8GDaAM1eSGeLwwctp1M4=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>NA5nIPVyXkII6dln/99WtjL4jhCppjchdwC1aNG6zv8FMGmY5FGujwsvLYKpPRLvSM+51pBbggrMfYEIb6IDGMLHMZq9BZUaiU+WFhRZig97iXiGEMFDaM3V0+JTI7Wp07+OYNj8DB8cb/vdksawbUsjjtGLDNDe47Epn0aGm1wRZtOk5p/inPYRKkM+MwV+pzIrFhFvm12zUlzxfWE0zzkcAshG5OtResXqLef11yKHJSIsk+RgkrN85/jOxsmI5byrVLp0DXSG7S+LuQ3za6G2EY0XPamjMNt+tk/DFigFJScn8v9xh/3SljBJgMSXeGOozGD059duxreorHsL1w==</ds:SignatureValue>
+    <ds:KeyInfo>
+      <ds:X509Data>
+        <ds:X509Certificate>MIIDZjCCAk6gAwIBAgIVAJfrwoV8YNvMXzQxy/P+tTmLVdd2MA0GCSqGSIb3DQEBBQUAMCkxJzAlBgNVBAMTHnNoaWJib2xldGgtZGV2LmNjLmNvbHVtYmlhLmVkdTAeFw0xMzA1MTcxNTA0MjhaFw0zMzA1MTcxNTA0MjhaMCkxJzAlBgNVBAMTHnNoaWJib2xldGgtZGV2LmNjLmNvbHVtYmlhLmVkdTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ0C0taW9a9Ifp5quu28ogl7In9uu5CXgoDV8MKcE7WtbW8dCh98h17SIsbZKvFxJqj4xTskGefW7qli6m7aa8sxR47RXrPmkFxUEndg01eQE0OaYl6E6E7OfN2f8yL6PO0/rFA3FF9wImpTuUo2jcMk0LEES1sjKc4CjOpOhNmf//x20LmNn5h8yPYhGxjUcT4pDXQlKPaGuPY+lheOKW4AukyjBWkRvCzpxbohC8DlRtsUUznmmVhlaIsQNcjx7GsjbL7BPAjomyWEgOU6GLaS8XIRe5tER8o2cj4pPttmQ8BhNY3VZSUqVinszbuL+m1+LctfN5mWgvmSzYLKL6ECAwEAAaOBhDCBgTBgBgNVHREEWTBXgh5zaGliYm9sZXRoLWRldi5jYy5jb2x1bWJpYS5lZHWGNWh0dHBzOi8vc2hpYmJvbGV0aC1kZXYuY2MuY29sdW1iaWEuZWR1L2lkcC9zaGliYm9sZXRoMB0GA1UdDgQWBBQrL3ArXajqiuTyb0y8+/0voOBA3zANBgkqhkiG9w0BAQUFAAOCAQEAUiOmFYXrIdxqrTpOe9QgkFd2fSb+6h14gecI7iL/wHJVPeN+VO84+7eRBUkDdTJbikmA8BySCBKkMChGxTeNLkReJat7XaKs8AkK7fm7aliuTliR/nqd/ccY2NCPlySg/uFH/tzZ8OYF08Id2Zl8iPBOmIo9yG1XPNusLYlSepQcQRceGMz3bHYK0QJz9puBoY2sgTU116eKuP4Qihb94t+wojt+7GWQ2c5LU6gzuIiZPyXg+S8QGma0M7/0tx6diJwR5kLUAK8pgiKg6MLZLa4NU04EGK39M2kH31UrAo2J12U/jYwyS8iRI5c+JqaqVlKMyT94KnBx39pwbQzyaw==</ds:X509Certificate>
+      </ds:X509Data>
+    </ds:KeyInfo>
+  </ds:Signature>
+  <saml2p:Status>
+    <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </saml2p:Status>
+  <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="_d03a19c5d199615be4691a4c322b6e7d" IssueInstant="2020-07-23T13:10:25.397Z" Version="2.0">
+    <saml2:Issuer>https://shibboleth-dev.cc.columbia.edu/idp/shibboleth</saml2:Issuer>
+    <saml2:Subject>
+      <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml2:SubjectConfirmationData Address="37.120.133.91" InResponseTo="ONELOGIN_f220116d21195b57167c482fe4712929624c4287" NotOnOrAfter="2020-07-23T13:15:25.408Z" Recipient="https://demo.lyrasistechnology.org/saml_callback"/>
+      </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:Conditions NotBefore="2020-07-23T13:10:25.397Z" NotOnOrAfter="2020-07-23T13:15:25.397Z">
+      <saml2:AudienceRestriction>
+        <saml2:Audience>https://lyrasistechnology.org/simply-e/demo</saml2:Audience>
+      </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AuthnStatement AuthnInstant="2020-07-23T13:10:24.631Z" SessionIndex="_e0dae173d4e07def21a6344fd7b87738">
+      <saml2:SubjectLocality Address="37.120.133.91"/>
+      <saml2:AuthnContext>
+        <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef>
+      </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+      <saml2:Attribute FriendlyName="eduPersonScopedAffiliation" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.9" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">alum@columbia.edu</saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute FriendlyName="eduPersonTargetedID" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml2:AttributeValue>
+          <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" NameQualifier="https://shibboleth-dev.cc.columbia.edu/idp/shibboleth" SPNameQualifier="https://lyrasistechnology.org/simply-e/demo">0Mi3izMnex9L0sMt9wRfwY0pqQ8=</saml2:NameID>
+        </saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute FriendlyName="displayName" Name="urn:oid:2.16.840.1.113730.3.1.241" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+        <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">William Tester</saml2:AttributeValue>
+      </saml2:Attribute>
+    </saml2:AttributeStatement>
+  </saml2:Assertion>
+</saml2p:Response>
+'''
+
 
 class SAMLAuthenticationManagerTest(ControllerTest):
     @parameterized.expand([
@@ -94,7 +158,7 @@ class SAMLAuthenticationManagerTest(ControllerTest):
         configuration.get_service_provider = MagicMock(return_value=service_provider)
         configuration.get_identity_providers = MagicMock(return_value=identity_providers)
         onelogin_configuration = SAMLOneLoginConfiguration(configuration)
-        authentication_manager = SAMLAuthenticationManager(onelogin_configuration)
+        authentication_manager = SAMLAuthenticationManager(onelogin_configuration, SAMLSubjectParser())
 
         with self.app.test_request_context('/'):
             result = authentication_manager.start_authentication(self._db, fixtures.IDP_1_ENTITY_ID, '')
@@ -131,22 +195,45 @@ class SAMLAuthenticationManagerTest(ControllerTest):
 
             eq_(name_id_format, SERVICE_PROVIDER_WITH_UNSIGNED_REQUESTS.name_id_format)
 
-    def test_finish_authentication(self):
+    @parameterized.expand([
+        (
+                'with_name_id_and_attributes',
+                SAML_RESPONSE
+        ),
+        (
+                '',
+                SAML_COLUMBIA_RESPONSE,
+                True
+        )
+    ])
+    def test_finish_authentication(self, name, saml_response, mock_validation=False):
+        # Arrange
+        if mock_validation:
+            validate_mock = MagicMock(return_value=True)
+        else:
+            real_validate_sign = OneLogin_Saml2_Utils.validate_sign
+            validate_mock = MagicMock(
+                side_effect=lambda *args, **kwargs:
+                    real_validate_sign(*args, **kwargs)
+            )
         configuration = create_autospec(spec=SAMLConfiguration)
         configuration.get_debug = MagicMock(return_value=False)
         configuration.get_strict = MagicMock(return_value=False)
         configuration.get_service_provider = MagicMock(return_value=SERVICE_PROVIDER_WITH_UNSIGNED_REQUESTS)
         configuration.get_identity_providers = MagicMock(return_value=IDENTITY_PROVIDERS)
         onelogin_configuration = SAMLOneLoginConfiguration(configuration)
-        authentication_manager = SAMLAuthenticationManager(onelogin_configuration)
+        authentication_manager = SAMLAuthenticationManager(onelogin_configuration, SAMLSubjectParser())
+        saml_response = b64encode(saml_response)
 
-        saml_response = b64encode(SAML_RESPONSE)
-        with self.app.test_request_context('/', data={
-            'SAMLResponse': saml_response
-        }):
-            result = authentication_manager.finish_authentication(self._db, fixtures.IDP_1_ENTITY_ID)
+        # Act
+        with patch('onelogin.saml2.response.OneLogin_Saml2_Utils.validate_sign', validate_mock):
+            with self.app.test_request_context('/', data={
+                'SAMLResponse': saml_response
+            }):
+                result = authentication_manager.finish_authentication(self._db, fixtures.IDP_1_ENTITY_ID)
 
-            assert isinstance(result, Subject)
+                # Assert
+                assert isinstance(result, Subject)
 
 
 class SAMLAuthenticationManagerFactoryTest(DatabaseTest):

--- a/tests/saml/test_metadata.py
+++ b/tests/saml/test_metadata.py
@@ -9,8 +9,8 @@ class AttributeStatementTest(object):
     def test_init_accepts_list_of_attributes(self):
         # Arrange
         attributes = [
-            Attribute(SAMLAttributes.uid.value, [12345]),
-            Attribute(SAMLAttributes.eduPersonTargetedID.value, [12345])
+            Attribute(SAMLAttributes.uid.name, [12345]),
+            Attribute(SAMLAttributes.eduPersonTargetedID.name, [12345])
         ]
 
         # Act
@@ -22,27 +22,6 @@ class AttributeStatementTest(object):
 
         assert SAMLAttributes.eduPersonTargetedID.name in attribute_statement.attributes
         eq_(attribute_statement.attributes[SAMLAttributes.eduPersonTargetedID.name].values, attributes[1].values)
-
-    def test_init_accepts_dictionary_of_attributes(self):
-        # Arrange
-        attributes = {
-            SAMLAttributes.uid.value: [12345],
-            SAMLAttributes.eduPersonTargetedID.value: [12345]
-        }
-
-        # Act
-        attribute_statement = AttributeStatement(attributes)
-
-        # Assert
-        assert SAMLAttributes.uid.name in attribute_statement.attributes
-        eq_(
-            attribute_statement.attributes[SAMLAttributes.uid.name].values,
-            attributes[SAMLAttributes.uid.value])
-
-        assert SAMLAttributes.eduPersonTargetedID.name in attribute_statement.attributes
-        eq_(
-            attribute_statement.attributes[SAMLAttributes.eduPersonTargetedID.name].values,
-            attributes[SAMLAttributes.eduPersonTargetedID.value])
 
 
 class SubjectUIDExtractorTest(object):
@@ -56,11 +35,11 @@ class SubjectUIDExtractorTest(object):
             'subject_with_eduPersonTargetedID_attribute',
             Subject(
                 NameID(NameIDFormat.UNSPECIFIED, '', '', '12345'),
-                AttributeStatement({
-                    SAMLAttributes.eduPersonTargetedID.name: ['12345'],
-                    SAMLAttributes.eduPersonUniqueId.name: ['12345'],
-                    SAMLAttributes.uid.name: ['12345']
-                })
+                AttributeStatement([
+                    Attribute(name=SAMLAttributes.eduPersonTargetedID.name, values=['12345']),
+                    Attribute(name=SAMLAttributes.eduPersonUniqueId.name, values=['12345']),
+                    Attribute(name=SAMLAttributes.uid.name, values=['12345'])
+                ])
             ),
             '12345'
         ),
@@ -68,10 +47,10 @@ class SubjectUIDExtractorTest(object):
             'subject_with_eduPersonUniqueId_attribute',
             Subject(
                 NameID(NameIDFormat.UNSPECIFIED, '', '', '12345'),
-                AttributeStatement({
-                    SAMLAttributes.eduPersonUniqueId.name: ['12345'],
-                    SAMLAttributes.uid.name: ['12345']
-                })
+                AttributeStatement([
+                    Attribute(name=SAMLAttributes.eduPersonUniqueId.name, values=['12345']),
+                    Attribute(name=SAMLAttributes.uid.name, values=['12345'])
+                ])
             ),
             '12345'
         ),
@@ -79,9 +58,9 @@ class SubjectUIDExtractorTest(object):
             'subject_with_uid_attribute',
             Subject(
                 NameID(NameIDFormat.UNSPECIFIED, '', '', '12345'),
-                AttributeStatement({
-                    SAMLAttributes.uid.name: ['12345']
-                })
+                AttributeStatement([
+                    Attribute(name=SAMLAttributes.uid.name, values=['12345'])
+                ])
             ),
             '12345'
         ),
@@ -89,9 +68,9 @@ class SubjectUIDExtractorTest(object):
             'subject_with_name_id',
             Subject(
                 NameID(NameIDFormat.UNSPECIFIED, '', '', '12345'),
-                AttributeStatement({
-                    SAMLAttributes.eduPersonOrgUnitDN.name: ['12345']
-                })
+                AttributeStatement([
+                    Attribute(name=SAMLAttributes.eduPersonOrgUnitDN.name, values=['12345'])
+                ])
             ),
             '12345'
         ),

--- a/tests/saml/test_provider.py
+++ b/tests/saml/test_provider.py
@@ -10,7 +10,8 @@ from api.authenticator import PatronData
 from api.saml.auth import SAMLAuthenticationManager, SAMLAuthenticationManagerFactory
 from api.saml.configuration import SAMLConfiguration, SAMLOneLoginConfiguration
 from api.saml.metadata import ServiceProviderMetadata, NameIDFormat, UIInfo, Service, IdentityProviderMetadata, \
-    LocalizableMetadataItem, Subject, AttributeStatement, SAMLAttributes, SubjectJSONEncoder, Organization
+    LocalizableMetadataItem, Subject, AttributeStatement, SAMLAttributes, SubjectJSONEncoder, Organization, Attribute
+from api.saml.parser import SAMLSubjectParser
 from api.saml.provider import SAMLWebSSOAuthenticationProvider, SAML_INVALID_SUBJECT
 from core.util.problem_detail import ProblemDetail
 from tests.saml import fixtures
@@ -230,7 +231,7 @@ class SAMLWebSSOAuthenticationProviderTest(ControllerTest):
         configuration.get_service_provider = MagicMock(return_value=SERVICE_PROVIDER)
         configuration.get_identity_providers = MagicMock(return_value=identity_providers)
         onelogin_configuration = SAMLOneLoginConfiguration(configuration)
-        authentication_manager = SAMLAuthenticationManager(onelogin_configuration)
+        authentication_manager = SAMLAuthenticationManager(onelogin_configuration, SAMLSubjectParser())
 
         authentication_manager_factory = create_autospec(spec=SAMLAuthenticationManagerFactory)
         authentication_manager_factory.create = MagicMock(return_value=authentication_manager)
@@ -266,7 +267,9 @@ class SAMLWebSSOAuthenticationProviderTest(ControllerTest):
             'subject_has_unique_id',
             Subject(
                 None,
-                AttributeStatement({SAMLAttributes.eduPersonUniqueId.name: ['12345']})
+                AttributeStatement([
+                    Attribute(name=SAMLAttributes.eduPersonUniqueId.name, values=['12345'])
+                ])
             ),
             PatronData(
                 permanent_id='12345',
@@ -304,9 +307,9 @@ class SAMLWebSSOAuthenticationProviderTest(ControllerTest):
             'subject_has_unique_id',
             Subject(
                 None,
-                AttributeStatement({
-                    SAMLAttributes.eduPersonUniqueId.name: ['12345']
-                })
+                AttributeStatement([
+                    Attribute(name=SAMLAttributes.eduPersonUniqueId.name, values=['12345'])
+                ])
             ),
             PatronData(
                 permanent_id='12345',
@@ -319,9 +322,9 @@ class SAMLWebSSOAuthenticationProviderTest(ControllerTest):
             'subject_has_unique_id_and_non_default_expiration_timeout',
             Subject(
                 None,
-                AttributeStatement({
-                    SAMLAttributes.eduPersonUniqueId.name: ['12345']
-                }),
+                AttributeStatement([
+                    Attribute(name=SAMLAttributes.eduPersonUniqueId.name, values=['12345'])
+                ]),
                 valid_till=datetime.timedelta(days=1)
             ),
             PatronData(


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR enhances SAML attribute parsing, every time CM parses attribute's value it checks whether it contains `NameID`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`eduPersonTargetedID` usually contains `NameID` as a value and CM should parse it correctly.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
