### PR TITLE
SAML: Extract NameID containing in the list of SAML attributes

### DIFF
--- a/api/saml/parser.py
+++ b/api/saml/parser.py
@@ -531,7 +531,11 @@ class SAMLSubjectParser(object):
             if name in attribute_names:
                 name = attribute_names[name].name
 
-            name_id, parsed_attribute_values = self._parse_attribute_values(attribute_values)
+            current_name_id, parsed_attribute_values = self._parse_attribute_values(attribute_values)
+
+            if current_name_id:
+                name_id = current_name_id
+
             attribute = Attribute(name=name, values=parsed_attribute_values)
 
             parsed_attributes.append(attribute)

--- a/tests/saml/test_metadata.py
+++ b/tests/saml/test_metadata.py
@@ -69,7 +69,7 @@ class SubjectUIDExtractorTest(object):
             Subject(
                 NameID(NameIDFormat.UNSPECIFIED, '', '', '12345'),
                 AttributeStatement([
-                    Attribute(name=SAMLAttributes.eduPersonOrgUnitDN.name, values=['12345'])
+                    Attribute(name=SAMLAttributes.eduPersonPrincipalName.name, values=['12345'])
                 ])
             ),
             '12345'

--- a/tests/saml/test_parser.py
+++ b/tests/saml/test_parser.py
@@ -439,6 +439,38 @@ class SAMLSubjectParserTest(object):
             )
         ),
         (
+            'edu_person_targeted_id_as_name_id_and_other_attributes',
+            None, None, None, None,
+            {
+                SAMLAttributes.eduPersonTargetedID.value: [
+                    {
+                        'NameID': {
+                            'Format': NameIDFormat.PERSISTENT.value,
+                            'NameQualifier': fixtures.IDP_1_ENTITY_ID,
+                            'value': '12345'
+                        }
+                    }
+                ],
+                SAMLAttributes.eduPersonPrincipalName.value: [
+                    '12345'
+                ]
+            },
+            Subject(
+                NameID(
+                    NameIDFormat.PERSISTENT.value,
+                    fixtures.IDP_1_ENTITY_ID,
+                    None,
+                    '12345'
+                ),
+                AttributeStatement(
+                    [
+                        Attribute(SAMLAttributes.eduPersonTargetedID.name, ['12345']),
+                        Attribute(SAMLAttributes.eduPersonPrincipalName.name, ['12345'])
+                    ]
+                )
+            )
+        ),
+        (
             'edu_person_principal_name_as_name_id',
             None, None, None, None,
             {

--- a/tests/saml/test_parser.py
+++ b/tests/saml/test_parser.py
@@ -426,14 +426,42 @@ class SAMLSubjectParserTest(object):
             },
             Subject(
                 NameID(
+                    NameIDFormat.PERSISTENT.value,
+                    fixtures.IDP_1_ENTITY_ID,
                     None,
-                    None,
-                    None,
-                    None
+                    '12345'
                 ),
                 AttributeStatement(
                     [
                         Attribute(SAMLAttributes.eduPersonTargetedID.name, ['12345'])
+                    ]
+                )
+            )
+        ),
+        (
+            'edu_person_principal_name_as_name_id',
+            None, None, None, None,
+            {
+                SAMLAttributes.eduPersonPrincipalName.value: [
+                    {
+                        'NameID': {
+                            'Format': NameIDFormat.PERSISTENT.value,
+                            'NameQualifier': fixtures.IDP_1_ENTITY_ID,
+                            'value': '12345'
+                        }
+                    }
+                ]
+            },
+            Subject(
+                NameID(
+                    NameIDFormat.PERSISTENT.value,
+                    fixtures.IDP_1_ENTITY_ID,
+                    None,
+                    '12345'
+                ),
+                AttributeStatement(
+                    [
+                        Attribute(SAMLAttributes.eduPersonPrincipalName.name, ['12345'])
                     ]
                 )
             )


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR enhances the SAML parser and extracts a NameID containing in the list of SAML attributes.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

NYU's unique identifier is contained in eduPersonPrincipalName transmitted as the SAMLv2 NameID.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
