### PR TITLE
Patron last activity sync

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1165,7 +1165,7 @@ class CirculationAPI(object):
         local_loans = self.local_loans(patron)
         local_holds = self.local_holds(patron)
 
-        if patron.last_loan_activity_sync and not force:
+        if patron and patron.last_loan_activity_sync and not force:
             # Our local data is considered fresh, so we can return it
             # without calling out to the vendor APIs.
             return local_loans, local_holds

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1177,7 +1177,6 @@ class CirculationAPI(object):
 
         # Update the external view of the patron's current state.
         remote_loans, remote_holds, complete = self.patron_activity(patron, pin)
-        from nose.tools import set_trace; set_trace()
         __transaction = self._db.begin_nested()
 
         if not complete:
@@ -1186,8 +1185,6 @@ class CirculationAPI(object):
             # should never assume that our internal model of the
             # patron's loans is good enough to cache.
             last_loan_activity_sync = None
-
-        patron.last_loan_activity_sync = last_loan_activity_sync
 
         now = datetime.datetime.utcnow()
         local_loans_by_identifier = {}
@@ -1308,6 +1305,10 @@ class CirculationAPI(object):
             for hold in local_holds_by_identifier.values():
                 if hold.license_pool.collection_id in self.collection_ids_for_sync:
                     self._db.delete(hold)
+
+        # Now that we're in sync (or not), set last_loan_activity_sync
+        # to the conservative value obtained earlier.
+        patron.last_loan_activity_sync = last_loan_activity_sync
 
         __transaction.commit()
         return active_loans, active_holds

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1171,8 +1171,8 @@ class CirculationAPI(object):
             return local_loans, local_holds
 
         # Assuming everything goes well, we will set
-        # Patron.last_loan_activity_sync to this value -- immediately
-        # before we started contacting the vendor APIs.
+        # Patron.last_loan_activity_sync to this value -- the moment
+        # just before we started contacting the vendor APIs.
         last_loan_activity_sync = datetime.datetime.utcnow()
 
         # Update the external view of the patron's current state.

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1177,13 +1177,14 @@ class CirculationAPI(object):
 
         # Update the external view of the patron's current state.
         remote_loans, remote_holds, complete = self.patron_activity(patron, pin)
+        from nose.tools import set_trace; set_trace()
         __transaction = self._db.begin_nested()
 
         if not complete:
             # We were not able to get a complete picture of the
             # patron's loan activity. Until we are able to do that, we
-            # should never rely on our internal model of the patron's
-            # loans.
+            # should never assume that our internal model of the
+            # patron's loans is good enough to cache.
             last_loan_activity_sync = None
 
         patron.last_loan_activity_sync = last_loan_activity_sync

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1017,6 +1017,7 @@ class CirculationAPI(object):
             __transaction = self._db.begin_nested()
             logging.info("In revoke_loan(), deleting loan #%d" % loan.id)
             self._db.delete(loan)
+            patron.last_loan_activity_sync = None
             __transaction.commit()
 
             # Send out an analytics event to record the fact that
@@ -1049,6 +1050,7 @@ class CirculationAPI(object):
         if hold:
             __transaction = self._db.begin_nested()
             self._db.delete(hold)
+            patron.last_loan_activity_sync = None
             __transaction.commit()
 
             # Send out an analytics event to record the fact that
@@ -1154,9 +1156,7 @@ class CirculationAPI(object):
         local_loans = self.local_loans(patron)
         local_holds = self.local_holds(patron)
 
-        fresh = patron.loan_activity_fresher_than(max_age)
-
-        if fresh:
+        if patron.last_loan_activity_sync:
             # Our local data is considered fresh, so we can return it
             # without calling out to the vendor APIs.
             return local_loans, local_holds

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1308,7 +1308,8 @@ class CirculationAPI(object):
 
         # Now that we're in sync (or not), set last_loan_activity_sync
         # to the conservative value obtained earlier.
-        patron.last_loan_activity_sync = last_loan_activity_sync
+        if patron:
+            patron.last_loan_activity_sync = last_loan_activity_sync
 
         __transaction.commit()
         return active_loans, active_holds

--- a/api/controller.py
+++ b/api/controller.py
@@ -596,7 +596,7 @@ class CirculationManagerController(BaseCirculationManagerController):
         return search_engine
 
     def handle_conditional_request(self, last_modified=None):
-        """Handle conditional HTTP requests.
+        """Handle a conditional HTTP request.
 
         :param last_modified: A datetime representing the time this
            resource was last modified.
@@ -1182,12 +1182,18 @@ class LoanController(CirculationManagerController):
         """
         patron = flask.request.patron
 
+        # Save some time if we don't believe the patron's loans or holds have
+        # changed since the last time the client requested this feed.
         response = self.handle_conditional_request(
             patron.last_loan_activity_sync
         )
         if isinstance(response, Response):
             return response
 
+        # TODO: SimplyE used to make a HEAD request to the bookshelf feed
+        # as a quick way of checking authentication. Does this still happen?
+        # It shouldn't -- the patron profile feed should be used instead.
+        # If it's not used, we can take this out.
         if flask.request.method=='HEAD':
             return Response()
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -1,4 +1,5 @@
 from nose.tools import set_trace
+import email
 import json
 import logging
 import sys
@@ -607,15 +608,19 @@ class CirculationManagerController(BaseCirculationManagerController):
         if not last_modified:
             return None
 
+        # TODO: This can be cleaned up significantly in Python 3.
         if_modified_since = flask.request.headers.get('If-Modified-Since')
-        parsed_if_modified_since = email.utils.parsedate_to_datetime(
+        if_modified_since_tuple = email.utils.parsedate(
             if_modified_since
+        )
+        parsed_if_modified_since = datetime.datetime.fromtimestamp(
+            mktime(if_modified_since_tuple)
         )
         if not parsed_if_modified_since:
             return None
 
         if parsed_if_modified_since >= last_modified:
-            return Response(status_code=304)
+            return Response(status=304)
         return None
 
     def load_lane(self, lane_identifier):

--- a/api/controller.py
+++ b/api/controller.py
@@ -610,9 +610,15 @@ class CirculationManagerController(BaseCirculationManagerController):
 
         # TODO: This can be cleaned up significantly in Python 3.
         if_modified_since = flask.request.headers.get('If-Modified-Since')
+        if not if_modified_since:
+            return None
+
         if_modified_since_tuple = email.utils.parsedate(
             if_modified_since
         )
+        if not if_modified_since_tuple:
+            return None
+
         parsed_if_modified_since = datetime.datetime.fromtimestamp(
             mktime(if_modified_since_tuple)
         )

--- a/api/odl.py
+++ b/api/odl.py
@@ -349,6 +349,7 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI):
         if not any(unexpired_licenses):
             raise NoLicenses()
 
+        set_trace()
         # Make sure pool info is updated.
         self.update_hold_queue(licensepool)
 

--- a/api/odl.py
+++ b/api/odl.py
@@ -349,7 +349,6 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI):
         if not any(unexpired_licenses):
             raise NoLicenses()
 
-        set_trace()
         # Make sure pool info is updated.
         self.update_hold_queue(licensepool)
 

--- a/api/opds.py
+++ b/api/opds.py
@@ -1422,7 +1422,9 @@ class LibraryLoanAndHoldAnnotator(LibraryAnnotator):
 
         feed_obj = AcquisitionFeed(db, "Active loans and holds", url, works, annotator)
         annotator.annotate_feed(feed_obj, None)
-        return feed_obj.as_response(max_age=60*30, private=True)
+        return feed_obj.as_response(
+            max_age=patron.seconds_until_loan_activity_stale(), private=True
+        )
 
     @classmethod
     def single_item_feed(cls, circulation, item, fulfillment=None, test_mode=False,

--- a/api/opds.py
+++ b/api/opds.py
@@ -1424,7 +1424,6 @@ class LibraryLoanAndHoldAnnotator(LibraryAnnotator):
         annotator.annotate_feed(feed_obj, None)
         response = feed_obj.as_response(max_age=0, private=True)
         last_modified = patron.last_loan_activity_sync
-        set_trace()
         if last_modified:
             response.last_modified = last_modified
         return response

--- a/api/opds.py
+++ b/api/opds.py
@@ -1422,9 +1422,12 @@ class LibraryLoanAndHoldAnnotator(LibraryAnnotator):
 
         feed_obj = AcquisitionFeed(db, "Active loans and holds", url, works, annotator)
         annotator.annotate_feed(feed_obj, None)
-        return feed_obj.as_response(
-            max_age=patron.seconds_until_loan_activity_stale(), private=True
-        )
+        response = feed_obj.as_response(max_age=0, private=True)
+        last_modified = patron.last_loan_activity_sync
+        set_trace()
+        if last_modified:
+            response.last_modified = last_modified
+        return response
 
     @classmethod
     def single_item_feed(cls, circulation, item, fulfillment=None, test_mode=False,

--- a/tests/saml/test_controller.py
+++ b/tests/saml/test_controller.py
@@ -238,7 +238,7 @@ class SAMLControllerTest(ControllerTest):
                 })
             },
             None,
-            (create_autospec(spec=Credential), create_autospec(spec=Patron), create_patron_data_mock()),
+            (create_autospec(spec=Credential), object(), create_patron_data_mock()),
             'ABCDEFG',
             'http://localhost?access_token=ABCDEFG&patron_info=%22%22',
             None

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -1165,7 +1165,7 @@ class TestCirculationAPI(DatabaseTest):
 
         # Since we know our picture of the patron's bookshelf is up-to-date,
         # patron.last_loan_activity_sync has been set to the current time.
-        now = datetime.datetime.utcnow()
+        now = datetime.utcnow()
         assert (now-self.patron.last_loan_activity_sync).total_seconds() < 2
 
     def test_sync_bookshelf_updates_local_loan_and_hold_with_modified_timestamps(self):

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -1122,7 +1122,7 @@ class TestCirculationAPI(DatabaseTest):
         eq_([loan], loans)
 
     def test_sync_bookshelf_with_incomplete_remotes_keeps_local_loan(self):
-        self.patron.last_loan_activity_sync = datetime.datetime.utcnow()
+        self.patron.last_loan_activity_sync = datetime.utcnow()
         loan, ignore = self.pool.loan_to(self.patron)
         loan.start = self.YESTERDAY
 
@@ -1146,7 +1146,7 @@ class TestCirculationAPI(DatabaseTest):
         # Since we don't have complete loan data,
         # patron.last_loan_activity_sync has been cleared out -- we know
         # the data we have is unreliable.
-        eq_(None, patron.last_loan_activity_sync)
+        eq_(None, self.patron.last_loan_activity_sync)
 
         class CompleteCirculationAPI(MockCirculationAPI):
             def patron_activity(self, patron, pin):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2172,13 +2172,71 @@ class TestLoanController(CirculationControllerTest):
             eq_("Cannot release a hold once it enters reserved state.", response.detail)
 
     def test_active_loans(self):
+
+        # First, verify that this controller supports conditional HTTP
+        # GET by calling handle_conditional_request and propagating
+        # any Response it returns.
+        response_304 = Response(status=304)
+        def handle_conditional_request(last_modified=None):
+            return response_304
+        original_handle_conditional_request = self.controller.handle_conditional_request
+        self.manager.loans.handle_conditional_request = handle_conditional_request
+
+        # Before making any requests, set the patron's last_loan_activity_sync
+        # to a known value.
+        patron = None
+        with self.request_context_with_library("/"):
+            patron = self.controller.authenticated_patron(
+                self.valid_credentials
+            )
+        now = datetime.datetime.utcnow()
+        patron.last_loan_activity_sync = now
+
+        # Make a request -- it doesn't have If-Modified-Since, but our
+        # mocked handle_conditional_request will treat it as a
+        # successful conditional request.
         with self.request_context_with_library(
-                "/", headers=dict(Authorization=self.valid_auth)):
+            "/", headers=dict(Authorization=self.valid_auth)
+        ):
+            patron = self.manager.loans.authenticated_patron_from_request()
+            response = self.manager.loans.sync()
+            assert response is response_304
+
+        # Since the conditional request succeeded, we did not call out
+        # to the vendor APIs, and patron.last_loan_activity_sync was
+        # not updated.
+        eq_(now, patron.last_loan_activity_sync)
+
+        # Leaving patron.last_loan_activity_sync alone will stop the
+        # circulation manager from calling out to the external APIs,
+        # since it was set to a recent time. We test this explicitly
+        # later, but for now, clear it out.
+        patron.last_loan_activity_sync = None
+
+        # Un-mock handle_conditional_request. It will be called over
+        # the course of this test, but it will not notice any more
+        # conditional requests -- the detailed behavior of
+        # handle_conditional_request is tested elsewhere.
+        self.manager.loans.handle_conditional_request = (
+            original_handle_conditional_request
+        )
+
+        # If the request is not conditional, an OPDS feed is returned.
+        # This feed is empty because the patron has no loans.
+        with self.request_context_with_library(
+            "/", headers=dict(Authorization=self.valid_auth)
+        ):
             patron = self.manager.loans.authenticated_patron_from_request()
             response = self.manager.loans.sync()
             assert not "<entry>" in response.data
             assert response.headers['Cache-Control'].startswith('private,')
 
+            # patron.last_loan_activity_sync was set to the moment the
+            # LoanController started calling out to the remote APIs.
+            new_sync_time = patron.last_loan_activity_sync
+            assert new_sync_time > now
+
+        # Set up a bunch of loans on the remote APIs.
         overdrive_edition, overdrive_pool = self._edition(
             with_open_access_download=False,
             data_source_name=DataSource.OVERDRIVE,
@@ -2218,11 +2276,33 @@ class TestLoanController(CirculationControllerTest):
             0,
         )
 
+        # Making a new request so soon after the last one means the
+        # circulation manager won't actually call out to the vendor
+        # APIs. The resulting feed won't reflect what we know to be
+        # the reality.
+        with self.request_context_with_library(
+                "/", headers=dict(Authorization=self.valid_auth)):
+            patron = self.manager.loans.authenticated_patron_from_request()
+            response = self.manager.loans.sync()
+            assert '<entry>' not in response.data
+
+        # patron.last_loan_activity_sync was not changed as the result
+        # of this request, since we didn't go to the vendor APIs.
+        eq_(patron.last_loan_activity_sync, new_sync_time)
+
+        # Change it now, to a timestamp far in the past.
+        long_ago = datetime.datetime(2000, 1, 1)
+        patron.last_loan_activity_sync = long_ago
+
+        # This ensures that when we request the loans feed again, the
+        # LoanController actually goes out to the vendor APIs for new
+        # information.
         with self.request_context_with_library(
                 "/", headers=dict(Authorization=self.valid_auth)):
             patron = self.manager.loans.authenticated_patron_from_request()
             response = self.manager.loans.sync()
 
+            # This time, the feed contains entries.
             feed = feedparser.parse(response.data)
             entries = feed['entries']
 
@@ -2244,6 +2324,9 @@ class TestLoanController(CirculationControllerTest):
             assert urllib.quote("%s/%s/borrow" % (bibliotheca_pool.identifier.type, bibliotheca_pool.identifier.identifier)) in borrow_link
             eq_(0, len(bibliotheca_revoke_links))
 
+            # Since we went out the the vendor APIs,
+            # patron.last_loan_activity_sync was updated.
+            assert patron.last_loan_activity_sync > new_sync_time
 
 class TestAnnotationController(CirculationControllerTest):
     def setup(self):

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -1736,6 +1736,7 @@ class TestSyncBookshelf(OverdriveAPITest):
         eq_([], holds)
 
         # Running the sync again leaves all four loans in place.
+        patron.last_loan_activity_sync = None
         self.api.queue_response(200, content=loans_data)
         self.api.queue_response(200, content=holds_data)
         loans, holds = self.circulation.sync_bookshelf(patron, "dummy pin")
@@ -1801,6 +1802,7 @@ class TestSyncBookshelf(OverdriveAPITest):
         eq_(sorted(holds), sorted(patron.holds))
 
         # Running the sync again leaves all four holds in place.
+        patron.last_loan_activity_sync = None
         self.api.queue_response(200, content=loans_data)
         self.api.queue_response(200, content=holds_data)
         loans, holds = self.circulation.sync_bookshelf(patron, "dummy pin")


### PR DESCRIPTION
## Description

This is the circulation portion of the work for https://jira.nypl.org/browse/SIMPLY-2922. (Core is [here](https://github.com/NYPL-Simplified/server_core/pull/1190).) It has four main components:

* When generating a patron's bookshelf feed, we only call out to external vendors if Patron.last_loan_activity_sync is null. (See https://github.com/NYPL-Simplified/server_core/pull/1190 for the rules about when it's null.)

* We clear out Patron.last_loan_activity_sync when revoking a loan or hold.

* The bookshelf feed response includes a Last-Modified header with the value of Patron.last_loan_activity_sync. (This value is always set by the time the bookshelf feed has been generated.)

* The controller that generates the bookshelf feed supports conditional HTTP GET. A client that sends the Last-Modified header back as If-Last-Modified will get a 304 (Not Modified) response if the CM believes there has been no loan activity since then.

## Motivation and Context

The general idea is to allow a client to hit a patron's bookshelf feed whenever it wants, without creating a performance problem on the server side. We address performance with (very limited) server-side caching, and support for conditional HTTP GET.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
