### PR TITLE
Rename SAML tests according to the convention used by nosetests

### DIFF
--- a/tests/saml/test_auth.py
+++ b/tests/saml/test_auth.py
@@ -146,7 +146,7 @@ SAML_COLUMBIA_RESPONSE = \
 '''
 
 
-class SAMLAuthenticationManagerTest(ControllerTest):
+class TestSAMLAuthenticationManager(ControllerTest):
     @parameterized.expand([
         ('with_unsigned_authentication_request', SERVICE_PROVIDER_WITH_UNSIGNED_REQUESTS, IDENTITY_PROVIDERS),
         ('with_signed_authentication_request', SERVICE_PROVIDER_WITH_SIGNED_REQUESTS, IDENTITY_PROVIDERS)
@@ -236,7 +236,7 @@ class SAMLAuthenticationManagerTest(ControllerTest):
                 assert isinstance(result, Subject)
 
 
-class SAMLAuthenticationManagerFactoryTest(DatabaseTest):
+class TestSAMLAuthenticationManagerFactory(DatabaseTest):
     def test_create(self):
         # Arrange
         factory = SAMLAuthenticationManagerFactory()

--- a/tests/saml/test_configuration.py
+++ b/tests/saml/test_configuration.py
@@ -48,7 +48,7 @@ IDENTITY_PROVIDERS = [
 ]
 
 
-class SAMLConfigurationTest(object):
+class TestSAMLConfiguration(object):
     def test_service_provider_returns_correct_value(self):
         # Arrange
         service_provider_metadata = ''
@@ -91,7 +91,7 @@ class SAMLConfigurationTest(object):
         metadata_parser.parse.assert_called_once_with(identity_providers_metadata)
 
 
-class SAMLOneLoginConfigurationTest(object):
+class TestSAMLOneLoginConfiguration(object):
     def test_get_identity_provider_settings_returns_correct_result(self):
         # Arrange
         configuration = create_autospec(spec=SAMLConfiguration)

--- a/tests/saml/test_controller.py
+++ b/tests/saml/test_controller.py
@@ -54,7 +54,7 @@ def create_patron_data_mock():
     return patron_data_mock
 
 
-class SAMLControllerTest(ControllerTest):
+class TestSAMLController(ControllerTest):
     @parameterized.expand([
         (
             'with_missing_provider_name',

--- a/tests/saml/test_loader.py
+++ b/tests/saml/test_loader.py
@@ -5,7 +5,7 @@ from api.saml.loader import SAMLMetadataLoadingError, SAMLMetadataLoader
 from tests.saml import fixtures
 
 
-class SAMLMetadataLoaderTest(object):
+class TestSAMLMetadataLoader(object):
     @patch('urllib2.urlopen')
     @raises(SAMLMetadataLoadingError)
     def test_load_idp_metadata_raises_error_when_xml_is_incorrect(self, urlopen_mock):

--- a/tests/saml/test_metadata.py
+++ b/tests/saml/test_metadata.py
@@ -5,7 +5,7 @@ from api.saml.metadata import Attribute, SAMLAttributes, AttributeStatement, Sub
     NameIDFormat
 
 
-class AttributeStatementTest(object):
+class TestAttributeStatement(object):
     def test_init_accepts_list_of_attributes(self):
         # Arrange
         attributes = [
@@ -24,7 +24,7 @@ class AttributeStatementTest(object):
         eq_(attribute_statement.attributes[SAMLAttributes.eduPersonTargetedID.name].values, attributes[1].values)
 
 
-class SubjectUIDExtractorTest(object):
+class TestSubjectUIDExtractor(object):
     @parameterized.expand([
         (
             'subject_without_unique_id',

--- a/tests/saml/test_parser.py
+++ b/tests/saml/test_parser.py
@@ -10,7 +10,7 @@ from tests.saml import fixtures
 from tests.saml.fixtures import strip_certificate
 
 
-class SAMLMetadataParserTest(object):
+class TestSAMLMetadataParser(object):
     @raises(SAMLMetadataParsingError)
     def test_parse_raises_exception_when_xml_metadata_has_incorrect_format(self):
         # Arrange
@@ -388,7 +388,7 @@ class SAMLMetadataParserTest(object):
         )
 
 
-class SAMLSubjectParserTest(object):
+class TestSAMLSubjectParser(object):
     @parameterized.expand([
         (
             'name_id_and_attributes',

--- a/tests/saml/test_provider.py
+++ b/tests/saml/test_provider.py
@@ -76,7 +76,7 @@ IDENTITY_PROVIDER_WITHOUT_DISPLAY_NAMES = IdentityProviderMetadata(
 )
 
 
-class SAMLWebSSOAuthenticationProviderTest(ControllerTest):
+class TestSAMLWebSSOAuthenticationProvider(ControllerTest):
     @parameterized.expand([
         (
             'identity_provider_with_display_name',

--- a/tests/saml/test_validator.py
+++ b/tests/saml/test_validator.py
@@ -13,7 +13,7 @@ from tests.saml import fixtures
 from tests.saml.database_test import DatabaseTest
 
 
-class SAMLSettingsValidatorTest(DatabaseTest):
+class TestSAMLSettingsValidator(DatabaseTest):
     @parameterized.expand([
         (
             'missing_sp_metadata_and_missing_idp_metadata',
@@ -77,7 +77,7 @@ class SAMLSettingsValidatorTest(DatabaseTest):
             eq_(result, expected_validation_result)
 
 
-class SAMLSettingsValidatorFactoryTest(object):
+class TestSAMLSettingsValidatorFactory(object):
     @parameterized.expand([
         ('validator_using_factory_method', 'api.saml.provider')
     ])


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR renames SAML tests according to the naming convention used by `nosetests`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It turned out that SAML tests have never been run by CI because of incorrect names.
Locally I used different settings (custom regex pattern set to `test_\w+|\w+Test`) which allowed me to run them.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
