### PR TITLE
If-Last-Modified has lower resolution than the datetime it's being compared against

### DIFF
--- a/api/admin/package-lock.json
+++ b/api/admin/package-lock.json
@@ -4,8 +4,1274 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "simplified-circulation-web": {
+    "@babel/runtime": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
+    "@babel/runtime-corejs2": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.8.4.tgz",
+      "integrity": "sha512-7jU2FgNqNHX6yTuU/Dr/vH5/O8eVL9U85MG5aDw1LzGfCvvhXC1shdXfVzCQDsoY967yrAKeLujRv7l8BU+dZA==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
+    "@icons/material": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
+    },
+    "@nypl/dgx-svg-icons": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.4.tgz",
+      "integrity": "sha512-B4nPRkGSvzUiObFIEfq+dkSWgBhK56EFxYor5SCcY/A+rWsuGSNq22JlN6wDU/gsA6x0txxVJlUjUhtfwso/qQ=="
+    },
+    "abab": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+    },
+    "acorn": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
+    },
+    "acorn-globals": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+      "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
+      "requires": {
+        "acorn": "^2.1.0"
+      }
+    },
+    "ajv": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "bootstrap": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "content-type-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
+    },
+    "core-js": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "create-react-class": {
+      "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+      "requires": {
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        },
+        "fbjs": {
+          "version": "0.8.17",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        }
+      }
+    },
+    "cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+    },
+    "cssstyle": {
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "requires": {
+        "cssom": "0.3.x"
+      }
+    },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "d3-color": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.0.tgz",
+      "integrity": "sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg=="
+    },
+    "d3-format": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.3.tgz",
+      "integrity": "sha512-mm/nE2Y9HgGyjP+rKIekeITVgBtX97o1nrvHCWX8F/yBYyevUTvu9vb5pUnKwrcSw7o7GuwMOWjS9gFDs4O+uQ=="
+    },
+    "d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "requires": {
+        "d3-color": "1"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "d3-scale": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
+      "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
+      "requires": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "requires": {
+        "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "d3-time-format": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
+      "integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
+      "requires": {
+        "d3-time": "1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "decimal.js-light": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.0.tgz",
+      "integrity": "sha512-b3VJCbd2hwUpeRGG3Toob+CRo8W22xplipNhP3tN7TSVB/cyMX71P1vM2Xjc9H74uV6dS2hDDmo/rHq8L87Upg=="
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
+    "dompurify": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-0.8.9.tgz",
+      "integrity": "sha1-/OwCH5F7UfQqeK9x14dae6UU/WQ="
+    },
+    "downloadjs": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
+      "integrity": "sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw="
+    },
+    "draft-convert": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/draft-convert/-/draft-convert-2.1.8.tgz",
+      "integrity": "sha512-69etPa5JzZVELs4Lzobgxes1oka5IUyJC+NVIVnA9HPO5eOYLqAONFYxmav1vJjYyHsabq/20nSXj2MtIIQ4Fg==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "immutable": "~3.7.4",
+        "invariant": "^2.2.1"
+      }
+    },
+    "draft-js": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.2.tgz",
+      "integrity": "sha512-JU96XdAigQ4hAmyBMVXps6RQ8+dMhhNI1dDJPMP6OeHuSv+uwDzDg/7lxGQ1PEq+1Q6575jtvxDa7Aw3vy0WHA==",
+      "requires": {
+        "fbjs": "^1.0.0",
+        "immutable": "~3.7.4",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "escodegen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fbjs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+      "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+      "requires": {
+        "core-js": "^2.4.1",
+        "fbjs-css-vars": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
+    },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "history": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-3.3.0.tgz",
+      "integrity": "sha1-/O3M6PEpdTcVRdc1RhAzV5ptrpw=",
+      "requires": {
+        "invariant": "^2.2.1",
+        "loose-envify": "^1.2.0",
+        "query-string": "^4.2.2",
+        "warning": "^3.0.0"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "requires": {
+        "whatwg-encoding": "^1.0.1"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "immutable": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "jsdom": {
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.9.1.tgz",
+      "integrity": "sha1-hPOXKtOUq5YyM6+HJSEbzk0Bv9U=",
+      "requires": {
+        "abab": "^1.0.0",
+        "acorn": "^2.4.0",
+        "acorn-globals": "^1.0.4",
+        "array-equal": "^1.0.0",
+        "content-type-parser": "^1.0.1",
+        "cssom": ">= 0.3.0 < 0.4.0",
+        "cssstyle": ">= 0.2.36 < 0.3.0",
+        "escodegen": "^1.6.1",
+        "html-encoding-sniffer": "^1.0.1",
+        "iconv-lite": "^0.4.13",
+        "nwmatcher": ">= 1.3.9 < 2.0.0",
+        "parse5": "^1.5.1",
+        "request": "^2.55.0",
+        "sax": "^1.1.4",
+        "symbol-tree": ">= 3.1.0 < 4.0.0",
+        "tough-cookie": "^2.3.1",
+        "webidl-conversions": "^3.0.1",
+        "whatwg-encoding": "^1.0.1",
+        "whatwg-url": "^4.1.0",
+        "xml-name-validator": ">= 2.0.1 < 3.0.0"
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "keycode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
+      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "library-simplified-reusable-components": {
+      "version": "1.3.16",
+      "resolved": "https://registry.npmjs.org/library-simplified-reusable-components/-/library-simplified-reusable-components-1.3.16.tgz",
+      "integrity": "sha512-Tt1K5InyA+jf3Ydg7/vIPDVWe7TYsd9xus4t07P9SGseS8pl3FmjPQNvcu0Pc41YaUody+Hy2ZmXWrATCt5SSQ==",
+      "requires": {
+        "@nypl/dgx-svg-icons": "^0.3.9",
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6"
+      },
+      "dependencies": {
+        "@nypl/dgx-svg-icons": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.9.tgz",
+          "integrity": "sha512-y4cgTHunDgBAhKon/ukkKdlTlS4Xpo7sRUGbsLpbbjsc6stcxAU8Kkjde5ycxOaR4jVNCG65kLEiQGZycZ+fPw=="
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash-es": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "material-colors": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
+    },
+    "math-expression-evaluator": {
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.22.tgz",
+      "integrity": "sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ=="
+    },
+    "memoize-one": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-3.1.1.tgz",
+      "integrity": "sha512-YqVh744GsMlZu6xkhGslPSqSurOv6P+kLN2J3ysBZfagLcL5FdRK/0UpgLoL8hwjjEvvAVkjJZyFP+1T6p1vgA=="
+    },
+    "mime-db": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "requires": {
+        "mime-db": "1.43.0"
+      }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "numeral": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
+    },
+    "nwmatcher": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "opds-feed-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/opds-feed-parser/-/opds-feed-parser-0.0.17.tgz",
+      "integrity": "sha512-qLHrvQKnvyh6ZCvuYlbQkJTyQQ1EdeXp5yXPSoOypn07HMDbKG27r0aMxVSYeZArpaPffMdrElTSvuB/ADc2fA==",
+      "requires": {
+        "core-js": "^2.6.9",
+        "requirejs": "^2.1.22",
+        "xml2js": "^0.4.16"
+      }
+    },
+    "opds-web-client": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.3.4.tgz",
+      "integrity": "sha512-qpno/swMpFq+glPEJROlmF0AjGALvG2OpfgkVuGOodfJtnWp05TQa2bWzcBwbi4djPrODoRzko1ZhL7zDf8DhQ==",
+      "requires": {
+        "@nypl/dgx-svg-icons": "^0.3.4",
+        "dompurify": "^0.8.1",
+        "downloadjs": "^1.4.4",
+        "font-awesome": "^4.7.0",
+        "isomorphic-fetch": "^2.2.1",
+        "js-cookie": "^2.1.2",
+        "jsdom": "9.9.1",
+        "moment": "^2.14.1",
+        "opds-feed-parser": "0.0.17",
+        "prop-types": "^15.7.2",
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6",
+        "react-redux": "^7.1.0",
+        "react-router": "^3.2.0",
+        "redux": "4.0.1",
+        "redux-localstorage": "^0.4.1",
+        "redux-thunk": "^2.3.0",
+        "seedrandom": "^2.4.2",
+        "throttle-debounce": "1.0.1",
+        "xml2js": "^0.4.16"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+          "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "symbol-observable": "^1.2.0"
+          }
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
+    "parse5": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "prop-types-extra": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
+      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "requires": {
+        "react-is": "^16.3.2",
+        "warning": "^4.0.0"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
+    "psl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "requires": {
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
+    "raf-schd": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-2.1.2.tgz",
+      "integrity": "sha512-Orl0IEvMtUCgPddgSxtxreK77UiQz4nPYJy9RggVzu4mKsZkQWiAaG1y9HlYWdvm9xtN348xRaT37qkvL/+A+g=="
+    },
+    "react": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
+      "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "react-beautiful-dnd": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-2.6.4.tgz",
+      "integrity": "sha512-P+iXbRNpO23PwjsnK1zaoCK2HMdnTMznOfbtf+oU/hZo2F2OuYAVcR1JkbZNk6+P4Aqcu3HfAUT6NlsWzOwGWg==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "invariant": "^2.2.2",
+        "memoize-one": "^3.0.1",
+        "prop-types": "^15.6.0",
+        "raf-schd": "^2.0.2",
+        "react-motion": "^0.5.2",
+        "react-redux": "^5.0.6",
+        "redux": "^3.7.2",
+        "redux-thunk": "^2.2.0",
+        "reselect": "^3.0.1"
+      },
+      "dependencies": {
+        "react-redux": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
+          "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "hoist-non-react-statics": "^3.3.0",
+            "invariant": "^2.2.4",
+            "loose-envify": "^1.1.0",
+            "prop-types": "^15.6.1",
+            "react-is": "^16.6.0",
+            "react-lifecycles-compat": "^3.0.0"
+          }
+        },
+        "redux": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+          "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+          "requires": {
+            "lodash": "^4.2.1",
+            "lodash-es": "^4.2.1",
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.0.3"
+          }
+        }
+      }
+    },
+    "react-bootstrap": {
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.32.4.tgz",
+      "integrity": "sha512-xj+JfaPOvnvr3ow0aHC7Y3HaBKZNR1mm361hVxVzVX3fcdJNIrfiodbQ0m9nLBpNxiKG6FTU2lq/SbTDYT2vew==",
+      "requires": {
+        "@babel/runtime-corejs2": "^7.0.0",
+        "classnames": "^2.2.5",
+        "dom-helpers": "^3.2.0",
+        "invariant": "^2.2.4",
+        "keycode": "^2.2.0",
+        "prop-types": "^15.6.1",
+        "prop-types-extra": "^1.0.1",
+        "react-overlays": "^0.8.0",
+        "react-prop-types": "^0.4.0",
+        "react-transition-group": "^2.0.0",
+        "uncontrollable": "^5.0.0",
+        "warning": "^3.0.0"
+      }
+    },
+    "react-color": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.18.0.tgz",
+      "integrity": "sha512-FyVeU1kQiSokWc8NPz22azl1ezLpJdUyTbWL0LPUpcuuYDrZ/Y1veOk9rRK5B3pMlyDGvTk4f4KJhlkIQNRjEA==",
+      "requires": {
+        "@icons/material": "^0.2.4",
+        "lodash": "^4.17.11",
+        "material-colors": "^1.2.1",
+        "prop-types": "^15.5.10",
+        "reactcss": "^1.2.0",
+        "tinycolor2": "^1.4.1"
+      }
+    },
+    "react-dom": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
+      "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.18.0"
+      }
+    },
+    "react-is": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-motion": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
+      "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
+      "requires": {
+        "performance-now": "^0.2.0",
+        "prop-types": "^15.5.8",
+        "raf": "^3.1.0"
+      },
+      "dependencies": {
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+        }
+      }
+    },
+    "react-overlays": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.8.3.tgz",
+      "integrity": "sha512-h6GT3jgy90PgctleP39Yu3eK1v9vaJAW73GOA/UbN9dJ7aAN4BTZD6793eI1D5U+ukMk17qiqN/wl3diK1Z5LA==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "dom-helpers": "^3.2.1",
+        "prop-types": "^15.5.10",
+        "prop-types-extra": "^1.0.1",
+        "react-transition-group": "^2.2.0",
+        "warning": "^3.0.0"
+      }
+    },
+    "react-prop-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
+      "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
+      "requires": {
+        "warning": "^3.0.0"
+      }
+    },
+    "react-redux": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.1.3.tgz",
+      "integrity": "sha512-uI1wca+ECG9RoVkWQFF4jDMqmaw0/qnvaSvOoL/GA4dNxf6LoV8sUAcNDvE5NWKs4hFpn0t6wswNQnY3f7HT3w==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
+      }
+    },
+    "react-resize-detector": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-2.3.0.tgz",
+      "integrity": "sha512-oCAddEWWeFWYH5FAcHdBYcZjAw9fMzRUK9sWSx6WvSSOPVRxcHd5zTIGy/mOus+AhN/u6T4TMiWxvq79PywnJQ==",
+      "requires": {
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "prop-types": "^15.6.0",
+        "resize-observer-polyfill": "^1.5.0"
+      }
+    },
+    "react-router": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-3.2.5.tgz",
+      "integrity": "sha512-0/edMhPfOLRZ5IT3y6UkCpW7a13WrnGMR75ayAh2ZLynujEJOSptJt856GKnoCMW+7rk0/WYGUp/QaZNS9dTKg==",
+      "requires": {
+        "create-react-class": "^15.5.1",
+        "history": "^3.0.0",
+        "hoist-non-react-statics": "^2.3.1",
+        "invariant": "^2.2.1",
+        "loose-envify": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6",
+        "warning": "^3.0.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
+      }
+    },
+    "react-smooth": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-1.0.5.tgz",
+      "integrity": "sha512-eW057HT0lFgCKh8ilr0y2JaH2YbNcuEdFpxyg7Gf/qDKk9hqGMyXryZJ8iMGJEuKH0+wxS0ccSsBBB3W8yCn8w==",
+      "requires": {
+        "lodash": "~4.17.4",
+        "prop-types": "^15.6.0",
+        "raf": "^3.4.0",
+        "react-transition-group": "^2.5.0"
+      }
+    },
+    "react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "requires": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "reactcss": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+      "requires": {
+        "lodash": "^4.0.1"
+      }
+    },
+    "recharts": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-1.8.5.tgz",
+      "integrity": "sha512-tM9mprJbXVEBxjM7zHsIy6Cc41oO/pVYqyAsOHLxlJrbNBuLs0PHB3iys2M+RqCF0//k8nJtZF6X6swSkWY3tg==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "core-js": "^2.6.10",
+        "d3-interpolate": "^1.3.0",
+        "d3-scale": "^2.1.0",
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.5",
+        "prop-types": "^15.6.0",
+        "react-resize-detector": "^2.3.0",
+        "react-smooth": "^1.0.5",
+        "recharts-scale": "^0.4.2",
+        "reduce-css-calc": "^1.3.0"
+      }
+    },
+    "recharts-scale": {
       "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.3.tgz",
+      "integrity": "sha512-t8p5sccG9Blm7c1JQK/ak9O8o95WGhNXD7TXg/BW5bYbVlr6eCeRBNpgyigD4p6pSSMehC5nSvBUPj6F68rbFA==",
+      "requires": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "reduce-css-calc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+      "requires": {
+        "balanced-match": "^0.4.2",
+        "math-expression-evaluator": "^1.2.14",
+        "reduce-function-call": "^1.0.1"
+      }
+    },
+    "reduce-function-call": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.3.tgz",
+      "integrity": "sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==",
+      "requires": {
+        "balanced-match": "^1.0.0"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        }
+      }
+    },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      }
+    },
+    "redux-localstorage": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/redux-localstorage/-/redux-localstorage-0.4.1.tgz",
+      "integrity": "sha1-+vbXGcWBOXKU2BFHP/zt7gZckzw="
+    },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        }
+      }
+    },
+    "requirejs": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
+      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg=="
+    },
+    "reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "scheduler": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+      "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "seedrandom": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.4.tgz",
+      "integrity": "sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA=="
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "simplified-circulation-web": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.4.11.tgz",
+      "integrity": "sha512-+lgMVJ2q8PRFA4kNCVkcneUkjstk5A66dPYg4tUDEwppqgfGN6l6669VPcQ9VfjWSbU8M+jI00U7tgyACPdiPw==",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.4",
         "bootstrap": "^3.3.6",
@@ -16,7 +1282,7 @@
         "library-simplified-reusable-components": "1.3.16",
         "numeral": "^2.0.6",
         "opds-feed-parser": "0.0.17",
-        "opds-web-client": "0.3.2",
+        "opds-web-client": "0.3.4",
         "prop-types": "^15.7.2",
         "qs": "^6.2.0",
         "react": "^16.8.6",
@@ -30,8326 +1296,184 @@
         "redux": "^4.0.1",
         "redux-thunk": "^2.3.0",
         "request": "^2.85.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.5.0",
-          "bundled": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/runtime": {
-          "version": "7.5.4",
-          "bundled": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "@babel/runtime-corejs2": {
-          "version": "7.5.4",
-          "bundled": true,
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "@icons/material": {
-          "version": "0.2.4",
-          "bundled": true
-        },
-        "@nypl/dgx-svg-icons": {
-          "version": "0.3.4",
-          "bundled": true
-        },
-        "@sinonjs/commons": {
-          "version": "1.6.0",
-          "bundled": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          },
-          "dependencies": {
-            "type-detect": {
-              "version": "4.0.8",
-              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-              "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
-            }
-          }
-        },
-        "@sinonjs/formatio": {
-          "version": "3.2.2",
-          "bundled": true,
-          "requires": {
-            "@sinonjs/commons": "^1",
-            "@sinonjs/samsam": "^3.1.0"
-          }
-        },
-        "@sinonjs/samsam": {
-          "version": "3.3.3",
-          "bundled": true,
-          "requires": {
-            "@sinonjs/commons": "^1.3.0",
-            "array-from": "^2.1.1",
-            "lodash": "^4.17.15"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.17.15",
-              "bundled": true
-            }
-          }
-        },
-        "@sinonjs/text-encoding": {
-          "version": "0.7.1",
-          "bundled": true
-        },
-        "@types/events": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "@types/glob": {
-          "version": "7.1.1",
-          "bundled": true,
-          "requires": {
-            "@types/events": "*",
-            "@types/minimatch": "*",
-            "@types/node": "*"
-          }
-        },
-        "@types/minimatch": {
-          "version": "3.0.3",
-          "bundled": true
-        },
-        "@types/mocha": {
-          "version": "5.2.7",
-          "bundled": true
-        },
-        "@types/node": {
-          "version": "12.12.8",
-          "bundled": true
-        },
-        "@types/prop-types": {
-          "version": "15.7.3",
-          "bundled": true
-        },
-        "@types/react": {
-          "version": "16.9.11",
-          "bundled": true,
-          "requires": {
-            "@types/prop-types": "*",
-            "csstype": "^2.2.0"
-          }
-        },
-        "@webassemblyjs/ast": {
-          "version": "1.8.5",
-          "bundled": true,
-          "requires": {
-            "@webassemblyjs/helper-module-context": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/wast-parser": "1.8.5"
-          }
-        },
-        "@webassemblyjs/floating-point-hex-parser": {
-          "version": "1.8.5",
-          "bundled": true
-        },
-        "@webassemblyjs/helper-api-error": {
-          "version": "1.8.5",
-          "bundled": true
-        },
-        "@webassemblyjs/helper-buffer": {
-          "version": "1.8.5",
-          "bundled": true
-        },
-        "@webassemblyjs/helper-code-frame": {
-          "version": "1.8.5",
-          "bundled": true,
-          "requires": {
-            "@webassemblyjs/wast-printer": "1.8.5"
-          }
-        },
-        "@webassemblyjs/helper-fsm": {
-          "version": "1.8.5",
-          "bundled": true
-        },
-        "@webassemblyjs/helper-module-context": {
-          "version": "1.8.5",
-          "bundled": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "mamacro": "^0.0.3"
-          }
-        },
-        "@webassemblyjs/helper-wasm-bytecode": {
-          "version": "1.8.5",
-          "bundled": true
-        },
-        "@webassemblyjs/helper-wasm-section": {
-          "version": "1.8.5",
-          "bundled": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-buffer": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/wasm-gen": "1.8.5"
-          }
-        },
-        "@webassemblyjs/ieee754": {
-          "version": "1.8.5",
-          "bundled": true,
-          "requires": {
-            "@xtuc/ieee754": "^1.2.0"
-          }
-        },
-        "@webassemblyjs/leb128": {
-          "version": "1.8.5",
-          "bundled": true,
-          "requires": {
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "@webassemblyjs/utf8": {
-          "version": "1.8.5",
-          "bundled": true
-        },
-        "@webassemblyjs/wasm-edit": {
-          "version": "1.8.5",
-          "bundled": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-buffer": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/helper-wasm-section": "1.8.5",
-            "@webassemblyjs/wasm-gen": "1.8.5",
-            "@webassemblyjs/wasm-opt": "1.8.5",
-            "@webassemblyjs/wasm-parser": "1.8.5",
-            "@webassemblyjs/wast-printer": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wasm-gen": {
-          "version": "1.8.5",
-          "bundled": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/ieee754": "1.8.5",
-            "@webassemblyjs/leb128": "1.8.5",
-            "@webassemblyjs/utf8": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wasm-opt": {
-          "version": "1.8.5",
-          "bundled": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-buffer": "1.8.5",
-            "@webassemblyjs/wasm-gen": "1.8.5",
-            "@webassemblyjs/wasm-parser": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wasm-parser": {
-          "version": "1.8.5",
-          "bundled": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-api-error": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/ieee754": "1.8.5",
-            "@webassemblyjs/leb128": "1.8.5",
-            "@webassemblyjs/utf8": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wast-parser": {
-          "version": "1.8.5",
-          "bundled": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/floating-point-hex-parser": "1.8.5",
-            "@webassemblyjs/helper-api-error": "1.8.5",
-            "@webassemblyjs/helper-code-frame": "1.8.5",
-            "@webassemblyjs/helper-fsm": "1.8.5",
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "@webassemblyjs/wast-printer": {
-          "version": "1.8.5",
-          "bundled": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/wast-parser": "1.8.5",
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "@xtuc/ieee754": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "@xtuc/long": {
-          "version": "4.2.2",
-          "bundled": true
-        },
-        "abab": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "acorn": {
-          "version": "2.7.0",
-          "bundled": true
-        },
-        "acorn-globals": {
-          "version": "1.0.9",
-          "bundled": true,
-          "requires": {
-            "acorn": "^2.1.0"
-          }
-        },
-        "acorn-jsx": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "acorn": "^3.0.4"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "3.3.0",
-              "bundled": true
-            }
-          }
-        },
-        "agent-base": {
-          "version": "4.3.0",
-          "bundled": true,
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
-        "airbnb-prop-types": {
-          "version": "2.13.2",
-          "bundled": true,
-          "requires": {
-            "array.prototype.find": "^2.0.4",
-            "function.prototype.name": "^1.1.0",
-            "has": "^1.0.3",
-            "is-regex": "^1.0.4",
-            "object-is": "^1.0.1",
-            "object.assign": "^4.1.0",
-            "object.entries": "^1.1.0",
-            "prop-types": "^15.7.2",
-            "prop-types-exact": "^1.2.0",
-            "react-is": "^16.8.6"
-          }
-        },
-        "ajv": {
-          "version": "6.10.2",
-          "bundled": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "ajv-errors": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "ajv-keywords": {
-          "version": "3.4.1",
-          "bundled": true
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "ansi-colors": {
-          "version": "3.2.3",
-          "bundled": true
-        },
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "bundled": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "anymatch": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
-          },
-          "dependencies": {
-            "normalize-path": {
-              "version": "2.1.1",
-              "bundled": true,
-              "requires": {
-                "remove-trailing-separator": "^1.0.1"
-              }
-            }
-          }
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "argparse": {
-          "version": "1.0.10",
-          "bundled": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "arr-diff": {
-          "version": "4.0.0",
-          "bundled": true
-        },
-        "arr-flatten": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "arr-union": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "array-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "array-filter": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "array-find-index": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "array-from": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "array-union": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "array-uniq": "^1.0.1"
-          }
-        },
-        "array-uniq": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "array.prototype.find": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.13.0"
-          }
-        },
-        "array.prototype.flat": {
-          "version": "1.2.1",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "es-abstract": "^1.10.0",
-            "function-bind": "^1.1.1"
-          }
-        },
-        "asap": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "asn1": {
-          "version": "0.2.4",
-          "bundled": true,
-          "requires": {
-            "safer-buffer": "~2.1.0"
-          }
-        },
-        "asn1.js": {
-          "version": "4.10.1",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "assert": {
-          "version": "1.5.0",
-          "bundled": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "util": "0.10.3"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "util": {
-              "version": "0.10.3",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.1"
-              }
-            }
-          }
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "assertion-error": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "assign-symbols": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ast-types": {
-          "version": "0.13.2",
-          "bundled": true
-        },
-        "async": {
-          "version": "2.6.3",
-          "bundled": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
-        "async-each": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "async-foreach": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "atob": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.8.0",
-          "bundled": true
-        },
-        "axe-core": {
-          "version": "3.4.0",
-          "bundled": true
-        },
-        "babel-polyfill": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "^6.26.0",
-            "core-js": "^2.5.0",
-            "regenerator-runtime": "^0.10.5"
-          },
-          "dependencies": {
-            "regenerator-runtime": {
-              "version": "0.10.5",
-              "bundled": true
-            }
-          }
-        },
-        "babel-runtime": {
-          "version": "6.26.0",
-          "bundled": true,
-          "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
-          },
-          "dependencies": {
-            "regenerator-runtime": {
-              "version": "0.11.1",
-              "bundled": true
-            }
-          }
-        },
-        "backbone": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "underscore": ">=1.8.3"
-          }
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "base": {
-          "version": "0.11.2",
-          "bundled": true,
-          "requires": {
-            "cache-base": "^1.0.1",
-            "class-utils": "^0.3.5",
-            "component-emitter": "^1.2.1",
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.1",
-            "mixin-deep": "^1.2.0",
-            "pascalcase": "^0.1.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            }
-          }
-        },
-        "base64-js": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "tweetnacl": "^0.14.3"
-          }
-        },
-        "big.js": {
-          "version": "5.2.2",
-          "bundled": true
-        },
-        "binary-extensions": {
-          "version": "1.13.1",
-          "bundled": true
-        },
-        "bl": {
-          "version": "2.2.0",
-          "bundled": true,
-          "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              },
-              "dependencies": {
-                "safe-buffer": {
-                  "version": "5.1.2",
-                  "bundled": true
-                }
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              },
-              "dependencies": {
-                "safe-buffer": {
-                  "version": "5.1.2",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "~2.0.0"
-          }
-        },
-        "bluebird": {
-          "version": "3.5.5",
-          "bundled": true
-        },
-        "bn.js": {
-          "version": "4.11.8",
-          "bundled": true
-        },
-        "boolbase": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "bootstrap": {
-          "version": "3.4.1",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          },
-          "dependencies": {
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "braces": {
-          "version": "2.3.2",
-          "bundled": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "brorand": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "browser-stdout": {
-          "version": "1.3.1",
-          "bundled": true
-        },
-        "browserify-aes": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "buffer-xor": "^1.0.3",
-            "cipher-base": "^1.0.0",
-            "create-hash": "^1.1.0",
-            "evp_bytestokey": "^1.0.3",
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "browserify-cipher": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "browserify-aes": "^1.0.4",
-            "browserify-des": "^1.0.0",
-            "evp_bytestokey": "^1.0.0"
-          }
-        },
-        "browserify-des": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "cipher-base": "^1.0.1",
-            "des.js": "^1.0.0",
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.1.2"
-          }
-        },
-        "browserify-rsa": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.1.0",
-            "randombytes": "^2.0.1"
-          }
-        },
-        "browserify-sign": {
-          "version": "4.0.4",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.1.1",
-            "browserify-rsa": "^4.0.0",
-            "create-hash": "^1.1.0",
-            "create-hmac": "^1.1.2",
-            "elliptic": "^6.0.0",
-            "inherits": "^2.0.1",
-            "parse-asn1": "^5.0.0"
-          }
-        },
-        "browserify-zlib": {
-          "version": "0.2.0",
-          "bundled": true,
-          "requires": {
-            "pako": "~1.0.5"
-          }
-        },
-        "buffer": {
-          "version": "4.9.1",
-          "bundled": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "buffer-crc32": {
-          "version": "0.2.13",
-          "bundled": true
-        },
-        "buffer-from": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "buffer-xor": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "builtin-status-codes": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "bytes": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "cacache": {
-          "version": "11.3.3",
-          "bundled": true,
-          "requires": {
-            "bluebird": "^3.5.5",
-            "chownr": "^1.1.1",
-            "figgy-pudding": "^3.5.1",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.1.15",
-            "lru-cache": "^5.1.1",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.3",
-            "ssri": "^6.0.1",
-            "unique-filename": "^1.1.1",
-            "y18n": "^4.0.0"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "5.1.1",
-              "bundled": true,
-              "requires": {
-                "yallist": "^3.0.2"
-              }
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "yallist": {
-              "version": "3.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "cache-base": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "collection-visit": "^1.0.0",
-            "component-emitter": "^1.2.1",
-            "get-value": "^2.0.6",
-            "has-value": "^1.0.0",
-            "isobject": "^3.0.1",
-            "set-value": "^2.0.0",
-            "to-object-path": "^0.3.0",
-            "union-value": "^1.0.0",
-            "unset-value": "^1.0.0"
-          }
-        },
-        "caller-path": {
-          "version": "0.1.0",
-          "bundled": true,
-          "requires": {
-            "callsites": "^0.2.0"
-          }
-        },
-        "callsites": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "bundled": true
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "2.1.1",
-              "bundled": true
-            }
-          }
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "chai": {
-          "version": "4.2.0",
-          "bundled": true,
-          "requires": {
-            "assertion-error": "^1.1.0",
-            "check-error": "^1.0.2",
-            "deep-eql": "^3.0.1",
-            "get-func-name": "^2.0.0",
-            "pathval": "^1.1.0",
-            "type-detect": "^4.0.5"
-          },
-          "dependencies": {
-            "deep-eql": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "type-detect": "^4.0.0"
-              }
-            }
-          }
-        },
-        "chai-nightwatch": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "assertion-error": "1.0.0",
-            "deep-eql": "0.1.3"
-          },
-          "dependencies": {
-            "assertion-error": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "bundled": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "bundled": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "check-error": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cheerio": {
-          "version": "1.0.0-rc.3",
-          "bundled": true,
-          "requires": {
-            "css-select": "~1.2.0",
-            "dom-serializer": "~0.1.1",
-            "entities": "~1.1.1",
-            "htmlparser2": "^3.9.1",
-            "lodash": "^4.15.0",
-            "parse5": "^3.0.1"
-          },
-          "dependencies": {
-            "parse5": {
-              "version": "3.0.3",
-              "bundled": true,
-              "requires": {
-                "@types/node": "*"
-              }
-            }
-          }
-        },
-        "chokidar": {
-          "version": "2.1.6",
-          "bundled": true,
-          "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.1",
-            "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.3",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^3.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.2.1",
-            "upath": "^1.1.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "chrome-trace-event": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
-        "cipher-base": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "circular-json": {
-          "version": "0.3.3",
-          "bundled": true
-        },
-        "class-utils": {
-          "version": "0.3.6",
-          "bundled": true,
-          "requires": {
-            "arr-union": "^3.1.0",
-            "define-property": "^0.2.5",
-            "isobject": "^3.0.0",
-            "static-extend": "^0.1.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            }
-          }
-        },
-        "classnames": {
-          "version": "2.2.6",
-          "bundled": true
-        },
-        "clean-webpack-plugin": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "del": "^4.0.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "restore-cursor": "^1.0.1"
-          }
-        },
-        "cli-width": {
-          "version": "2.2.0",
-          "bundled": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "bundled": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "clone-deep": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "for-own": "^1.0.0",
-            "is-plain-object": "^2.0.4",
-            "kind-of": "^6.0.0",
-            "shallow-clone": "^1.0.0"
-          }
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "collection-visit": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "map-visit": "^1.0.0",
-            "object-visit": "^1.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "bundled": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.8",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.20.0",
-          "bundled": true
-        },
-        "commondir": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "component-emitter": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "concat-stream": {
-          "version": "1.6.2",
-          "bundled": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "console-browserify": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "date-now": "^0.1.4"
-          }
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "constants-browserify": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "content-type-parser": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "copy-concurrently": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "aproba": "^1.1.1",
-            "fs-write-stream-atomic": "^1.0.8",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.0"
-          }
-        },
-        "copy-descriptor": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "core-js": {
-          "version": "2.6.9",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "create-ecdh": {
-          "version": "4.0.3",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.1.0",
-            "elliptic": "^6.0.0"
-          }
-        },
-        "create-hash": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "cipher-base": "^1.0.1",
-            "inherits": "^2.0.1",
-            "md5.js": "^1.3.4",
-            "ripemd160": "^2.0.1",
-            "sha.js": "^2.4.0"
-          }
-        },
-        "create-hmac": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "cipher-base": "^1.0.3",
-            "create-hash": "^1.1.0",
-            "inherits": "^2.0.1",
-            "ripemd160": "^2.0.0",
-            "safe-buffer": "^5.0.1",
-            "sha.js": "^2.4.8"
-          }
-        },
-        "create-react-class": {
-          "version": "15.6.3",
-          "bundled": true,
-          "requires": {
-            "fbjs": "^0.8.9",
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          },
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.17",
-              "bundled": true,
-              "requires": {
-                "core-js": "^1.0.0",
-                "isomorphic-fetch": "^2.1.1",
-                "loose-envify": "^1.0.0",
-                "object-assign": "^4.1.0",
-                "promise": "^7.1.1",
-                "setimmediate": "^1.0.5",
-                "ua-parser-js": "^0.7.18"
-              }
-            }
-          }
-        },
-        "cross-spawn": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
-          }
-        },
-        "crypto-browserify": {
-          "version": "3.12.0",
-          "bundled": true,
-          "requires": {
-            "browserify-cipher": "^1.0.0",
-            "browserify-sign": "^4.0.0",
-            "create-ecdh": "^4.0.0",
-            "create-hash": "^1.1.0",
-            "create-hmac": "^1.1.0",
-            "diffie-hellman": "^5.0.0",
-            "inherits": "^2.0.1",
-            "pbkdf2": "^3.0.3",
-            "public-encrypt": "^4.0.0",
-            "randombytes": "^2.0.0",
-            "randomfill": "^1.0.3"
-          }
-        },
-        "css-loader": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "camelcase": "^5.2.0",
-            "icss-utils": "^4.1.0",
-            "loader-utils": "^1.2.3",
-            "normalize-path": "^3.0.0",
-            "postcss": "^7.0.14",
-            "postcss-modules-extract-imports": "^2.0.0",
-            "postcss-modules-local-by-default": "^2.0.6",
-            "postcss-modules-scope": "^2.1.0",
-            "postcss-modules-values": "^2.0.0",
-            "postcss-value-parser": "^3.3.0",
-            "schema-utils": "^1.0.0"
-          }
-        },
-        "css-select": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "boolbase": "~1.0.0",
-            "css-what": "2.1",
-            "domutils": "1.5.1",
-            "nth-check": "~1.0.1"
-          }
-        },
-        "css-what": {
-          "version": "2.1.3",
-          "bundled": true
-        },
-        "cssesc": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "cssom": {
-          "version": "0.3.8",
-          "bundled": true
-        },
-        "cssstyle": {
-          "version": "0.2.37",
-          "bundled": true,
-          "requires": {
-            "cssom": "0.3.x"
-          }
-        },
-        "csstype": {
-          "version": "2.6.7",
-          "bundled": true
-        },
-        "currently-unhandled": {
-          "version": "0.4.1",
-          "bundled": true,
-          "requires": {
-            "array-find-index": "^1.0.1"
-          }
-        },
-        "cyclist": {
-          "version": "0.2.2",
-          "bundled": true
-        },
-        "d": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "es5-ext": "^0.10.50",
-            "type": "^1.0.1"
-          }
-        },
-        "d3-array": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "d3-collection": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "d3-color": {
-          "version": "1.2.8",
-          "bundled": true
-        },
-        "d3-format": {
-          "version": "1.3.2",
-          "bundled": true
-        },
-        "d3-interpolate": {
-          "version": "1.3.2",
-          "bundled": true,
-          "requires": {
-            "d3-color": "1"
-          }
-        },
-        "d3-path": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "d3-scale": {
-          "version": "2.2.2",
-          "bundled": true,
-          "requires": {
-            "d3-array": "^1.2.0",
-            "d3-collection": "1",
-            "d3-format": "1",
-            "d3-interpolate": "1",
-            "d3-time": "1",
-            "d3-time-format": "2"
-          }
-        },
-        "d3-shape": {
-          "version": "1.3.5",
-          "bundled": true,
-          "requires": {
-            "d3-path": "1"
-          }
-        },
-        "d3-time": {
-          "version": "1.0.11",
-          "bundled": true
-        },
-        "d3-time-format": {
-          "version": "2.1.3",
-          "bundled": true,
-          "requires": {
-            "d3-time": "1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
-        },
-        "data-uri-to-buffer": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "@types/node": "^8.0.7"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "8.10.50",
-              "bundled": true
-            }
-          }
-        },
-        "date-now": {
-          "version": "0.1.4",
-          "bundled": true
-        },
-        "debug": {
-          "version": "3.2.6",
-          "bundled": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "decimal.js-light": {
-          "version": "2.5.0",
-          "bundled": true
-        },
-        "decode-uri-component": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "deep-eql": {
-          "version": "0.1.3",
-          "bundled": true,
-          "requires": {
-            "type-detect": "0.1.1"
-          },
-          "dependencies": {
-            "type-detect": {
-              "version": "0.1.1",
-              "bundled": true
-            }
-          }
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "define-properties": {
-          "version": "1.1.3",
-          "bundled": true,
-          "requires": {
-            "object-keys": "^1.0.12"
-          }
-        },
-        "define-property": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "is-descriptor": "^1.0.2",
-            "isobject": "^3.0.1"
-          },
-          "dependencies": {
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            }
-          }
-        },
-        "degenerator": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "ast-types": "0.x.x",
-            "escodegen": "1.x.x",
-            "esprima": "3.x.x"
-          }
-        },
-        "del": {
-          "version": "4.1.1",
-          "bundled": true,
-          "requires": {
-            "@types/glob": "^7.1.1",
-            "globby": "^6.1.0",
-            "is-path-cwd": "^2.0.0",
-            "is-path-in-cwd": "^2.0.0",
-            "p-map": "^2.0.0",
-            "pify": "^4.0.1",
-            "rimraf": "^2.6.3"
-          }
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "depd": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "des.js": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "detect-file": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "diff": {
-          "version": "3.5.0",
-          "bundled": true
-        },
-        "diffie-hellman": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.1.0",
-            "miller-rabin": "^4.0.0",
-            "randombytes": "^2.0.0"
-          }
-        },
-        "discontinuous-range": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "doctrine": {
-          "version": "1.5.0",
-          "bundled": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "dom-helpers": {
-          "version": "3.4.0",
-          "bundled": true,
-          "requires": {
-            "@babel/runtime": "^7.1.2"
-          }
-        },
-        "dom-serializer": {
-          "version": "0.1.1",
-          "bundled": true,
-          "requires": {
-            "domelementtype": "^1.3.0",
-            "entities": "^1.1.1"
-          }
-        },
-        "domain-browser": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "domelementtype": {
-          "version": "1.3.1",
-          "bundled": true
-        },
-        "domhandler": {
-          "version": "2.4.2",
-          "bundled": true,
-          "requires": {
-            "domelementtype": "1"
-          }
-        },
-        "dompurify": {
-          "version": "0.8.9",
-          "bundled": true
-        },
-        "domutils": {
-          "version": "1.5.1",
-          "bundled": true,
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          }
-        },
-        "dotenv": {
-          "version": "7.0.0",
-          "bundled": true
-        },
-        "downloadjs": {
-          "version": "1.4.7",
-          "bundled": true
-        },
-        "draft-convert": {
-          "version": "2.1.5",
-          "bundled": true,
-          "requires": {
-            "immutable": "~3.7.4",
-            "invariant": "^2.2.1"
-          }
-        },
-        "draft-js": {
-          "version": "0.11.2",
-          "bundled": true,
-          "requires": {
-            "fbjs": "^1.0.0",
-            "immutable": "~3.7.4",
-            "object-assign": "^4.1.0"
-          }
-        },
-        "duplexify": {
-          "version": "3.7.1",
-          "bundled": true,
-          "requires": {
-            "end-of-stream": "^1.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0",
-            "stream-shift": "^1.0.0"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "ecc-jsbn": {
-          "version": "0.1.2",
-          "bundled": true,
-          "requires": {
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.1.0"
-          }
-        },
-        "ejs": {
-          "version": "2.6.2",
-          "bundled": true
-        },
-        "elliptic": {
-          "version": "6.5.0",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "bundled": true
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "~0.4.13"
-          }
-        },
-        "end-of-stream": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "once": "^1.4.0"
-          }
-        },
-        "enhanced-resolve": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "memory-fs": "^0.4.0",
-            "tapable": "^1.0.0"
-          }
-        },
-        "entities": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "enzyme": {
-          "version": "3.10.0",
-          "bundled": true,
-          "requires": {
-            "array.prototype.flat": "^1.2.1",
-            "cheerio": "^1.0.0-rc.2",
-            "function.prototype.name": "^1.1.0",
-            "has": "^1.0.3",
-            "html-element-map": "^1.0.0",
-            "is-boolean-object": "^1.0.0",
-            "is-callable": "^1.1.4",
-            "is-number-object": "^1.0.3",
-            "is-regex": "^1.0.4",
-            "is-string": "^1.0.4",
-            "is-subset": "^0.1.1",
-            "lodash.escape": "^4.0.1",
-            "lodash.isequal": "^4.5.0",
-            "object-inspect": "^1.6.0",
-            "object-is": "^1.0.1",
-            "object.assign": "^4.1.0",
-            "object.entries": "^1.0.4",
-            "object.values": "^1.0.4",
-            "raf": "^3.4.0",
-            "rst-selector-parser": "^2.2.3",
-            "string.prototype.trim": "^1.1.2"
-          }
-        },
-        "enzyme-adapter-react-16": {
-          "version": "1.14.0",
-          "bundled": true,
-          "requires": {
-            "enzyme-adapter-utils": "^1.12.0",
-            "has": "^1.0.3",
-            "object.assign": "^4.1.0",
-            "object.values": "^1.1.0",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.6",
-            "react-test-renderer": "^16.0.0-0",
-            "semver": "^5.7.0"
-          }
-        },
-        "enzyme-adapter-utils": {
-          "version": "1.12.0",
-          "bundled": true,
-          "requires": {
-            "airbnb-prop-types": "^2.13.2",
-            "function.prototype.name": "^1.1.0",
-            "object.assign": "^4.1.0",
-            "object.fromentries": "^2.0.0",
-            "prop-types": "^15.7.2",
-            "semver": "^5.6.0"
-          }
-        },
-        "errno": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "prr": "~1.0.1"
-          }
-        },
-        "error-ex": {
-          "version": "1.3.2",
-          "bundled": true,
-          "requires": {
-            "is-arrayish": "^0.2.1"
-          }
-        },
-        "es-abstract": {
-          "version": "1.13.0",
-          "bundled": true,
-          "requires": {
-            "es-to-primitive": "^1.2.0",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "is-callable": "^1.1.4",
-            "is-regex": "^1.0.4",
-            "object-keys": "^1.0.12"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "es5-ext": {
-          "version": "0.10.50",
-          "bundled": true,
-          "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.1",
-            "next-tick": "^1.0.0"
-          }
-        },
-        "es6-iterator": {
-          "version": "2.0.3",
-          "bundled": true,
-          "requires": {
-            "d": "1",
-            "es5-ext": "^0.10.35",
-            "es6-symbol": "^3.1.1"
-          }
-        },
-        "es6-map": {
-          "version": "0.1.5",
-          "bundled": true,
-          "requires": {
-            "d": "1",
-            "es5-ext": "~0.10.14",
-            "es6-iterator": "~2.0.1",
-            "es6-set": "~0.1.5",
-            "es6-symbol": "~3.1.1",
-            "event-emitter": "~0.3.5"
-          }
-        },
-        "es6-promise": {
-          "version": "4.2.8",
-          "bundled": true
-        },
-        "es6-promisify": {
-          "version": "5.0.0",
-          "bundled": true,
-          "requires": {
-            "es6-promise": "^4.0.3"
-          }
-        },
-        "es6-set": {
-          "version": "0.1.5",
-          "bundled": true,
-          "requires": {
-            "d": "1",
-            "es5-ext": "~0.10.14",
-            "es6-iterator": "~2.0.1",
-            "es6-symbol": "3.1.1",
-            "event-emitter": "~0.3.5"
-          }
-        },
-        "es6-symbol": {
-          "version": "3.1.1",
-          "bundled": true,
-          "requires": {
-            "d": "1",
-            "es5-ext": "~0.10.14"
-          }
-        },
-        "es6-weak-map": {
-          "version": "2.0.3",
-          "bundled": true,
-          "requires": {
-            "d": "1",
-            "es5-ext": "^0.10.46",
-            "es6-iterator": "^2.0.3",
-            "es6-symbol": "^3.1.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "escodegen": {
-          "version": "1.11.1",
-          "bundled": true,
-          "requires": {
-            "esprima": "^3.1.3",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
-          }
-        },
-        "escope": {
-          "version": "3.6.0",
-          "bundled": true,
-          "requires": {
-            "es6-map": "^0.1.3",
-            "es6-weak-map": "^2.0.1",
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "eslint": {
-          "version": "2.13.1",
-          "bundled": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "concat-stream": "^1.4.6",
-            "debug": "^2.1.1",
-            "doctrine": "^1.2.2",
-            "es6-map": "^0.1.3",
-            "escope": "^3.6.0",
-            "espree": "^3.1.6",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "file-entry-cache": "^1.1.1",
-            "glob": "^7.0.3",
-            "globals": "^9.2.0",
-            "ignore": "^3.1.2",
-            "imurmurhash": "^0.1.4",
-            "inquirer": "^0.12.0",
-            "is-my-json-valid": "^2.10.0",
-            "is-resolvable": "^1.0.0",
-            "js-yaml": "^3.5.1",
-            "json-stable-stringify": "^1.0.0",
-            "levn": "^0.3.0",
-            "lodash": "^4.0.0",
-            "mkdirp": "^0.5.0",
-            "optionator": "^0.8.1",
-            "path-is-absolute": "^1.0.0",
-            "path-is-inside": "^1.0.1",
-            "pluralize": "^1.2.1",
-            "progress": "^1.1.8",
-            "require-uncached": "^1.0.2",
-            "shelljs": "^0.6.0",
-            "strip-json-comments": "~1.0.1",
-            "table": "^3.7.8",
-            "text-table": "~0.2.0",
-            "user-home": "^2.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "eslint-scope": {
-          "version": "4.0.3",
-          "bundled": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "espree": {
-          "version": "3.5.4",
-          "bundled": true,
-          "requires": {
-            "acorn": "^5.5.0",
-            "acorn-jsx": "^3.0.0"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "5.7.3",
-              "bundled": true
-            }
-          }
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "bundled": true
-        },
-        "esrecurse": {
-          "version": "4.2.1",
-          "bundled": true,
-          "requires": {
-            "estraverse": "^4.1.0"
-          }
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "event-emitter": {
-          "version": "0.3.5",
-          "bundled": true,
-          "requires": {
-            "d": "1",
-            "es5-ext": "~0.10.14"
-          }
-        },
-        "events": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "evp_bytestokey": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "md5.js": "^1.3.4",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "execa": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "6.0.5",
-              "bundled": true,
-              "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            }
-          }
-        },
-        "exit-hook": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "bundled": true,
-          "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "expand-tilde": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "homedir-polyfill": "^1.0.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "extend-shallow": {
-          "version": "3.0.2",
-          "bundled": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "bundled": true,
-          "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            }
-          }
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "fbjs": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "core-js": "^2.4.1",
-            "fbjs-css-vars": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        },
-        "fbjs-css-vars": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "fd-slicer": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "pend": "~1.2.0"
-          }
-        },
-        "fetch-mock": {
-          "version": "7.3.6",
-          "bundled": true,
-          "requires": {
-            "babel-polyfill": "^6.26.0",
-            "core-js": "^2.6.9",
-            "glob-to-regexp": "^0.4.0",
-            "path-to-regexp": "^2.2.1",
-            "whatwg-url": "^6.5.0"
-          },
-          "dependencies": {
-            "tr46": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "punycode": "^2.1.0"
-              }
-            },
-            "webidl-conversions": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "whatwg-url": {
-              "version": "6.5.0",
-              "bundled": true,
-              "requires": {
-                "lodash.sortby": "^4.7.0",
-                "tr46": "^1.0.1",
-                "webidl-conversions": "^4.0.2"
-              }
-            }
-          }
-        },
-        "figgy-pudding": {
-          "version": "3.5.1",
-          "bundled": true
-        },
-        "figures": {
-          "version": "1.7.0",
-          "bundled": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
-          }
-        },
-        "file-entry-cache": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "flat-cache": "^1.2.1",
-            "object-assign": "^4.0.1"
-          }
-        },
-        "file-loader": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "loader-utils": "^1.0.2",
-            "schema-utils": "^1.0.0"
-          }
-        },
-        "file-uri-to-path": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "find-cache-dir": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^2.0.0",
-            "pkg-dir": "^3.0.0"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "bundled": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "flat": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "is-buffer": "~2.0.3"
-          },
-          "dependencies": {
-            "is-buffer": {
-              "version": "2.0.4",
-              "bundled": true
-            }
-          }
-        },
-        "flat-cache": {
-          "version": "1.3.4",
-          "bundled": true,
-          "requires": {
-            "circular-json": "^0.3.1",
-            "graceful-fs": "^4.1.2",
-            "rimraf": "~2.6.2",
-            "write": "^0.2.1"
-          }
-        },
-        "flush-write-stream": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.3.6"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "follow-redirects": {
-          "version": "1.7.0",
-          "bundled": true,
-          "requires": {
-            "debug": "^3.2.6"
-          }
-        },
-        "font-awesome": {
-          "version": "4.7.0",
-          "bundled": true
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "for-own": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "for-in": "^1.0.1"
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "fragment-cache": {
-          "version": "0.2.1",
-          "bundled": true,
-          "requires": {
-            "map-cache": "^0.2.2"
-          }
-        },
-        "from2": {
-          "version": "2.3.0",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "front-matter": {
-          "version": "2.1.2",
-          "bundled": true,
-          "requires": {
-            "js-yaml": "^3.4.6"
-          }
-        },
-        "fs-constants": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fs-extra": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^3.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "fs-write-stream-atomic": {
-          "version": "1.0.10",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "iferr": "^0.1.5",
-            "imurmurhash": "^0.1.4",
-            "readable-stream": "1 || 2"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fsevents": {
-          "version": "1.2.9",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "nan": "^2.12.1",
-            "node-pre-gyp": "^0.12.0"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-              }
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "brace-expansion": {
-              "version": "1.1.11",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "chownr": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "debug": {
-              "version": "4.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "deep-extend": {
-              "version": "0.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "detect-libc": {
-              "version": "1.0.3",
-              "bundled": true,
-              "optional": true
-            },
-            "fs-minipass": {
-              "version": "1.2.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              }
-            },
-            "glob": {
-              "version": "7.1.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "iconv-lite": {
-              "version": "0.4.24",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-              }
-            },
-            "ignore-walk": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "minimatch": "^3.0.4"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true,
-              "optional": true
-            },
-            "ini": {
-              "version": "1.3.5",
-              "bundled": true,
-              "optional": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true,
-              "optional": true
-            },
-            "minipass": {
-              "version": "2.3.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            },
-            "minizlib": {
-              "version": "1.2.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "needle": {
-              "version": "2.3.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "debug": "^4.1.0",
-                "iconv-lite": "^0.4.4",
-                "sax": "^1.2.4"
-              }
-            },
-            "node-pre-gyp": {
-              "version": "0.12.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "detect-libc": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "needle": "^2.2.1",
-                "nopt": "^4.0.1",
-                "npm-packlist": "^1.1.6",
-                "npmlog": "^4.0.2",
-                "rc": "^1.2.7",
-                "rimraf": "^2.6.1",
-                "semver": "^5.3.0",
-                "tar": "^4"
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "npm-bundled": {
-              "version": "1.0.6",
-              "bundled": true,
-              "optional": true
-            },
-            "npm-packlist": {
-              "version": "1.4.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "osenv": {
-              "version": "0.1.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "rc": {
-              "version": "1.2.8",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "safer-buffer": {
-              "version": "2.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true,
-              "optional": true
-            },
-            "semver": {
-              "version": "5.7.0",
-              "bundled": true,
-              "optional": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "4.4.8",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "chownr": "^1.1.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.4",
-                "minizlib": "^1.1.1",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.2"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "wide-align": {
-              "version": "1.1.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "string-width": "^1.0.2 || 2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "yallist": {
-              "version": "3.0.3",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "fstream": {
-          "version": "1.0.12",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
-          }
-        },
-        "ftp": {
-          "version": "0.3.10",
-          "bundled": true,
-          "requires": {
-            "readable-stream": "1.1.x",
-            "xregexp": "2.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.1.14",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "bundled": true
-            }
-          }
-        },
-        "function-bind": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "function.prototype.name": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "function-bind": "^1.1.1",
-            "is-callable": "^1.1.3"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "gaze": {
-          "version": "1.1.3",
-          "bundled": true,
-          "requires": {
-            "globule": "^1.0.0"
-          }
-        },
-        "generate-function": {
-          "version": "2.3.1",
-          "bundled": true,
-          "requires": {
-            "is-property": "^1.0.2"
-          }
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "is-property": "^1.0.0"
-          }
-        },
-        "get-caller-file": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "get-func-name": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "bundled": true
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "get-uri": {
-          "version": "2.0.3",
-          "bundled": true,
-          "requires": {
-            "data-uri-to-buffer": "2",
-            "debug": "4",
-            "extend": "~3.0.2",
-            "file-uri-to-path": "1",
-            "ftp": "~0.3.10",
-            "readable-stream": "3"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
-          }
-        },
-        "get-value": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.4",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "^2.1.0"
-              }
-            }
-          }
-        },
-        "glob-to-regexp": {
-          "version": "0.4.1",
-          "bundled": true
-        },
-        "global-modules": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "global-prefix": "^3.0.0"
-          },
-          "dependencies": {
-            "global-prefix": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "ini": "^1.3.5",
-                "kind-of": "^6.0.2",
-                "which": "^1.3.1"
-              }
-            }
-          }
-        },
-        "global-prefix": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "expand-tilde": "^2.0.2",
-            "homedir-polyfill": "^1.0.1",
-            "ini": "^1.3.4",
-            "is-windows": "^1.0.1",
-            "which": "^1.2.14"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "bundled": true
-        },
-        "globby": {
-          "version": "6.1.0",
-          "bundled": true,
-          "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "bundled": true
-            }
-          }
-        },
-        "globule": {
-          "version": "1.2.1",
-          "bundled": true,
-          "requires": {
-            "glob": "~7.1.1",
-            "lodash": "~4.17.10",
-            "minimatch": "~3.0.2"
-          }
-        },
-        "gonzales-pe-sl": {
-          "version": "4.2.3",
-          "bundled": true,
-          "requires": {
-            "minimist": "1.1.x"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.1.3",
-              "bundled": true
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "growl": {
-          "version": "1.10.5",
-          "bundled": true
-        },
-        "handlebars": {
-          "version": "4.5.2",
-          "bundled": true,
-          "requires": {
-            "neo-async": "^2.6.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.1.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "^6.5.5",
-            "har-schema": "^2.0.0"
-          }
-        },
-        "has": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "function-bind": "^1.1.1"
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "has-symbols": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "has-value": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "get-value": "^2.0.6",
-            "has-values": "^1.0.0",
-            "isobject": "^3.0.0"
-          }
-        },
-        "has-values": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "hash-base": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "hash.js": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.1"
-          }
-        },
-        "he": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "highlight.js": {
-          "version": "9.16.2",
-          "bundled": true
-        },
-        "history": {
-          "version": "3.3.0",
-          "bundled": true,
-          "requires": {
-            "invariant": "^2.2.1",
-            "loose-envify": "^1.2.0",
-            "query-string": "^4.2.2",
-            "warning": "^3.0.0"
-          }
-        },
-        "hmac-drbg": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "hash.js": "^1.0.3",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.1"
-          }
-        },
-        "hoist-non-react-statics": {
-          "version": "3.3.0",
-          "bundled": true,
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        },
-        "homedir-polyfill": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "parse-passwd": "^1.0.0"
-          }
-        },
-        "hosted-git-info": {
-          "version": "2.7.1",
-          "bundled": true
-        },
-        "html-element-map": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "array-filter": "^1.0.0"
-          }
-        },
-        "html-encoding-sniffer": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "whatwg-encoding": "^1.0.1"
-          }
-        },
-        "htmlparser2": {
-          "version": "3.10.1",
-          "bundled": true,
-          "requires": {
-            "domelementtype": "^1.3.1",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^3.1.1"
-          }
-        },
-        "http-errors": {
-          "version": "1.7.3",
-          "bundled": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.4",
-            "setprototypeof": "1.1.1",
-            "statuses": ">= 1.5.0 < 2",
-            "toidentifier": "1.0.0"
-          }
-        },
-        "http-proxy-agent": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "agent-base": "4",
-            "debug": "3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "https-browserify": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "https-proxy-agent": {
-          "version": "2.2.2",
-          "bundled": true,
-          "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "icss-replace-symbols": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "icss-utils": {
-          "version": "4.1.1",
-          "bundled": true,
-          "requires": {
-            "postcss": "^7.0.14"
-          }
-        },
-        "ieee754": {
-          "version": "1.1.13",
-          "bundled": true
-        },
-        "iferr": {
-          "version": "0.1.5",
-          "bundled": true
-        },
-        "ignore": {
-          "version": "3.3.10",
-          "bundled": true
-        },
-        "immutable": {
-          "version": "3.7.6",
-          "bundled": true
-        },
-        "import-local": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "pkg-dir": "^3.0.0",
-            "resolve-cwd": "^2.0.0"
-          }
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true
-        },
-        "in-publish": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "repeating": "^2.0.0"
-          }
-        },
-        "indexes-of": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true
-        },
-        "inquirer": {
-          "version": "0.12.0",
-          "bundled": true,
-          "requires": {
-            "ansi-escapes": "^1.1.0",
-            "ansi-regex": "^2.0.0",
-            "chalk": "^1.0.0",
-            "cli-cursor": "^1.0.1",
-            "cli-width": "^2.0.0",
-            "figures": "^1.3.5",
-            "lodash": "^4.3.0",
-            "readline2": "^1.0.1",
-            "run-async": "^0.1.0",
-            "rx-lite": "^3.1.2",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.0",
-            "through": "^2.3.6"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "interpret": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "invariant": {
-          "version": "2.2.4",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ip": {
-          "version": "1.1.5",
-          "bundled": true
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "bundled": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true
-        },
-        "is-binary-path": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "binary-extensions": "^1.0.0"
-          }
-        },
-        "is-boolean-object": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-buffer": {
-          "version": "1.1.6",
-          "bundled": true
-        },
-        "is-callable": {
-          "version": "1.1.4",
-          "bundled": true
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "bundled": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-date-object": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "bundled": true,
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "bundled": true
-            }
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "is-glob": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "is-my-ip-valid": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-my-json-valid": {
-          "version": "2.20.0",
-          "bundled": true,
-          "requires": {
-            "generate-function": "^2.0.0",
-            "generate-object-property": "^1.1.0",
-            "is-my-ip-valid": "^1.0.0",
-            "jsonpointer": "^4.0.0",
-            "xtend": "^4.0.0"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-number-object": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "is-path-cwd": {
-          "version": "2.2.0",
-          "bundled": true
-        },
-        "is-path-in-cwd": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "is-path-inside": "^2.1.0"
-          }
-        },
-        "is-path-inside": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "path-is-inside": "^1.0.2"
-          }
-        },
-        "is-plain-object": {
-          "version": "2.0.4",
-          "bundled": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "is-regex": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "has": "^1.0.1"
-          }
-        },
-        "is-resolvable": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-string": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "is-subset": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "is-symbol": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "has-symbols": "^1.0.0"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "bundled": true
-        },
-        "is-windows": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "is-wsl": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "node-fetch": "^1.0.1",
-            "whatwg-fetch": ">=0.10.0"
-          }
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "jquery": {
-          "version": "3.4.1",
-          "bundled": true
-        },
-        "js-base64": {
-          "version": "2.5.1",
-          "bundled": true
-        },
-        "js-cookie": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "bundled": true
-        },
-        "js-yaml": {
-          "version": "3.13.1",
-          "bundled": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          },
-          "dependencies": {
-            "esprima": {
-              "version": "4.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "jsdom": {
-          "version": "9.9.1",
-          "bundled": true,
-          "requires": {
-            "abab": "^1.0.0",
-            "acorn": "^2.4.0",
-            "acorn-globals": "^1.0.4",
-            "array-equal": "^1.0.0",
-            "content-type-parser": "^1.0.1",
-            "cssom": ">= 0.3.0 < 0.4.0",
-            "cssstyle": ">= 0.2.36 < 0.3.0",
-            "escodegen": "^1.6.1",
-            "html-encoding-sniffer": "^1.0.1",
-            "iconv-lite": "^0.4.13",
-            "nwmatcher": ">= 1.3.9 < 2.0.0",
-            "parse5": "^1.5.1",
-            "request": "^2.55.0",
-            "sax": "^1.1.4",
-            "symbol-tree": ">= 3.1.0 < 4.0.0",
-            "tough-cookie": "^2.3.1",
-            "webidl-conversions": "^3.0.1",
-            "whatwg-encoding": "^1.0.1",
-            "whatwg-url": "^4.1.0",
-            "xml-name-validator": ">= 2.0.1 < 3.0.0"
-          }
-        },
-        "json-loader": {
-          "version": "0.5.7",
-          "bundled": true
-        },
-        "json-parse-better-errors": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "bundled": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "jsonify": "~0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "json5": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "jsonfile": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true
-        },
-        "jsonpointer": {
-          "version": "4.0.1",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "just-extend": {
-          "version": "4.0.2",
-          "bundled": true
-        },
-        "keycode": {
-          "version": "2.2.0",
-          "bundled": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "bundled": true
-        },
-        "known-css-properties": {
-          "version": "0.3.0",
-          "bundled": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "levn": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
-        },
-        "library-simplified-reusable-components": {
-          "version": "1.3.16",
-          "bundled": true,
-          "requires": {
-            "@nypl/dgx-svg-icons": "^0.3.9",
-            "react": "^16.8.6",
-            "react-dom": "^16.8.6"
-          },
-          "dependencies": {
-            "@nypl/dgx-svg-icons": {
-              "version": "0.3.9",
-              "bundled": true
-            }
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "bundled": true
-            }
-          }
-        },
-        "loader-runner": {
-          "version": "2.4.0",
-          "bundled": true
-        },
-        "loader-utils": {
-          "version": "1.2.3",
-          "bundled": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
-            "json5": "^1.0.1"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          },
-          "dependencies": {
-            "path-exists": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "bundled": true
-        },
-        "lodash-es": {
-          "version": "4.17.14",
-          "bundled": true
-        },
-        "lodash._arraycopy": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "lodash._arrayeach": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "lodash._baseassign": {
-          "version": "3.2.0",
-          "bundled": true,
-          "requires": {
-            "lodash._basecopy": "^3.0.0",
-            "lodash.keys": "^3.0.0"
-          }
-        },
-        "lodash._baseclone": {
-          "version": "3.3.0",
-          "bundled": true,
-          "requires": {
-            "lodash._arraycopy": "^3.0.0",
-            "lodash._arrayeach": "^3.0.0",
-            "lodash._baseassign": "^3.0.0",
-            "lodash._basefor": "^3.0.0",
-            "lodash.isarray": "^3.0.0",
-            "lodash.keys": "^3.0.0"
-          }
-        },
-        "lodash._basecopy": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "lodash._basefor": {
-          "version": "3.0.3",
-          "bundled": true
-        },
-        "lodash._bindcallback": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "bundled": true
-        },
-        "lodash._isiterateecall": {
-          "version": "3.0.9",
-          "bundled": true
-        },
-        "lodash.assign": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "lodash.capitalize": {
-          "version": "4.2.1",
-          "bundled": true
-        },
-        "lodash.clone": {
-          "version": "3.0.3",
-          "bundled": true,
-          "requires": {
-            "lodash._baseclone": "^3.0.0",
-            "lodash._bindcallback": "^3.0.0",
-            "lodash._isiterateecall": "^3.0.0"
-          }
-        },
-        "lodash.clonedeep": {
-          "version": "4.5.0",
-          "bundled": true
-        },
-        "lodash.debounce": {
-          "version": "4.0.8",
-          "bundled": true
-        },
-        "lodash.defaultsdeep": {
-          "version": "4.6.1",
-          "bundled": true
-        },
-        "lodash.escape": {
-          "version": "4.0.1",
-          "bundled": true
-        },
-        "lodash.flattendeep": {
-          "version": "4.4.0",
-          "bundled": true
-        },
-        "lodash.isarguments": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "lodash.isequal": {
-          "version": "4.5.0",
-          "bundled": true
-        },
-        "lodash.kebabcase": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "lodash.keys": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "lodash._getnative": "^3.0.0",
-            "lodash.isarguments": "^3.0.0",
-            "lodash.isarray": "^3.0.0"
-          }
-        },
-        "lodash.merge": {
-          "version": "4.6.2",
-          "bundled": true
-        },
-        "lodash.mergewith": {
-          "version": "4.6.2",
-          "bundled": true
-        },
-        "lodash.sortby": {
-          "version": "4.7.0",
-          "bundled": true
-        },
-        "lodash.tail": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "lodash.throttle": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "log-symbols": {
-          "version": "2.2.0",
-          "bundled": true,
-          "requires": {
-            "chalk": "^2.0.1"
-          }
-        },
-        "lolex": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "loud-rejection": {
-          "version": "1.6.0",
-          "bundled": true,
-          "requires": {
-            "currently-unhandled": "^0.4.1",
-            "signal-exit": "^3.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.5",
-          "bundled": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "lunr": {
-          "version": "2.3.8",
-          "bundled": true
-        },
-        "make-dir": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "mamacro": {
-          "version": "0.0.3",
-          "bundled": true
-        },
-        "map-age-cleaner": {
-          "version": "0.1.3",
-          "bundled": true,
-          "requires": {
-            "p-defer": "^1.0.0"
-          }
-        },
-        "map-cache": {
-          "version": "0.2.2",
-          "bundled": true
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "map-visit": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "object-visit": "^1.0.0"
-          }
-        },
-        "marked": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "material-colors": {
-          "version": "1.2.6",
-          "bundled": true
-        },
-        "math-expression-evaluator": {
-          "version": "1.2.17",
-          "bundled": true
-        },
-        "md5.js": {
-          "version": "1.3.5",
-          "bundled": true,
-          "requires": {
-            "hash-base": "^3.0.0",
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.1.2"
-          }
-        },
-        "mem": {
-          "version": "4.3.0",
-          "bundled": true,
-          "requires": {
-            "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^2.0.0",
-            "p-is-promise": "^2.0.0"
-          }
-        },
-        "memoize-one": {
-          "version": "3.1.1",
-          "bundled": true
-        },
-        "memory-fs": {
-          "version": "0.4.1",
-          "bundled": true,
-          "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "meow": {
-          "version": "3.7.0",
-          "bundled": true,
-          "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
-          }
-        },
-        "merge": {
-          "version": "1.2.1",
-          "bundled": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "bundled": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "miller-rabin": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.0.0",
-            "brorand": "^1.0.1"
-          }
-        },
-        "mime": {
-          "version": "2.4.4",
-          "bundled": true
-        },
-        "mime-db": {
-          "version": "1.40.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.24",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.40.0"
-          }
-        },
-        "mimic-fn": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "mini-css-extract-plugin": {
-          "version": "0.5.0",
-          "bundled": true,
-          "requires": {
-            "loader-utils": "^1.1.0",
-            "schema-utils": "^1.0.0",
-            "webpack-sources": "^1.1.0"
-          }
-        },
-        "minimalistic-assert": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "minimalistic-crypto-utils": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "mississippi": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
-          }
-        },
-        "mixin-deep": {
-          "version": "1.3.2",
-          "bundled": true,
-          "requires": {
-            "for-in": "^1.0.2",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "mixin-object": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "for-in": "^0.1.3",
-            "is-extendable": "^0.1.1"
-          },
-          "dependencies": {
-            "for-in": {
-              "version": "0.1.8",
-              "bundled": true
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            }
-          }
-        },
-        "mkpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "mocha": {
-          "version": "6.2.2",
-          "bundled": true,
-          "requires": {
-            "ansi-colors": "3.2.3",
-            "browser-stdout": "1.3.1",
-            "debug": "3.2.6",
-            "diff": "3.5.0",
-            "escape-string-regexp": "1.0.5",
-            "find-up": "3.0.0",
-            "glob": "7.1.3",
-            "growl": "1.10.5",
-            "he": "1.2.0",
-            "js-yaml": "3.13.1",
-            "log-symbols": "2.2.0",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "ms": "2.1.1",
-            "node-environment-flags": "1.0.5",
-            "object.assign": "4.1.0",
-            "strip-json-comments": "2.0.1",
-            "supports-color": "6.0.0",
-            "which": "1.3.1",
-            "wide-align": "1.1.3",
-            "yargs": "13.3.0",
-            "yargs-parser": "13.1.1",
-            "yargs-unparser": "1.6.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "bundled": true
-            },
-            "cliui": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "string-width": "^3.1.0",
-                "strip-ansi": "^5.2.0",
-                "wrap-ansi": "^5.1.0"
-              }
-            },
-            "find-up": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "get-caller-file": {
-              "version": "2.0.5",
-              "bundled": true
-            },
-            "glob": {
-              "version": "7.1.3",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "ms": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "require-main-filename": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "supports-color": {
-              "version": "6.0.0",
-              "bundled": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            },
-            "which-module": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "wrap-ansi": {
-              "version": "5.1.0",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^3.2.0",
-                "string-width": "^3.0.0",
-                "strip-ansi": "^5.0.0"
-              }
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "yargs": {
-              "version": "13.3.0",
-              "bundled": true,
-              "requires": {
-                "cliui": "^5.0.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^2.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
-                "string-width": "^3.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^13.1.1"
-              }
-            },
-            "yargs-parser": {
-              "version": "13.1.1",
-              "bundled": true,
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
-            }
-          }
-        },
-        "moment": {
-          "version": "2.24.0",
-          "bundled": true
-        },
-        "moo": {
-          "version": "0.4.3",
-          "bundled": true
-        },
-        "move-concurrently": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "aproba": "^1.1.1",
-            "copy-concurrently": "^1.0.0",
-            "fs-write-stream-atomic": "^1.0.8",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.3"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "mute-stream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "nan": {
-          "version": "2.14.0",
-          "bundled": true
-        },
-        "nanomatch": {
-          "version": "1.2.13",
-          "bundled": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "fragment-cache": "^0.2.1",
-            "is-windows": "^1.0.2",
-            "kind-of": "^6.0.2",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          }
-        },
-        "nearley": {
-          "version": "2.16.0",
-          "bundled": true,
-          "requires": {
-            "commander": "^2.19.0",
-            "moo": "^0.4.3",
-            "railroad-diagrams": "^1.0.0",
-            "randexp": "0.4.6",
-            "semver": "^5.4.1"
-          }
-        },
-        "neo-async": {
-          "version": "2.6.1",
-          "bundled": true
-        },
-        "netmask": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "next-tick": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "nice-try": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "nightwatch": {
-          "version": "1.1.13",
-          "bundled": true,
-          "requires": {
-            "assertion-error": "^1.1.0",
-            "chai-nightwatch": "^0.3.0",
-            "dotenv": "7.0.0",
-            "ejs": "^2.5.9",
-            "lodash.clone": "3.0.3",
-            "lodash.defaultsdeep": "^4.6.0",
-            "lodash.merge": "^4.6.1",
-            "minimatch": "3.0.4",
-            "mkpath": "1.0.0",
-            "mocha": "^5.2.0",
-            "optimist": "^0.6.1",
-            "proxy-agent": "^3.0.0"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "2.15.1",
-              "bundled": true,
-              "optional": true
-            },
-            "debug": {
-              "version": "3.1.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "he": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "mocha": {
-              "version": "5.2.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "browser-stdout": "1.3.1",
-                "commander": "2.15.1",
-                "debug": "3.1.0",
-                "diff": "3.5.0",
-                "escape-string-regexp": "1.0.5",
-                "glob": "7.1.2",
-                "growl": "1.10.5",
-                "he": "1.1.1",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "supports-color": "5.4.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "supports-color": {
-              "version": "5.4.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "nise": {
-          "version": "1.5.2",
-          "bundled": true,
-          "requires": {
-            "@sinonjs/formatio": "^3.2.1",
-            "@sinonjs/text-encoding": "^0.7.1",
-            "just-extend": "^4.0.2",
-            "lolex": "^4.1.0",
-            "path-to-regexp": "^1.7.0"
-          },
-          "dependencies": {
-            "path-to-regexp": {
-              "version": "1.8.0",
-              "bundled": true,
-              "requires": {
-                "isarray": "0.0.1"
-              }
-            }
-          }
-        },
-        "node-environment-flags": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "object.getownpropertydescriptors": "^2.0.3",
-            "semver": "^5.7.0"
-          }
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "bundled": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        },
-        "node-gyp": {
-          "version": "3.8.0",
-          "bundled": true,
-          "requires": {
-            "fstream": "^1.0.0",
-            "glob": "^7.0.3",
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "^0.5.0",
-            "nopt": "2 || 3",
-            "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
-            "request": "^2.87.0",
-            "rimraf": "2",
-            "semver": "~5.3.0",
-            "tar": "^2.0.0",
-            "which": "1"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true
-            }
-          }
-        },
-        "node-libs-browser": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "assert": "^1.1.1",
-            "browserify-zlib": "^0.2.0",
-            "buffer": "^4.3.0",
-            "console-browserify": "^1.1.0",
-            "constants-browserify": "^1.0.0",
-            "crypto-browserify": "^3.11.0",
-            "domain-browser": "^1.1.1",
-            "events": "^3.0.0",
-            "https-browserify": "^1.0.0",
-            "os-browserify": "^0.3.0",
-            "path-browserify": "0.0.1",
-            "process": "^0.11.10",
-            "punycode": "^1.2.4",
-            "querystring-es3": "^0.2.0",
-            "readable-stream": "^2.3.3",
-            "stream-browserify": "^2.0.1",
-            "stream-http": "^2.7.2",
-            "string_decoder": "^1.0.0",
-            "timers-browserify": "^2.0.4",
-            "tty-browserify": "0.0.0",
-            "url": "^0.11.0",
-            "util": "^0.11.0",
-            "vm-browserify": "^1.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              },
-              "dependencies": {
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "util": {
-              "version": "0.11.1",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3"
-              },
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.3",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "node-sass": {
-          "version": "4.11.0",
-          "bundled": true,
-          "requires": {
-            "async-foreach": "^0.1.3",
-            "chalk": "^1.1.1",
-            "cross-spawn": "^3.0.0",
-            "gaze": "^1.0.0",
-            "get-stdin": "^4.0.1",
-            "glob": "^7.0.3",
-            "in-publish": "^2.0.0",
-            "lodash.assign": "^4.2.0",
-            "lodash.clonedeep": "^4.3.2",
-            "lodash.mergewith": "^4.6.0",
-            "meow": "^3.7.0",
-            "mkdirp": "^0.5.1",
-            "nan": "^2.10.0",
-            "node-gyp": "^3.8.0",
-            "npmlog": "^4.0.0",
-            "request": "^2.88.0",
-            "sass-graph": "^2.2.4",
-            "stdout-stream": "^1.4.0",
-            "true-case-path": "^1.0.2"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "bundled": true,
-          "requires": {
-            "abbrev": "1"
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "bundled": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "normalize-path": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "nth-check": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "boolbase": "~1.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "numeral": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "nwmatcher": {
-          "version": "1.4.4",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "object-copy": {
-          "version": "0.1.0",
-          "bundled": true,
-          "requires": {
-            "copy-descriptor": "^0.1.0",
-            "define-property": "^0.2.5",
-            "kind-of": "^3.0.3"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "kind-of": {
-              "version": "3.2.2",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "object-inspect": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "object-is": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "object-visit": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "isobject": "^3.0.0"
-          }
-        },
-        "object.assign": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "function-bind": "^1.1.1",
-            "has-symbols": "^1.0.0",
-            "object-keys": "^1.0.11"
-          }
-        },
-        "object.entries": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.12.0",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3"
-          }
-        },
-        "object.fromentries": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "es-abstract": "^1.11.0",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.1"
-          }
-        },
-        "object.getownpropertydescriptors": {
-          "version": "2.0.3",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "es-abstract": "^1.5.1"
-          }
-        },
-        "object.pick": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        },
-        "object.values": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.12.0",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "opds-feed-parser": {
-          "version": "0.0.17",
-          "bundled": true,
-          "requires": {
-            "core-js": "^2.6.9",
-            "requirejs": "^2.1.22",
-            "xml2js": "^0.4.16"
-          }
-        },
-        "opds-web-client": {
-          "version": "0.3.2",
-          "bundled": true,
-          "requires": {
-            "@nypl/dgx-svg-icons": "^0.3.4",
-            "dompurify": "^0.8.1",
-            "downloadjs": "^1.4.4",
-            "font-awesome": "^4.7.0",
-            "isomorphic-fetch": "^2.2.1",
-            "js-cookie": "^2.1.2",
-            "jsdom": "9.9.1",
-            "moment": "^2.14.1",
-            "opds-feed-parser": "0.0.17",
-            "prop-types": "^15.7.2",
-            "react": "^16.8.6",
-            "react-dom": "^16.8.6",
-            "react-redux": "^7.1.0",
-            "react-router": "^3.2.0",
-            "redux": "4.0.1",
-            "redux-localstorage": "^0.4.1",
-            "redux-thunk": "^2.3.0",
-            "seedrandom": "^2.4.2",
-            "throttle-debounce": "1.0.1",
-            "xml2js": "^0.4.16"
-          },
-          "dependencies": {
-            "redux": {
-              "version": "4.0.1",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "^1.4.0",
-                "symbol-observable": "^1.2.0"
-              }
-            }
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.10",
-              "bundled": true
-            },
-            "wordwrap": {
-              "version": "0.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "bundled": true,
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.4",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "wordwrap": "~1.0.0"
-          }
-        },
-        "os-browserify": {
-          "version": "0.3.0",
-          "bundled": true
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "lcid": "^1.0.0"
-          }
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "p-defer": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "p-is-promise": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "p-limit": {
-          "version": "2.2.0",
-          "bundled": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-map": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "bundled": true
-        },
-        "pac-proxy-agent": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "agent-base": "^4.2.0",
-            "debug": "^3.1.0",
-            "get-uri": "^2.0.0",
-            "http-proxy-agent": "^2.1.0",
-            "https-proxy-agent": "^2.2.1",
-            "pac-resolver": "^3.0.0",
-            "raw-body": "^2.2.0",
-            "socks-proxy-agent": "^4.0.1"
-          }
-        },
-        "pac-resolver": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "co": "^4.6.0",
-            "degenerator": "^1.0.4",
-            "ip": "^1.1.5",
-            "netmask": "^1.0.6",
-            "thunkify": "^2.1.2"
-          }
-        },
-        "pako": {
-          "version": "1.0.10",
-          "bundled": true
-        },
-        "parallel-transform": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "cyclist": "~0.2.2",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.1.5"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "parse-asn1": {
-          "version": "5.1.4",
-          "bundled": true,
-          "requires": {
-            "asn1.js": "^4.0.0",
-            "browserify-aes": "^1.0.0",
-            "create-hash": "^1.1.0",
-            "evp_bytestokey": "^1.0.0",
-            "pbkdf2": "^3.0.3",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "bundled": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "parse-passwd": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "parse5": {
-          "version": "1.5.1",
-          "bundled": true
-        },
-        "pascalcase": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "path-browserify": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "path-dirname": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "path-parse": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "path-to-regexp": {
-          "version": "2.4.0",
-          "bundled": true
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "bundled": true
-            }
-          }
-        },
-        "pathval": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "pbkdf2": {
-          "version": "3.0.17",
-          "bundled": true,
-          "requires": {
-            "create-hash": "^1.1.2",
-            "create-hmac": "^1.1.4",
-            "ripemd160": "^2.0.1",
-            "safe-buffer": "^5.0.1",
-            "sha.js": "^2.4.8"
-          }
-        },
-        "pend": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "picomatch": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "pify": {
-          "version": "4.0.1",
-          "bundled": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "bundled": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "pinkie": "^2.0.0"
-          }
-        },
-        "pkg-dir": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "find-up": "^3.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            }
-          }
-        },
-        "pluralize": {
-          "version": "1.2.1",
-          "bundled": true
-        },
-        "posix-character-classes": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "postcss": {
-          "version": "7.0.17",
-          "bundled": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "postcss-modules-extract-imports": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "postcss": "^7.0.5"
-          }
-        },
-        "postcss-modules-local-by-default": {
-          "version": "2.0.6",
-          "bundled": true,
-          "requires": {
-            "postcss": "^7.0.6",
-            "postcss-selector-parser": "^6.0.0",
-            "postcss-value-parser": "^3.3.1"
-          }
-        },
-        "postcss-modules-scope": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "postcss": "^7.0.6",
-            "postcss-selector-parser": "^6.0.0"
-          }
-        },
-        "postcss-modules-values": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "icss-replace-symbols": "^1.1.0",
-            "postcss": "^7.0.6"
-          }
-        },
-        "postcss-selector-parser": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "cssesc": "^3.0.0",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
-          }
-        },
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "bundled": true
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "process": {
-          "version": "0.11.10",
-          "bundled": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "progress": {
-          "version": "1.1.8",
-          "bundled": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true,
-          "requires": {
-            "asap": "~2.0.3"
-          }
-        },
-        "promise-inflight": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "prop-types": {
-          "version": "15.7.2",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
-        "prop-types-exact": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "has": "^1.0.3",
-            "object.assign": "^4.1.0",
-            "reflect.ownkeys": "^0.2.0"
-          }
-        },
-        "prop-types-extra": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "react-is": "^16.3.2",
-            "warning": "^3.0.0"
-          }
-        },
-        "proxy-agent": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "agent-base": "^4.2.0",
-            "debug": "^3.1.0",
-            "http-proxy-agent": "^2.1.0",
-            "https-proxy-agent": "^2.2.1",
-            "lru-cache": "^4.1.2",
-            "pac-proxy-agent": "^3.0.0",
-            "proxy-from-env": "^1.0.0",
-            "socks-proxy-agent": "^4.0.1"
-          }
-        },
-        "proxy-from-env": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "prr": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "psl": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "public-encrypt": {
-          "version": "4.0.3",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.1.0",
-            "browserify-rsa": "^4.0.0",
-            "create-hash": "^1.1.0",
-            "parse-asn1": "^5.0.0",
-            "randombytes": "^2.0.1",
-            "safe-buffer": "^5.1.2"
-          }
-        },
-        "pump": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "pumpify": {
-          "version": "1.5.1",
-          "bundled": true,
-          "requires": {
-            "duplexify": "^3.6.0",
-            "inherits": "^2.0.3",
-            "pump": "^2.0.0"
-          },
-          "dependencies": {
-            "pump": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            }
-          }
-        },
-        "punycode": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.7.0",
-          "bundled": true
-        },
-        "query-string": {
-          "version": "4.3.4",
-          "bundled": true,
-          "requires": {
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
-          }
-        },
-        "querystring": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "querystring-es3": {
-          "version": "0.2.1",
-          "bundled": true
-        },
-        "raf": {
-          "version": "3.4.1",
-          "bundled": true,
-          "requires": {
-            "performance-now": "^2.1.0"
-          }
-        },
-        "raf-schd": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "railroad-diagrams": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "randexp": {
-          "version": "0.4.6",
-          "bundled": true,
-          "requires": {
-            "discontinuous-range": "1.0.0",
-            "ret": "~0.1.10"
-          }
-        },
-        "randombytes": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "^5.1.0"
-          }
-        },
-        "randomfill": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "randombytes": "^2.0.5",
-            "safe-buffer": "^5.1.0"
-          }
-        },
-        "raw-body": {
-          "version": "2.4.1",
-          "bundled": true,
-          "requires": {
-            "bytes": "3.1.0",
-            "http-errors": "1.7.3",
-            "iconv-lite": "0.4.24",
-            "unpipe": "1.0.0"
-          }
-        },
-        "react": {
-          "version": "16.8.6",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.13.6"
-          }
-        },
-        "react-axe": {
-          "version": "3.3.0",
-          "bundled": true,
-          "requires": {
-            "axe-core": "^3.3.2",
-            "requestidlecallback": "^0.3.0"
-          }
-        },
-        "react-beautiful-dnd": {
-          "version": "2.6.4",
-          "bundled": true,
-          "requires": {
-            "babel-runtime": "^6.26.0",
-            "invariant": "^2.2.2",
-            "memoize-one": "^3.0.1",
-            "prop-types": "^15.6.0",
-            "raf-schd": "^2.0.2",
-            "react-motion": "^0.5.2",
-            "react-redux": "^5.0.6",
-            "redux": "^3.7.2",
-            "redux-thunk": "^2.2.0",
-            "reselect": "^3.0.1"
-          },
-          "dependencies": {
-            "react-redux": {
-              "version": "5.1.1",
-              "bundled": true,
-              "requires": {
-                "@babel/runtime": "^7.1.2",
-                "hoist-non-react-statics": "^3.1.0",
-                "invariant": "^2.2.4",
-                "loose-envify": "^1.1.0",
-                "prop-types": "^15.6.1",
-                "react-is": "^16.6.0",
-                "react-lifecycles-compat": "^3.0.0"
-              }
-            },
-            "redux": {
-              "version": "3.7.2",
-              "bundled": true,
-              "requires": {
-                "lodash": "^4.2.1",
-                "lodash-es": "^4.2.1",
-                "loose-envify": "^1.1.0",
-                "symbol-observable": "^1.0.3"
-              }
-            }
-          }
-        },
-        "react-bootstrap": {
-          "version": "0.32.4",
-          "bundled": true,
-          "requires": {
-            "@babel/runtime-corejs2": "^7.0.0",
-            "classnames": "^2.2.5",
-            "dom-helpers": "^3.2.0",
-            "invariant": "^2.2.4",
-            "keycode": "^2.2.0",
-            "prop-types": "^15.6.1",
-            "prop-types-extra": "^1.0.1",
-            "react-overlays": "^0.8.0",
-            "react-prop-types": "^0.4.0",
-            "react-transition-group": "^2.0.0",
-            "uncontrollable": "^5.0.0",
-            "warning": "^3.0.0"
-          }
-        },
-        "react-color": {
-          "version": "2.17.3",
-          "bundled": true,
-          "requires": {
-            "@icons/material": "^0.2.4",
-            "lodash": "^4.17.11",
-            "material-colors": "^1.2.1",
-            "prop-types": "^15.5.10",
-            "reactcss": "^1.2.0",
-            "tinycolor2": "^1.4.1"
-          }
-        },
-        "react-dom": {
-          "version": "16.8.6",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.13.6"
-          }
-        },
-        "react-is": {
-          "version": "16.8.6",
-          "bundled": true
-        },
-        "react-lifecycles-compat": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "react-motion": {
-          "version": "0.5.2",
-          "bundled": true,
-          "requires": {
-            "performance-now": "^0.2.0",
-            "prop-types": "^15.5.8",
-            "raf": "^3.1.0"
-          },
-          "dependencies": {
-            "performance-now": {
-              "version": "0.2.0",
-              "bundled": true
-            }
-          }
-        },
-        "react-overlays": {
-          "version": "0.8.3",
-          "bundled": true,
-          "requires": {
-            "classnames": "^2.2.5",
-            "dom-helpers": "^3.2.1",
-            "prop-types": "^15.5.10",
-            "prop-types-extra": "^1.0.1",
-            "react-transition-group": "^2.2.0",
-            "warning": "^3.0.0"
-          }
-        },
-        "react-prop-types": {
-          "version": "0.4.0",
-          "bundled": true,
-          "requires": {
-            "warning": "^3.0.0"
-          }
-        },
-        "react-redux": {
-          "version": "7.1.0",
-          "bundled": true,
-          "requires": {
-            "@babel/runtime": "^7.4.5",
-            "hoist-non-react-statics": "^3.3.0",
-            "invariant": "^2.2.4",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.6"
-          }
-        },
-        "react-resize-detector": {
-          "version": "2.3.0",
-          "bundled": true,
-          "requires": {
-            "lodash.debounce": "^4.0.8",
-            "lodash.throttle": "^4.1.1",
-            "prop-types": "^15.6.0",
-            "resize-observer-polyfill": "^1.5.0"
-          }
-        },
-        "react-router": {
-          "version": "3.2.0",
-          "bundled": true,
-          "requires": {
-            "create-react-class": "^15.5.1",
-            "history": "^3.0.0",
-            "hoist-non-react-statics": "^1.2.0",
-            "invariant": "^2.2.1",
-            "loose-envify": "^1.2.0",
-            "prop-types": "^15.5.6",
-            "warning": "^3.0.0"
-          },
-          "dependencies": {
-            "hoist-non-react-statics": {
-              "version": "1.2.0",
-              "bundled": true
-            }
-          }
-        },
-        "react-smooth": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "lodash": "~4.17.4",
-            "prop-types": "^15.6.0",
-            "raf": "^3.4.0",
-            "react-transition-group": "^2.5.0"
-          }
-        },
-        "react-test-renderer": {
-          "version": "16.8.6",
-          "bundled": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-is": "^16.8.6",
-            "scheduler": "^0.13.6"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "bundled": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        },
-        "reactcss": {
-          "version": "1.2.3",
-          "bundled": true,
-          "requires": {
-            "lodash": "^4.0.1"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "3.4.0",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "readdirp": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "micromatch": "^3.1.10",
-            "readable-stream": "^2.0.2"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "readline2": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "mute-stream": "0.0.5"
-          }
-        },
-        "recharts": {
-          "version": "1.6.2",
-          "bundled": true,
-          "requires": {
-            "classnames": "^2.2.5",
-            "core-js": "^2.5.1",
-            "d3-interpolate": "^1.3.0",
-            "d3-scale": "^2.1.0",
-            "d3-shape": "^1.2.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.6.0",
-            "react-resize-detector": "^2.3.0",
-            "react-smooth": "^1.0.0",
-            "recharts-scale": "^0.4.2",
-            "reduce-css-calc": "^1.3.0"
-          }
-        },
-        "recharts-scale": {
-          "version": "0.4.2",
-          "bundled": true,
-          "requires": {
-            "decimal.js-light": "^2.4.1"
-          }
-        },
-        "rechoir": {
-          "version": "0.6.2",
-          "bundled": true,
-          "requires": {
-            "resolve": "^1.1.6"
-          }
-        },
-        "redent": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
-          }
-        },
-        "reduce-css-calc": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "^0.4.2",
-            "math-expression-evaluator": "^1.2.14",
-            "reduce-function-call": "^1.0.1"
-          }
-        },
-        "reduce-function-call": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "^0.4.2"
-          }
-        },
-        "redux": {
-          "version": "4.0.4",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "symbol-observable": "^1.2.0"
-          }
-        },
-        "redux-localstorage": {
-          "version": "0.4.1",
-          "bundled": true
-        },
-        "redux-thunk": {
-          "version": "2.3.0",
-          "bundled": true
-        },
-        "reflect.ownkeys": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "regenerator-runtime": {
-          "version": "0.13.2",
-          "bundled": true
-        },
-        "regex-not": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "extend-shallow": "^3.0.2",
-            "safe-regex": "^1.1.0"
-          }
-        },
-        "remove-trailing-separator": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "repeat-element": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "bundled": true
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "is-finite": "^1.0.0"
-          }
-        },
-        "request": {
-          "version": "2.88.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.4.3",
-              "bundled": true,
-              "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
-              }
-            }
-          }
-        },
-        "requestidlecallback": {
-          "version": "0.3.0",
-          "bundled": true
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "require-uncached": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "caller-path": "^0.1.0",
-            "resolve-from": "^1.0.0"
-          }
-        },
-        "requirejs": {
-          "version": "2.3.6",
-          "bundled": true
-        },
-        "reselect": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "resize-observer-polyfill": {
-          "version": "1.5.1",
-          "bundled": true
-        },
-        "resolve": {
-          "version": "1.11.1",
-          "bundled": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        },
-        "resolve-cwd": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "resolve-from": "^3.0.0"
-          },
-          "dependencies": {
-            "resolve-from": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "resolve-dir": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "expand-tilde": "^2.0.0",
-            "global-modules": "^1.0.0"
-          },
-          "dependencies": {
-            "global-modules": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "global-prefix": "^1.0.1",
-                "is-windows": "^1.0.1",
-                "resolve-dir": "^1.0.0"
-              }
-            }
-          }
-        },
-        "resolve-from": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "resolve-url": {
-          "version": "0.2.1",
-          "bundled": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
-          }
-        },
-        "ret": {
-          "version": "0.1.15",
-          "bundled": true
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "ripemd160": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "hash-base": "^3.0.0",
-            "inherits": "^2.0.1"
-          }
-        },
-        "rst-selector-parser": {
-          "version": "2.2.3",
-          "bundled": true,
-          "requires": {
-            "lodash.flattendeep": "^4.4.0",
-            "nearley": "^2.7.10"
-          }
-        },
-        "run-async": {
-          "version": "0.1.0",
-          "bundled": true,
-          "requires": {
-            "once": "^1.3.0"
-          }
-        },
-        "run-queue": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "aproba": "^1.1.1"
-          }
-        },
-        "rx-lite": {
-          "version": "3.1.2",
-          "bundled": true
-        },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "bundled": true
-        },
-        "safe-regex": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "ret": "~0.1.10"
-          }
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "sass-graph": {
-          "version": "2.2.4",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.0.0",
-            "lodash": "^4.0.0",
-            "scss-tokenizer": "^0.2.3",
-            "yargs": "^7.0.0"
-          }
-        },
-        "sass-lint": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "commander": "^2.8.1",
-            "eslint": "^2.7.0",
-            "front-matter": "2.1.2",
-            "fs-extra": "^3.0.1",
-            "glob": "^7.0.0",
-            "globule": "^1.0.0",
-            "gonzales-pe-sl": "^4.2.3",
-            "js-yaml": "^3.5.4",
-            "known-css-properties": "^0.3.0",
-            "lodash.capitalize": "^4.1.0",
-            "lodash.kebabcase": "^4.0.0",
-            "merge": "^1.2.0",
-            "path-is-absolute": "^1.0.0",
-            "util": "^0.10.3"
-          }
-        },
-        "sass-loader": {
-          "version": "7.1.0",
-          "bundled": true,
-          "requires": {
-            "clone-deep": "^2.0.1",
-            "loader-utils": "^1.0.1",
-            "lodash.tail": "^4.1.1",
-            "neo-async": "^2.5.0",
-            "pify": "^3.0.0",
-            "semver": "^5.5.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "scheduler": {
-          "version": "0.13.6",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "schema-utils": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        },
-        "scss-tokenizer": {
-          "version": "0.2.3",
-          "bundled": true,
-          "requires": {
-            "js-base64": "^2.1.8",
-            "source-map": "^0.4.2"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "bundled": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        },
-        "seedrandom": {
-          "version": "2.4.4",
-          "bundled": true
-        },
-        "selenium-standalone": {
-          "version": "6.16.0",
-          "bundled": true,
-          "requires": {
-            "async": "^2.6.2",
-            "commander": "^2.19.0",
-            "cross-spawn": "^6.0.5",
-            "debug": "^4.1.1",
-            "lodash": "^4.17.11",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "progress": "2.0.3",
-            "request": "2.88.0",
-            "tar-stream": "2.0.0",
-            "urijs": "^1.19.1",
-            "which": "^1.3.1",
-            "yauzl": "^2.10.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "6.0.5",
-              "bundled": true,
-              "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            },
-            "debug": {
-              "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "progress": {
-              "version": "2.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "bundled": true
-        },
-        "serialize-javascript": {
-          "version": "1.7.0",
-          "bundled": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "set-value": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.3",
-            "split-string": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "setprototypeof": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "sha.js": {
-          "version": "2.4.11",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "shallow-clone": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "is-extendable": "^0.1.1",
-            "kind-of": "^5.0.0",
-            "mixin-object": "^2.0.1"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "bundled": true
-            }
-          }
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "shelljs": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "sinon": {
-          "version": "7.5.0",
-          "bundled": true,
-          "requires": {
-            "@sinonjs/commons": "^1.4.0",
-            "@sinonjs/formatio": "^3.2.1",
-            "@sinonjs/samsam": "^3.3.3",
-            "diff": "^3.5.0",
-            "lolex": "^4.2.0",
-            "nise": "^1.5.2",
-            "supports-color": "^5.5.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "bundled": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "slice-ansi": {
-          "version": "0.0.4",
-          "bundled": true
-        },
-        "smart-buffer": {
-          "version": "4.0.2",
-          "bundled": true
-        },
-        "snapdragon": {
-          "version": "0.8.2",
-          "bundled": true,
-          "requires": {
-            "base": "^0.11.1",
-            "debug": "^2.2.0",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "map-cache": "^0.2.2",
-            "source-map": "^0.5.6",
-            "source-map-resolve": "^0.5.0",
-            "use": "^3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true
-            }
-          }
-        },
-        "snapdragon-node": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.0",
-            "snapdragon-util": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            }
-          }
-        },
-        "snapdragon-util": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "kind-of": "^3.2.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "socks": {
-          "version": "2.3.2",
-          "bundled": true,
-          "requires": {
-            "ip": "^1.1.5",
-            "smart-buffer": "4.0.2"
-          }
-        },
-        "socks-proxy-agent": {
-          "version": "4.0.2",
-          "bundled": true,
-          "requires": {
-            "agent-base": "~4.2.1",
-            "socks": "~2.3.2"
-          },
-          "dependencies": {
-            "agent-base": {
-              "version": "4.2.1",
-              "bundled": true,
-              "requires": {
-                "es6-promisify": "^5.0.0"
-              }
-            }
-          }
-        },
-        "source-list-map": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "source-map-resolve": {
-          "version": "0.5.2",
-          "bundled": true,
-          "requires": {
-            "atob": "^2.1.1",
-            "decode-uri-component": "^0.2.0",
-            "resolve-url": "^0.2.1",
-            "source-map-url": "^0.4.0",
-            "urix": "^0.1.0"
-          }
-        },
-        "source-map-support": {
-          "version": "0.5.12",
-          "bundled": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        },
-        "source-map-url": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "spdx-correct": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-exceptions": {
-          "version": "2.2.0",
-          "bundled": true
-        },
-        "spdx-expression-parse": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-license-ids": {
-          "version": "3.0.5",
-          "bundled": true
-        },
-        "split-string": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "extend-shallow": "^3.0.0"
-          }
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "sshpk": {
-          "version": "1.16.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
-          }
-        },
-        "ssri": {
-          "version": "6.0.1",
-          "bundled": true,
-          "requires": {
-            "figgy-pudding": "^3.5.1"
-          }
-        },
-        "static-extend": {
-          "version": "0.1.2",
-          "bundled": true,
-          "requires": {
-            "define-property": "^0.2.5",
-            "object-copy": "^0.1.0"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            }
-          }
-        },
-        "statuses": {
-          "version": "1.5.0",
-          "bundled": true
-        },
-        "stdout-stream": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "readable-stream": "^2.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "stream-browserify": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "^2.0.2"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "stream-each": {
-          "version": "1.2.3",
-          "bundled": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "stream-shift": "^1.0.0"
-          }
-        },
-        "stream-http": {
-          "version": "2.8.3",
-          "bundled": true,
-          "requires": {
-            "builtin-status-codes": "^3.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.3.6",
-            "to-arraybuffer": "^1.0.0",
-            "xtend": "^4.0.0"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "stream-shift": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "strict-uri-encode": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string.prototype.trim": {
-          "version": "1.1.2",
-          "bundled": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "es-abstract": "^1.5.0",
-            "function-bind": "^1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "get-stdin": "^4.0.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "style-loader": {
-          "version": "0.13.2",
-          "bundled": true,
-          "requires": {
-            "loader-utils": "^1.0.2"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "bundled": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "symbol-observable": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "symbol-tree": {
-          "version": "3.2.4",
-          "bundled": true
-        },
-        "table": {
-          "version": "3.8.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "^4.7.0",
-            "ajv-keywords": "^1.0.0",
-            "chalk": "^1.1.1",
-            "lodash": "^4.0.0",
-            "slice-ansi": "0.0.4",
-            "string-width": "^2.0.0"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "requires": {
-                "co": "^4.6.0",
-                "json-stable-stringify": "^1.0.1"
-              }
-            },
-            "ajv-keywords": {
-              "version": "1.5.1",
-              "bundled": true
-            },
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "2.1.1",
-              "bundled": true,
-              "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-              },
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "tapable": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "tar": {
-          "version": "2.2.2",
-          "bundled": true,
-          "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.12",
-            "inherits": "2"
-          }
-        },
-        "tar-stream": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "bl": "^2.2.0",
-            "end-of-stream": "^1.4.1",
-            "fs-constants": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1"
-          }
-        },
-        "terser": {
-          "version": "4.1.2",
-          "bundled": true,
-          "requires": {
-            "commander": "^2.20.0",
-            "source-map": "~0.6.1",
-            "source-map-support": "~0.5.12"
-          }
-        },
-        "terser-webpack-plugin": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "cacache": "^11.3.2",
-            "find-cache-dir": "^2.0.0",
-            "is-wsl": "^1.1.0",
-            "loader-utils": "^1.2.3",
-            "schema-utils": "^1.0.0",
-            "serialize-javascript": "^1.7.0",
-            "source-map": "^0.6.1",
-            "terser": "^4.0.0",
-            "webpack-sources": "^1.3.0",
-            "worker-farm": "^1.7.0"
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "throttle-debounce": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "through": {
-          "version": "2.3.8",
-          "bundled": true
-        },
-        "through2": {
-          "version": "2.0.5",
-          "bundled": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "thunkify": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "timers-browserify": {
-          "version": "2.0.10",
-          "bundled": true,
-          "requires": {
-            "setimmediate": "^1.0.4"
-          }
-        },
-        "tinycolor2": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "to-arraybuffer": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "to-object-path": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "to-regex": {
-          "version": "3.0.2",
-          "bundled": true,
-          "requires": {
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "regex-not": "^1.0.2",
-            "safe-regex": "^1.1.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        },
-        "toidentifier": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "tough-cookie": {
-          "version": "2.5.0",
-          "bundled": true,
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        },
-        "tr46": {
-          "version": "0.0.3",
-          "bundled": true
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "true-case-path": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.1.2"
-          }
-        },
-        "ts-loader": {
-          "version": "6.2.1",
-          "bundled": true,
-          "requires": {
-            "chalk": "^2.3.0",
-            "enhanced-resolve": "^4.0.0",
-            "loader-utils": "^1.0.2",
-            "micromatch": "^4.0.0",
-            "semver": "^6.0.0"
-          },
-          "dependencies": {
-            "braces": {
-              "version": "3.0.2",
-              "bundled": true,
-              "requires": {
-                "fill-range": "^7.0.1"
-              }
-            },
-            "fill-range": {
-              "version": "7.0.1",
-              "bundled": true,
-              "requires": {
-                "to-regex-range": "^5.0.1"
-              }
-            },
-            "is-number": {
-              "version": "7.0.0",
-              "bundled": true
-            },
-            "micromatch": {
-              "version": "4.0.2",
-              "bundled": true,
-              "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.0.5"
-              }
-            },
-            "semver": {
-              "version": "6.3.0",
-              "bundled": true
-            },
-            "to-regex-range": {
-              "version": "5.0.1",
-              "bundled": true,
-              "requires": {
-                "is-number": "^7.0.0"
-              }
-            }
-          }
-        },
-        "tslib": {
-          "version": "1.10.0",
-          "bundled": true
-        },
-        "tslint": {
-          "version": "5.20.1",
-          "bundled": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "builtin-modules": "^1.1.1",
-            "chalk": "^2.3.0",
-            "commander": "^2.12.1",
-            "diff": "^4.0.1",
-            "glob": "^7.1.1",
-            "js-yaml": "^3.13.1",
-            "minimatch": "^3.0.4",
-            "mkdirp": "^0.5.1",
-            "resolve": "^1.3.2",
-            "semver": "^5.3.0",
-            "tslib": "^1.8.0",
-            "tsutils": "^2.29.0"
-          },
-          "dependencies": {
-            "diff": {
-              "version": "4.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "tslint-microsoft-contrib": {
-          "version": "6.2.0",
-          "bundled": true,
-          "requires": {
-            "tsutils": "^2.27.2 <2.29.0"
-          },
-          "dependencies": {
-            "tsutils": {
-              "version": "2.28.0",
-              "bundled": true,
-              "requires": {
-                "tslib": "^1.8.1"
-              }
-            }
-          }
-        },
-        "tslint-react-a11y": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "tslint-microsoft-contrib": "^6.2.0"
-          }
-        },
-        "tsutils": {
-          "version": "2.29.0",
-          "bundled": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        },
-        "tty-browserify": {
-          "version": "0.0.0",
-          "bundled": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true
-        },
-        "type": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "~1.1.2"
-          }
-        },
-        "type-detect": {
-          "version": "4.0.8",
-          "bundled": true
-        },
-        "typedarray": {
-          "version": "0.0.6",
-          "bundled": true
-        },
-        "typedoc": {
-          "version": "0.15.2",
-          "bundled": true,
-          "requires": {
-            "@types/minimatch": "3.0.3",
-            "fs-extra": "^8.1.0",
-            "handlebars": "^4.5.1",
-            "highlight.js": "^9.16.2",
-            "lodash": "^4.17.15",
-            "marked": "^0.7.0",
-            "minimatch": "^3.0.0",
-            "progress": "^2.0.3",
-            "shelljs": "^0.8.3",
-            "typedoc-default-themes": "^0.6.1",
-            "typescript": "3.7.x"
-          },
-          "dependencies": {
-            "fs-extra": {
-              "version": "8.1.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-              }
-            },
-            "jsonfile": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.6"
-              }
-            },
-            "lodash": {
-              "version": "4.17.15",
-              "bundled": true
-            },
-            "progress": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "shelljs": {
-              "version": "0.8.3",
-              "bundled": true,
-              "requires": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-              }
-            }
-          }
-        },
-        "typedoc-default-themes": {
-          "version": "0.6.1",
-          "bundled": true,
-          "requires": {
-            "backbone": "^1.4.0",
-            "jquery": "^3.4.1",
-            "lunr": "^2.3.8",
-            "underscore": "^1.9.1"
-          }
-        },
-        "typescript": {
-          "version": "3.7.2",
-          "bundled": true
-        },
-        "ua-parser-js": {
-          "version": "0.7.20",
-          "bundled": true
-        },
-        "uglify-js": {
-          "version": "3.6.0",
-          "bundled": true,
-          "requires": {
-            "commander": "~2.20.0",
-            "source-map": "~0.6.1"
-          }
-        },
-        "uglifyjs-webpack-plugin": {
-          "version": "2.1.3",
-          "bundled": true,
-          "requires": {
-            "cacache": "^11.3.2",
-            "find-cache-dir": "^2.1.0",
-            "is-wsl": "^1.1.0",
-            "schema-utils": "^1.0.0",
-            "serialize-javascript": "^1.7.0",
-            "source-map": "^0.6.1",
-            "uglify-js": "^3.5.12",
-            "webpack-sources": "^1.3.0",
-            "worker-farm": "^1.7.0"
-          }
-        },
-        "uncontrollable": {
-          "version": "5.1.0",
-          "bundled": true,
-          "requires": {
-            "invariant": "^2.2.4"
-          }
-        },
-        "underscore": {
-          "version": "1.9.1",
-          "bundled": true
-        },
-        "union-value": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^2.0.1"
-          }
-        },
-        "uniq": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "unique-filename": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "unique-slug": "^2.0.0"
-          }
-        },
-        "unique-slug": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "imurmurhash": "^0.1.4"
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "unpipe": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "unset-value": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0"
-          },
-          "dependencies": {
-            "has-value": {
-              "version": "0.3.1",
-              "bundled": true,
-              "requires": {
-                "get-value": "^2.0.3",
-                "has-values": "^0.1.4",
-                "isobject": "^2.0.0"
-              },
-              "dependencies": {
-                "isobject": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "isarray": "1.0.0"
-                  }
-                }
-              }
-            },
-            "has-values": {
-              "version": "0.1.4",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "upath": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "uri-js": {
-          "version": "4.2.2",
-          "bundled": true,
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
-        "urijs": {
-          "version": "1.19.1",
-          "bundled": true
-        },
-        "urix": {
-          "version": "0.1.0",
-          "bundled": true
-        },
-        "url": {
-          "version": "0.11.0",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.3.2",
-            "querystring": "0.2.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "1.3.2",
-              "bundled": true
-            }
-          }
-        },
-        "url-loader": {
-          "version": "2.2.0",
-          "bundled": true,
-          "requires": {
-            "loader-utils": "^1.2.3",
-            "mime": "^2.4.4",
-            "schema-utils": "^2.4.1"
-          },
-          "dependencies": {
-            "schema-utils": {
-              "version": "2.5.0",
-              "bundled": true,
-              "requires": {
-                "ajv": "^6.10.2",
-                "ajv-keywords": "^3.4.1"
-              }
-            }
-          }
-        },
-        "use": {
-          "version": "3.1.1",
-          "bundled": true
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "os-homedir": "^1.0.0"
-          }
-        },
-        "util": {
-          "version": "0.10.4",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "bundled": true
-        },
-        "v8-compile-cache": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
-          }
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
-          }
-        },
-        "vm-browserify": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "warning": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        },
-        "watchpack": {
-          "version": "1.6.0",
-          "bundled": true,
-          "requires": {
-            "chokidar": "^2.0.2",
-            "graceful-fs": "^4.1.2",
-            "neo-async": "^2.5.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "webpack": {
-          "version": "4.35.3",
-          "bundled": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-module-context": "1.8.5",
-            "@webassemblyjs/wasm-edit": "1.8.5",
-            "@webassemblyjs/wasm-parser": "1.8.5",
-            "acorn": "^6.2.0",
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0",
-            "chrome-trace-event": "^1.0.0",
-            "enhanced-resolve": "^4.1.0",
-            "eslint-scope": "^4.0.0",
-            "json-parse-better-errors": "^1.0.2",
-            "loader-runner": "^2.3.0",
-            "loader-utils": "^1.1.0",
-            "memory-fs": "~0.4.1",
-            "micromatch": "^3.1.8",
-            "mkdirp": "~0.5.0",
-            "neo-async": "^2.5.0",
-            "node-libs-browser": "^2.0.0",
-            "schema-utils": "^1.0.0",
-            "tapable": "^1.1.0",
-            "terser-webpack-plugin": "^1.1.0",
-            "watchpack": "^1.5.0",
-            "webpack-sources": "^1.3.0"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "6.2.0",
-              "bundled": true
-            }
-          }
-        },
-        "webpack-cli": {
-          "version": "3.3.6",
-          "bundled": true,
-          "requires": {
-            "chalk": "2.4.2",
-            "cross-spawn": "6.0.5",
-            "enhanced-resolve": "4.1.0",
-            "findup-sync": "3.0.0",
-            "global-modules": "2.0.0",
-            "import-local": "2.0.0",
-            "interpret": "1.2.0",
-            "loader-utils": "1.2.3",
-            "supports-color": "6.1.0",
-            "v8-compile-cache": "2.0.3",
-            "yargs": "13.2.4"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "bundled": true
-            },
-            "cliui": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "string-width": "^3.1.0",
-                "strip-ansi": "^5.2.0",
-                "wrap-ansi": "^5.1.0"
-              }
-            },
-            "cross-spawn": {
-              "version": "6.0.5",
-              "bundled": true,
-              "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            },
-            "find-up": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "findup-sync": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "detect-file": "^1.0.0",
-                "is-glob": "^4.0.0",
-                "micromatch": "^3.0.4",
-                "resolve-dir": "^1.0.1"
-              }
-            },
-            "get-caller-file": {
-              "version": "2.0.5",
-              "bundled": true
-            },
-            "invert-kv": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "lcid": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "invert-kv": "^2.0.0"
-              }
-            },
-            "os-locale": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "execa": "^1.0.0",
-                "lcid": "^2.0.0",
-                "mem": "^4.0.0"
-              }
-            },
-            "require-main-filename": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            },
-            "which-module": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "wrap-ansi": {
-              "version": "5.1.0",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^3.2.0",
-                "string-width": "^3.0.0",
-                "strip-ansi": "^5.0.0"
-              }
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "yargs": {
-              "version": "13.2.4",
-              "bundled": true,
-              "requires": {
-                "cliui": "^5.0.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^2.0.1",
-                "os-locale": "^3.1.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
-                "string-width": "^3.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^13.1.0"
-              }
-            },
-            "yargs-parser": {
-              "version": "13.1.1",
-              "bundled": true,
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
-            }
-          }
-        },
-        "webpack-merge": {
-          "version": "4.2.1",
-          "bundled": true,
-          "requires": {
-            "lodash": "^4.17.5"
-          }
-        },
-        "webpack-sources": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "source-list-map": "^2.0.0",
-            "source-map": "~0.6.1"
-          }
-        },
-        "whatwg-encoding": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.24"
-          }
-        },
-        "whatwg-fetch": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "whatwg-url": {
-          "version": "4.8.0",
-          "bundled": true,
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "which-module": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "worker-farm": {
-          "version": "1.7.0",
-          "bundled": true,
-          "requires": {
-            "errno": "~0.1.7"
-          }
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "write": {
-          "version": "0.2.1",
-          "bundled": true,
-          "requires": {
-            "mkdirp": "^0.5.1"
-          }
-        },
-        "xml-name-validator": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "xml2js": {
-          "version": "0.4.19",
-          "bundled": true,
-          "requires": {
-            "sax": ">=0.6.0",
-            "xmlbuilder": "~9.0.1"
-          }
-        },
-        "xmlbuilder": {
-          "version": "9.0.7",
-          "bundled": true
-        },
-        "xregexp": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "xtend": {
-          "version": "4.0.2",
-          "bundled": true
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "yargs": {
-          "version": "7.1.0",
-          "bundled": true,
-          "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "5.0.0",
-          "bundled": true,
-          "requires": {
-            "camelcase": "^3.0.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "yargs-unparser": {
-          "version": "1.6.0",
-          "bundled": true,
-          "requires": {
-            "flat": "^4.1.0",
-            "lodash": "^4.17.15",
-            "yargs": "^13.3.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "bundled": true
-            },
-            "cliui": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "string-width": "^3.1.0",
-                "strip-ansi": "^5.2.0",
-                "wrap-ansi": "^5.1.0"
-              }
-            },
-            "find-up": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "get-caller-file": {
-              "version": "2.0.5",
-              "bundled": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "lodash": {
-              "version": "4.17.15",
-              "bundled": true
-            },
-            "require-main-filename": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            },
-            "which-module": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "wrap-ansi": {
-              "version": "5.1.0",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^3.2.0",
-                "string-width": "^3.0.0",
-                "strip-ansi": "^5.0.0"
-              }
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "yargs": {
-              "version": "13.3.0",
-              "bundled": true,
-              "requires": {
-                "cliui": "^5.0.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^2.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
-                "string-width": "^3.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^13.1.1"
-              }
-            },
-            "yargs-parser": {
-              "version": "13.1.1",
-              "bundled": true,
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
-            }
-          }
-        },
-        "yauzl": {
-          "version": "2.10.0",
-          "bundled": true,
-          "requires": {
-            "buffer-crc32": "~0.2.3",
-            "fd-slicer": "~1.1.0"
-          }
-        }
       }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "optional": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "throttle-debounce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-1.0.1.tgz",
+      "integrity": "sha1-2tD+Ew+drzcZ/eoz3Dao5rp/MLU="
+    },
+    "tinycolor2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
+      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "ua-parser-js": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
+    },
+    "uncontrollable": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-5.1.0.tgz",
+      "integrity": "sha512-5FXYaFANKaafg4IVZXUNtGyzsnYEvqlr9wQ3WpZxFpEUxl29A3H6Q4G1Dnnorvq9TGOGATBApWR4YpLAh+F5hw==",
+      "requires": {
+        "invariant": "^2.2.4"
+      }
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+    },
+    "whatwg-url": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+      "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "xml-name-validator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     }
   }
 }

--- a/api/controller.py
+++ b/api/controller.py
@@ -608,6 +608,12 @@ class CirculationManagerController(BaseCirculationManagerController):
         if not last_modified:
             return None
 
+        # If-Modified-Since values have resolution of one second. If
+        # last_modified has millisecond resolution, change its
+        # resolution to one second.
+        if last_modified.microsecond:
+            last_modified = last_modified.replace(microsecond=0)
+
         # TODO: This can be cleaned up significantly in Python 3.
         if_modified_since = flask.request.headers.get('If-Modified-Since')
         if not if_modified_since:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -859,6 +859,9 @@ class TestBaseController(CirculationControllerTest):
         now_string = email.utils.formatdate(now_int)
         now_datetime = datetime.datetime.utcfromtimestamp(now_int)
 
+        # To make the test more realistic, set the microseconds value of 'now'.
+        now_datetime = now_datetime.replace(microsecond=random.randint(0, 999999))
+
         # If all of that was correct, we ended up with a datetime
         # that's very close to the one we can get with
         # datetime.datetime.utcnow(). If it's off (due to a


### PR DESCRIPTION
## Description

This branch fixes a bug I found while doing QA for SIMPLY-2922. Patron.last_loan_activity_sync has resolution of one microsecond, and If-Last-Modified values have resolution of one second. This means an If-Last-Modified value will almost always evaluate to "before" the last_loan_activity_sync used to generate it. This makes conditional HTTP GET fail in real cases.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
