### PR TITLE
The If-Modified-Since value has lower resolution than datetime.datetime, which makes conditional GET not work in real cases.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -608,6 +608,12 @@ class CirculationManagerController(BaseCirculationManagerController):
         if not last_modified:
             return None
 
+        # If-Modified-Since values have resolution of one second. If
+        # last_modified has millisecond resolution, change its
+        # resolution to one second.
+        if last_modified.microsecond:
+            last_modified = last_modified.replace(microsecond=0)
+
         # TODO: This can be cleaned up significantly in Python 3.
         if_modified_since = flask.request.headers.get('If-Modified-Since')
         if not if_modified_since:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -859,6 +859,9 @@ class TestBaseController(CirculationControllerTest):
         now_string = email.utils.formatdate(now_int)
         now_datetime = datetime.datetime.utcfromtimestamp(now_int)
 
+        # To make the test more realistic, set the microseconds value of 'now'.
+        now_datetime = now_datetime.replace(microsecond=random.randint(0, 999999))
+
         # If all of that was correct, we ended up with a datetime
         # that's very close to the one we can get with
         # datetime.datetime.utcnow(). If it's off (due to a


### PR DESCRIPTION
This branch fixes a bug I found while doing QA for https://jira.nypl.org/browse/SIMPLY-2922. Patron.last_loan_activity_sync has resolution of one microsecond, and If-Last-Modified values have resolution of one second. This means an If-Last-Modified value will almost always evaluate to "before" the last_loan_activity_sync used to generate it (the first microsecond of the second in question, versus let's say the 121301st microsecond). This makes conditional HTTP GET fail in real cases.

## Description

<!--- Describe your changes -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
