### PR TITLE
Fix test so missing WebPub manifest property can be null OR absent.

### DIFF
--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -600,7 +600,7 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         # part #0. Within that part, the items have been sorted by
         # their sequence.
         for i, item in enumerate(reading_order):
-            eq_(None, item['href'])
+            eq_(None, item.get('href', None))
             eq_(Representation.MP3_MEDIA_TYPE, item['type'])
             eq_(0, item['findaway:part'])
             eq_(i+1, item['findaway:sequence'])


### PR DESCRIPTION
## Description

Fix a test that expected a missing [Web Publication Manifiest](https://github.com/readium/webpub-manifest) property value to be represented by the presence of the property with the value of `None`, but did allow that state to also be represented by the absence of the property. Updated the test to accept both representations.

## Motivation and Context

It is acceptable (and even recommended) to represent the absence of a Web Publication Manifiest by not specifying the property at all.

The failing test is blocking [Server Core PR 1193](https://github.com/NYPL-Simplified/server_core/pull/1193).

## How Has This Been Tested?

Ran full test suite.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
