### PR TITLE
For URLs, use only path component to guess content type.

### DIFF
--- a/api/rbdigital.py
+++ b/api/rbdigital.py
@@ -2590,13 +2590,13 @@ class AudiobookManifest(CoreAudiobookManifest):
         if download_url:
             self.add_link(
                 download_url, 'alternate',
-                type=Representation.guess_media_type(download_url)
+                type=Representation.guess_url_media_type_from_path(download_url)
             )
 
         cover = self.best_cover(self.raw.get('images', []))
         if cover:
             self.add_link(
-                cover, "cover", type=Representation.guess_media_type(cover)
+                cover, "cover", type=Representation.guess_url_media_type_from_path(cover)
             )
 
     @classmethod


### PR DESCRIPTION
## Description

Use only the URL `path` component when attempting to determine the type of each of the RBdigital audiobook's manifest `links`.

## Motivation and Context

This PR depends on [Server Core PR 1192](https://github.com/NYPL-Simplified/server_core/pull/1192).

Because the RBdigital `alternate` download url link contains at the end of the URL, attempting to guess its media type using the file-oriented `Representation.guess_media_type` was failing, resulting in a null value for that property.

## How Has This Been Tested?

- Ran full test suite.
- Tests for the new method that provides this functionality are provided in [Server Core PR 1192](https://github.com/NYPL-Simplified/server_core/pull/1192), on which this PR depends.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
