### PR TITLE
Peg Flask-Babel version. Python 2 support dropped in v2.0.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ loggly-python-handler
 mock
 py-bcrypt
 pyspellchecker
-Flask-Babel
 money
 pymarc
 accept-types
@@ -34,6 +33,10 @@ ndg-httpsclient
 
 # In circ, feedparser is only used in tests.
 feedparser
+
+# Flask-Babel 2.0.0 drops support for Python 2.
+# https://github.com/python-babel/flask-babel/commit/52dbb6f632e07ceb7299bf8c41b6f691a36e9fe3#diff-2eeaed663bd0d25b7e608891384b7298
+Flask-Babel<2.0
 
 # nltk is a textblob dependency, and this is the last release that supports Python 2
 nltk==3.4.5


### PR DESCRIPTION
## Description

Pegs `Flask-Babel` package dependency to `<2.0`.

## Motivation and Context

`Flask-Babel` [drops Python 2.7 support](https://github.com/python-babel/flask-babel/commit/52dbb6f632e07ceb7299bf8c41b6f691a36e9fe3#diff-2eeaed663bd0d25b7e608891384b7298) in version 2.0.0.

## How Has This Been Tested?

Built the `circ-webapps` docker image from this branch and successfully ran `./hooks/test` script.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
