### PR TITLE
Fix site_configuration_has_changed parameter

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1181,9 +1181,9 @@ class TestBaseController(CirculationControllerTest):
         self._default_library.short_name = new_name
         self._db.commit()
 
-        # Bypass the 1-second timeout and make sure the site knows
+        # Bypass the 1-second cooldown and make sure the site knows
         # the configuration has actually changed.
-        model.site_configuration_has_changed(self._db, timeout=0)
+        model.site_configuration_has_changed(self._db, cooldown=0)
 
         # Just making the change and calling
         # site_configuration_has_changed was not enough to update the


### PR DESCRIPTION
## Description

Updates circulation manager to accommodate `site_configuration_has_changed` parameter change introduced in [Server Core PR 1195](https://github.com/NYPL-Simplified/server_core/pull/1195). It turns out the parameter was used in only a single test and was not present elsewhere in the code.

## Motivation and Context

Failing test in this repo.

## How Has This Been Tested?

Reviewed all code in this repo for calls to that function.
Ran all tests.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
