### PR TITLE
Fix issue with uszipcode library not loading DB

### DIFF
--- a/api/admin/geographic_validator.py
+++ b/api/admin/geographic_validator.py
@@ -15,12 +15,23 @@ from pypostalcode import PostalCodeDatabase
 import re
 import urllib
 import uszipcode
+import os
 
 class GeographicValidator(Validator):
+
+    @staticmethod
+    def get_us_search():
+        # Use a known path for the uszipcode db_file_dir that already contains the DB that the
+        # library would otherwise download. This is done because the host for this file can
+        # be flaky. There is an issue for this in the underlying library here:
+        # https://github.com/MacHu-GWU/uszipcode-project/issues/40
+        db_file_path = os.path.join(os.path.dirname(__file__), "..", "..", "data", "uszipcode")
+        return uszipcode.SearchEngine(simple_zipcode=True, db_file_dir=db_file_path)
+
     def validate_geographic_areas(self, values, db):
         # Note: the validator does not recognize data from US territories other than Puerto Rico.
 
-        us_search = uszipcode.SearchEngine(simple_zipcode=True)
+        us_search = self.get_us_search()
         ca_search = PostalCodeDatabase()
         CA_PROVINCES = {
             "AB": "Alberta",
@@ -106,7 +117,7 @@ class GeographicValidator(Validator):
 
     def look_up_zip(self, zip, country, formatted=False):
         if country == "US":
-            info = uszipcode.SearchEngine(simple_zipcode=True).by_zipcode(zip)
+            info = self.get_us_search().by_zipcode(zip)
             if formatted:
                 info = self.format_place(zip, info.major_city, info.state)
         elif country == "CA":

--- a/data/uszipcode/README.md
+++ b/data/uszipcode/README.md
@@ -1,0 +1,3 @@
+This files source is: https://datahub.io/machu-gwu/uszipcode-0.2.0-simple_db/r/simple_db.sqlite
+
+Its mirrored here for the reasons outlined in `api/admin/geographic_validator.py`. 


### PR DESCRIPTION
## Description

The [`uszipcode`](https://github.com/MacHu-GWU/uszipcode-project) library downloads a sql file on first request that it uses to look up zip codes. The host of this file is down currently and
appears to have been for several days.

This won't effect running circulation managers that have the file cached, but any new CM or one whose docker containers are restarted will see it failing.

## Motivation and Context

This PR takes the strategy outlined here:
https://github.com/MacHu-GWU/uszipcode-project/issues/40#issuecomment-688323810

It puts the db file in the repo, and passes the location of the DB into the `uszipcode` library so it doesn't have to go out and download it. 

This fix was discussed in slack here: 
https://librarysimplified.slack.com/archives/C3CLGUYGN/p1599680363036000

Issue here: 
https://jira.nypl.org/browse/SIMPLY-3062

## How Has This Been Tested?

Before this change the tests were failing as the library could not download its file. After these changes the tests pass again.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
