### PR TITLE
Deploy docs from the 'main' branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,6 @@ deploy:
   keep-history: true
   github_token: $GITHUB_TOKEN
   on:
-    branch: master
+    branch: main
   local_dir: docs/build/html/
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Library Simplified Circulation Manager
-[![Build Status](https://travis-ci.org/NYPL-Simplified/circulation.svg?branch=master)](https://travis-ci.org/NYPL-Simplified/circulation)
+[![Build Status](https://travis-ci.org/NYPL-Simplified/circulation.svg?branch=main)](https://travis-ci.org/NYPL-Simplified/circulation)
 
 This is the Circulation Manager for [Library Simplified](http://www.librarysimplified.org/). The circulation manager is the main connection between a library's collection and Library Simplified's various client-side applications. It handles user authentication, combines licensed works with open access content, pulls in updated book information from the [Metadata Wrangler](https://github.com/NYPL-Simplified/metadata_wrangler), and serves up available books in appropriately organized OPDS feeds.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -59,7 +59,7 @@ For troubleshooting information and installation directions for the entire Circu
 
 This image builds containers that will run a single script and stop. It's useful in conjunction with a tool like Amazon ECS Scheduled Tasks, where you can run script containers on a cron-style schedule.
 
-Unlike the `circ-scripts` image, which runs constantly and executes every possible maintenance script--whether or not your configuration requires it--`circ-exec` offers more nuanced control of your Library Simplified Circulation Manager jobs. The most accurate place to look for recommended jobs and their recommended frequencies is [the existing `circ-scripts` crontab](https://github.com/NYPL-Simplified/circulation-docker/blob/master/services/simplified_crontab).
+Unlike the `circ-scripts` image, which runs constantly and executes every possible maintenance script--whether or not your configuration requires it--`circ-exec` offers more nuanced control of your Library Simplified Circulation Manager jobs. The most accurate place to look for recommended jobs and their recommended frequencies is [the existing `circ-scripts` crontab](https://github.com/NYPL-Simplified/circulation/blob/main/docker/services/simplified_crontab).
 
 Because containers based on `circ-exec` are built, run their job, and are destroyed, it's important to configure an external log aggregator to find &#42;.log files in `/var/log/simplified/${SIMPLIFIED_SCRIPT_NAME}.log`.
 


### PR DESCRIPTION
## Description

This branch changes .travis.yml so that generated documentation comes from the `main` branch (previously `master`). As far as I can tell this is the only piece of this change that requires a change to our code base.

