### PR TITLE
Peg feedparser to a version that supports Python 2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,9 @@ sphinx # for code documentation
 # Ensure that we support SNI-based SSL
 ndg-httpsclient
 
-# In circ, feedparser is only used in tests.
-feedparser
+# In circ, feedparser is only used in tests. feedparser 6.0.0 drops
+# support for Python 2.
+feedparser<6.0.0
 
 # Flask-Babel 2.0.0 drops support for Python 2.
 # https://github.com/python-babel/flask-babel/commit/52dbb6f632e07ceb7299bf8c41b6f691a36e9fe3#diff-2eeaed663bd0d25b7e608891384b7298


### PR DESCRIPTION
Feedparser 6.0.0 was just released, and drops support for Python 2. This branch pegs our feedparser to a version that supports Python 2.

We're getting pretty close to being able to migrate to Python 3, so hopefully this won't keep happening for much longer.

Fixes https://jira.nypl.org/browse/SIMPLY-3080