### PR TITLE
An OPDS feed designed to help out automated integration tests

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -808,7 +808,7 @@ class OPDSFeedController(CirculationManagerController):
 
         for collection in self._db.query(Collection):
             for medium in Edition.FULFILLABLE_MEDIA:
-                for availability in ("now"):
+                for availability in ['now']:
                     filter_list.append((collection, medium, availability))
 
         search_engine = self.search_engine
@@ -827,6 +827,7 @@ class OPDSFeedController(CirculationManagerController):
         return feed_class.groups(
             _db=self._db, title="QA test feed", url=url, worklist=jwl,
             annotator=annotator, search_engine=search_engine,
+            max_age=CachedFeed.IGNORE_CACHE
         )
 
     def groups(self, lane_identifier, feed_class=AcquisitionFeed):

--- a/api/controller.py
+++ b/api/controller.py
@@ -89,7 +89,6 @@ from core.model import (
     CustomList,
     DataSource,
     DeliveryMechanism,
-    Edition,
     ExternalIntegration,
     Hold,
     Identifier,
@@ -802,28 +801,6 @@ class IndexController(CirculationManagerController):
         )
 
 class OPDSFeedController(CirculationManagerController):
-    def qa_feed(self, feed_class=AcquisitionFeed):
-        library = flask.request.library
-        search_engine = self.search_engine
-        if isinstance(search_engine, ProblemDetail):
-            return search_engine
-
-        url = self.cdn_url_for(
-            "qa_feed",
-            library_short_name=library.short_name,
-        )
-
-        jwl = JackpotWorkList(library)
-        annotator = self.manager.annotator(jwl)
-
-        # TODO: Make it possible to pass a pagination object into
-        # groups() to override the standard size of a grouped lane,
-        # improving performance.
-        return feed_class.groups(
-            _db=self._db, title="QA test feed", url=url, worklist=jwl,
-            annotator=annotator, search_engine=search_engine,
-            max_age=CachedFeed.IGNORE_CACHE
-        )
 
     def groups(self, lane_identifier, feed_class=AcquisitionFeed):
         """Build or retrieve a grouped acquisition feed.
@@ -1097,6 +1074,34 @@ class OPDSFeedController(CirculationManagerController):
             url=make_url(), lane=lane, search_engine=search_engine,
             query=query, annotator=annotator, pagination=pagination,
             facets=facets
+        )
+
+    def qa_feed(self, feed_class=AcquisitionFeed):
+        """Create an OPDS feed containing the information necessary to
+        run a full set of integration tests against this server and
+        the vendors it relies on.
+        """
+
+        library = flask.request.library
+        search_engine = self.search_engine
+        if isinstance(search_engine, ProblemDetail):
+            return search_engine
+
+        url = self.url_for(
+            "qa_feed",
+            library_short_name=library.short_name,
+        )
+
+        jwl = JackpotWorkList(library)
+        annotator = self.manager.annotator(jwl)
+
+        # TODO: Make it possible to pass a pagination object into
+        # groups() to override the standard size of a grouped lane,
+        # improving performance.
+        return feed_class.groups(
+            _db=self._db, title="QA test feed", url=url, worklist=jwl,
+            annotator=annotator, search_engine=search_engine,
+            max_age=CachedFeed.IGNORE_CACHE
         )
 
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -73,6 +73,7 @@ from core.lane import (
     Lane,
     SearchFacets,
     WorkList,
+    JackpotWorkList,
 )
 from core.log import LogConfiguration
 from core.marc import MARCExporter
@@ -807,7 +808,7 @@ class OPDSFeedController(CirculationManagerController):
 
         for collection in self._db.query(Collection):
             for medium in Edition.FULFILLABLE_MEDIA:
-                for availability in ("now", "all"):
+                for availability in ("now"):
                     filter_list.append((collection, medium, availability))
 
         search_engine = self.search_engine
@@ -819,10 +820,13 @@ class OPDSFeedController(CirculationManagerController):
             library_short_name=library.short_name,
         )
 
-        annotator = self.manager.annotator(None)
-        return feed_class.qa_feed(
-            _db=self._db, title="QA test feed", url=url, annotator=annotator,
-            search_engine=search_engine, filter_list=filter_list
+        jwl = JackpotWorkList()
+        jwl.initialize(library, filter_list=filter_list)
+
+        annotator = self.manager.annotator(jwl)
+        return feed_class.groups(
+            _db=self._db, title="QA test feed", url=url, worklist=jwl,
+            annotator=annotator, search_engine=search_engine,
         )
 
     def groups(self, lane_identifier, feed_class=AcquisitionFeed):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1244,17 +1244,31 @@ class CrawlableCustomListBasedLane(CrawlableLane):
         return self.ROUTE, kwargs
 
 class KnownOverviewFacetsWorkList(WorkList):
+    """A WorkList whose defining feature is that the Facets object
+    to be used when generating a grouped feed is known in advance.
+    """
     def __init__(self, facets, *args, **kwargs):
+        """Constructor.
+
+        :param facets: A Facets object to be used when generating a grouped
+           feed.
+        """
         super(KnownOverviewFacetsWorkList, self).__init__(*args, **kwargs)
         self.facets = facets
 
     def overview_facets(self, _db, facets):
+        """Return the faceting object to be used when generating a grouped
+        feed.
+        
+        :param _db: Ignored -- only present for API compatibility.
+        :param facets: Ignored -- only present for API compatibility.
+        """
         return self.facets
 
 
 class JackpotWorkList(WorkList):
-    """A WorkList guaranteed to, if possible, contain the exact selection
-    of books necessary to perform common QA tasks.
+    """A WorkList guaranteed to, so far as possible, contain the exact
+    selection of books necessary to perform common QA tasks.
 
     This makes it easy to write integration tests that work on real
     circulation managers and real books.

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1266,7 +1266,6 @@ class JackpotWorkList(WorkList):
         :param library: A Library
         """
         super(JackpotWorkList, self).initialize(library)
-        self.library = library
 
         # Initialize a list of child Worklists; one for each test that
         # a client might need to run.
@@ -1275,23 +1274,32 @@ class JackpotWorkList(WorkList):
         # Add one or more WorkLists for every collection in the
         # system, so that a client can test borrowing a book from
         # every collection.
-        for collection in library.collections:
+        for collection in sorted(library.collections, key=lambda x: x.name):
             for medium in Edition.FULFILLABLE_MEDIA:
                 for availability in [Facets.AVAILABLE_NOW]:
                     facets = Facets.default(
-                        self.library, availability=availability
+                        library, availability=availability
                     )
 
                     # Give each Worklist a name that is distinctive
                     # and easy for a client to parse.
-                    display_name = "[Collection test] - License source {%s} - Medium {%s} - Availability {%s} - Collection name {%s}" % (collection.data_source.name, medium, availability, collection.name)
+                    if collection.data_source:
+                        data_source_name = collection.data_source.name
+                    else:
+                        data_source_name = "[Unknown]"
+                    display_name = "[Collection test] - License source {%s} - Medium {%s} - Availability {%s} - Collection name {%s}" % (data_source_name, medium, availability, collection.name)
                     child = KnownOverviewFacetsWorkList(facets)
-                    child.initialize(self.library, display_name=display_name)
+                    child.initialize(
+                        library, media=[medium], display_name=display_name
+                    )
                     child.collection_ids = [collection.id]
                     self.children.append(child)
 
-            # TODO: Add other child lanes for other types of tests,
-            # e.g. a lane where all the books belong to some series.
+            # TODO: Add other child lanes for other types of tests:
+            #  One lane for every collection containing only books
+            #   that are _not_ available.
+            #  A lane where all books belong to some series
+            #  A lane where all books use a particular DRM scheme/format
 
     def works(self, _db, *args, **kwargs):
         """This worklist never has works of its own.

--- a/api/routes.py
+++ b/api/routes.py
@@ -242,6 +242,7 @@ def acquisition_groups(lane_identifier):
 @library_route('/qa-feed')
 @has_library
 @allows_patron_web
+@requires_auth
 @returns_problem_detail
 @compressible
 def qa_feed():

--- a/api/routes.py
+++ b/api/routes.py
@@ -239,6 +239,14 @@ def public_key_document():
 def acquisition_groups(lane_identifier):
     return app.manager.opds_feeds.groups(lane_identifier)
 
+@library_route('/qa-feed')
+@has_library
+@allows_patron_web
+@returns_problem_detail
+@compressible
+def qa_feed():
+    return app.manager.opds_feeds.qa_feed()
+
 @library_dir_route('/feed', defaults=dict(lane_identifier=None))
 @library_route('/feed/<lane_identifier>')
 @has_library

--- a/api/routes.py
+++ b/api/routes.py
@@ -267,7 +267,7 @@ def public_key_document():
 def acquisition_groups(lane_identifier):
     return app.manager.opds_feeds.groups(lane_identifier)
 
-@library_route('/qa-feed')
+@library_route('/feed/qa')
 @has_library
 @allows_patron_web
 @requires_auth

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -46,6 +46,7 @@ from api.lanes import (
     CrawlableCustomListBasedLane,
     CrawlableFacets,
     DynamicLane,
+    JackpotWorkList,
     RecommendationLane,
     RelatedBooksLane,
     SeriesFacets,
@@ -3848,6 +3849,54 @@ class TestOPDSFeedController(CirculationControllerTest):
             eq_(REMOTE_INTEGRATION_FAILED.uri, problem.uri)
             eq_(u'The search index for this site is not properly configured.',
                 problem.detail)
+
+    def test_qa_feed(self):
+        # Test the qa_feed() controller method.
+
+        # Bad search index setup -> Problem detail
+        self.assert_bad_search_index_gives_problem_detail(
+            lambda: self.manager.opds_feeds.qa_feed(None)
+        )
+
+        # The AcquisitionFeed.groups method is tested in core, so we're
+        # just going to test that appropriate values are passed into that
+        # method:
+        class MockFeed(object):
+            @classmethod
+            def groups(cls, **kwargs):
+                self.called_with = kwargs
+                return "An OPDS feed"
+
+        with self.request_context_with_library("/"):
+            expect_url = self.manager.opds_feeds.url_for(
+                'qa_feed', library_short_name=self._default_library.short_name,
+            )
+            response = self.manager.opds_feeds.qa_feed(feed_class=MockFeed)
+            eq_("An OPDS feed", response)
+
+        kwargs = self.called_with
+        eq_(self._db, kwargs.pop('_db'))
+        eq_("QA test feed", kwargs.pop("title"))
+        eq_(self.manager.external_search, kwargs.pop('search_engine'))
+        eq_(expect_url, kwargs.pop('url'))
+
+        # These feeds are never to be cached.
+        eq_(CachedFeed.IGNORE_CACHE, kwargs.pop('max_age'))
+
+        # To build the feed, a JackpotWorkList was instantiated for
+        # the Library.
+        worklist = kwargs.pop('worklist')
+        assert isinstance(worklist, JackpotWorkList)
+        eq_(self._default_library, worklist.get_library(self._db))
+
+        # Then a LibraryAnnotator object was created from the JackpotWorkList.
+        annotator = kwargs.pop('annotator')
+        assert isinstance(annotator, LibraryAnnotator)
+        eq_(worklist, annotator.lane)
+        eq_(None, annotator.facets)
+
+        # No other arguments were passed into qa_feed().
+        eq_({}, kwargs)
 
 
 class TestCrawlableFeed(CirculationControllerTest):

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -873,6 +873,31 @@ class TestCrawlableCustomListBasedLane(DatabaseTest):
         eq_(customlist.name, kwargs.get("list_name"))
 
 
+class TestKnownOverviewFacetsWorkList(DatabaseTest):
+    """Test of the KnownOverviewFacetsWorkList class.
+
+    This is an unusual class which should be used when hard-coding the
+    faceting object to use for a given WorkList when generating a
+    grouped feed.
+    """
+    def test_overview_facets(self):
+        # Show that we can hard-code the return value of overview_facets.
+        #
+        # core/tests/test_lanes.py#TestWorkList.test_groups_propagates_facets
+        # verifies that WorkList.groups() calls
+        # WorkList.overview_facets() and passes the return value
+        # (which we hard-code here) into WorkList.works().
+
+        # Pass in a known faceting object.
+        known_facets = object()
+        wl = KnownOverviewFacetsWorkList(known_facets)
+
+        # That faceting object is always returned when we're
+        # making a grouped feed.
+        some_other_facets = object()
+        eq_(known_facets, wl.overview_facets(self._db, some_other_facets))
+
+
 class TestJackpotWorkList(DatabaseTest):
     """Test the 'jackpot' WorkList that always contains the information
     necessary to run a full suite of integration tests.

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -363,6 +363,10 @@ class TestOPDSFeed(RouteTest):
             url, self.controller.search, "<lane_identifier>"
         )
 
+    def test_qa_feed(self):
+        url = '/feed/qa'
+        self.assert_authenticated_request_calls(url, self.controller.qa_feed)
+
 class TestMARCRecord(RouteTest):
     CONTROLLER_NAME = 'marc_records'
 


### PR DESCRIPTION
## Description

This branch adds a new grouped OPDS feed at /feed/QA whose sole purpose is to make it easy to run client-side functional tests against a working circulation manager.

Currently the feed contains two "lanes" for each of a library's collections: one containing currently available ebooks from that collection, and one containing currently available audiobooks from that collection. This eliminates the need for functional tests to guess at, search for, or randomly hope to be presented with books from various sources that can be borrowed and read or played.

In the future, we can expand this feed (or add more feeds) to make it easy to write other integration tests like the ones laid out in [SIMPLY-2973](https://jira.nypl.org/browse/SIMPLY-2973).

Note that generating this feed takes a long time on a site such as NYPL that has a lot of different collections. We can do work to optimize this later, but it's always going to be somewhat slow. For this reason adding more QA feeds for specific tests might be better than expanding this feed.

## Motivation and Context

Partially resolves [SIMPLY-2973](https://jira.nypl.org/browse/SIMPLY-2973).

## How Has This Been Tested?

In addition to the unit tests I ran this against NYPL's QA circulation manager. It took about 90 seconds to generate an OPDS feed but the feed contained the data I expected.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ x] All new and existing tests passed.
