### PR TITLE
Fix RelayState construction

### DIFF
--- a/api/saml/controller.py
+++ b/api/saml/controller.py
@@ -78,11 +78,10 @@ class SAMLController(object):
         :rtype: string
         """
         query = urllib.urlencode(params)
-
-        if '?' in url:
-            url += '&' + query
-        else:
-            url += '?' + query
+        url_parts = urlparse.urlsplit(url)
+        url_parts = urlparse.SplitResult(
+            url_parts.scheme, url_parts.netloc, url_parts.path, url_parts.query + query, url_parts.fragment)
+        url = url_parts.geturl()
 
         return url
 

--- a/tests/saml/test_controller.py
+++ b/tests/saml/test_controller.py
@@ -95,6 +95,18 @@ class TestSAMLController(ControllerTest):
                 SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
                 SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[0].entity_id
             })
+        ),
+        (
+            'with_all_parameters_set_and_fragment',
+            SAMLWebSSOAuthenticationProvider.NAME,
+            IDENTITY_PROVIDERS[0].entity_id,
+            'http://localhost#fragment',
+            None,
+            'http://localhost?' + urllib.urlencode({
+                SAMLController.LIBRARY_SHORT_NAME: 'default',
+                SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
+                SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[0].entity_id
+            }) + '#fragment'
         )
     ])
     def test_saml_authentication_redirect(


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR fixes the way CM constructs `RelayState`. Before it was trying to add required SAML parameters to the end of `RelayState` URL which wasn't correct. For example, if `RelayState` contained `#` symbol followed by a fragment part in the end, the resulting `RelayState` would end up being an incorrect URL which would lead to a failed SAML authentication.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
