### PR TITLE
Remove a library name from LCP endpoint URLs

### DIFF
--- a/api/lcp/controller.py
+++ b/api/lcp/controller.py
@@ -6,7 +6,7 @@ from flask import Response
 from api.controller import CirculationManagerController
 from api.lcp.factory import LCPServerFactory
 from core.lcp.credential import LCPCredentialFactory
-from core.model import Session, ExternalIntegration
+from core.model import Session, ExternalIntegration, Collection
 
 
 class LCPController(CirculationManagerController):
@@ -54,21 +54,21 @@ class LCPController(CirculationManagerController):
 
         return lcp_passphrase
 
-    def _get_lcp_collection(self, library):
+    def _get_lcp_collection(self, patron, collection_name):
         """Returns an LCP collection for a specified library
         NOTE: We assume that there is only ONE LCP collection per library
 
-        :param library: Library
-        :type library: core.model.library.Library
+        :param patron: Patron object
+        :type patron: core.model.patron.Patron
+
+        :param collection_name: Name of the collection
+        :type collection_name: string
 
         :return: LCP collection
         :rtype: core.model.collection.Collection
         """
-        lcp_collection = next(iter([
-            collection
-            for collection in library.collections
-            if collection.protocol == ExternalIntegration.LCP
-        ]))
+        db = Session.object_session(patron)
+        lcp_collection, _ = Collection.by_name_and_protocol(db, collection_name, ExternalIntegration.LCP)
 
         return lcp_collection
 
@@ -91,8 +91,14 @@ class LCPController(CirculationManagerController):
 
         return response
 
-    def get_lcp_license(self, license_id):
+    def get_lcp_license(self, collection_name, license_id):
         """Returns an LCP license with the specified ID
+
+        :param collection_name: Name of the collection
+        :type collection_name: string
+
+        :param license_id: License ID
+        :type license_id: string
 
         :return: Flask response containing the LCP license with the specified ID
         :rtype: string
@@ -100,9 +106,7 @@ class LCPController(CirculationManagerController):
         self._logger.info('Started fetching license # {0}'.format(license_id))
 
         patron = self._get_patron()
-
-        library = flask.request.library
-        lcp_collection = self._get_lcp_collection(library)
+        lcp_collection = self._get_lcp_collection(patron, collection_name)
         lcp_api = self.circulation.api_for_collection.get(lcp_collection.id)
         lcp_server = self._lcp_server_factory.create(lcp_api)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -570,20 +570,18 @@ def saml_callback():
     return app.manager.saml_controller.saml_authentication_callback(request, app.manager._db)
 
 
-@library_route('/lcp/hint')
-@has_library
+@app.route('/lcp/hint')
 @requires_auth
 @returns_problem_detail
 def lcp_passphrase():
     return app.manager.lcp_controller.get_lcp_passphrase()
 
 
-@library_route('/lcp/licenses/<license_id>')
-@has_library
+@app.route('/<collection_name>/lcp/licenses/<license_id>')
 @requires_auth
 @returns_problem_detail
-def lcp_license(license_id):
-    return app.manager.lcp_controller.get_lcp_license(license_id)
+def lcp_license(collection_name, license_id):
+    return app.manager.lcp_controller.get_lcp_license(collection_name, license_id)
 
 # Loan notifications for ODL distributors, eg. Feedbooks
 @library_route('/odl_notify/<loan_id>', methods=['GET', 'POST'])

--- a/tests/lcp/test_controller.py
+++ b/tests/lcp/test_controller.py
@@ -30,7 +30,7 @@ class TestLCPController(ControllerTest):
             controller = LCPController(manager)
             controller.authenticated_patron_from_request = MagicMock(return_value=patron)
 
-            url = 'http://circulationmanager.org/{0}/lcp/hint'.format(self._default_library.short_name)
+            url = 'http://circulationmanager.org/lcp/hint'
 
             with self.app.test_request_context(url):
                 request.library = self._default_library
@@ -72,15 +72,15 @@ class TestLCPController(ControllerTest):
             controller = LCPController(manager)
             controller.authenticated_patron_from_request = MagicMock(return_value=patron)
 
-            url = 'http://circulationmanager.org/{0}/lcp/licenses{0}'.format(
-                self._default_library.short_name, license_id)
+            url = 'http://circulationmanager.org/{0}/licenses{1}'.format(
+                LCPAPI.NAME, license_id)
 
             with self.app.test_request_context(url):
                 request.library = self._default_library
 
                 # Act
-                result1 = controller.get_lcp_license(license_id)
-                result2 = controller.get_lcp_license(license_id)
+                result1 = controller.get_lcp_license(LCPAPI.NAME, license_id)
+                result2 = controller.get_lcp_license(LCPAPI.NAME, license_id)
 
                 # Assert
                 for result in [result1, result2]:

--- a/tests/lcp/test_controller.py
+++ b/tests/lcp/test_controller.py
@@ -52,6 +52,39 @@ class TestLCPController(ControllerTest):
                     ]
                 )
 
+    def test_get_lcp_license_returns_problem_detail_when_collection_is_missing(self):
+        # Arrange
+        missing_collection_name = 'missing-collection'
+        license_id = 'e99be177-4902-426a-9b96-0872ae877e2f'
+        expected_license = json.loads(fixtures.LCPSERVER_LICENSE)
+        lcp_server = create_autospec(spec=LCPServer)
+        lcp_server.get_license = MagicMock(return_value=expected_license)
+        library = self.make_default_library(self._db)
+        lcp_collection = self._collection(LCPAPI.NAME, ExternalIntegration.LCP)
+        library.collections.append(lcp_collection)
+
+        with patch('api.lcp.controller.LCPServerFactory') as lcp_server_factory_constructor_mock:
+            lcp_server_factory = create_autospec(spec=LCPServerFactory)
+            lcp_server_factory.create = MagicMock(return_value=lcp_server)
+            lcp_server_factory_constructor_mock.return_value = lcp_server_factory
+
+            patron = self.default_patron
+            manager = CirculationManager(self._db, testing=True)
+            controller = LCPController(manager)
+            controller.authenticated_patron_from_request = MagicMock(return_value=patron)
+
+            url = 'http://circulationmanager.org/{0}/licenses{1}'.format(
+                missing_collection_name, license_id)
+
+            with self.app.test_request_context(url):
+                request.library = self._default_library
+
+                # Act
+                result = controller.get_lcp_license(missing_collection_name, license_id)
+
+                # Assert
+                eq_(result.status_code, 404)
+
     def test_get_lcp_license_returns_the_same_license_for_authenticated_patron(self):
         # Arrange
         license_id = 'e99be177-4902-426a-9b96-0872ae877e2f'


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

It removes a library name from all LCP endpoint URLs which means that LCP Status Server doesn't have to be bind to a particular library anymore.

## Motivation and Context

This PR solves the problem related to inability to reuse the single LCP Status Server with multiple libraries.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
