### PR TITLE
Explicitly set version numbers for all Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ docker==4.3.1
 docutils==0.16
 expiringdict==1.2.1
 Flask-Cors==3.0.9
+flask-sqlalchemy-session==1.1
 # freezegun is used for unit tests.
 freezegun==0.3.15
 html-sanitizer==1.9.1
@@ -34,6 +35,7 @@ pyfakefs==3.7
 Pygments==2.5.2
 PyJWT==1.4.2
 PyLD==0.7.3
+pypostalcode==0.3.4
 pyOpenSSL==19.1.0
 # TODO: python-Levenshtein is supposedly required for author name
 # matching, but is not a core requirement; perhaps it can be removed.
@@ -50,7 +52,9 @@ soupsieve==1.9.6
 Sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2
 typing==3.7.4.3
+unicodecsv==0.14.1
 uritemplate==3.0.1
+uszipcode==0.2.4
 wcag-contrast-ratio==0.9
 websocket-client==0.57.0
 # xmlsec is required for SAML authentication

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ ndg-httpsclient==0.5.1
 newrelic==5.18.0.148
 oauth2client==4.1.3
 packaging==20.4
-pkg-resources==0.0.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,83 +1,58 @@
-# Core requirements
-boto3
-elasticsearch>6.0.0,<7.0.0
-elasticsearch-dsl>6.0.0,<7.0.0
-pillow
-psycopg2
-requests==2.20.0
-urllib3<1.24 # Travis problem introduced 20181016 - check to see when we can remove
-sqlalchemy==1.2.0
-flask-sqlalchemy-session
-lxml
-flask>1.0.1
-werkzeug
-isbnlib
-nose
-python-dateutil
-uwsgi
-loggly-python-handler
-mock
-py-bcrypt
-pyspellchecker
-money
-pymarc
-accept-types
-unicodecsv
-uszipcode
-pypostalcode
-watchtower # for cloudwatch logging
-sphinx # for code documentation
+-r core/requirements.txt
 
-# Ensure that we support SNI-based SSL
-ndg-httpsclient
-
-# In circ, feedparser is only used in tests. feedparser 6.0.0 drops
-# support for Python 2.
-feedparser<6.0.0
-
-# Flask-Babel 2.0.0 drops support for Python 2.
-# https://github.com/python-babel/flask-babel/commit/52dbb6f632e07ceb7299bf8c41b6f691a36e9fe3#diff-2eeaed663bd0d25b7e608891384b7298
-Flask-Babel<2.0
-
-# nltk is a textblob dependency, and this is the last release that supports Python 2
-nltk==3.4.5
-
-# rsa is an oauth2client dependency. This is the last version to support Python 2.
-rsa==4.3
-
-# TODO: This is only used for summary evaluation, which I think should
-# only happen in the metadata wrangler, so it should be possible to move
-# it out of core.
-textblob
-
-# Used only by circulation
-oauth2client
-pyjwt==1.4.2
-flask-cors
-PyLD==0.7.3
-pycryptodome
-wcag-contrast-ratio
-uritemplate
-html-sanitizer
-expiringdict
-
-# A NYPL-specific requirement
-newrelic
-
-# for author name manipulations
-nameparser
-fuzzywuzzy
-python-Levenshtein
-
-# For SAML authentication
-python-saml
-isodate
-defusedxml
-xmlsec
-parameterized
-freezegun
-
-# For the LCP feature
-docker
+alabaster==0.7.12
+backports.functools-lru-cache==1.6.1
+backports.ssl-match-hostname==3.7.0.1
+beautifulsoup4==4.9.1
+cffi==1.14.3
+cryptography==3.1
+# defusedxml is required for SAML authentication
+defusedxml==0.6.0
+dm.xmlsec.binding==1.3.7
+# docker is used for the LCP feature.
+docker==4.3.1
+docutils==0.16
+expiringdict==1.2.1
+Flask-Cors==3.0.9
+# freezegun is used for unit tests.
+freezegun==0.3.15
+html-sanitizer==1.9.1
+httplib2==0.18.1
+imagesize==1.2.0
+# ndg-httpsclient ensures we support SNI-based SSL
+ndg-httpsclient==0.5.1
+# newrelic is an NYPL-sepcific requirement that might be removeable.
+newrelic==5.18.0.148
+oauth2client==4.1.3
+packaging==20.4
+pkg-resources==0.0.0
+pyasn1==0.4.8
+pyasn1-modules==0.2.8
+pycparser==2.20
+pycryptodome==3.9.8
+# pyfakefs is used for unit tests.
 pyfakefs==3.7
-requests-mock
+Pygments==2.5.2
+PyJWT==1.4.2
+PyLD==0.7.3
+pyOpenSSL==19.1.0
+# TODO: python-Levenshtein is supposedly required for author name
+# matching, but is not a core requirement; perhaps it can be removed.
+python-Levenshtein==0.12.0
+# python-saml is required for SAML authentication
+python-saml==2.8.0
+# requests-mock is used for unit tests.
+requests-mock==1.8.0
+# rsa is an oauth2client dependency. 4.3 is the last version to support Python 2.
+rsa==4.3
+snowballstemmer==2.0.0
+soupsieve==1.9.6
+# Sphinx is for code documentation
+Sphinx==1.8.5
+sphinxcontrib-websupport==1.1.2
+typing==3.7.4.3
+uritemplate==3.0.1
+wcag-contrast-ratio==0.9
+websocket-client==0.57.0
+# xmlsec is required for SAML authentication
+xmlsec==1.3.8


### PR DESCRIPTION
## Description

This is the circulation portion of https://jira.nypl.org/browse/SIMPLY-3100. The core portion is https://github.com/NYPL-Simplified/server_core/pull/1199

## Motivation and Context

Releases of Python dependencies can cause our builds to mysteriously break, especially now that Python packages are dropping Python 2 support.

I used a similar technique to the one mentioned in the core branch, but with a couple differences:

* Rather than including dependencies of core, I include the core requirements.txt file by reference.
* A few dependencies that were explicitly added to circulation (such as isodate) turned out to be dependencies-of-dependencies of core, so I didn't specify them again.
* There are a couple dependencies I don't think are actually required; I flagged them but haven't taken them out.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The main test is verifying that the environment set up to run the automated tests works. It's possible that that will work but the docker build will fail.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
