### PR TITLE
WIP: Use LCP license ID as a loan's external identifier to fetch the current library

### DIFF
--- a/api/base_controller.py
+++ b/api/base_controller.py
@@ -99,16 +99,7 @@ class BaseCirculationManagerController(object):
         """
         self.manager.reload_settings_if_changed()
 
-        loan = None
-
-        try:
-            loan = get_one(self._db, Loan, external_identifier=loan_external_identifier)
-        except:
-            logging.exception(
-                'An unexpected exception occurred during fetching a loan with external identifier {0}'.format(
-                    loan_external_identifier
-                )
-            )
+        loan = get_one(self._db, Loan, external_identifier=loan_external_identifier)
 
         if loan is None:
             return LOAN_NOT_FOUND

--- a/api/routes.py
+++ b/api/routes.py
@@ -598,11 +598,11 @@ def saml_callback():
     return app.manager.saml_controller.saml_authentication_callback(request, app.manager._db)
 
 
-@library_route('/lcp/hint')
-@has_library
+@app.route('/<collection_name>/lcp/licenses/<license_id>/hint')
+@has_library_through_external_loan_identifier(parameter_name='license_id')
 @requires_auth
 @returns_problem_detail
-def lcp_passphrase():
+def lcp_passphrase(collection_name, license_id):
     return app.manager.lcp_controller.get_lcp_passphrase()
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -150,6 +150,34 @@ def has_library(f):
             return f(*args, **kwargs)
     return decorated
 
+def has_library_through_external_loan_identifier(parameter_name='external_loan_identifier'):
+    """Decorator to get a library using the loan's external identifier.
+
+    :param parameter_name: Name of the parameter holding the loan's external identifier
+    :type parameter_name: string
+
+    :return: Decorated function
+    :rtype: Callable
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if parameter_name in kwargs:
+                external_loan_identifier = kwargs[parameter_name]
+            else:
+                external_loan_identifier = None
+
+            library = app.manager.index_controller.library_through_external_loan_identifier(external_loan_identifier)
+
+            if isinstance(library, ProblemDetail):
+                return library.response
+            else:
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
 def allows_library(f):
     """Decorator similar to @has_library but if there is no library short name,
     then don't set the request library.
@@ -570,7 +598,8 @@ def saml_callback():
     return app.manager.saml_controller.saml_authentication_callback(request, app.manager._db)
 
 
-@app.route('/lcp/hint')
+@library_route('/lcp/hint')
+@has_library
 @requires_auth
 @returns_problem_detail
 def lcp_passphrase():
@@ -578,6 +607,7 @@ def lcp_passphrase():
 
 
 @app.route('/<collection_name>/lcp/licenses/<license_id>')
+@has_library_through_external_loan_identifier(parameter_name='license_id')
 @requires_auth
 @returns_problem_detail
 def lcp_license(collection_name, license_id):


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR updates LCP endpoint URLs. I described the issue in more detail in [SIMPLY-3121](https://jira.nypl.org/browse/SIMPLY-3121).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
