### PR TITLE
HOTFIX - Fix overwrite of underlying dict in static settings.

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1723,15 +1723,25 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
     TEST_IDENTIFIER = 'test_identifier'
     TEST_PASSWORD = 'test_password'
 
+    TEST_IDENTIFIER_DESCRIPTION_FOR_REQUIRED_PASSWORD = _(
+        "A valid identifier that can be used to test that patron authentication is working."
+    )
+    TEST_IDENTIFIER_DESCRIPTION_FOR_OPTIONAL_PASSWORD = _("{} {}".format(
+        TEST_IDENTIFIER_DESCRIPTION_FOR_REQUIRED_PASSWORD,
+        "An optional Test Password for this identifier can be set in the next section.",
+    ))
+    TEST_PASSWORD_DESCRIPTION_REQUIRED = _("The password for the Test Identifier.")
+    TEST_PASSWORD_DESCRIPTION_OPTIONAL = _("The password for the Test Identifier (above, in previous section).")
+
     SETTINGS = [
         { "key": TEST_IDENTIFIER,
           "label": _("Test Identifier"),
-          "description": _("A valid identifier that can be used to test that patron authentication is working."),
+          "description": TEST_IDENTIFIER_DESCRIPTION_FOR_OPTIONAL_PASSWORD,
           "required": True,
         },
         { "key": TEST_PASSWORD,
           "label": _("Test Password"),
-          "description": _("The password for the test identifier."),
+          "description": TEST_PASSWORD_DESCRIPTION_OPTIONAL,
         },
         { "key" : IDENTIFIER_BARCODE_FORMAT,
           "label": _("Patron identifier barcode format"),

--- a/api/simple_authentication.py
+++ b/api/simple_authentication.py
@@ -31,9 +31,16 @@ class SimpleAuthenticationProvider(BasicAuthenticationProvider):
     TEST_NEIGHBORHOOD = 'neighborhood'
 
     basic_settings = list(BasicAuthenticationProvider.SETTINGS)
-    for setting in basic_settings:
-        if setting['key'] == BasicAuthenticationProvider.TEST_PASSWORD:
-            setting['required'] = True
+    for i, setting in enumerate(basic_settings):
+        if setting['key'] == BasicAuthenticationProvider.TEST_IDENTIFIER:
+            s = dict(**setting)
+            s['description'] = BasicAuthenticationProvider.TEST_IDENTIFIER_DESCRIPTION_FOR_REQUIRED_PASSWORD
+            basic_settings[i] = s
+        elif setting['key'] == BasicAuthenticationProvider.TEST_PASSWORD:
+            s = dict(**setting)
+            s['required'] = True
+            s['description'] = BasicAuthenticationProvider.TEST_PASSWORD_DESCRIPTION_REQUIRED
+            basic_settings[i] = s
 
     SETTINGS = basic_settings + [
         { "key": ADDITIONAL_TEST_IDENTIFIERS,


### PR DESCRIPTION
## Description

HOTFIX - Fixes an old regression that removed the ability to leave the `Test Password` credential unset for patron authentication integrations that were subclassed from `BasicAuthenticationProvider`.

In addition, this branch introduces some context-sensitive changes to the explanatory text for the `Test Identifier` and `Test Password` fields. Because of the way `circulation-web` handles the settings, it is currently not possible to group a required field with an optional one. They will end up in different sections. The text changes are a less than ideal, but hopefully workable, approach to giving the user a clue to the relationship between the fields in the case where the test password is optional.

## Motivation and Context

For BasicAuthenticationProvider and its subclasses, at least, the presence of a password when one is not expected causes patron authentication to fail [here](https://github.com/NYPL-Simplified/circulation/blob/develop/api/authenticator.py#L2061-L2063) in BasicAuthenticationProvider.server_side_validation. When the `Test Password` cannot be set/unset appropriately, certain capabilities of the `self-test` functionality are unavailable.

https://jira.nypl.org/browse/SIMPLY-1646

## How Has This Been Tested?

Manually tested UI in my dev environment. Specifically tested the following:
- That the `Test Password` is required when configuring a `Simple Authentication Provider` integration.
- That the `Test Password` is NOT required when configuring a `Millenium` or `SIP2` patron authentication integration.
- That when `Test Password` is required, it appears directly under `Test Identifier` in the `Required Fields` section and both fields have the correct explanatory text.
- That when `Test Password` is NOT required, it appears in the the `Optional Fields` section and both fields have the correct explanatory text (referencing each other from another section).
- That both fields appear in only one section.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
