### PR TITLE
Use "long" web client URLs in MARC 856 fields 

### DIFF
--- a/api/marc.py
+++ b/api/marc.py
@@ -2,6 +2,7 @@ from nose.tools import set_trace
 from pymarc import Field
 import urllib
 
+from core.config import Configuration
 from core.marc import (
     Annotator,
     MARCExporter,
@@ -15,6 +16,8 @@ class LibraryAnnotator(Annotator):
     def __init__(self, library):
         super(LibraryAnnotator, self).__init__()
         self.library = library
+        _db = Session.object_session(library)
+        self.base_url = ConfigurationSetting.sitewide(_db, Configuration.BASE_URL_KEY).value
 
     def value(self, key, integration):
         _db = Session.object_session(integration)
@@ -60,13 +63,18 @@ class LibraryAnnotator(Annotator):
             ConfigurationSetting.library_id==library.id
         ) if s.value]
 
-        for setting in settings:
+        qualified_identifier = urllib.quote(identifier.type + "/" + identifier.identifier, safe='')
+
+        for web_client_base_url in settings:
+            url = "{}/book/{}/{}/works/{}".format(
+                web_client_base_url,
+                self.base_url,
+                library.short_name,
+                qualified_identifier,
+            )
             record.add_field(
                 Field(
                     tag="856",
                     indicators=["4", "0"],
-                    subfields=[
-                        "u", setting + "/book/" + urllib.quote(identifier.type + "/" + identifier.identifier, safe='')
-                    ]))
-
-
+                    subfields=["u", url],
+                ))

--- a/migration/20200930-re-generate-marc-856-u-urls.sql
+++ b/migration/20200930-re-generate-marc-856-u-urls.sql
@@ -1,0 +1,10 @@
+-- Delete all generate-marc workcoveragerecords records, so that new links will be created.
+delete from workcoveragerecords where operation = 'generate-marc';
+
+-- Delete cached MARC delta files (those with a start time),
+-- as they will contain invalid links in the 856|u.
+delete from cachedmarcfiles where start_time is not null;
+
+-- Null out the end_time for remaining cached MARC files so that the
+-- coverage provider will regenerate the records as soon as possible.
+update cachedmarcfiles set end_time = null;


### PR DESCRIPTION
## Description

This branch does the following:
- Changes the format of the MARC `856|u` links created by `LibraryAnnotator.add_web_client_urls`. 
- Provides a DB migration to perform either `(1a)` or `(1b)` *and* `(2)` below:
  1a. Delete all `generate-marc workcoveragerecords` records, so that the next delta will contain all records (needed only if we decide to retain existing delta files).
  1b. Delete cached MARC delta files (those with a start time), as they will contain invalid links in the `856|u` (needed only if we decide NOT to retain existing delta files).
  2. Null out the end_time for remaining (full dump) cached MARC files, so that the coverage provider will regenerate the records as soon as possible.
- Updates associated tests for the new format and reorganizes the code slightly to make it easier to make future adjustments to the format.

The new format is of the form:
```
<web-client-base-url>/book/<cm-base-url>/<lib-short-name>/works/<qualified-identifier>
```
rather than the previous, _shortened_, form:
```
<web-client-base-url>/book/<qualified-identifier>
```
## Motivation and Context

Handling of so-called shortened URLs has been removed from [Circulation Patron Web PR #135](https://github.com/NYPL-Simplified/circulation-patron-web/pull/135). The links in MARC record `856|u` need to conform to this new format.

https://jira.nypl.org/browse/SIMPLY-3093

## How Has This Been Tested?

Tested various database migration scenarios against the `cache_marc_files` script to ensure that I understood their effects and to arrive at what is articulated above in the description.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
