### PR TITLE
Remove line of bad CSS from template styles

### DIFF
--- a/api/admin/template_styles.py
+++ b/api/admin/template_styles.py
@@ -6,7 +6,6 @@ body_style = """
     color: #403d37;
     border: 1px solid #DDD;
     border-radius: 4px;
-    0 1px 1px rgba(0, 0, 0, .05);
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
Resolves (hopefully!!) https://jira.nypl.org/browse/SIMPLY-3136

This is largely guesswork, because the only way I've been able to reproduce the bug is on production in Firefox, but Firefox is upset about a problematic line of CSS in `api/admin/template_styles`.  Which is very fair; there was a value with no key.  Not sure how/when that got in there...or why other browsers haven't complained about it!  

I don't know which CSS property the value was initially supposed to go with--my best guess would be a drop shadow--but removing the line doesn't alter the appearance of the interface in any way (presumably because the value wasn't usable anyway), so I vote we just get rid of it.

I can't promise that this is going to completely resolve the bug...but it's definitely something that should be fixed either way, and I imagine it's at least a piece of the problem.

@killerpuppytails If you run into this bug again, then please expand the error messages in the console--click on the little arrows on the left, and follow the link to the problem spot in the code (all the way on the right)--and screenshot the results.
