### PR TITLE
Encode work link param for MARC 856|u web client URLs

### DIFF
--- a/api/marc.py
+++ b/api/marc.py
@@ -66,11 +66,15 @@ class LibraryAnnotator(Annotator):
         qualified_identifier = urllib.quote(identifier.type + "/" + identifier.identifier, safe='')
 
         for web_client_base_url in settings:
-            url = "{}/book/{}/{}/works/{}".format(
-                web_client_base_url,
+            link = "{}/{}/works/{}".format(
                 self.base_url,
                 library.short_name,
                 qualified_identifier,
+            )
+            encoded_link = urllib.quote(link, safe='')
+            url = "{}/book/{}".format(
+                web_client_base_url,
+                encoded_link
             )
             record.add_field(
                 Field(

--- a/migration/20201002-redo-re-generate-marc-856-u-urls.sql
+++ b/migration/20201002-redo-re-generate-marc-856-u-urls.sql
@@ -1,0 +1,7 @@
+-- Delete cached MARC delta files (those with a start time),
+-- as they will contain invalid links in the 856|u.
+delete from cachedmarcfiles where start_time is not null;
+
+-- Null out the end_time for remaining cached MARC files so that the
+-- coverage provider will regenerate the records as soon as possible.
+update cachedmarcfiles set end_time = null where start_time is null;


### PR DESCRIPTION
## Description

This branch does the following:
- Fixes the format of the MARC `856|u` links created by `LibraryAnnotator.add_web_client_urls` to encode the entire work URL param (which includes the already encoded qualified identifer (`type + '/' + indentifier`).
- Provides a DB migration to:
  1. Delete cached MARC delta files (those with a `start_time`), as they will contain invalid links in the `856|u`.
  2. Null out the `end_time` for remaining (full dump, without a `start_time`) cached MARC files, so that the coverage provider will regenerate the records as soon as possible.
- Updates associated tests for the new format .

The URL for a work is constructed as follows and then encoded:
```
<cm-base>/<lib-short-name>/works/<qualified-identifier>
```

The associated web client URL is constructed as:
```
<web-client-base>/book/<encoded-work-url>
```

## Motivation and Context

PR #1498, the first PR aimed at generating "long" web client URLs, did not encode the work URL param. Circulation Patron Web needs it to be encoded.

A somewhat redundant database migration is included, since it is theoretically possible that new records were generated somewhere based on PR #1498 changes.

https://jira.nypl.org/browse/SIMPLY-3093

## How Has This Been Tested?

Modified one test method for the specific format change and ran all tests.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
