### PR TITLE
Deny a patron with a root lane access to lanes and books not visible through that lane.

### DIFF
--- a/api/adobe_vendor_id.py
+++ b/api/adobe_vendor_id.py
@@ -739,8 +739,11 @@ class AuthdataUtility(object):
         ):
             raise CannotLoadConfiguration(
                 "Short Client Token configuration is incomplete. "
-                "vendor_id, username, password and "
-                "Library website_url must all be defined.")
+                "vendor_id (%s), username (%s), password (%s) and "
+                "Library website_url (%s) must all be defined." % (
+                    vendor_id, library_uri, library_short_name, secret
+                )
+            )
         if '|' in library_short_name:
             raise CannotLoadConfiguration(
                 "Library short name cannot contain the pipe character."

--- a/api/controller.py
+++ b/api/controller.py
@@ -1882,7 +1882,7 @@ class WorkController(CirculationManagerController):
             lane = RelatedBooksLane(
                 library, work, lane_name, novelist_api=novelist_api
             )
-        except ValueError, e:
+        except ValueError:
             # No related books were found.
             return NO_SUCH_LANE.detailed(e.message)
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -167,13 +167,13 @@ class CirculationManager(object):
         application-specific access restrictions:
 
         * You can't use nonstandard caching rules unless you're an authenticated administrator.
-        * You can't access a WorkList that's not visible to you.
+        * You can't access a WorkList that's not accessible to you.
         """
 
         facets = load_facets_from_request(*args, **kwargs)
 
         worklist = kwargs.get('worklist')
-        if worklist is not None and not worklist.is_visible_to(self.request_patron):
+        if worklist is not None and not worklist.accessible_to(self.request_patron):
             return NO_SUCH_LANE.detailed(_("Lane does not exist"))
 
         if isinstance(facets, BaseFacets) and getattr(facets, 'max_cache_age', None) is not None:
@@ -638,8 +638,8 @@ class CirculationManagerController(BaseCirculationManagerController):
                     self._db, Lane, id=lane_identifier, library_id=library_id
                 )
 
-        if lane and not lane.visible_to(self.request_patron):
-            # The authenticated patron cannot see the lane they
+        if lane and not lane.accessible_to(self.request_patron):
+            # The authenticated patron cannot access the lane they
             # requested. Act like the lane does not exist.
             lane = None
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -1882,7 +1882,7 @@ class WorkController(CirculationManagerController):
             lane = RelatedBooksLane(
                 library, work, lane_name, novelist_api=novelist_api
             )
-        except ValueError:
+        except ValueError as e:
             # No related books were found.
             return NO_SUCH_LANE.detailed(e.message)
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -711,7 +711,7 @@ class CirculationManagerController(BaseCirculationManagerController):
             return patron
 
         work = license_pool.work
-        if not work.age_appropriate_for(patron):
+        if not work.age_appropriate_for_patron(patron):
             return FORBIDDEN_BY_POLICY.detailed(
                 _("Library policy considers this title inappropriate for your patron type."),
                 status_code=451

--- a/api/controller.py
+++ b/api/controller.py
@@ -703,7 +703,7 @@ class CirculationManagerController(BaseCirculationManagerController):
             return patron
 
         work = license_pool.work
-        if work.too_grown_up_for(patron):
+        if not work.age_appropriate_for(patron):
             return FORBIDDEN_BY_POLICY.detailed(
                 _("Library policy considers this title inappropriate for your patron type."),
                 status_code=451

--- a/api/controller.py
+++ b/api/controller.py
@@ -721,6 +721,21 @@ class CirculationManagerController(BaseCirculationManagerController):
         return mechanism or BAD_DELIVERY_MECHANISM
 
     def apply_borrowing_policy(self, patron, license_pool):
+        """Apply the borrowing policy of the patron's library to the
+        book they're trying to check out.
+
+        This prevents a patron from borrowing an age-inappropriate book
+        or from placing a hold in a library that prohibits holds.
+
+        Generally speaking, both of these operations should be
+        prevented before they get to this point; this is an extra
+        layer of protection.
+
+        :param patron: A `Patron`. It's okay if this turns out to be a
+           `ProblemDetail` or `None` due to a problem earlier in the
+           process.
+        :param license_pool`: The `LicensePool` the patron is trying to act on.
+        """
         if patron is None or isinstance(patron, ProblemDetail):
             # An earlier stage in the process failed to authenticate
             # the patron.

--- a/api/controller.py
+++ b/api/controller.py
@@ -1959,6 +1959,8 @@ class ProfileController(CirculationManagerController):
     def _controller(self):
         """Instantiate a CoreProfileController that actually does the work.
         """
+        # TODO: Probably better to use request_patron and check for
+        # None here.
         patron = self.authenticated_patron_from_request()
         storage = CirculationPatronProfileStorage(patron, flask.url_for)
         return CoreProfileController(storage)

--- a/api/controller.py
+++ b/api/controller.py
@@ -666,7 +666,13 @@ class CirculationManagerController(BaseCirculationManagerController):
 
         # We know there is at least one LicensePool, and all LicensePools
         # for an Identifier have the same Work.
-        return pools[0].work
+        work = pools[0].work
+
+        if work and not work.age_appropriate_for_patron(self.request_patron):
+            # This work is not age-appropriate for the authenticated
+            # patron. Act like it doesn't exist.
+            work = None
+        return work
 
     def load_licensepools(self, library, identifier_type, identifier):
         """Turn user input into one or more LicensePool objects.

--- a/api/controller.py
+++ b/api/controller.py
@@ -173,8 +173,15 @@ class CirculationManager(object):
         facets = load_facets_from_request(*args, **kwargs)
 
         worklist = kwargs.get('worklist')
-        if worklist is not None and not worklist.accessible_to(self.request_patron):
-            return NO_SUCH_LANE.detailed(_("Lane does not exist"))
+        if worklist is not None:
+
+            # Try to get the index controller. If it's not initialized
+            # for any reason, don't run this check -- we have bigger
+            # problems.
+            index_controller = getattr(self, 'index_controller', None)
+            if (index_controller and not
+                worklist.accessible_to(index_controller.request_patron)):
+                return NO_SUCH_LANE.detailed(_("Lane does not exist"))
 
         if isinstance(facets, BaseFacets) and getattr(facets, 'max_cache_age', None) is not None:
             # A faceting object was loaded, and it tried to do something nonstandard

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -853,14 +853,14 @@ class WorkBasedLane(DynamicLane):
         worklist.languages = self.languages
         worklist.audiences = self.audiences
 
-    def visible_to(self, patron):
-        """A lane based on a specific Work is visible to a Patron if the
+    def accessible_to(self, patron):
+        """A lane based on a specific Work is accessible to a Patron if the
         Work is age-appropriate for the patron.
 
         :param patron: A Patron
         :return: A boolean
         """
-        return self.work.age_appropriate_for_patron(patron)
+        return (not self.work or self.work.age_appropriate_for_patron(patron))
 
 
 class RecommendationLane(WorkBasedLane):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -854,13 +854,17 @@ class WorkBasedLane(DynamicLane):
         worklist.audiences = self.audiences
 
     def accessible_to(self, patron):
-        """A lane based on a specific Work is accessible to a Patron if the
-        Work is age-appropriate for the patron.
+        """In addition to the restrictions imposed by the superclass, a lane
+        based on a specific Work is accessible to a Patron only if the
+        Work itself is age-appropriate for the patron.
 
         :param patron: A Patron
         :return: A boolean
         """
-        return (not self.work or self.work.age_appropriate_for_patron(patron))
+        superclass_ok = super(WorkBasedLane, self).accessible_to(patron)
+        return superclass_ok and (
+            not self.work or self.work.age_appropriate_for_patron(patron)
+        )
 
 
 class RecommendationLane(WorkBasedLane):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -853,6 +853,15 @@ class WorkBasedLane(DynamicLane):
         worklist.languages = self.languages
         worklist.audiences = self.audiences
 
+    def visible_to(self, patron):
+        """A lane based on a specific Work is visible to a Patron if the
+        Work is age-appropriate for the patron.
+
+        :param patron: A Patron
+        :return: A boolean
+        """
+        return self.work.age_appropriate_for_patron(patron)
+
 
 class RecommendationLane(WorkBasedLane):
     """A lane of recommended Works based on a particular Work"""

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -188,6 +188,11 @@ FORBIDDEN_BY_POLICY = pd(
       _("Library policy prevents us from carrying out your request."),
 )
 
+NOT_AGE_APPROPRIATE = FORBIDDEN_BY_POLICY.detailed(
+    _("Library policy considers this title inappropriate for your patron type."),
+    status_code=451
+)
+
 CANNOT_FULFILL = pd(
       "http://librarysimplified.org/terms/problem/cannot-fulfill-loan",
       400,

--- a/api/routes.py
+++ b/api/routes.py
@@ -81,6 +81,9 @@ def requires_auth(f):
 def allows_auth(f):
     """Decorator function for a controller method that supports both
     authenticated and unauthenticated requests.
+
+    NOTE: This decorator might not be necessary; you can probably call
+    BaseCirculationManagerController.request_patron instead.
     """
     @wraps(f)
     def decorated(*args, **kwargs):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -419,7 +419,6 @@ class TestCirculationManager(CirculationControllerTest):
         manager.adobe_device_management = object()
         manager.oauth_controller = object()
         manager.auth = object()
-        manager.lending_policy = object()
         manager.shared_collection_api = object()
         manager.new_custom_index_views = object()
         manager.patron_web_domains = object()
@@ -484,9 +483,6 @@ class TestCirculationManager(CirculationControllerTest):
 
         # The ExternalSearch object has been reset.
         assert isinstance(manager.external_search, MockExternalSearchIndex)
-
-        # So has the lending policy.
-        assert isinstance(manager.lending_policy, dict)
 
         # The OAuth controller has been recreated.
         assert isinstance(manager.oauth_controller, OAuthController)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2970,6 +2970,9 @@ class TestWorkController(CirculationControllerTest):
         # An end-to-end test of the idea that a patron can't access
         # feeds configured to include titles that would not be
         # age-appropriate for that patron.
+        #
+        # A similar test could be run for any of the other subclasses
+        # of DynamicLane.
         m = self.manager.work_controller.contributor
 
         contributor, ignore = self._contributor()

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -395,10 +395,10 @@ class TestWorkBasedLane(DatabaseTest):
         # A lane based on a Work is accessible to a patron only if
         # the Work is age-appropriate for the patron.
         work = self._work()
-        patron = object()
+        patron = self._patron()
+        lane = WorkBasedLane(self._default_library, work)
 
         work.age_appropriate_for_patron = MagicMock(return_value=False)
-        lane = WorkBasedLane(self._default_library, work)
         eq_(False, lane.accessible_to(patron))
         work.age_appropriate_for_patron.assert_called_once_with(patron)
 
@@ -411,9 +411,13 @@ class TestWorkBasedLane(DatabaseTest):
         lane.work = work
         work.age_appropriate_for_patron = MagicMock(return_value=True)
         lane = WorkBasedLane(self._default_library, work)
-        patron = object()
         eq_(True, lane.accessible_to(patron))
         work.age_appropriate_for_patron.assert_called_once_with(patron)
+
+        # The WorkList rules are still enforced -- a patron from
+        # library B can't access any kind of WorkList from library A.
+        other_library_patron = self._patron(library=self._library())
+        eq_(False, lane.accessible_to(other_library_patron))
 
 
 class TestRelatedBooksLane(DatabaseTest):

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -408,7 +408,10 @@ class TestWorkBasedLane(DatabaseTest):
         # accessible -- but things probably won't work.
         lane.work = None
         eq_(True, lane.accessible_to(patron))
-        eq_(1, work.age_appropriate_for_patron.call_count)
+
+        # age_appropriate_for_patron wasn't called, since there was no
+        # work.
+        work.age_appropriate_for_patron.assert_called_once_with(patron)
 
         lane.work = work
         work.age_appropriate_for_patron = MagicMock(return_value=True)
@@ -421,6 +424,11 @@ class TestWorkBasedLane(DatabaseTest):
         # library A.
         other_library_patron = self._patron(library=self._library())
         eq_(False, lane.accessible_to(other_library_patron))
+
+        # age_appropriate_for_patron was never called with the new
+        # patron -- the WorkList rules answered the question before we
+        # got to that point.
+        work.age_appropriate_for_patron.assert_called_once_with(patron)
 
 
 class TestRelatedBooksLane(DatabaseTest):

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -414,8 +414,9 @@ class TestWorkBasedLane(DatabaseTest):
         eq_(True, lane.accessible_to(patron))
         work.age_appropriate_for_patron.assert_called_once_with(patron)
 
-        # The WorkList rules are still enforced -- a patron from
-        # library B can't access any kind of WorkList from library A.
+        # The WorkList rules are still enforced -- for instance, a
+        # patron from library B can't access any kind of WorkList from
+        # library A.
         other_library_patron = self._patron(library=self._library())
         eq_(False, lane.accessible_to(other_library_patron))
 

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -8,6 +8,7 @@ from nose.tools import (
 )
 import json
 import datetime
+from mock import MagicMock
 
 from . import (
     DatabaseTest,
@@ -389,6 +390,30 @@ class TestWorkBasedLane(DatabaseTest):
         # of children. It doesn't reuse the first lane's list.
         lane2 = WorkBasedLane(self._default_library, work)
         eq_([], lane2.children)
+
+    def test_accessible_to(self):
+        # A lane based on a Work is accessible to a patron only if
+        # the Work is age-appropriate for the patron.
+        work = self._work()
+        patron = object()
+
+        work.age_appropriate_for_patron = MagicMock(return_value=False)
+        lane = WorkBasedLane(self._default_library, work)
+        eq_(False, lane.accessible_to(patron))
+        work.age_appropriate_for_patron.assert_called_once_with(patron)
+
+        # If for whatever reason Work is not set, we just we say the Lane is
+        # accessible -- but things probably won't work.
+        lane.work = None
+        eq_(True, lane.accessible_to(patron))
+        eq_(1, work.age_appropriate_for_patron.call_count)
+
+        lane.work = work
+        work.age_appropriate_for_patron = MagicMock(return_value=True)
+        lane = WorkBasedLane(self._default_library, work)
+        patron = object()
+        eq_(True, lane.accessible_to(patron))
+        work.age_appropriate_for_patron.assert_called_once_with(patron)
 
 
 class TestRelatedBooksLane(DatabaseTest):


### PR DESCRIPTION
## Description

This branch removes a feature that was had not been used for a long time -- the library's loan policy -- and reimplements it in terms of an existing feature -- the patron's root lane.

A patron may or may not have a root lane. Before this branch, the root lane only controlled which lane a patron saw when they hit the root feed URL. Now, a patron's root lane puts additional restrictions on their activity:

* A patron with a root lane cannot view an OPDS feed for a Lanes that is 'above' their root lane 
* A patron with a root lane cannot view an OPDS feeds for a WorkList that might contain material not age-appropriate for their root lane. (As an example: a `ContributorLane` with `.audiences` set to include an age-inappropriate audience.)
* A patron with a root lane cannot access any controller for a book that is not age-appropriate for their root lane -- the circulation manager will send a problem detail. This includes the "permalink" controller but also the "borrow" and "place hold" controllers.
* A patron with a root lane cannot borrow a book that is not age-appropriate for their root lane. (But it shouldn't come to this because they won't be able to access the "borrow" controller in the first place.)

"Age-appropriate" is a concept defined in the [core branch](https://github.com/NYPL-Simplified/server_core/pull/1201) that goes along with this branch. In fact most of the code is in the core branch; this branch just uses that code to enforce the rules.

## Motivation and Context

https://jira.nypl.org/browse/SIMPLY-3125

## How Has This Been Tested?

`authenticated_patron_from_request` had no specific unit test coverage, so I added some. `load_lane` had test coverage but it was out of date because the class it was in had a name that didn't start with `Test`. I rewrote it.

In addition to the unit tests, I wrote some end-to-end tests illustrating the way people think of this feature: not in terms of certain methods being called, but in terms of certain patrons trying to take certain actions and not being allowed.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
