### PR TITLE
Add support for RWPM .audiobook files

### DIFF
--- a/api/lcp/utils.py
+++ b/api/lcp/utils.py
@@ -27,6 +27,8 @@ def get_target_extension(input_extension):
         target_extension = '.lcpdf'
     elif input_extension == '.lpf':
         target_extension = ".audiobook"
+    elif input_extension == '.audiobook':
+        target_extension = ".audiobook"
     else:
         raise LCPError('Unknown extension "{0}"'.format(input_extension))
 

--- a/scripts.py
+++ b/scripts.py
@@ -1312,7 +1312,7 @@ class DirectoryImportScript(TimestampScript):
         parser.add_argument(
             '--default-medium-type',
             help=u'Default medium type used in the case when it\'s not explicitly specified in a metadata file. '
-                 u'Valid values are: EditionConstants.FULFILLABLE_MEDIA.',
+                 u'Valid values are: {0}.'.format(', '.join(EditionConstants.FULFILLABLE_MEDIA)),
             type=str,
             choices=EditionConstants.FULFILLABLE_MEDIA
         )

--- a/scripts.py
+++ b/scripts.py
@@ -90,7 +90,7 @@ from core.model import (
     Subject,
     Timestamp,
     Work,
-)
+    EditionConstants)
 from core.model.configuration import ExternalIntegrationLink
 from core.opds import (
     AcquisitionFeed,
@@ -1309,6 +1309,14 @@ class DirectoryImportScript(TimestampScript):
             help=u"Show what would be imported, but don't actually do the import.",
             action='store_true',
         )
+        parser.add_argument(
+            '--default-medium-type',
+            help=u'Default medium type used in the case when it\'s not explicitly specified in a metadata file. '
+                 u'Valid values are: Book, Audio.',
+            type=str,
+            choices=(EditionConstants.BOOK_MEDIUM, EditionConstants.AUDIO_MEDIUM)
+        )
+
         return parser
 
     def do_run(self, cmd_args=None):
@@ -1323,16 +1331,33 @@ class DirectoryImportScript(TimestampScript):
         ebook_directory = parsed.ebook_directory
         rights_uri = parsed.rights_uri
         dry_run = parsed.dry_run
+        default_medium_type = parsed.default_medium_type
+
         return self.run_with_arguments(
-            collection_name, collection_type, data_source_name,
-            metadata_file, metadata_format, cover_directory,
-            ebook_directory, rights_uri, dry_run
+            collection_name,
+            collection_type,
+            data_source_name,
+            metadata_file,
+            metadata_format,
+            cover_directory,
+            ebook_directory,
+            rights_uri,
+            dry_run,
+            default_medium_type
         )
 
     def run_with_arguments(
-            self, collection_name, collection_type, data_source_name, metadata_file,
-            metadata_format, cover_directory, ebook_directory, rights_uri,
-            dry_run
+            self,
+            collection_name,
+            collection_type,
+            data_source_name,
+            metadata_file,
+            metadata_format,
+            cover_directory,
+            ebook_directory,
+            rights_uri,
+            dry_run,
+            default_medium_type=None
     ):
         if dry_run:
             self.log.warn(
@@ -1351,7 +1376,7 @@ class DirectoryImportScript(TimestampScript):
 
         replacement_policy = ReplacementPolicy.from_license_source(self._db)
         replacement_policy.mirrors = mirrors
-        metadata_records = self.load_metadata(metadata_file, metadata_format, data_source_name)
+        metadata_records = self.load_metadata(metadata_file, metadata_format, data_source_name, default_medium_type)
         for metadata in metadata_records:
             self.work_from_metadata(
                 collection,
@@ -1428,7 +1453,7 @@ class DirectoryImportScript(TimestampScript):
 
         return collection, mirrors
 
-    def load_metadata(self, metadata_file, metadata_format, data_source_name):
+    def load_metadata(self, metadata_file, metadata_format, data_source_name, default_medium_type):
         """Read a metadata file and convert the data into Metadata records."""
         metadata_records = []
 
@@ -1438,7 +1463,7 @@ class DirectoryImportScript(TimestampScript):
             extractor = ONIXExtractor()
 
         with open(metadata_file) as f:
-            metadata_records.extend(extractor.parse(f, data_source_name))
+            metadata_records.extend(extractor.parse(f, data_source_name, default_medium_type))
         return metadata_records
 
     def work_from_metadata(self, collection, collection_type, metadata, policy, *args, **kwargs):

--- a/scripts.py
+++ b/scripts.py
@@ -1312,9 +1312,9 @@ class DirectoryImportScript(TimestampScript):
         parser.add_argument(
             '--default-medium-type',
             help=u'Default medium type used in the case when it\'s not explicitly specified in a metadata file. '
-                 u'Valid values are: Book, Audio.',
+                 u'Valid values are: EditionConstants.FULFILLABLE_MEDIA.',
             type=str,
-            choices=(EditionConstants.BOOK_MEDIUM, EditionConstants.AUDIO_MEDIUM)
+            choices=EditionConstants.FULFILLABLE_MEDIA
         )
 
         return parser
@@ -1334,16 +1334,16 @@ class DirectoryImportScript(TimestampScript):
         default_medium_type = parsed.default_medium_type
 
         return self.run_with_arguments(
-            collection_name,
-            collection_type,
-            data_source_name,
-            metadata_file,
-            metadata_format,
-            cover_directory,
-            ebook_directory,
-            rights_uri,
-            dry_run,
-            default_medium_type
+            collection_name=collection_name,
+            collection_type=collection_type,
+            data_source_name=data_source_name,
+            metadata_file=metadata_file,
+            metadata_format=metadata_format,
+            cover_directory=cover_directory,
+            ebook_directory=ebook_directory,
+            rights_uri=rights_uri,
+            dry_run=dry_run,
+            default_medium_type=default_medium_type
         )
 
     def run_with_arguments(

--- a/tests/files/onix/onix_example.xml
+++ b/tests/files/onix/onix_example.xml
@@ -326,4 +326,26 @@
       </supplydetail>
     </productsupply>
   </product>
+  <product>
+    <a001>001043-32582478</a001>
+    <a002>03</a002>
+    <b385>01</b385>
+    <productidentifier>
+      <b221>02</b221>
+      <b244>0262343665</b244>
+    </productidentifier>
+    <productidentifier>
+      <b221>03</b221>
+      <b244>9780262343664</b244>
+    </productidentifier>
+    <productidentifier>
+      <b221>15</b221>
+      <b244>9780262343664</b244>
+    </productidentifier>
+    <productidentifier>
+      <b221>01</b221>
+      <b233>MIT Press Title ID</b233>
+      <b244>11245</b244>
+    </productidentifier>
+  </product>
 </ONIXmessage>

--- a/tests/test_onix.py
+++ b/tests/test_onix.py
@@ -27,7 +27,7 @@ class TestONIXExtractor(object):
         file = self.sample_data("onix_example.xml")
         metadata_records = ONIXExtractor().parse(StringIO(file), "MIT Press")
 
-        eq_(1, len(metadata_records))
+        eq_(2, len(metadata_records))
 
         record = metadata_records[0]
         eq_("Safe Spaces, Brave Spaces", record.title)
@@ -52,6 +52,9 @@ class TestONIXExtractor(object):
 
         eq_(1, len(record.links))
         assert "the essential democratic values of diversity and free expression" in record.links[0].content
+
+        record = metadata_records[1]
+        eq_(Edition.AUDIO_MEDIUM, record.medium)
 
     @parameterized.expand([
         (

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -67,7 +67,7 @@ from core.model import (
     Representation,
     RightsStatus,
     Timestamp,
-)
+    EditionConstants)
 from core.model.configuration import ExternalIntegrationLink
 
 from core.opds import AcquisitionFeed
@@ -877,7 +877,8 @@ class TestDirectoryImportScript(DatabaseTest):
                 "--cover-directory=covers",
                 "--ebook-directory=ebooks",
                 "--rights-uri=rights",
-                "--dry-run"
+                "--dry-run",
+                "--default-medium-type=Audiobook"
             ]
         )
         eq_(
@@ -890,7 +891,8 @@ class TestDirectoryImportScript(DatabaseTest):
                 'covers',
                 'ebooks',
                 'rights',
-                True
+                True,
+                'Audiobook'
             ),
             script.ran_with
         )
@@ -938,7 +940,7 @@ class TestDirectoryImportScript(DatabaseTest):
             "ebook directory",
             "rights URI"
         ]
-        script.run_with_arguments(*(basic_args + [True]))
+        script.run_with_arguments(*(basic_args + [True] + [EditionConstants.BOOK_MEDIUM]))
 
         # load_collection was called with the collection and data source names.
         eq_(
@@ -947,7 +949,7 @@ class TestDirectoryImportScript(DatabaseTest):
         )
 
         # load_metadata was called with the metadata file and data source name.
-        eq_([('metadata file', 'marc', 'data source name')], script.load_metadata_calls)
+        eq_([('metadata file', 'marc', 'data source name', EditionConstants.BOOK_MEDIUM)], script.load_metadata_calls)
 
         # work_from_metadata was called twice, once on each metadata
         # object.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -864,8 +864,8 @@ class TestDirectoryImportScript(DatabaseTest):
         # arguments and calls run_with_arguments.
 
         class Mock(DirectoryImportScript):
-            def run_with_arguments(self, *args):
-                self.ran_with = args
+            def run_with_arguments(self, *args, **kwargs):
+                self.ran_with = kwargs
 
         script = Mock(self._db)
         script.do_run(
@@ -878,22 +878,22 @@ class TestDirectoryImportScript(DatabaseTest):
                 "--ebook-directory=ebooks",
                 "--rights-uri=rights",
                 "--dry-run",
-                "--default-medium-type=Audiobook"
+                "--default-medium-type={0}".format(EditionConstants.AUDIO_MEDIUM)
             ]
         )
         eq_(
-            (
-                'coll1',
-                CollectionType.OPEN_ACCESS,
-                'ds1',
-                'metadata',
-                'marc',
-                'covers',
-                'ebooks',
-                'rights',
-                True,
-                'Audiobook'
-            ),
+            {
+                'collection_name': 'coll1',
+                'collection_type': CollectionType.OPEN_ACCESS,
+                'data_source_name': 'ds1',
+                'metadata_file': 'metadata',
+                'metadata_format': 'marc',
+                'cover_directory': 'covers',
+                'ebook_directory': 'ebooks',
+                'rights_uri': 'rights',
+                'dry_run': True,
+                'default_medium_type': EditionConstants.AUDIO_MEDIUM
+            },
             script.ran_with
         )
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds media types for supporting RWPM `.audiobook` files. You can find more information in [SIMPLY-3183](https://jira.nypl.org/browse/SIMPLY-3183). 

This PR depends on [PR # 1203 in server_core](https://github.com/NYPL-Simplified/server_core/pull/1203).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
