### PR TITLE
Add OPDS 2.0 import support

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -81,6 +81,7 @@ from core.model import (
 )
 from core.model.configuration import ExternalIntegrationLink
 from core.opds import AcquisitionFeed
+from core.opds2_import import OPDS2Importer
 from core.opds_import import (OPDSImporter, OPDSImportMonitor)
 from core.s3 import S3UploaderConfiguration
 from core.selftest import HasSelfTests
@@ -1285,6 +1286,7 @@ class SettingsController(AdminCirculationManagerController):
 
     PROVIDER_APIS = [OPDSImporter,
                      OPDSForDistributorsAPI,
+                     OPDS2Importer,
                      OverdriveAPI,
                      OdiloAPI,
                      BibliothecaAPI,

--- a/bin/opds2_import_monitor
+++ b/bin/opds2_import_monitor
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+"""Update the circulation manager server with new books from OPDS 2.0 import collections."""
+import os
+import sys
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from core.scripts import OPDSImportScript
+from core.model import ExternalIntegration
+from core.opds2_import import OPDS2Importer, OPDS2ImportMonitor
+
+import_script = OPDSImportScript(
+    importer_class=OPDS2Importer,
+    monitor_class=OPDS2ImportMonitor,
+    protocol=ExternalIntegration.OPDS2_IMPORT
+)
+
+import_script.run()


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds OPDS 2.0 support to Circulation Manager:
- adds `OPDS2Importer` implemented in [PR 1205](https://github.com/NYPL-Simplified/server_core/pull/1205) to a list of available collection types
- adds `opds2_import_monitor` script

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.