### PR TITLE
Significantly reduce the size of the jackpot feed, improving performance

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1095,12 +1095,13 @@ class OPDSFeedController(CirculationManagerController):
         jwl = JackpotWorkList(library)
         annotator = self.manager.annotator(jwl)
 
-        # TODO: Make it possible to pass a pagination object into
-        # groups() to override the standard size of a grouped lane,
-        # improving performance.
+        # Since this feed will be consumed by an automated client, and
+        # we're choosing titles for specific purposes, there's no
+        # reason to put more than a single item in each group.
+        pagination = Pagination(size=1)
         return feed_class.groups(
-            _db=self._db, title="QA test feed", url=url, worklist=jwl,
-            annotator=annotator, search_engine=search_engine,
+            _db=self._db, title="QA test feed", url=url, pagination=pagination,
+            worklist=jwl, annotator=annotator, search_engine=search_engine,
             max_age=CachedFeed.IGNORE_CACHE
         )
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -4118,6 +4118,12 @@ class TestOPDSFeedController(CirculationControllerTest):
         eq_(worklist, annotator.lane)
         eq_(None, annotator.facets)
 
+        # To improve performance, a Pagination object was created that
+        # limits each lane to a single Work.
+        pagination = kwargs.pop('pagination')
+        assert isinstance(pagination, Pagination)
+        eq_(1, pagination.size)
+
         # No other arguments were passed into qa_feed().
         eq_({}, kwargs)
 


### PR DESCRIPTION
## Description

Make it possible to pass a Pagination object into WorkList.groups(), and use a Pagination object with size=1 when creating  the jackpot feed.

This is the circulation portion of https://github.com/NYPL-Simplified/server_core/pull/1206. It improves performance of the jackpot feed significantly, though it may be necessary to do more work if integration tests are being run against libraries with a lot of collections.

We call groups() in a few cases, but the jackpot feed is the only place where we need to overwrite the default behavior, so none of the other tests needed to change.

## Motivation and Context

https://jira.nypl.org/browse/SIMPLY-3234

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
