### PR TITLE
A patron with a root lane who attempts to access a library's top-level lane will be redirected to their root lane rather than denied access.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -846,6 +846,22 @@ class OPDSFeedController(CirculationManagerController):
         """
         library = flask.request.library
 
+        # Special case: a patron with a root lane who attempts to access
+        # the library's top-level WorkList is redirected to their root
+        # lane (as though they had accessed the index controller)
+        # rather than being denied access.
+        if lane_identifier is None:
+            patron = self.request_patron
+            if patron is not None and patron.root_lane:
+                return redirect(
+                    self.cdn_url_for(
+                        'acquisition_groups',
+                        library_short_name=library.short_name,
+                        lane_identifier=patron.root_lane.id,
+                        external=True
+                    )
+                )
+
         lane = self.load_lane(lane_identifier)
         if isinstance(lane, ProblemDetail):
             return lane

--- a/api/controller.py
+++ b/api/controller.py
@@ -858,7 +858,7 @@ class OPDSFeedController(CirculationManagerController):
                         'acquisition_groups',
                         library_short_name=library.short_name,
                         lane_identifier=patron.root_lane.id,
-                        external=True
+                        _external=True
                     )
                 )
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3743,6 +3743,22 @@ class TestOPDSFeedController(CirculationControllerTest):
         library.setting(library.MINIMUM_FEATURED_QUALITY).value = 0.15
         library.setting(library.FEATURED_LANE_SIZE).value = 2
 
+        # Patron with root lane -> redirect to root lane
+        lane = self._lane()
+        lane.root_for_patron_type = ["1"]
+        self.default_patron.external_type = "1"
+        auth = dict(Authorization=self.valid_auth)
+        with self.request_context_with_library("/", headers=auth):
+            controller = self.manager.opds_feeds
+            response = controller.groups(None)
+            eq_(302, response.status_code)
+            expect_url = controller.cdn_url_for(
+                'acquisition_groups',
+                library_short_name=self._default_library.short_name,
+                lane_identifier=lane.id, external=True
+            )
+            eq_(response.headers['Location'], expect_url)
+
         # Bad lane -> Problem detail
         with self.request_context_with_library("/"):
             response = self.manager.opds_feeds.groups(-1)
@@ -3779,7 +3795,12 @@ class TestOPDSFeedController(CirculationControllerTest):
                 self.page_called_with = kwargs
                 return Response("A paginated feed")
 
-        with self.request_context_with_library("/?entrypoint=Audio"):
+        # Earlier we tested an authenticated request for a patron with an
+        # external type. Now try an authenticated request for a patron with
+        # no external type, just to verify that nothing unusual happens
+        # for that kind of patron.
+        self.default_patron.external_type = None
+        with self.request_context_with_library("/?entrypoint=Audio", headers=auth):
             # In default_config, there are no LARGE_COLLECTION_LANGUAGES,
             # so the sole top-level lane is "World Languages", which covers the
             # SMALL and TINY_COLLECTION_LANGUAGES.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3755,7 +3755,7 @@ class TestOPDSFeedController(CirculationControllerTest):
             expect_url = controller.cdn_url_for(
                 'acquisition_groups',
                 library_short_name=self._default_library.short_name,
-                lane_identifier=lane.id, external=True
+                lane_identifier=lane.id, _external=True
             )
             eq_(response.headers['Location'], expect_url)
 


### PR DESCRIPTION
## Description

With my change from https://github.com/NYPL-Simplified/server_core/pull/1209, the library's top-level lane ("/groups/") becomes inaccessible to patrons who have a root lane set. This is correct from a security perspective, but that's a convenient URL to access, and "/groups/" is the URL used by the old catalog code currently deployed at https://catalog.openebooks.us/.

This branch adds a special case to the OPDS feed controller such that an authenticated request to the top-level lane by a patron with a root lane results in a redirect rather than a 404 error.

## Motivation and Context

https://jira.nypl.org/browse/SIMPLY-3125

## How Has This Been Tested?

Using a local circulation manager that goes against Open eBooks QA server:

`curl https://qa-circulation.openebooks.us/USOEI/groups/` gives the same OPDS feed as before, listing "High School", "Middle Grades", and "Early Grades" sublanes.

`curl https://earlygrades:password@qa-circulation.openebooks.us/USOEI/groups/` redirects to https://qa-circulation.openebooks.us/USOEI/groups/429 (the same as a request to /USOEI/ does).

`curl https://highschool:password@qa-circulation.openebooks.us/USOEI/groups/` redirects to https://qa-circulation.openebooks.us/USOEI/groups/406 (the same as a request to /USOEI/ does).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
