### PR TITLE
Fix the way SAMLController concatenates RelayState parameters and existing parameters specified in the query string of the redirection URL

### DIFF
--- a/tests/saml/test_controller.py
+++ b/tests/saml/test_controller.py
@@ -1,19 +1,29 @@
 import json
 import urllib
-import urlparse
 
 from flask import request
-from mock import create_autospec, MagicMock, PropertyMock
+from mock import MagicMock, PropertyMock, create_autospec
 from nose.tools import eq_
 from parameterized import parameterized
+from six.moves.urllib.parse import parse_qs, urlsplit
 
 from api.authenticator import Authenticator, PatronData
-from api.saml.auth import SAMLAuthenticationManager, SAML_INCORRECT_RESPONSE
-from api.saml.controller import SAMLController, SAML_INVALID_REQUEST, SAML_INVALID_RESPONSE
-from api.saml.metadata import ServiceProviderMetadata, UIInfo, NameIDFormat, Service, IdentityProviderMetadata, \
-    Organization
-from api.saml.provider import SAMLWebSSOAuthenticationProvider, SAML_INVALID_SUBJECT
-from core.model import Credential, Patron
+from api.saml.auth import SAML_INCORRECT_RESPONSE, SAMLAuthenticationManager
+from api.saml.controller import (
+    SAML_INVALID_REQUEST,
+    SAML_INVALID_RESPONSE,
+    SAMLController,
+)
+from api.saml.metadata import (
+    IdentityProviderMetadata,
+    NameIDFormat,
+    Organization,
+    Service,
+    ServiceProviderMetadata,
+    UIInfo,
+)
+from api.saml.provider import SAML_INVALID_SUBJECT, SAMLWebSSOAuthenticationProvider
+from core.model import Credential
 from core.util.problem_detail import ProblemDetail
 from tests.saml import fixtures
 from tests.saml.controller_test import ControllerTest
@@ -23,7 +33,7 @@ SERVICE_PROVIDER = ServiceProviderMetadata(
     UIInfo(),
     Organization(),
     NameIDFormat.UNSPECIFIED.value,
-    Service(fixtures.SP_ACS_URL, fixtures.SP_ACS_BINDING)
+    Service(fixtures.SP_ACS_URL, fixtures.SP_ACS_BINDING),
 )
 
 IDENTITY_PROVIDERS = [
@@ -33,101 +43,162 @@ IDENTITY_PROVIDERS = [
         Organization(),
         NameIDFormat.UNSPECIFIED.value,
         Service(fixtures.IDP_1_SSO_URL, fixtures.IDP_1_SSO_BINDING),
-        signing_certificates=[
-            fixtures.SIGNING_CERTIFICATE
-        ]
+        signing_certificates=[fixtures.SIGNING_CERTIFICATE],
     ),
     IdentityProviderMetadata(
         fixtures.IDP_2_ENTITY_ID,
         UIInfo(),
         Organization(),
         NameIDFormat.UNSPECIFIED.value,
-        Service(fixtures.IDP_2_SSO_URL, fixtures.IDP_2_SSO_BINDING)
-    )
+        Service(fixtures.IDP_2_SSO_URL, fixtures.IDP_2_SSO_BINDING),
+    ),
 ]
 
 
 def create_patron_data_mock():
     patron_data_mock = create_autospec(spec=PatronData)
-    type(patron_data_mock).to_response_parameters = PropertyMock(return_value='')
+    type(patron_data_mock).to_response_parameters = PropertyMock(return_value="")
 
     return patron_data_mock
 
 
 class TestSAMLController(ControllerTest):
-    @parameterized.expand([
-        (
-            'with_missing_provider_name',
-            None,
-            None,
-            None,
-            SAML_INVALID_REQUEST.detailed('Required parameter {0} is missing'.format(SAMLController.PROVIDER_NAME)),
-            None
-        ),
-        (
-            'with_missing_idp_entity_id',
-            SAMLWebSSOAuthenticationProvider.NAME,
-            None,
-            None,
-            SAML_INVALID_REQUEST.detailed('Required parameter {0} is missing'.format(SAMLController.IDP_ENTITY_ID)),
-            None
-        ),
-        (
-            'with_missing_redirect_uri',
-            SAMLWebSSOAuthenticationProvider.NAME,
-            IDENTITY_PROVIDERS[0].entity_id,
-            None,
-            SAML_INVALID_REQUEST.detailed('Required parameter {0} is missing'.format(SAMLController.REDIRECT_URI)),
-            'http://localhost?' + urllib.urlencode({
-                SAMLController.LIBRARY_SHORT_NAME: 'default',
-                SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
-                SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[0].entity_id
-            })
-        ),
-        (
-            'with_all_parameters_set',
-            SAMLWebSSOAuthenticationProvider.NAME,
-            IDENTITY_PROVIDERS[0].entity_id,
-            'http://localhost',
-            None,
-            'http://localhost?' + urllib.urlencode({
-                SAMLController.LIBRARY_SHORT_NAME: 'default',
-                SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
-                SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[0].entity_id
-            })
-        ),
-        (
-            'with_all_parameters_set_and_fragment',
-            SAMLWebSSOAuthenticationProvider.NAME,
-            IDENTITY_PROVIDERS[0].entity_id,
-            'http://localhost#fragment',
-            None,
-            'http://localhost?' + urllib.urlencode({
-                SAMLController.LIBRARY_SHORT_NAME: 'default',
-                SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
-                SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[0].entity_id
-            }) + '#fragment'
-        )
-    ])
+    @parameterized.expand(
+        [
+            (
+                "with_missing_provider_name",
+                None,
+                None,
+                None,
+                SAML_INVALID_REQUEST.detailed(
+                    "Required parameter {0} is missing".format(
+                        SAMLController.PROVIDER_NAME
+                    )
+                ),
+                None,
+            ),
+            (
+                "with_missing_idp_entity_id",
+                SAMLWebSSOAuthenticationProvider.NAME,
+                None,
+                None,
+                SAML_INVALID_REQUEST.detailed(
+                    "Required parameter {0} is missing".format(
+                        SAMLController.IDP_ENTITY_ID
+                    )
+                ),
+                None,
+            ),
+            (
+                "with_missing_redirect_uri",
+                SAMLWebSSOAuthenticationProvider.NAME,
+                IDENTITY_PROVIDERS[0].entity_id,
+                None,
+                SAML_INVALID_REQUEST.detailed(
+                    "Required parameter {0} is missing".format(
+                        SAMLController.REDIRECT_URI
+                    )
+                ),
+                "http://localhost?"
+                + urllib.urlencode(
+                    {
+                        SAMLController.LIBRARY_SHORT_NAME: "default",
+                        SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
+                        SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[0].entity_id,
+                    }
+                ),
+            ),
+            (
+                "with_all_parameters_set",
+                SAMLWebSSOAuthenticationProvider.NAME,
+                IDENTITY_PROVIDERS[0].entity_id,
+                "http://localhost",
+                None,
+                "http://localhost?"
+                + urllib.urlencode(
+                    {
+                        SAMLController.LIBRARY_SHORT_NAME: "default",
+                        SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
+                        SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[0].entity_id,
+                    }
+                ),
+            ),
+            (
+                "with_all_parameters_set_and_fragment",
+                SAMLWebSSOAuthenticationProvider.NAME,
+                IDENTITY_PROVIDERS[0].entity_id,
+                "http://localhost#fragment",
+                None,
+                "http://localhost?"
+                + urllib.urlencode(
+                    {
+                        SAMLController.LIBRARY_SHORT_NAME: "default",
+                        SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
+                        SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[0].entity_id,
+                    }
+                )
+                + "#fragment",
+            ),
+            (
+                "with_all_parameters_set_and_redirect_uri_containing_other_parameters",
+                SAMLWebSSOAuthenticationProvider.NAME,
+                IDENTITY_PROVIDERS[0].entity_id,
+                "http://localhost?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9&patron_info=%7B%7D",
+                None,
+                "http://localhost?"
+                + urllib.urlencode(
+                    {
+                        "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+                        "patron_info": "{}",
+                        SAMLController.LIBRARY_SHORT_NAME: "default",
+                        SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
+                        SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[0].entity_id,
+                    }
+                ),
+            ),
+        ]
+    )
     def test_saml_authentication_redirect(
-            self,
-            name,
-            provider_name,
-            idp_entity_id,
-            redirect_uri,
-            expected_problem,
-            expected_relay_state):
+        self,
+        _,
+        provider_name,
+        idp_entity_id,
+        redirect_uri,
+        expected_problem,
+        expected_relay_state,
+    ):
+        """Make sure that SAMLController.saml_authentication_redirect creates a correct RelayState or
+        returns a correct ProblemDetail object in the case of any error.
+
+        :param provider_name: Name of the authentication provider which should be passed as a request parameter
+        :type provider_name: str
+
+        :param idp_entity_id: Identity Provider's ID which should be passed as a request parameter
+        :type idp_entity_id: str
+
+        :param expected_problem: (Optional) Expected ProblemDetail object describing the error occurred (if any)
+        :type expected_problem: Optional[ProblemDetail]
+
+        :param expected_relay_state: (Optional) String containing the expected RelayState value
+        :type expected_relay_state: Optional[str]
+        """
         # Arrange
-        expected_authentication_redirect_uri = 'https://idp.circulationmanager.org'
+        expected_authentication_redirect_uri = "https://idp.circulationmanager.org"
         authentication_manager = create_autospec(spec=SAMLAuthenticationManager)
-        authentication_manager.start_authentication = MagicMock(return_value=expected_authentication_redirect_uri)
+        authentication_manager.start_authentication = MagicMock(
+            return_value=expected_authentication_redirect_uri
+        )
         provider = create_autospec(spec=SAMLWebSSOAuthenticationProvider)
-        type(provider).NAME = PropertyMock(return_value=SAMLWebSSOAuthenticationProvider.NAME)
-        provider.get_authentication_manager = MagicMock(return_value=authentication_manager)
+        type(provider).NAME = PropertyMock(
+            return_value=SAMLWebSSOAuthenticationProvider.NAME
+        )
+        provider.get_authentication_manager = MagicMock(
+            return_value=authentication_manager
+        )
         provider.library = MagicMock(return_value=self._default_library)
         authenticator = Authenticator(self._db)
 
-        authenticator.library_authenticators['default'].register_saml_provider(provider)
+        authenticator.library_authenticators["default"].register_saml_provider(provider)
 
         controller = SAMLController(self.app.manager, authenticator)
         params = {}
@@ -141,7 +212,9 @@ class TestSAMLController(ControllerTest):
 
         query = urllib.urlencode(params)
 
-        with self.app.test_request_context('http://circulationmanager.org/saml_authenticate?' + query):
+        with self.app.test_request_context(
+            "http://circulationmanager.org/saml_authenticate?" + query
+        ):
             request.library = self._default_library
 
             # Act
@@ -152,164 +225,217 @@ class TestSAMLController(ControllerTest):
                 assert isinstance(result, ProblemDetail)
                 eq_(result.response, expected_problem.response)
             else:
-                eq_(result.status_code, 302)
-                eq_(result.headers.get('Location'), expected_authentication_redirect_uri)
+                eq_(302, result.status_code)
+                eq_(
+                    expected_authentication_redirect_uri, result.headers.get("Location")
+                )
 
                 authentication_manager.start_authentication.assert_called_once_with(
-                    self._db, idp_entity_id, expected_relay_state)
+                    self._db, idp_entity_id, expected_relay_state
+                )
 
-    @parameterized.expand([
-        (
-            'with_missing_relay_state',
-            None,
-            None,
-            None,
-            None,
-            None,
-            SAML_INVALID_RESPONSE.detailed(
-                'Required parameter {0} is missing from the response body'.format(SAMLController.RELAY_STATE))
-        ),
-        (
-            'with_incorrect_relay_state',
-            {
-                SAMLController.RELAY_STATE: '<>'
-            },
-            None,
-            None,
-            None,
-            None,
-            SAML_INVALID_RESPONSE.detailed(
-                'Required parameter {0} is missing from RelayState'.format(SAMLController.LIBRARY_SHORT_NAME))
-        ),
-        (
-            'with_missing_provider_name',
-            {
-                SAMLController.RELAY_STATE: 'http://localhost?' + urllib.urlencode({
-                    SAMLController.LIBRARY_SHORT_NAME: 'default'
-                })
-            },
-            None,
-            None,
-            None,
-            None,
-            SAML_INVALID_RESPONSE.detailed(
-                'Required parameter {0} is missing from RelayState'.format(SAMLController.PROVIDER_NAME))
-        ),
-        (
-            'with_missing_idp_entity_id',
-            {
-                SAMLController.RELAY_STATE: 'http://localhost?' + urllib.urlencode({
-                    SAMLController.LIBRARY_SHORT_NAME: 'default',
-                    SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME
-                })
-            },
-            None,
-            None,
-            None,
-            None,
-            SAML_INVALID_RESPONSE.detailed(
-                'Required parameter {0} is missing from RelayState'.format(SAMLController.IDP_ENTITY_ID))
-        ),
-        (
-            'when_finish_authentication_fails',
-            {
-                SAMLController.RELAY_STATE: 'http://localhost?' + urllib.urlencode({
-                    SAMLController.LIBRARY_SHORT_NAME: 'default',
-                    SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
-                    SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[0].entity_id
-                })
-            },
-            SAML_INCORRECT_RESPONSE.detailed('Authentication failed'),
-            None,
-            None,
-            None,
-            None
-        ),
-        (
-            'when_saml_callback_fails',
-            {
-                SAMLController.RELAY_STATE: 'http://localhost?' + urllib.urlencode({
-                    SAMLController.LIBRARY_SHORT_NAME: 'default',
-                    SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
-                    SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[0].entity_id
-                })
-            },
-            None,
-            SAML_INVALID_SUBJECT.detailed('Authentication failed'),
-            None,
-            None,
-            None
-        ),
-        (
-            'when_saml_callback_returns_correct_patron',
-            {
-                SAMLController.RELAY_STATE: 'http://localhost?' + urllib.urlencode({
-                    SAMLController.LIBRARY_SHORT_NAME: 'default',
-                    SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
-                    SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[0].entity_id
-                })
-            },
-            None,
-            (create_autospec(spec=Credential), object(), create_patron_data_mock()),
-            'ABCDEFG',
-            'http://localhost?access_token=ABCDEFG&patron_info=%22%22',
-            None
-        )
-    ])
+    @parameterized.expand(
+        [
+            (
+                "with_missing_relay_state",
+                None,
+                None,
+                None,
+                None,
+                None,
+                SAML_INVALID_RESPONSE.detailed(
+                    "Required parameter {0} is missing from the response body".format(
+                        SAMLController.RELAY_STATE
+                    )
+                ),
+            ),
+            (
+                "with_incorrect_relay_state",
+                {SAMLController.RELAY_STATE: "<>"},
+                None,
+                None,
+                None,
+                None,
+                SAML_INVALID_RESPONSE.detailed(
+                    "Required parameter {0} is missing from RelayState".format(
+                        SAMLController.LIBRARY_SHORT_NAME
+                    )
+                ),
+            ),
+            (
+                "with_missing_provider_name",
+                {
+                    SAMLController.RELAY_STATE: "http://localhost?"
+                    + urllib.urlencode({SAMLController.LIBRARY_SHORT_NAME: "default"})
+                },
+                None,
+                None,
+                None,
+                None,
+                SAML_INVALID_RESPONSE.detailed(
+                    "Required parameter {0} is missing from RelayState".format(
+                        SAMLController.PROVIDER_NAME
+                    )
+                ),
+            ),
+            (
+                "with_missing_idp_entity_id",
+                {
+                    SAMLController.RELAY_STATE: "http://localhost?"
+                    + urllib.urlencode(
+                        {
+                            SAMLController.LIBRARY_SHORT_NAME: "default",
+                            SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
+                        }
+                    )
+                },
+                None,
+                None,
+                None,
+                None,
+                SAML_INVALID_RESPONSE.detailed(
+                    "Required parameter {0} is missing from RelayState".format(
+                        SAMLController.IDP_ENTITY_ID
+                    )
+                ),
+            ),
+            (
+                "when_finish_authentication_fails",
+                {
+                    SAMLController.RELAY_STATE: "http://localhost?"
+                    + urllib.urlencode(
+                        {
+                            SAMLController.LIBRARY_SHORT_NAME: "default",
+                            SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
+                            SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[
+                                0
+                            ].entity_id,
+                        }
+                    )
+                },
+                SAML_INCORRECT_RESPONSE.detailed("Authentication failed"),
+                None,
+                None,
+                None,
+                None,
+            ),
+            (
+                "when_saml_callback_fails",
+                {
+                    SAMLController.RELAY_STATE: "http://localhost?"
+                    + urllib.urlencode(
+                        {
+                            SAMLController.LIBRARY_SHORT_NAME: "default",
+                            SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
+                            SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[
+                                0
+                            ].entity_id,
+                        }
+                    )
+                },
+                None,
+                SAML_INVALID_SUBJECT.detailed("Authentication failed"),
+                None,
+                None,
+                None,
+            ),
+            (
+                "when_saml_callback_returns_correct_patron",
+                {
+                    SAMLController.RELAY_STATE: "http://localhost?"
+                    + urllib.urlencode(
+                        {
+                            SAMLController.LIBRARY_SHORT_NAME: "default",
+                            SAMLController.PROVIDER_NAME: SAMLWebSSOAuthenticationProvider.NAME,
+                            SAMLController.IDP_ENTITY_ID: IDENTITY_PROVIDERS[
+                                0
+                            ].entity_id,
+                        }
+                    )
+                },
+                None,
+                (create_autospec(spec=Credential), object(), create_patron_data_mock()),
+                "ABCDEFG",
+                "http://localhost?access_token=ABCDEFG&patron_info=%22%22",
+                None,
+            ),
+        ]
+    )
     def test_saml_authentication_callback(
-            self,
-            name,
-            data,
-            finish_authentication_result,
-            saml_callback_result,
-            bearer_token,
-            expected_authentication_redirect_uri,
-            expected_problem):
+        self,
+        _,
+        data,
+        finish_authentication_result,
+        saml_callback_result,
+        bearer_token,
+        expected_authentication_redirect_uri,
+        expected_problem,
+    ):
         # Arrange
         authentication_manager = create_autospec(spec=SAMLAuthenticationManager)
-        authentication_manager.finish_authentication = MagicMock(return_value=finish_authentication_result)
+        authentication_manager.finish_authentication = MagicMock(
+            return_value=finish_authentication_result
+        )
         provider = create_autospec(spec=SAMLWebSSOAuthenticationProvider)
-        type(provider).NAME = PropertyMock(return_value=SAMLWebSSOAuthenticationProvider.NAME)
-        provider.get_authentication_manager = MagicMock(return_value=authentication_manager)
+        type(provider).NAME = PropertyMock(
+            return_value=SAMLWebSSOAuthenticationProvider.NAME
+        )
+        provider.get_authentication_manager = MagicMock(
+            return_value=authentication_manager
+        )
         provider.library = MagicMock(return_value=self._default_library)
         provider.saml_callback = MagicMock(return_value=saml_callback_result)
         authenticator = Authenticator(self._db)
 
-        authenticator.library_authenticators['default'].register_saml_provider(provider)
-        authenticator.bearer_token_signing_secret = 'test'
-        authenticator.library_authenticators['default'].bearer_token_signing_secret = 'test'
+        authenticator.library_authenticators["default"].register_saml_provider(provider)
+        authenticator.bearer_token_signing_secret = "test"
+        authenticator.library_authenticators[
+            "default"
+        ].bearer_token_signing_secret = "test"
         authenticator.create_bearer_token = MagicMock(return_value=bearer_token)
 
         controller = SAMLController(self.app.manager, authenticator)
 
-        with self.app.test_request_context('http://circulationmanager.org/saml_callback', data=data):
+        with self.app.test_request_context(
+            "http://circulationmanager.org/saml_callback", data=data
+        ):
             # Act
             result = controller.saml_authentication_callback(request, self._db)
 
             # Assert
-            if isinstance(finish_authentication_result, ProblemDetail) or \
-                    isinstance(saml_callback_result, ProblemDetail):
+            if isinstance(finish_authentication_result, ProblemDetail) or isinstance(
+                saml_callback_result, ProblemDetail
+            ):
                 eq_(result.status_code, 302)
 
-                query_items = urlparse.parse_qs(urlparse.urlsplit(result.location).query)
+                query_items = parse_qs(urlsplit(result.location).query)
 
                 assert SAMLController.ERROR in query_items
 
                 error = query_items[SAMLController.ERROR][0]
                 error = json.loads(error)
 
-                problem = finish_authentication_result if finish_authentication_result else saml_callback_result
-                eq_(error['type'], problem.uri),
-                eq_(error['status'], problem.status_code)
-                eq_(error['title'], problem.title)
-                eq_(error['detail'], problem.detail)
+                problem = (
+                    finish_authentication_result
+                    if finish_authentication_result
+                    else saml_callback_result
+                )
+                eq_(error["type"], problem.uri),
+                eq_(error["status"], problem.status_code)
+                eq_(error["title"], problem.title)
+                eq_(error["detail"], problem.detail)
             elif expected_problem:
                 assert isinstance(result, ProblemDetail)
                 eq_(result.response, expected_problem.response)
             else:
                 eq_(result.status_code, 302)
-                eq_(result.headers.get('Location'), expected_authentication_redirect_uri)
+                eq_(
+                    result.headers.get("Location"), expected_authentication_redirect_uri
+                )
 
                 authentication_manager.finish_authentication.assert_called_once_with(
-                    self._db, IDENTITY_PROVIDERS[0].entity_id)
-                provider.saml_callback.assert_called_once_with(self._db, finish_authentication_result)
+                    self._db, IDENTITY_PROVIDERS[0].entity_id
+                )
+                provider.saml_callback.assert_called_once_with(
+                    self._db, finish_authentication_result
+                )


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR fixes the logic in `SAMLController` used for creating RelayState, it considers that the redirection URL also can contain parameters specified in the query string and they have to be correctly concatenated with mandatory RelayState parameters.

Except functional changes, `isort` and `black` were used to reformat the code.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[SIMPLY-3268](https://jira.nypl.org/browse/SIMPLY-3268)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
