### PR TITLE
Fix the tests by replacing DatabaseTest._edition's publicationDate parameter with publication_date

### DIFF
--- a/tests/test_novelist.py
+++ b/tests/test_novelist.py
@@ -409,7 +409,7 @@ class TestNoveListAPI(DatabaseTest):
         eq_(items, [])
 
         # Set up a book for this library.
-        edition = self._edition(identifier_type=Identifier.ISBN, publicationDate="2012-01-01")
+        edition = self._edition(identifier_type=Identifier.ISBN, publication_date="2012-01-01")
         pool = self._licensepool(edition, collection=self._default_collection)
         contributor = self._contributor(sort_name=edition.sort_author, name=edition.author)
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

[PR # 1213 in server_core](https://github.com/NYPL-Simplified/server_core/pull/1213) changed `publicationDate` parameter in `DatabaseTest._edition` to `publication_date`. This PR updates the tests in `circulation` by replacing `publicationDate` with `publication_date`.

**NOTE**: I changed `core` submodule configuration temporarily to make sure that all the tests in `circulation` succeed. 
Once this PR is ready to be merged I'll revert these changes back and squash all the commits in this branch to keep the history clean.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[SIMPLY-3269](https://jira.nypl.org/browse/SIMPLY-3269)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
