### PR TITLE
Add faceting capability to the jackpot feed

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -121,6 +121,7 @@ from lanes import (
     load_lanes,
     ContributorFacets,
     ContributorLane,
+    JackpotFacets,
     JackpotWorkList,
     RecommendationLane,
     RelatedBooksLane,
@@ -1126,7 +1127,9 @@ class OPDSFeedController(CirculationManagerController):
             library_short_name=library.short_name,
         )
 
-        jwl = JackpotWorkList(library)
+        facets = load_facets_from_request(base_class=JackpotFacets)
+
+        jwl = JackpotWorkList(library, facets)
         annotator = self.manager.annotator(jwl)
 
         # TODO: Make it possible to pass a pagination object into

--- a/api/controller.py
+++ b/api/controller.py
@@ -1128,6 +1128,8 @@ class OPDSFeedController(CirculationManagerController):
         )
 
         facets = load_facets_from_request(base_class=JackpotFacets)
+        if isinstance(facets, ProblemDetail):
+            return facets
 
         jwl = JackpotWorkList(library, facets)
         annotator = self.manager.annotator(jwl)

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1288,7 +1288,8 @@ class JackpotFacets(Facets):
                 config, facet_group_name
             )
 
-        return [Facets.AVAILABLE_NOW, Facets.AVAILABLE_NOT_NOW]
+        return [Facets.AVAILABLE_NOW, Facets.AVAILABLE_NOT_NOW,
+                Facets.AVAILABLE_OPEN_ACCESS]
 
 
 class JackpotWorkList(WorkList):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1280,6 +1280,11 @@ class KnownOverviewFacetsWorkList(WorkList):
 
 
 class JackpotFacets(Facets):
+    """A faceting object for a jackpot feed.
+
+    Unlike other faceting objects, AVAILABLE_NOT_NOW is an acceptable
+    option for the availability facet.
+    """
 
     @classmethod
     def default_facet(cls, config, facet_group_name):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1336,7 +1336,7 @@ class JackpotWorkList(WorkList):
                     data_source_name = collection.data_source.name
                 else:
                     data_source_name = "[Unknown]"
-                display_name = "[Collection test] - License source {%s} - Medium {%s} - Collection name {%s}" % (data_source_name, medium, collection.name)
+                display_name = "License source {%s} - Medium {%s} - Collection name {%s}" % (data_source_name, medium, collection.name)
                 child = KnownOverviewFacetsWorkList(facets)
                 child.initialize(
                     library, media=[medium], display_name=display_name

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1282,14 +1282,22 @@ class KnownOverviewFacetsWorkList(WorkList):
 class JackpotFacets(Facets):
 
     @classmethod
+    def default_facet(cls, config, facet_group_name):
+        if facet_group_name != cls.AVAILABILITY_FACET_GROUP_NAME:
+            return super(JackpotFacets, cls).default_facet(
+                config, facet_group_name
+            )
+        return cls.AVAILABLE_NOW
+
+    @classmethod
     def available_facets(cls, config, facet_group_name):
         if facet_group_name != cls.AVAILABILITY_FACET_GROUP_NAME:
             return super(JackpotFacets, cls).available_facets(
                 config, facet_group_name
             )
 
-        return [Facets.AVAILABLE_NOW, Facets.AVAILABLE_NOT_NOW,
-                Facets.AVAILABLE_OPEN_ACCESS]
+        return [cls.AVAILABLE_NOW, cls.AVAILABLE_NOT_NOW,
+                cls.AVAILABLE_ALL, cls.AVAILABLE_OPEN_ACCESS]
 
 
 class JackpotWorkList(WorkList):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1279,6 +1279,18 @@ class KnownOverviewFacetsWorkList(WorkList):
         return self.facets
 
 
+class JackpotFacets(Facets):
+
+    @classmethod
+    def available_facets(cls, config, facet_group_name):
+        if facet_group_name != cls.AVAILABILITY_FACET_GROUP_NAME:
+            return super(JackpotFacets, cls).available_facets(
+                config, facet_group_name
+            )
+
+        return [Facets.AVAILABLE_NOW, Facets.AVAILABLE_NOT_NOW]
+
+
 class JackpotWorkList(WorkList):
     """A WorkList guaranteed to, so far as possible, contain the exact
     selection of books necessary to perform common QA tasks.
@@ -1287,10 +1299,11 @@ class JackpotWorkList(WorkList):
     circulation managers and real books.
     """
 
-    def __init__(self, library):
+    def __init__(self, library, facets):
         """Constructor.
 
         :param library: A Library
+        :param facets: A Facets object.
         """
         super(JackpotWorkList, self).initialize(library)
 
@@ -1303,30 +1316,19 @@ class JackpotWorkList(WorkList):
         # every collection.
         for collection in sorted(library.collections, key=lambda x: x.name):
             for medium in Edition.FULFILLABLE_MEDIA:
-                for availability in [Facets.AVAILABLE_NOW]:
-                    facets = Facets.default(
-                        library, availability=availability
-                    )
-
-                    # Give each Worklist a name that is distinctive
-                    # and easy for a client to parse.
-                    if collection.data_source:
-                        data_source_name = collection.data_source.name
-                    else:
-                        data_source_name = "[Unknown]"
-                    display_name = "[Collection test] - License source {%s} - Medium {%s} - Availability {%s} - Collection name {%s}" % (data_source_name, medium, availability, collection.name)
-                    child = KnownOverviewFacetsWorkList(facets)
-                    child.initialize(
-                        library, media=[medium], display_name=display_name
-                    )
-                    child.collection_ids = [collection.id]
-                    self.children.append(child)
-
-            # TODO: Add other child lanes for other types of tests:
-            #  One lane for every collection containing only books
-            #   that are _not_ available.
-            #  A lane where all books belong to some series
-            #  A lane where all books use a particular DRM scheme/format
+                # Give each Worklist a name that is distinctive
+                # and easy for a client to parse.
+                if collection.data_source:
+                    data_source_name = collection.data_source.name
+                else:
+                    data_source_name = "[Unknown]"
+                display_name = "[Collection test] - License source {%s} - Medium {%s} - Collection name {%s}" % (data_source_name, medium, collection.name)
+                child = KnownOverviewFacetsWorkList(facets)
+                child.initialize(
+                    library, media=[medium], display_name=display_name
+                )
+                child.collection_ids = [collection.id]
+                self.children.append(child)
 
     def works(self, _db, *args, **kwargs):
         """This worklist never has works of its own.

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -60,6 +60,7 @@ from api.lanes import (
     CrawlableCollectionBasedLane,
     CrawlableFacets,
     CrawlableCustomListBasedLane,
+    JackpotFacets,
     JackpotWorkList,
     KnownOverviewFacetsWorkList,
     RecommendationLane,
@@ -934,6 +935,33 @@ class TestKnownOverviewFacetsWorkList(DatabaseTest):
         # making a grouped feed.
         some_other_facets = object()
         eq_(known_facets, wl.overview_facets(self._db, some_other_facets))
+
+
+class TestJackpotFacets(DatabaseTest):
+
+    def test_available_facets(self):
+
+        m = JackpotFacets.available_facets
+
+        # A JackpotFacets object always has the same availability
+        # facets. Normal facet configuration is ignored.
+        available = m(None, JackpotFacets.AVAILABILITY_FACET_GROUP_NAME)
+        eq_([Facets.AVAILABLE_NOW, Facets.AVAILABLE_NOT_NOW,
+             Facets.AVAILABLE_OPEN_ACCESS],
+             available)
+
+        # For other facet groups, the class defers to the Facets
+        # superclass. (But this doesn't matter because it's not relevant
+        # to the creation of jackpot feeds.)
+        for group in (Facets.COLLECTION_FACET_GROUP_NAME,
+                      Facets.ORDER_FACET_GROUP_NAME):
+            eq_(m(self._default_library, group),
+                Facets.available_facets(self._default_library, group))
+
+        eq_(Facets.ORDER_SERIES_POSITION, SeriesFacets.DEFAULT_SORT_ORDER)
+        facets = SeriesFacets.default(self._default_library)
+        assert isinstance(facets, DefaultSortOrderFacets)
+        eq_(Facets.ORDER_SERIES_POSITION, facets.order)
 
 
 class TestJackpotWorkList(DatabaseTest):

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -956,11 +956,6 @@ class TestJackpotFacets(DatabaseTest):
             eq_(m(self._default_library, group),
                 Facets.default_facet(self._default_library, group))
 
-        eq_(Facets.ORDER_SERIES_POSITION, SeriesFacets.DEFAULT_SORT_ORDER)
-        facets = SeriesFacets.default(self._default_library)
-        assert isinstance(facets, DefaultSortOrderFacets)
-        eq_(Facets.ORDER_SERIES_POSITION, facets.order)
-
     def test_available_facets(self):
         # A JackpotFacets object always has the same availability
         # facets. Normal facet configuration is ignored.
@@ -978,11 +973,6 @@ class TestJackpotFacets(DatabaseTest):
                       Facets.ORDER_FACET_GROUP_NAME):
             eq_(m(self._default_library, group),
                 Facets.available_facets(self._default_library, group))
-
-        eq_(Facets.ORDER_SERIES_POSITION, SeriesFacets.DEFAULT_SORT_ORDER)
-        facets = SeriesFacets.default(self._default_library)
-        assert isinstance(facets, DefaultSortOrderFacets)
-        eq_(Facets.ORDER_SERIES_POSITION, facets.order)
 
 
 class TestJackpotWorkList(DatabaseTest):
@@ -1043,23 +1033,23 @@ class TestJackpotWorkList(DatabaseTest):
             available_now
         )
 
-        eq_("[Collection test] - License source {[Unknown]} - Medium {Book} - Collection name {%s}" % self._default_collection.name,
+        eq_("License source {[Unknown]} - Medium {Book} - Collection name {%s}" % self._default_collection.name,
             default_ebooks.display_name)
         eq_([self._default_collection.id], default_ebooks.collection_ids)
         eq_([Edition.BOOK_MEDIUM], default_ebooks.media)
 
-        eq_("[Collection test] - License source {[Unknown]} - Medium {Audio} - Collection name {%s}" % self._default_collection.name,
+        eq_("License source {[Unknown]} - Medium {Audio} - Collection name {%s}" % self._default_collection.name,
             default_audio.display_name)
         eq_([self._default_collection.id], default_audio.collection_ids)
         eq_([Edition.AUDIO_MEDIUM], default_audio.media)
 
-        eq_("[Collection test] - License source {Overdrive} - Medium {Book} - Collection name {Test Overdrive Collection}",
+        eq_("License source {Overdrive} - Medium {Book} - Collection name {Test Overdrive Collection}",
             overdrive_ebooks.display_name)
         eq_([overdrive_collection.id], overdrive_ebooks.collection_ids)
         eq_([Edition.BOOK_MEDIUM], overdrive_ebooks.media)
 
 
-        eq_("[Collection test] - License source {Overdrive} - Medium {Audio} - Collection name {Test Overdrive Collection}",
+        eq_("License source {Overdrive} - Medium {Audio} - Collection name {Test Overdrive Collection}",
             overdrive_audio.display_name)
         eq_([overdrive_collection.id], overdrive_audio.collection_ids)
         eq_([Edition.AUDIO_MEDIUM], overdrive_audio.media)

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -943,7 +943,7 @@ class TestJackpotFacets(DatabaseTest):
         # A JackpotFacets object defaults to showing only books that
         # are currently available. Normal facet configuration is
         # ignored.
-        m = JackpotFacets.default_facets
+        m = JackpotFacets.default_facet
 
         default = m(None, JackpotFacets.AVAILABILITY_FACET_GROUP_NAME)
         eq_(Facets.AVAILABLE_NOW, default)
@@ -968,7 +968,7 @@ class TestJackpotFacets(DatabaseTest):
         m = JackpotFacets.available_facets
         available = m(None, JackpotFacets.AVAILABILITY_FACET_GROUP_NAME)
         eq_([Facets.AVAILABLE_NOW, Facets.AVAILABLE_NOT_NOW,
-             Facets.AVAILABLE_OPEN_ACCESS],
+             Facets.AVAILABLE_ALL, Facets.AVAILABLE_OPEN_ACCESS],
              available)
 
         # For other facet groups, the class defers to the Facets

--- a/tests/test_novelist.py
+++ b/tests/test_novelist.py
@@ -409,7 +409,7 @@ class TestNoveListAPI(DatabaseTest):
         eq_(items, [])
 
         # Set up a book for this library.
-        edition = self._edition(identifier_type=Identifier.ISBN, publicationDate="2012-01-01")
+        edition = self._edition(identifier_type=Identifier.ISBN, publication_date="2012-01-01")
         pool = self._licensepool(edition, collection=self._default_collection)
         contributor = self._contributor(sort_name=edition.sort_author, name=edition.author)
 


### PR DESCRIPTION
## Description

This branch makes it possible to request a jackpot feed with different facets, similar to the way other feed controllers work. 

## Motivation and Context

In combination with https://github.com/NYPL-Simplified/server_core/pull/1211, which adds a "not_now" availability facet, this completes https://jira.nypl.org/browse/SIMPLY-3236.

## How Has This Been Tested?

To test the 'not_now' facet specifically:

`curl http://user:pass@localhost:6500/feed/qa?available=not_now`

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
