### PR TITLE
Rename the new First Book authentication type 

### DIFF
--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -21,7 +21,7 @@ from core.model import (
 
 class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
 
-    NAME = 'First Book'
+    NAME = 'First Book (deprecated)'
 
     DESCRIPTION = _("""
         An authentication service for Open eBooks that authenticates

--- a/api/firstbook2.py
+++ b/api/firstbook2.py
@@ -25,7 +25,7 @@ from core.model import (
 
 class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
 
-    NAME = 'First Book - JWT'
+    NAME = 'First Book'
 
     DESCRIPTION = _("""
         An authentication service for Open eBooks that authenticates


### PR DESCRIPTION
The mobile client displays whatever we put in the description, and "JWT" has no meaning to users, so just call it "First Book".

I renamed the old FirstBook API rather than removing it, because I want to change the code as little as possible before we deploy to Open eBooks production.

## Motivation and Context

https://jira.nypl.org/browse/SIMPLY-3274
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
