### PR TITLE
Set EverythingEntryPoint when initializing JackpotFacets.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1143,7 +1143,9 @@ class OPDSFeedController(CirculationManagerController):
             library_short_name=library.short_name,
         )
 
-        facets = load_facets_from_request(base_class=JackpotFacets)
+        facets = load_facets_from_request(
+            base_class=JackpotFacets, default_entrypoint=EverythingEntryPoint
+        )
         if isinstance(facets, ProblemDetail):
             return facets
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -4148,6 +4148,11 @@ class TestOPDSFeedController(CirculationControllerTest):
         for child in worklist.children:
             assert isinstance(child.facets, JackpotFacets)
 
+            # Each JackpotFacets uses the EverythingEntryPoint, since
+            # the jackpot feed is designed to include all types of
+            # books.
+            eq_(EverythingEntryPoint, child.facets.entrypoint)
+
         # Then a LibraryAnnotator object was created from the JackpotWorkList.
         annotator = kwargs.pop('annotator')
         assert isinstance(annotator, LibraryAnnotator)


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

## Motivation and Context

This branch fixes a problem found while doing QA on https://jira.nypl.org/browse/SIMPLY-3236. When you request the jackpot feed, it includes lanes for audiobooks, but those lanes don't actually contain audiobooks.

This is because the 3236 fix introduced a faceting object -- JackpotFacets -- which is loaded from the incoming HTTP request. Since JackpotFacets inherits from Facets, it can take an EntryPoint that modifies the Elasticsearch filter. The default EntryPoint for most libraries is "Books", which restricts Elasticsearch to find only ebooks.

The faceting object takes precedence over the `WorkList` and can override its settings. In this case, we make a `JackpotWorkList` that's supposed to find only audiobooks, but the `EntryPoint` associated with the `JackpotFacets` object overrides that, and Elasticsearch ends up searching for only ebooks.

Without the faceting object, there was nothing to override the settings in `JackpotWorkList`. This branch restores the status quo by changing the default entry point for a `JackpotFacets` to `EverythingEntryPoint`. Theoretically you could use the `entrypoint` option to change the entrypoint, which would result in inconsistent results, but I figure that's something you can do if you know what you're doing.

## How Has This Been Tested?

I used NYPL's QA database against local code.

Make sure ebooks still show up:
curl http://user:pass@localhost:6500/feed/qa | grep application/epub+zip

Make sure Overdrive audiobooks show up:
curl http://user:pass@localhost:6500/feed/qa | grep application/vnd.overdrive.circulation.api+json;profile=audiobook

Make sure Findaway audiobooks show up:
curl http://user:pass@localhost:6500/feed/qa | grep application/vnd.librarysimplified.findaway.license+json

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
