### PR TITLE
Fix issue causing logrotate to fail

### DIFF
--- a/docker/services/logrotate.conf
+++ b/docker/services/logrotate.conf
@@ -4,7 +4,7 @@ weekly
 
 # use the syslog group by default, since this is the owning group
 # of /var/log/syslog.
-su root
+su root adm
 
 # keep 4 weeks worth of backlogs
 # rotate 4


### PR DESCRIPTION
## Description

Log rotate stopped rotating logs around the middle of September. This lines up with some changes made to the docker containers to pull in a different base image.

## Motivation and Context

When running logrotate by hand I am seeing:
`error: error switching euid to 0 and egid to -1: Invalid argument`

Some info in a [ticket upstream](https://github.com/logrotate/logrotate/issues/276) for log rotate. This can come from not specifying a group in the log rotate config. In this PR I just add a group to the logrotate config.

## How Has This Been Tested?

I added this to the config on the LYRASIS servers a month or so ago to see if it would solve the issue and logs have been rotating successfully since.
