### PR TITLE
Remove NYPL URL in docker build

### DIFF
--- a/docker/simplified_app.sh
+++ b/docker/simplified_app.sh
@@ -46,7 +46,7 @@ cd circulation
 git checkout $version
 
 # Use https to access submodules.
-git config submodule.core.url https://github.com/NYPL-Simplified/server_core.git
+set +x && git config submodule.core.url $(git config submodule.core.url | perl -p -e 's|git@(.*?):|https://\1/|g') && set -x
 git submodule update --init --recursive
 
 # Add a .version file to the directory. This file

--- a/docker/simplified_app.sh
+++ b/docker/simplified_app.sh
@@ -46,6 +46,7 @@ cd circulation
 git checkout $version
 
 # Use https to access submodules.
+git submodule init
 git config submodule.core.url $(git config submodule.core.url | perl -p -e 's|git@(.*?):|https://\1/|g')
 git submodule update --init --recursive
 

--- a/docker/simplified_app.sh
+++ b/docker/simplified_app.sh
@@ -46,7 +46,7 @@ cd circulation
 git checkout $version
 
 # Use https to access submodules.
-set +x && git config submodule.core.url $(git config submodule.core.url | perl -p -e 's|git@(.*?):|https://\1/|g') && set -x
+git config submodule.core.url $(git config submodule.core.url | perl -p -e 's|git@(.*?):|https://\1/|g')
 git submodule update --init --recursive
 
 # Add a .version file to the directory. This file


### PR DESCRIPTION
## Description

The docker build currently assumes that the core sub-module has to come from an NYPL repo. This can be annoying when building a version of the docker containers for testing that has core commits from a different repo.

## Motivation and Context

This replaces the hard-coded NYPL url with a perl regex that replaces the `git` url with a `https` one. This does the same thing as the previous replacement for a NYPL URL, but allows other URLs to be used as well.

## How Has This Been Tested?

A container was build and pushed with this change an its [available on dockerhub](https://hub.docker.com/layers/lyrasis/circ-webapp/remove_hardcoded_nypl_url/images/sha256-10fcb78a9171d7f6943847241ea4aadc73b91d57702c87ea25c49978c50f9750?context=repo&tab=layers).
