### PR TITLE
Add logrotation for UWSGI logs

### DIFF
--- a/docker/services/simplified_logrotate.conf
+++ b/docker/services/simplified_logrotate.conf
@@ -9,3 +9,15 @@
     notifempty
     dateext
 }
+
+/var/log/uwsgi/*.log {
+    missingok
+    daily
+    create 0660 simplified adm
+    rotate 13
+    copytruncate
+    compress
+    delaycompress
+    notifempty
+    dateext
+}


### PR DESCRIPTION
## Description

UWSGI puts logs in `/var/log/uwsgi` and these are not currently being rotated by the logrotate config.

## Motivation and Context

The logs aren't huge, so they don't quickly fill the disk, but they do slowly creep up in size. This makes sure they are properly rotated, just as the other logs are.

## How Has This Been Tested?

This config has been running on the LYRASIS servers for a few months and has been properly rotating the UWSGI logs for us. Thought I would contribute the change upstream if there is interest in it.