### PR TITLE
Upgrade Nodejs Package in Docker Image

### DIFF
--- a/docker/Dockerfile.exec
+++ b/docker/Dockerfile.exec
@@ -12,7 +12,7 @@ RUN go get -v github.com/readium/readium-lcp-server/lcpencrypt
 ## Final image
 ###############################################################################
 
-FROM phusion/baseimage:latest-amd64
+FROM phusion/baseimage:bionic-1.0.0
 
 COPY --from=builder /go/bin/lcpencrypt /go/bin/lcpencrypt
 

--- a/docker/Dockerfile.scripts
+++ b/docker/Dockerfile.scripts
@@ -12,7 +12,7 @@ RUN go get -v github.com/readium/readium-lcp-server/lcpencrypt
 ## Final image
 ###############################################################################
 
-FROM phusion/baseimage:latest-amd64
+FROM phusion/baseimage:bionic-1.0.0
 
 COPY --from=builder /go/bin/lcpencrypt /go/bin/lcpencrypt
 

--- a/docker/Dockerfile.webapp
+++ b/docker/Dockerfile.webapp
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:latest-amd64
+FROM phusion/baseimage:bionic-1.0.0
 MAINTAINER Library Simplified <info@librarysimplified.org>
 
 ARG version

--- a/docker/simplified_app.sh
+++ b/docker/simplified_app.sh
@@ -6,7 +6,17 @@ set -x
 repo="$1"
 version="$2"
 
-apt-get update && $minimal_apt_get_install python-dev \
+# Install the nodesource nodejs package
+# This lets us use node 10 and avoids dependency conflict between node and libxmlsec1 over the
+# version of the ssl library that we find from package managemnet
+curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+echo "deb https://deb.nodesource.com/node_10.x bionic main" >> /etc/apt/sources.list.d/nodesource.list
+echo "deb-src https://deb.nodesource.com/node_10.x bionic main" >> /etc/apt/sources.list.d/nodesource.list
+
+# Add packages we need to build the app and its dependancies
+apt-get update
+$minimal_apt_get_install --no-upgrade \
+  python-dev \
   python2.7 \
   python-nose \
   python-setuptools \
@@ -17,23 +27,11 @@ apt-get update && $minimal_apt_get_install python-dev \
   libffi-dev \
   libjpeg-dev \
   nodejs \
-  npm \
+  libssl-dev \
   libpq-dev \
-  libxml2-dev \
-  libltdl-dev \
-  libxmlsec1 libxmlsec1-openssl libxslt1.1 libxslt-dev
-
-# Build `xmlsec1` locally to avoid dependency conflict
-# between `libssl-dev` and `libssl1.0-dev`.
-(
-  XMLSEC_VERSION="1.2.30"
-  cd /tmp && \
-  curl -L -O "http://www.aleksey.com/xmlsec/download/xmlsec1-${XMLSEC_VERSION}.tar.gz" && \
-  tar xfz "xmlsec1-${XMLSEC_VERSION}.tar.gz" && \
-  cd "xmlsec1-${XMLSEC_VERSION}" && \
-  ./configure && make && make install
-)
-rm -rf "/tmp/xmlsec1-${XMLSEC_VERSION}"
+  libxmlsec1-dev \
+  libxmlsec1-openssl \
+  libxml2-dev
 
 # Create a user.
 useradd -ms /bin/bash -U simplified


### PR DESCRIPTION
## Description

This PR does two things: 
- Updates the base image that we use
- Uses a version of Node 10 from package management

## Motivation and Context

### Change in base image

We are currently using the [`latest-amd64`](https://registry.hub.docker.com/layers/phusion/baseimage/latest-amd64/images/sha256-6c28526342cc588732aff25fc97e2c7054899cee6ff03f8f0f34ec4c0c66bb4e?context=explore) tag for our base image. It was last pushed more then a year ago. The [phusion docs](https://github.com/phusion/baseimage-docker#getting-started) say we should be using one or their [released versions](https://github.com/phusion/baseimage-docker/releases). The latest stable release is 'bionic-1.0.0' which was pushed 5 months ago. Since its not architecture specific and has been released more recently this seems like the tag we should be using.

### Node 10 from Nodesource Packages

Currently we are compiling our own version of `libxmlsec1` because the verison of OpenSSL it requires conflicts with the version of OpenSSL needed for NodeJS 8. 

NodeJS 8 is out of support and several node modules we are using complain about the old version we are using when doing 'npm install' inside the container.
```
simplified-circulation-web@0.4.30: wanted: {"node":">=8.0.0","npm":">=5.0.0"} (current: {"node":"8.10.0","npm":"3.5.2"})
jsdom@16.4.0: wanted: {"node":">=10"} (current: {"node":"8.10.0","npm":"3.5.2"})
data-urls@2.0.0: wanted: {"node":">=10"} (current: {"node":"8.10.0","npm":"3.5.2"})
w3c-xmlserializer@2.0.0: wanted: {"node":">=10"} (current: {"node":"8.10.0","npm":"3.5.2"})
webidl-conversions@6.1.0: wanted: {"node":">=10.4"} (current: {"node":"8.10.0","npm":"3.5.2"})
whatwg-url@8.4.0: wanted: {"node":">=10"} (current: {"node":"8.10.0","npm":"3.5.2"})
saxes@5.0.1: wanted: {"node":">=10"} (current: {"node":"8.10.0","npm":"3.5.2"})
html-encoding-sniffer@2.0.1: wanted: {"node":">=10"} (current: {"node":"8.10.0","npm":"3.5.2"})
```

This PR switches from using the version for Node from Ubuntu package management to the version from the [nodesource  repo](https://github.com/nodesource/distributions). This allows us to just install `libxmlsec` from Ubuntu package management, which should reduce container build time and make sure we have any security updates to that package provided by Ubuntu.

@EdwinGuzman @adriana-alter @kristojorg Is it fine to be building `simplified-circulation-web` using Node 10? It appears the travis tests on that repo are being run on Node 10 and the changelog seems to confirm that building with Node 10 is supported, but I wanted to check to be sure.

## How Has This Been Tested?

There is a build of this branch [on dockerhub](https://registry.hub.docker.com/layers/lyrasis/circ-webapp/upgrade-node/images/sha256-f3d5a001f4676e8dbbe87caf6d69f9653f52274fea68c24ae9061a5d409979ba?context=explore). I've run the circulation manager and core tests inside this container and tested out the container in our development environment and everything seems to be working fine. 


