### PR TITLE
Increase the logs we keep for UWSGI.

### DIFF
--- a/docker/services/simplified_logrotate.conf
+++ b/docker/services/simplified_logrotate.conf
@@ -14,7 +14,7 @@
     missingok
     daily
     create 0660 simplified adm
-    rotate 13
+    rotate 30
     copytruncate
     compress
     delaycompress


### PR DESCRIPTION
## Description

Followup to https://github.com/NYPL-Simplified/circulation/pull/1527 based on @alsrlw feedback that perhaps keeping these logs for longer would be a good idea. 

## Motivation and Context

I modified this value to be 30 days, based on the feedback on #1527. But I'm open to other values as well. I was mostly concerned that this log doesn't grow unbounded more then the retention time.