### PR TITLE
Update Overdrive availability API to v2

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -1037,13 +1037,18 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
                 exc_info=e
             )
 
-        if status_code != 200:
+        # TODO: If you ask for a book that you know about, and
+        # Overdrive says the book doesn't exist in the collection,
+        # then it's appropriate to update an existing
+        # LicensePool. However we shouldn't be creating a *brand new*
+        # LicensePool for a book Overdrive says isn't in the
+        # collection.
+        if status_code not in (200, 404):
             self.log.error(
                 "Could not get availability for %s: status code %s",
                 book_id, status_code
             )
             return None, None, False
-
         if isinstance(content, basestring):
             content = json.loads(content)
         book.update(content)

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -1093,7 +1093,8 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
         pool's presentation_edition, promote it to presentation
         status.
         """
-        circulation = OverdriveRepresentationExtractor.book_info_to_circulation(
+        extractor = OverdriveRepresentationExtractor(self)
+        circulation = extractor.book_info_to_circulation(
             book
         )
         license_pool, circulation_changed = circulation.apply(

--- a/tests/files/overdrive/overdrive_availability_information.json
+++ b/tests/files/overdrive/overdrive_availability_information.json
@@ -1,22 +1,21 @@
 {
-    "available": true,
-    "collections": [
+    "accounts": [
         {
-            "copiesAvailable": 5,
+            "copiesAvailable": 1,
             "copiesOwned": 5,
-            "id": "New York Public Library (NY)",
-            "numberOfHolds": 0
+            "id": -1
         }
     ],
-    "copiesAvailable": 5,
+    "availabilityType": "Normal",
+    "available": false,
+    "copiesAvailable": 1,
     "copiesOwned": 5,
-    "id": "2a005d55-a417-4053-b90d-7a38ca6d2065",
-    "title": "Blah blah blah",
     "links": {
         "self": {
-            "href": "http://api.overdrive.com/v1/collections/collection-id/products/2a005d55-a417-4053-b90d-7a38ca6d2065/availability",
+            "href": "https://api.overdrive.com/v2/collections/v1L1BCgAAAA2C/products/2a005d55-a417-4053-b90d-7a38ca6d2065/availability",
             "type": "application/vnd.overdrive.api+json"
         }
     },
-    "numberOfHolds": 0
+    "numberOfHolds": 0,
+    "reserveId": "2a005d55-a417-4053-b90d-7a38ca6d2065"
 }

--- a/tests/files/overdrive/overdrive_availability_information_holds.json
+++ b/tests/files/overdrive/overdrive_availability_information_holds.json
@@ -1,21 +1,21 @@
 {
-    "available": true,
-    "collections": [
+    "accounts": [
         {
             "copiesAvailable": 0,
             "copiesOwned": 5,
-            "id": "New York Public Library (NY)",
-            "numberOfHolds": 10
+            "id": -1
         }
     ],
+    "availabilityType": "Normal",
+    "available": false,
     "copiesAvailable": 0,
     "copiesOwned": 5,
-    "id": "2a005d55-a417-4053-b90d-7a38ca6d2065",
     "links": {
         "self": {
-            "href": "http://api.overdrive.com/v1/collections/collection-id/products/2a005d55-a417-4053-b90d-7a38ca6d2065/availability",
+            "href": "https://api.overdrive.com/v2/collections/v1L1BCgAAAA2C/products/2a005d55-a417-4053-b90d-7a38ca6d2065/availability",
             "type": "application/vnd.overdrive.api+json"
         }
     },
-    "numberOfHolds": 10
+    "numberOfHolds": 10,
+    "reserveId": "2a005d55-a417-4053-b90d-7a38ca6d2065"
 }

--- a/tests/files/overdrive/overdrive_availability_not_found.json
+++ b/tests/files/overdrive/overdrive_availability_not_found.json
@@ -1,0 +1,5 @@
+{
+    "errorCode": "NotFound", 
+    "message": "The requested resource could not be found.", 
+    "token": "60a18218-0d25-42b8-80c3-0bf9df782f1b"
+}

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -1126,9 +1126,8 @@ class TestOverdriveAPI(OverdriveAPITest):
         eq_(Edition.BOOK_MEDIUM, edition.medium)
 
     def test_update_availability(self):
-        """Test the Overdrive implementation of the update_availability
-        method defined by the CirculationAPI interface.
-        """
+        # Test the Overdrive implementation of the update_availability
+        # method defined by the CirculationAPI interface.
 
         # Create a LicensePool that needs updating.
         edition, pool = self._edition(
@@ -1169,7 +1168,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         # The availability information has been updated, as has the
         # date the availability information was last checked.
         eq_(5, pool.licenses_owned)
-        eq_(5, pool.licenses_available)
+        eq_(1, pool.licenses_available)
         eq_(0, pool.patrons_in_hold_queue)
         assert pool.last_checked is not None
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -1199,6 +1199,28 @@ class TestOverdriveAPI(OverdriveAPITest):
         pool, was_new, changed = self.api.update_licensepool(book)
         eq_(None, pool)
 
+    def test_update_licensepool_not_found(self):
+        # If the Overdrive API says a book is not found in the
+        # collection, that's treated as useful information, not an error.
+        # Create an identifier.
+        identifier = self._identifier(
+            identifier_type=Identifier.OVERDRIVE_ID
+        )
+        ignore, not_found = self.sample_json(
+            "overdrive_availability_not_found.json"
+        )
+
+        # Queue the 'not found' response twice -- once for the circulation
+        # lookup and once for the metadata lookup.
+        self.api.queue_response(404, content=not_found)
+        self.api.queue_response(404, content=not_found)
+
+        book = dict(id=identifier.identifier, availability_link=self._url)
+        pool, was_new, changed = self.api.update_licensepool(book)
+        eq_(0, pool.licenses_owned)
+        eq_(0, pool.licenses_available)
+        eq_(0, pool.patrons_in_hold_queue)
+
     def test_update_licensepool_provides_bibliographic_coverage(self):
         # Create an identifier.
         identifier = self._identifier(
@@ -1273,7 +1295,7 @@ class TestOverdriveAPI(OverdriveAPITest):
 
         # Make it look like the availability information is for the
         # newly created Identifier.
-        raw['id'] = identifier.identifier
+        raw['reserveId'] = identifier.identifier
 
         pool, was_new = LicensePool.for_foreign_id(
             self._db, DataSource.OVERDRIVE,


### PR DESCRIPTION
## Description

This branch goes along with https://github.com/NYPL-Simplified/server_core/pull/1221 to get us using v2 of the Overdrive availability API without making any other changes.

## Motivation and Context

https://jira.nypl.org/browse/SIMPLY-3302

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested this using real Overdrive credentials, but they were for a regular Overdrive account, not an Overdrive Advantage account.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
