### PR TITLE
Allow to set up a custom session lifetime in the SAML authentication provider

### DIFF
--- a/api/saml/auth.py
+++ b/api/saml/auth.py
@@ -1,4 +1,5 @@
 import logging
+from urlparse import urlparse
 
 import six
 from flask import request

--- a/api/saml/configuration/model.py
+++ b/api/saml/configuration/model.py
@@ -77,6 +77,25 @@ class SAMLConfiguration(ConfigurationGrouping):
         required=False,
     )
 
+    session_lifetime = ConfigurationMetadata(
+        key="saml_session_lifetime",
+        label=_("Session Lifetime"),
+        description=_(
+            "This configuration setting determines how long "
+            "a session created by the SAML authentication provider will live in days. "
+            "By default it's empty meaning that the lifetime of the Circulation Manager's session "
+            "is exactly the same as the lifetime of the IdP's session. "
+            "Setting this value to a specific number will override this behaviour."
+            "<br>"
+            "NOTE: This setting affects the session's lifetime only Circulation Manager's side. "
+            "Accessing content protected by SAML will still be governed by the IdP and patrons "
+            "will have to reauthenticate each time the IdP's session expires."
+        ),
+        type=ConfigurationAttributeType.NUMBER,
+        required=False,
+        default=None,
+    )
+
     filter_expression = ConfigurationMetadata(
         key="saml_filter_expression",
         label=_("Filter Expression"),

--- a/api/saml/metadata/model.py
+++ b/api/saml/metadata/model.py
@@ -1118,6 +1118,22 @@ class SAMLSubject(object):
         """
         return self._name_id
 
+    @name_id.setter
+    def name_id(self, value):
+        """Set the name ID.
+
+        :param value: New name ID
+        :type value: Optional[SAMLNameID]
+        """
+        if value and not isinstance(value, SAMLNameID):
+            raise ValueError(
+                "Argument 'value' must be either None or an instance of {0} class".format(
+                    SAMLNameID
+                )
+            )
+
+        self._name_id = value
+
     @property
     def attribute_statement(self):
         """Returns the attribute statement

--- a/tests/saml/test_provider.py
+++ b/tests/saml/test_provider.py
@@ -28,8 +28,9 @@ from api.saml.metadata.model import (
     SAMLSubjectJSONEncoder,
     SAMLUIInfo,
 )
-from api.saml.metadata.parser import SAMLSubjectParser
+from api.saml.metadata.parser import SAMLSubjectParser, SAMLMetadataParser
 from api.saml.provider import SAML_INVALID_SUBJECT, SAMLWebSSOAuthenticationProvider
+from core.model.configuration import HasExternalIntegration, ConfigurationStorage
 from core.python_expression_dsl.evaluator import DSLEvaluationVisitor, DSLEvaluator
 from core.python_expression_dsl.parser import DSLParser
 from core.util.problem_detail import ProblemDetail
@@ -104,6 +105,25 @@ IDENTITY_PROVIDER_WITHOUT_DISPLAY_NAMES = SAMLIdentityProviderMetadata(
 
 
 class TestSAMLWebSSOAuthenticationProvider(ControllerTest):
+    def setup(self, _db=None, set_up_circulation_manager=True):
+        super(TestSAMLWebSSOAuthenticationProvider, self).setup(
+            _db, set_up_circulation_manager
+        )
+
+        metadata_parser = SAMLMetadataParser()
+
+        self._external_integration_association = create_autospec(
+            spec=HasExternalIntegration
+        )
+        self._external_integration_association.external_integration = MagicMock(
+            return_value=self._integration
+        )
+
+        self._configuration_storage = ConfigurationStorage(
+            self._external_integration_association
+        )
+        self._configuration_factory = SAMLConfigurationFactory(metadata_parser)
+
     @parameterized.expand(
         [
             (
@@ -375,6 +395,50 @@ class TestSAMLWebSSOAuthenticationProvider(ControllerTest):
                 ),
             ),
             (
+                "subject_has_unique_id_and_custom_session_lifetime",
+                SAMLSubject(
+                    None,
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["12345"],
+                            )
+                        ]
+                    ),
+                ),
+                PatronData(
+                    permanent_id="12345",
+                    authorization_identifier="12345",
+                    external_type="A",
+                    complete=True,
+                ),
+                datetime.datetime(2020, 1, 1) + datetime.timedelta(days=42),
+                42,
+            ),
+            (
+                "subject_has_unique_id_and_empty_session_lifetime",
+                SAMLSubject(
+                    None,
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["12345"],
+                            )
+                        ]
+                    ),
+                ),
+                PatronData(
+                    permanent_id="12345",
+                    authorization_identifier="12345",
+                    external_type="A",
+                    complete=True,
+                ),
+                None,
+                "",
+            ),
+            (
                 "subject_has_unique_id_and_non_default_expiration_timeout",
                 SAMLSubject(
                     None,
@@ -395,26 +459,91 @@ class TestSAMLWebSSOAuthenticationProvider(ControllerTest):
                     complete=True,
                 ),
             ),
+            (
+                "subject_has_unique_id_non_default_expiration_timeout_and_custom_session_lifetime",
+                SAMLSubject(
+                    None,
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["12345"],
+                            )
+                        ]
+                    ),
+                    valid_till=datetime.timedelta(days=1),
+                ),
+                PatronData(
+                    permanent_id="12345",
+                    authorization_identifier="12345",
+                    external_type="A",
+                    complete=True,
+                ),
+                datetime.datetime(2020, 1, 1) + datetime.timedelta(days=42),
+                42,
+            ),
+            (
+                "subject_has_unique_id_non_default_expiration_timeout_and_empty_session_lifetime",
+                SAMLSubject(
+                    None,
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["12345"],
+                            )
+                        ]
+                    ),
+                    valid_till=datetime.timedelta(days=1),
+                ),
+                PatronData(
+                    permanent_id="12345",
+                    authorization_identifier="12345",
+                    external_type="A",
+                    complete=True,
+                ),
+                None,
+                "",
+            ),
         ]
     )
     @freeze_time("2020-01-01 00:00:00")
-    def test_saml_callback(self, _, subject, expected_result):
+    def test_saml_callback(
+        self,
+        _,
+        subject,
+        expected_patron_data,
+        expected_expiration_time=None,
+        cm_session_lifetime=None,
+    ):
+        # This test makes sure that SAMLWebSSOAuthenticationProvider.saml_callback
+        # correctly processes a SAML subject and returns right PatronData.
+
         # Arrange
         provider = SAMLWebSSOAuthenticationProvider(
             self._default_library, self._integration
         )
         expected_credential = json.dumps(subject, cls=SAMLSubjectJSONEncoder)
 
+        if expected_expiration_time is None and subject is not None:
+            expected_expiration_time = datetime.datetime.utcnow() + subject.valid_till
+
+        if cm_session_lifetime is not None:
+            with self._configuration_factory.create(
+                self._configuration_storage, self._db, SAMLConfiguration
+            ) as configuration:
+                configuration.session_lifetime = cm_session_lifetime
+
         # Act
         result = provider.saml_callback(self._db, subject)
 
         # Assert
         if isinstance(result, ProblemDetail):
-            eq_(result.response, expected_result.response)
+            eq_(result.response, expected_patron_data.response)
         else:
             credential, patron, patron_data = result
 
             eq_(expected_credential, credential.credential)
-            eq_(expected_result.permanent_id, patron.external_identifier)
-            eq_(expected_result, patron_data)
-            eq_(datetime.datetime.utcnow() + subject.valid_till, credential.expires)
+            eq_(expected_patron_data.permanent_id, patron.external_identifier)
+            eq_(expected_patron_data, patron_data)
+            eq_(expected_expiration_time, credential.expires)


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds a new configuration setting allowing to set up a custom session lifetime in the SAML authentication provider.
**NOTE:** this PR depends on [PR # 1523](https://github.com/NYPL-Simplified/circulation/pull/1523).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[SIMPLY-3366](https://jira.nypl.org/browse/SIMPLY-3366)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
