### PR TITLE
Do not save transient Name Ids in credentials

### DIFF
--- a/api/saml/auth.py
+++ b/api/saml/auth.py
@@ -1,5 +1,4 @@
 import logging
-from urlparse import urlparse
 
 import six
 from flask import request

--- a/api/saml/provider.py
+++ b/api/saml/provider.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+from copy import deepcopy
 
 from contextlib2 import contextmanager
 from flask import url_for
@@ -14,6 +15,7 @@ from api.saml.configuration.validator import SAMLSettingsValidator
 from api.saml.metadata.filter import SAMLSubjectFilter
 from api.saml.metadata.model import (
     SAMLLocalizedMetadataItem,
+    SAMLNameIDFormat,
     SAMLSubject,
     SAMLSubjectJSONEncoder,
     SAMLSubjectUIDExtractor,
@@ -209,9 +211,32 @@ class SAMLWebSSOAuthenticationProvider(
             )
             return [SAMLLocalizedMetadataItem(display_name, language="en")]
 
-    def _create_token(self, db, patron, subject, cm_session_lifetime):
-        """Creates a Credential object that ties the given patron to the
-        given provider token.
+    @staticmethod
+    def _create_token_value(subject):
+        """Serialize the SAML subject.
+
+        :param subject: SAML subject
+        :type subject: api.saml.metadata.model.SAMLSubject
+
+        :return: Token value
+        :rtype: str
+        """
+        subject = deepcopy(subject)
+
+        # We should not save a transient Name ID because it changes each time
+        if (
+            subject.name_id
+            and subject.name_id.name_format == SAMLNameIDFormat.TRANSIENT.value
+        ):
+            subject.name_id = None
+
+        token_value = json.dumps(subject, cls=SAMLSubjectJSONEncoder)
+
+        return token_value
+
+    def _create_token(self, db, patron, subject, cm_session_lifetime=None):
+        """Create a Credential object that ties the given patron to the
+            given provider token.
 
         :param db: Database session
         :type db: sqlalchemy.orm.session.Session
@@ -228,12 +253,13 @@ class SAMLWebSSOAuthenticationProvider(
         :return: Credential object
         :rtype: Credential
         """
-        token = json.dumps(subject, cls=SAMLSubjectJSONEncoder)
-        data_source, ignore = self._get_token_data_source(db)
         session_lifetime = subject.valid_till
 
         if cm_session_lifetime:
             session_lifetime = datetime.timedelta(days=int(cm_session_lifetime))
+
+        token = self._create_token_value(subject)
+        data_source, ignore = self._get_token_data_source(db)
 
         return Credential.temporary_token_create(
             db, data_source, self.TOKEN_TYPE, patron, session_lifetime, token

--- a/tests/saml/test_provider.py
+++ b/tests/saml/test_provider.py
@@ -27,6 +27,7 @@ from api.saml.metadata.model import (
     SAMLSubject,
     SAMLSubjectJSONEncoder,
     SAMLUIInfo,
+    SAMLNameID,
 )
 from api.saml.metadata.parser import SAMLSubjectParser, SAMLMetadataParser
 from api.saml.provider import SAML_INVALID_SUBJECT, SAMLWebSSOAuthenticationProvider
@@ -395,6 +396,58 @@ class TestSAMLWebSSOAuthenticationProvider(ControllerTest):
                 ),
             ),
             (
+                "subject_has_unique_id_and_persistent_name_id",
+                SAMLSubject(
+                    SAMLNameID(
+                        SAMLNameIDFormat.PERSISTENT.value,
+                        "name-qualifier",
+                        "sp-name-qualifier",
+                        "12345",
+                    ),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["12345"],
+                            )
+                        ]
+                    ),
+                ),
+                PatronData(
+                    permanent_id="12345",
+                    authorization_identifier="12345",
+                    external_type="A",
+                    complete=True,
+                ),
+                None,
+            ),
+            (
+                "subject_has_unique_id_and_transient_name_id",
+                SAMLSubject(
+                    SAMLNameID(
+                        SAMLNameIDFormat.TRANSIENT.value,
+                        "name-qualifier",
+                        "sp-name-qualifier",
+                        "12345",
+                    ),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["12345"],
+                            )
+                        ]
+                    ),
+                ),
+                PatronData(
+                    permanent_id="12345",
+                    authorization_identifier="12345",
+                    external_type="A",
+                    complete=True,
+                ),
+                '{"attributes": {"eduPersonUniqueId": ["12345"]}}',
+            ),
+            (
                 "subject_has_unique_id_and_custom_session_lifetime",
                 SAMLSubject(
                     None,
@@ -413,6 +466,7 @@ class TestSAMLWebSSOAuthenticationProvider(ControllerTest):
                     external_type="A",
                     complete=True,
                 ),
+                None,
                 datetime.datetime(2020, 1, 1) + datetime.timedelta(days=42),
                 42,
             ),
@@ -435,6 +489,7 @@ class TestSAMLWebSSOAuthenticationProvider(ControllerTest):
                     external_type="A",
                     complete=True,
                 ),
+                None,
                 None,
                 "",
             ),
@@ -479,6 +534,7 @@ class TestSAMLWebSSOAuthenticationProvider(ControllerTest):
                     external_type="A",
                     complete=True,
                 ),
+                None,
                 datetime.datetime(2020, 1, 1) + datetime.timedelta(days=42),
                 42,
             ),
@@ -503,6 +559,7 @@ class TestSAMLWebSSOAuthenticationProvider(ControllerTest):
                     complete=True,
                 ),
                 None,
+                None,
                 "",
             ),
         ]
@@ -513,6 +570,7 @@ class TestSAMLWebSSOAuthenticationProvider(ControllerTest):
         _,
         subject,
         expected_patron_data,
+        expected_credential=None,
         expected_expiration_time=None,
         cm_session_lifetime=None,
     ):
@@ -523,7 +581,9 @@ class TestSAMLWebSSOAuthenticationProvider(ControllerTest):
         provider = SAMLWebSSOAuthenticationProvider(
             self._default_library, self._integration
         )
-        expected_credential = json.dumps(subject, cls=SAMLSubjectJSONEncoder)
+
+        if expected_credential is None:
+            expected_credential = json.dumps(subject, cls=SAMLSubjectJSONEncoder)
 
         if expected_expiration_time is None and subject is not None:
             expected_expiration_time = datetime.datetime.utcnow() + subject.valid_till


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds additional logic which doesn't allow Circulation Manager to save transient Name IDs.
**NOTE:** This PR depends on [1534](https://github.com/NYPL-Simplified/circulation/pull/1534).

## Motivation and Context

[SIMPLY-3368](https://jira.nypl.org/browse/SIMPLY-3368)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
