### PR TITLE
Add custom logic for processing ProQuest indirect acquisition links

### DIFF
--- a/api/proquest/credential.py
+++ b/api/proquest/credential.py
@@ -4,7 +4,6 @@ import logging
 from enum import Enum
 
 from api.saml.metadata.model import SAMLAttributeType, SAMLSubjectJSONDecoder
-
 from core.model import Credential, DataSource, DataSourceConstants, Patron
 from core.util import first_or_default, is_session
 from core.util.string_helpers import is_string
@@ -82,8 +81,8 @@ class ProQuestCredentialManager(object):
         :param patron: Patron object
         :type patron: core.model.patron.Patron
 
-        :return: ProQuest JWT bearer token (if any)
-        :rtype: Optional[str]
+        :return: Credential object containing the existing ProQuest JWT bearer token (if any)
+        :rtype: Optional[core.model.credential.Credential]
         """
         if not is_session(db):
             raise ValueError('"db" argument must be a valid SQLAlchemy session')
@@ -106,7 +105,7 @@ class ProQuestCredentialManager(object):
         )
 
         if credential:
-            return credential.credential
+            return credential
 
         return None
 
@@ -124,6 +123,9 @@ class ProQuestCredentialManager(object):
 
         :param token: ProQuest JWT bearer token
         :type token: str
+
+        :return: Credential object containing a new ProQuest JWT bearer token
+        :rtype: Optional[core.model.credential.Credential]
         """
         if not is_session(db):
             raise ValueError('"db" argument must be a valid SQLAlchemy session')
@@ -157,6 +159,8 @@ class ProQuestCredentialManager(object):
                 token, credential, is_new
             )
         )
+
+        return credential
 
     def lookup_patron_affiliation_id(
         self,

--- a/api/proquest/importer.py
+++ b/api/proquest/importer.py
@@ -1,13 +1,10 @@
 import datetime
+import json
 import logging
 from contextlib import contextmanager
 
 import six
-from flask_babel import lazy_gettext as _
-from requests import HTTPError
-from sqlalchemy import or_
-from webpub_manifest_parser.utils import encode
-
+import webpub_manifest_parser.opds2.ast as opds2_ast
 from api.circulation import BaseCirculationAPI, FulfillmentInfo, LoanInfo
 from api.circulation_exceptions import CannotFulfill, CannotLoan
 from api.proquest.client import ProQuestAPIClientConfiguration, ProQuestAPIClientFactory
@@ -16,7 +13,16 @@ from api.proquest.identifier import ProQuestIdentifierParser
 from api.saml.metadata.model import SAMLAttributeType
 from core.classifier import Classifier
 from core.exceptions import BaseError
-from core.model import Collection, Hyperlink, Identifier, LicensePool, Loan, get_one
+from core.model import (
+    Collection,
+    DeliveryMechanism,
+    Hyperlink,
+    Identifier,
+    LicensePool,
+    Loan,
+    MediaTypes,
+    get_one,
+)
 from core.model.configuration import (
     ConfigurationAttributeType,
     ConfigurationFactory,
@@ -29,6 +35,11 @@ from core.model.configuration import (
 )
 from core.opds2_import import OPDS2Importer, OPDS2ImportMonitor, parse_feed
 from core.opds_import import OPDSImporter
+from core.util.string_helpers import is_string
+from flask_babel import lazy_gettext as _
+from requests import HTTPError
+from sqlalchemy import or_
+from webpub_manifest_parser.utils import encode
 
 MISSING_AFFILIATION_ID = BaseError(
     _(
@@ -252,10 +263,33 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
         :return: Configured list of SAML attributes which can contain affiliation ID
         :rtype: List[str]
         """
+        affiliation_attributes = (
+            ProQuestOPDS2ImporterConfiguration.DEFAULT_AFFILIATION_ATTRIBUTES
+        )
+
         if configuration.affiliation_attributes:
-            return configuration.affiliation_attributes
-        else:
-            return ProQuestOPDS2ImporterConfiguration.DEFAULT_AFFILIATION_ATTRIBUTES
+            if isinstance(configuration.affiliation_attributes, list):
+                affiliation_attributes = configuration.affiliation_attributes
+            elif is_string(configuration.affiliation_attributes):
+                affiliation_attributes = tuple(
+                    map(
+                        str.strip,
+                        str(configuration.affiliation_attributes)
+                        .replace("[", "")
+                        .replace("]", "")
+                        .replace("(", "")
+                        .replace(")", "")
+                        .replace("'", "")
+                        .replace('"', "")
+                        .split(","),
+                    )
+                )
+            else:
+                raise ValueError(
+                    "Configuration setting 'affiliation_attributes' has an incorrect format"
+                )
+
+        return affiliation_attributes
 
     def _get_patron_affiliation_id(self, patron, configuration):
         """Get a patron's affiliation ID.
@@ -310,7 +344,7 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
         :type configuration: ProQuestOPDS2ImporterConfiguration
 
         :return: ProQuest JWT bearer token
-        :rtype: str
+        :rtype: core.model.credential.Credential
         """
         affiliation_id = self._get_patron_affiliation_id(patron, configuration)
 
@@ -321,8 +355,7 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
                 if configuration.token_expiration_timeout
                 else ProQuestOPDS2ImporterConfiguration.DEFAULT_TOKEN_EXPIRATION_TIMEOUT_SECONDS
             )
-
-            self._credential_manager.save_proquest_token(
+            token = self._credential_manager.save_proquest_token(
                 self._db,
                 patron,
                 datetime.timedelta(seconds=token_expiration_timeout),
@@ -345,7 +378,7 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
         :type configuration: ProQuestOPDS2ImporterConfiguration
 
         :return: ProQuest JWT bearer token
-        :rtype: str
+        :rtype: core.model.credential.Credential
         """
         token = self._credential_manager.lookup_proquest_token(self._db, patron)
 
@@ -378,7 +411,9 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
 
         while True:
             try:
-                book = self._api_client.get_book(self._db, token, document_id)
+                book = self._api_client.get_book(
+                    self._db, token.credential, document_id
+                )
 
                 return book
             except HTTPError as exception:
@@ -433,6 +468,80 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
         )
 
         return image_links
+
+    def _extract_media_types_and_drm_scheme_from_link(self, link):
+        """Extract information about content's media type and used DRM schema from the link.
+
+        We consider viable the following two options:
+        1. DRM-free books
+        {
+            "rel": "http://opds-spec.org/acquisition",
+            "href": "http://distributor.com/bookID",
+            "type": "application/epub+zip"
+        }
+
+        2. DRM-protected books
+        {
+            "rel": "http://opds-spec.org/acquisition",
+            "href": "http://distributor.com/bookID",
+            "type": "application/vnd.adobe.adept+xml",
+            "properties": {
+                "indirectAcquisition": [
+                    {
+                        "type": "application/epub+zip"
+                    }
+                ]
+            }
+        }
+
+        :param link: Link object
+        :type link: ast_core.Link
+
+        :return: 2-tuple containing information about the content's media type and its DRM schema
+        :rtype: List[Tuple[str, str]]
+        """
+        self._logger.debug(
+            u"Started extracting media types and a DRM scheme from {0}".format(
+                encode(link)
+            )
+        )
+
+        media_types_and_drm_scheme = []
+
+        if link.properties:
+            if (
+                not link.properties.availability
+                or link.properties.availability.state
+                == opds2_ast.OPDS2AvailabilityType.AVAILABLE.value
+            ):
+                drm_scheme = (
+                    link.type
+                    if link.type in DeliveryMechanism.KNOWN_DRM_TYPES
+                    else DeliveryMechanism.NO_DRM
+                )
+
+                for acquisition_object in link.properties.indirect_acquisition:
+                    media_types_and_drm_scheme.append(
+                        (acquisition_object.type, drm_scheme)
+                    )
+        else:
+            if (
+                link.type in MediaTypes.BOOK_MEDIA_TYPES
+                or link.type in MediaTypes.AUDIOBOOK_MEDIA_TYPES
+            ):
+                # Despite the fact that the book is DRM-free, we set its DRM type as DeliveryMechanism.BEARER_TOKEN.
+                # We need it to allow the book to be downloaded by a client app.
+                media_types_and_drm_scheme.append(
+                    (link.type, DeliveryMechanism.BEARER_TOKEN)
+                )
+
+        self._logger.debug(
+            u"Finished extracting media types and a DRM scheme from {0}: {1}".format(
+                encode(link), encode(media_types_and_drm_scheme)
+            )
+        )
+
+        return media_types_and_drm_scheme
 
     def _parse_identifier(self, identifier):
         """Parse the identifier and return an Identifier object representing it.
@@ -579,6 +688,7 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
 
         try:
             with self._get_configuration(self._db) as configuration:
+                token = self._get_or_create_proquest_token(patron, configuration)
                 book = self._get_book(
                     patron, configuration, licensepool.identifier.identifier
                 )
@@ -597,15 +707,24 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
                         content_expires=None,
                     )
                 else:
-                    fulfillment_info = FulfillmentInfo(
+                    now = datetime.datetime.utcnow()
+                    expires_in = (token.expires - now).total_seconds()
+                    token_document = dict(
+                        token_type="Bearer",
+                        access_token=token.credential,
+                        expires_in=expires_in,
+                        location=book.link,
+                    )
+
+                    return FulfillmentInfo(
                         licensepool.collection,
                         licensepool.data_source.name,
                         licensepool.identifier.type,
                         licensepool.identifier.identifier,
-                        content_link=book.link,
-                        content_type=internal_format.delivery_mechanism.media_type,
-                        content=None,
-                        content_expires=None,
+                        content_link=None,
+                        content_type=DeliveryMechanism.BEARER_TOKEN,
+                        content=json.dumps(token_document),
+                        content_expires=token.expires,
                     )
 
                 self._logger.info(

--- a/api/proquest/scripts.py
+++ b/api/proquest/scripts.py
@@ -2,7 +2,6 @@ import logging
 
 from api.proquest.client import ProQuestAPIClientFactory
 from api.proquest.importer import ProQuestOPDS2ImportMonitor
-
 from core.scripts import OPDSImportScript
 
 

--- a/tests/proquest/test_client.py
+++ b/tests/proquest/test_client.py
@@ -9,11 +9,6 @@ from api.proquest.client import (
     ProQuestBook,
 )
 from api.util.url import URLUtility
-from mock import MagicMock, create_autospec
-from nose.tools import assert_raises, eq_
-from parameterized import parameterized
-from requests import HTTPError
-
 from core.model import DeliveryMechanism, ExternalIntegration
 from core.model.configuration import (
     ConfigurationFactory,
@@ -21,6 +16,10 @@ from core.model.configuration import (
     HasExternalIntegration,
 )
 from core.testing import DatabaseTest
+from mock import MagicMock, create_autospec
+from nose.tools import assert_raises, eq_
+from parameterized import parameterized
+from requests import HTTPError
 
 BOOKS_CATALOG_SERVICE_URL = "https://proquest.com/lib/nyulibrary-ebooks/BooksCatalog"
 PARTNER_AUTH_TOKEN_SERVICE_URL = (

--- a/tests/proquest/test_credential.py
+++ b/tests/proquest/test_credential.py
@@ -10,11 +10,10 @@ from api.saml.metadata.model import (
     SAMLSubject,
     SAMLSubjectJSONEncoder,
 )
-from nose.tools import eq_
-from parameterized import parameterized
-
 from core.model import Credential, DataSource
 from core.testing import DatabaseTest
+from nose.tools import eq_
+from parameterized import parameterized
 from tests.saml import fixtures
 
 
@@ -56,7 +55,8 @@ class TestProQuestCredentialManager(DatabaseTest):
         token = credential_manager.lookup_proquest_token(self._db, patron)
 
         # Assert
-        eq_(expected_token, token)
+        eq_(True, isinstance(token, Credential))
+        eq_(expected_token, token.credential)
 
     def test_save_proquest_token_saves_token(self):
         # Arrange

--- a/tests/proquest/test_identifier.py
+++ b/tests/proquest/test_identifier.py
@@ -1,8 +1,7 @@
 from api.proquest.identifier import ProQuestIdentifierParser
+from core.model import Identifier
 from nose.tools import eq_
 from parameterized import parameterized
-
-from core.model import Identifier
 
 
 class TestProQuestIdentifierParser(object):

--- a/tests/proquest/test_importer.py
+++ b/tests/proquest/test_importer.py
@@ -218,9 +218,43 @@ class TestProQuestOPDS2Importer(DatabaseTest):
                 proquest_token,
             )
 
+    @parameterized.expand(
+        [
+            (
+                "tuple",
+                (
+                    SAMLAttributeType.mail.name,
+                    SAMLAttributeType.uid.name,
+                ),
+            ),
+            (
+                "list",
+                [
+                    SAMLAttributeType.mail.name,
+                    SAMLAttributeType.uid.name,
+                ],
+            ),
+            (
+                "tuple_string",
+                "({0}, {1})".format(
+                    SAMLAttributeType.mail.name,
+                    SAMLAttributeType.uid.name,
+                ),
+            ),
+            (
+                "list_string",
+                json.dumps(
+                    [
+                        SAMLAttributeType.mail.name,
+                        SAMLAttributeType.uid.name,
+                    ]
+                ),
+            ),
+        ]
+    )
     @freeze_time("2020-01-01 00:00:00")
     def test_checkout_creates_new_token_using_affiliation_id_from_custom_saml_attribute(
-        self,
+        self, _, custom_affiliation_attributes
     ):
         # We want to test that checkout operation without an existing ProQuest JWT bearer token leads to the following:
         # 1. Circulation Manager (CM) lookups for an existing token and doesn't find any.
@@ -232,7 +266,7 @@ class TestProQuestOPDS2Importer(DatabaseTest):
         affiliation_id = "12345"
         proquest_token = "1234567890"
 
-        custom_affiliation_attributes = (
+        expected_affiliation_attributes = (
             SAMLAttributeType.mail.name,
             SAMLAttributeType.uid.name,
         )
@@ -322,7 +356,7 @@ class TestProQuestOPDS2Importer(DatabaseTest):
                 credential_manager_mock.lookup_patron_affiliation_id.assert_called_once_with(
                     self._db,
                     self._proquest_patron,
-                    custom_affiliation_attributes,
+                    expected_affiliation_attributes,
                 )
 
                 # 3. Assert that ProQuest.create_token was called when CM tried to create


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR includes the following changes:
1. It overrides the way OPDS2 parser processes indirect acquisition links in order to cope with ProQuest format.
2. It implements [bearer token propagation](https://github.com/NYPL-Simplified/Simplified/wiki/OPDSForDistributors#bearer-token-propagation) in order to pass DRM-free links to client apps and not proxy DRM-free content through Circulation Manager.

**NOTE:** This PR depends on [PR # 1531](https://github.com/NYPL-Simplified/circulation/pull/1531).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[SIMPLY-3372](https://jira.nypl.org/browse/SIMPLY-3372)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
