### PR TITLE
Make ProQuest import process more resilient to network failures

### DIFF
--- a/api/proquest/importer.py
+++ b/api/proquest/importer.py
@@ -792,12 +792,27 @@ class ProQuestOPDS2ImportMonitor(OPDS2ImportMonitor, HasExternalIntegration):
     def _get_feeds(self):
         self._logger.info("Started fetching ProQuest paged OPDS 2.0 feeds")
 
+        feeds = []
+
+        self._logger.info("Started downloading feed pages")
+
+        for feed in self._client.download_all_feed_pages(self._db):
+            feeds.append(feed)
+
+        self._logger.info("Finished downloading {0} feed pages".format(len(feeds)))
+
         page = 1
         processed_number_of_items = 0
         total_number_of_items = None
 
-        for feed in self._client.download_all_feed_pages(self._db):
+        self._logger.info("Started processing feed pages")
+
+        for feed in feeds:
+            self._logger.info("Page # {0}. Started parsing the feed".format(page))
+
             feed = parse_feed(feed, silent=False)
+
+            self._logger.info("Page # {0}. Finished parsing the feed".format(page))
 
             # FIXME: We cannot short-circuit the feed import process
             #  because ProQuest feed is not ordered by the publication's modified date.
@@ -828,5 +843,7 @@ class ProQuestOPDS2ImportMonitor(OPDS2ImportMonitor, HasExternalIntegration):
             page += 1
 
             yield None, feed
+
+        self._logger.info("Finished processing {0} feed pages".format(len(feeds)))
 
         self._logger.info("Finished fetching ProQuest paged OPDS 2.0 feeds")

--- a/api/proquest/scripts.py
+++ b/api/proquest/scripts.py
@@ -2,6 +2,7 @@ import logging
 
 from api.proquest.client import ProQuestAPIClientFactory
 from api.proquest.importer import ProQuestOPDS2ImportMonitor
+
 from core.scripts import OPDSImportScript
 
 

--- a/tests/proquest/test_client.py
+++ b/tests/proquest/test_client.py
@@ -9,6 +9,11 @@ from api.proquest.client import (
     ProQuestBook,
 )
 from api.util.url import URLUtility
+from mock import MagicMock, create_autospec
+from nose.tools import assert_raises, eq_
+from parameterized import parameterized
+from requests import HTTPError
+
 from core.model import DeliveryMechanism, ExternalIntegration
 from core.model.configuration import (
     ConfigurationFactory,

--- a/tests/proquest/test_credential.py
+++ b/tests/proquest/test_credential.py
@@ -10,6 +10,9 @@ from api.saml.metadata.model import (
     SAMLSubject,
     SAMLSubjectJSONEncoder,
 )
+from nose.tools import eq_
+from parameterized import parameterized
+
 from core.model import Credential, DataSource
 from core.testing import DatabaseTest
 from nose.tools import eq_


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR changes the ProQuest import process:
1. First it downloads all the feed pages.
2. After all the pages are downloaded locally Circulation Manager starts processing thee one by one. 

**NOTE:** This PR depends on [PR # 1536](https://github.com/NYPL-Simplified/circulation/pull/1536).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[SIMPLY-3373](https://jira.nypl.org/browse/SIMPLY-3373)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
