### PR TITLE
Fix ProQuestOPDS2Importer.patron_activity method so it returns loans made by patrons

### DIFF
--- a/api/proquest/importer.py
+++ b/api/proquest/importer.py
@@ -588,10 +588,10 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
             .filter(
                 Collection.id == self._collection_id,
                 Loan.patron == patron,
-                or_(Loan.start is None, Loan.start <= now),
-                or_(Loan.end is None, Loan.end > now),
+                or_(Loan.start == None, Loan.start <= now),
+                or_(Loan.end == None, Loan.end > now),
             )
-        )
+        ).all()
 
         loan_info_objects = []
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR fixes `ProQuestOPDS2Importer.patron_activity` method so it returns loans made by patrons.
**NOTE:** This PR depends on [PR # 1535](https://github.com/NYPL-Simplified/circulation/pull/1535).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[SIMPLY-3380](https://jira.nypl.org/browse/SIMPLY-3380)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
