### PR TITLE
Use v2 of the availability API even if we get a v1 link from another API request.

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -991,8 +991,10 @@ class OverdriveAPI(BaseOverdriveAPI, BaseCirculationAPI, HasSelfTests):
             )
             book = dict(id=book_id)
         else:
-            book_id = book['id']
             circulation_link = book['availability_link']
+            # Make sure we use v2 of the availability API,
+            # even if Overdrive gave us a link to v1.
+            circulation_link = self.make_link_safe(circulation_link)
         return book, self.get(circulation_link, {})
 
     def update_formats(self, licensepool):


### PR DESCRIPTION
## Description

This branch fixes https://jira.nypl.org/browse/SIMPLY-3370, in conjunction with [core#1228](https://github.com/NYPL-Simplified/server_core/pull/1228).

## Motivation and Context

When we generate a URL to Overdrive's availability endpoint, we use v2 of the API. But sometimes Overdrive gives us links that we follow, and those links may use v1 of the API.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
