### PR TITLE
Solo OPDS catalog entries must contain self links

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -81,6 +81,21 @@ class CirculationManagerAnnotator(Annotator):
         self.hidden_content_types = hidden_content_types
         self.test_mode = test_mode
 
+    def is_work_entry_solo(self, work):
+        """Return a boolean value indicating whether the work's OPDS catalog entry is served by itself,
+            rather than as a part of the feed.
+
+        :param work: Work object
+        :type work: core.model.work.Work
+
+        :return: Boolean value indicating whether the work's OPDS catalog entry is served by itself,
+            rather than as a part of the feed
+        :rtype: bool
+        """
+        return any(
+            work in x for x in (self.active_loans_by_work, self.active_holds_by_work, self.active_fulfillments_by_work)
+        )
+
     def _lane_identifier(self, lane):
         if isinstance(lane, Lane):
             return lane.id


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds an ability to override `rel` of `application/atom+xml;type=entry;profile=opds-catalog` links: depending on whether the OPDS entry is complete or incomplete `rel` will be set to `self` or `alternate` accordingly.

This PR depends on [PR # 1230](https://github.com/NYPL-Simplified/server_core/pull/1230) in server_core.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[SIMPLY-3355](https://jira.nypl.org/browse/SIMPLY-3355)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.