### PR TITLE
Implement removals handling in the ProQuest integration

### DIFF
--- a/api/proquest/client.py
+++ b/api/proquest/client.py
@@ -2,6 +2,9 @@ import logging
 from contextlib import contextmanager
 
 import requests
+from flask_babel import lazy_gettext as _
+from requests import HTTPError, Request
+
 from core.exceptions import BaseError
 from core.model import DeliveryMechanism
 from core.model.configuration import (
@@ -13,8 +16,6 @@ from core.model.configuration import (
 )
 from core.util import is_session
 from core.util.string_helpers import is_string
-from flask_babel import lazy_gettext as _
-from requests import HTTPError, Request
 
 
 class ProQuestAPIClientConfiguration(ConfigurationGrouping):

--- a/api/proquest/scripts.py
+++ b/api/proquest/scripts.py
@@ -2,7 +2,6 @@ import logging
 
 from api.proquest.client import ProQuestAPIClientFactory
 from api.proquest.importer import ProQuestOPDS2ImportMonitor
-
 from core.scripts import OPDSImportScript
 
 
@@ -13,6 +12,18 @@ class ProQuestOPDS2ImportScript(OPDSImportScript):
         super(ProQuestOPDS2ImportScript, self).__init__(*args, **kwargs)
 
         self._logger = logging.getLogger(__name__)
+
+    @classmethod
+    def arg_parser(cls):
+        parser = OPDSImportScript.arg_parser()
+        parser.add_argument(
+            "--process-removals",
+            help="Remove from the Circulation Manager's catalog items that are no longer present in the ProQuest feed",
+            dest="process_removals",
+            action="store_true",
+        )
+
+        return parser
 
     def run_monitor(self, collection, force=None):
         """Run the monitor for the specified collection.
@@ -32,6 +43,7 @@ class ProQuestOPDS2ImportScript(OPDSImportScript):
             )
         )
 
+        parsed = self.parse_command_line(self._db)
         client_factory = ProQuestAPIClientFactory()
         monitor = self.monitor_class(
             client_factory,
@@ -39,6 +51,7 @@ class ProQuestOPDS2ImportScript(OPDSImportScript):
             collection,
             import_class=self.importer_class,
             force_reimport=force,
+            process_removals=parsed.process_removals,
         )
 
         monitor.run()

--- a/tests/proquest/fixtures.py
+++ b/tests/proquest/fixtures.py
@@ -66,8 +66,11 @@ PROQUEST_FEED_PAGE_2 = OPDS2Feed(
     ),
 )
 
-PROQUEST_RAW_PUBLICATION_ID = "12345"
-PROQUEST_RAW_PUBLICATION_COVER_HREF = "http://proquest.com/covers/12345-m.jpg"
+PROQUEST_RAW_PUBLICATION_1_ID = "12345"
+PROQUEST_RAW_PUBLICATION_1_COVER_HREF = "http://proquest.com/covers/12345-m.jpg"
+
+PROQUEST_RAW_PUBLICATION_2_ID = "12346"
+PROQUEST_RAW_PUBLICATION_2_COVER_HREF = "http://proquest.com/covers/12346-m.jpg"
 
 PROQUEST_RAW_FEED = """{{
   "metadata": {{
@@ -107,7 +110,7 @@ PROQUEST_RAW_FEED = """{{
       "metadata": {{
         "identifier": "urn:proquest.com/document-id/{0}",
         "@type": "http://schema.org/Book",
-        "title": "Test Book",
+        "title": "Test Book 1",
         "modified": "2020-11-19T08:00:00.000Z",
         "published": "2020-01-15T08:06:00.000Z",
         "language": [
@@ -155,9 +158,217 @@ PROQUEST_RAW_FEED = """{{
         "alternate": [],
         "children": []
       }}]
+    }},
+    {{
+      "metadata": {{
+        "identifier": "urn:proquest.com/document-id/{2}",
+        "@type": "http://schema.org/Book",
+        "title": "Test Book 2",
+        "modified": "2020-11-19T08:00:00.000Z",
+        "published": "2020-01-15T08:06:00.000Z",
+        "language": [
+          "eng"
+        ],
+        "author": [{{
+          "name": "Test, Author",
+          "links": [{{
+            "href": "https://catalog.feedbooks.com/catalog/index.json",
+            "type": "application/opds+json",
+            "alternate": [],
+            "children": []
+          }}]
+        }}],
+        "publisher": {{
+          "name": "Test Publisher",
+          "links": []
+        }},
+        "subject": [],
+        "readingProgression": "ltr"
+      }},
+      "links": [{{
+        "href": "https://proquest.com/lib/detail.action?docID={2}",
+        "type": "application/vnd.adobe.adept+xml",
+        "rel": "http://opds-spec.org/acquisition",
+        "properties": {{
+          "indirectAcquisition": [{{
+            "type": "application/epub+zip",
+            "alternate": [],
+            "children": []
+          }}]
+        }},
+        "language": [
+          "eng"
+        ],
+        "alternate": [],
+        "children": []
+      }}],
+      "images": [{{
+        "href": "{3}",
+        "type": "image/jpeg",
+        "language": [
+          "eng"
+        ],
+        "alternate": [],
+        "children": []
+      }}]
     }}]
   }}]
 }}
 """.format(
-    PROQUEST_RAW_PUBLICATION_ID, PROQUEST_RAW_PUBLICATION_COVER_HREF
+    PROQUEST_RAW_PUBLICATION_1_ID,
+    PROQUEST_RAW_PUBLICATION_1_COVER_HREF,
+    PROQUEST_RAW_PUBLICATION_2_ID,
+    PROQUEST_RAW_PUBLICATION_2_COVER_HREF,
+)
+
+PROQUEST_RAW_PUBLICATION_3_ID = "12347"
+PROQUEST_RAW_PUBLICATION_3_COVER_HREF = "http://proquest.com/covers/12347-m.jpg"
+
+PROQUEST_RAW_FEED_WITH_A_REMOVED_PUBLICATION = """{{
+  "metadata": {{
+    "title": "Test Feed",
+    "itemsPerPage": 1,
+    "numberOfItems": 1
+  }},
+  "links": [{{
+    "href": "https://drafts.opds.io/schema/feed.schema.json",
+    "type": "application/opds+json",
+    "rel": "self",
+    "alternate": [],
+    "children": []
+  }}],
+  "publications": [],
+  "navigation": [{{
+    "href": "https://drafts.opds.io/schema/feed.schema.json",
+    "type": "application/opds+json",
+    "title": "Test",
+    "rel": "self",
+    "alternate": [],
+    "children": []
+  }}],
+  "facets": [],
+  "groups": [{{
+    "metadata": {{
+      "title": "Test Group"
+    }},
+    "links": [{{
+      "href": "https://drafts.opds.io/schema/feed.schema.json",
+      "type": "application/opds+json",
+      "rel": "self",
+      "alternate": [],
+      "children": []
+    }}],
+    "publications": [{{
+      "metadata": {{
+        "identifier": "urn:proquest.com/document-id/{0}",
+        "@type": "http://schema.org/Book",
+        "title": "Test Book 1",
+        "modified": "2020-11-19T08:00:00.000Z",
+        "published": "2020-01-15T08:06:00.000Z",
+        "language": [
+          "eng"
+        ],
+        "author": [{{
+          "name": "Test, Author",
+          "links": [{{
+            "href": "https://catalog.feedbooks.com/catalog/index.json",
+            "type": "application/opds+json",
+            "alternate": [],
+            "children": []
+          }}]
+        }}],
+        "publisher": {{
+          "name": "Test Publisher",
+          "links": []
+        }},
+        "subject": [],
+        "readingProgression": "ltr"
+      }},
+      "links": [{{
+        "href": "https://proquest.com/lib/detail.action?docID={0}",
+        "type": "application/vnd.adobe.adept+xml",
+        "rel": "http://opds-spec.org/acquisition",
+        "properties": {{
+          "indirectAcquisition": [{{
+            "type": "application/epub+zip",
+            "alternate": [],
+            "children": []
+          }}]
+        }},
+        "language": [
+          "eng"
+        ],
+        "alternate": [],
+        "children": []
+      }}],
+      "images": [{{
+        "href": "{1}",
+        "type": "image/jpeg",
+        "language": [
+          "eng"
+        ],
+        "alternate": [],
+        "children": []
+      }}]
+    }},
+    {{
+      "metadata": {{
+        "identifier": "urn:proquest.com/document-id/{2}",
+        "@type": "http://schema.org/Book",
+        "title": "Test Book 3",
+        "modified": "2020-11-19T08:00:00.000Z",
+        "published": "2020-01-15T08:06:00.000Z",
+        "language": [
+          "eng"
+        ],
+        "author": [{{
+          "name": "Test, Author",
+          "links": [{{
+            "href": "https://catalog.feedbooks.com/catalog/index.json",
+            "type": "application/opds+json",
+            "alternate": [],
+            "children": []
+          }}]
+        }}],
+        "publisher": {{
+          "name": "Test Publisher",
+          "links": []
+        }},
+        "subject": [],
+        "readingProgression": "ltr"
+      }},
+      "links": [{{
+        "href": "https://proquest.com/lib/detail.action?docID={2}",
+        "type": "application/vnd.adobe.adept+xml",
+        "rel": "http://opds-spec.org/acquisition",
+        "properties": {{
+          "indirectAcquisition": [{{
+            "type": "application/epub+zip",
+            "alternate": [],
+            "children": []
+          }}]
+        }},
+        "language": [
+          "eng"
+        ],
+        "alternate": [],
+        "children": []
+      }}],
+      "images": [{{
+        "href": "{3}",
+        "type": "image/jpeg",
+        "language": [
+          "eng"
+        ],
+        "alternate": [],
+        "children": []
+      }}]
+    }}]
+  }}]
+}}
+""".format(
+    PROQUEST_RAW_PUBLICATION_1_ID,
+    PROQUEST_RAW_PUBLICATION_1_COVER_HREF,
+    PROQUEST_RAW_PUBLICATION_3_ID,
+    PROQUEST_RAW_PUBLICATION_3_COVER_HREF,
 )

--- a/tests/proquest/test_client.py
+++ b/tests/proquest/test_client.py
@@ -1,6 +1,11 @@
 import json
 
 import requests_mock
+from mock import MagicMock, create_autospec
+from nose.tools import assert_raises, eq_
+from parameterized import parameterized
+from requests import HTTPError
+
 from api.proquest.client import (
     ProQuestAPIClient,
     ProQuestAPIClientConfiguration,
@@ -9,11 +14,6 @@ from api.proquest.client import (
     ProQuestBook,
 )
 from api.util.url import URLUtility
-from mock import MagicMock, create_autospec
-from nose.tools import assert_raises, eq_
-from parameterized import parameterized
-from requests import HTTPError
-
 from core.model import DeliveryMechanism, ExternalIntegration
 from core.model.configuration import (
     ConfigurationFactory,
@@ -21,10 +21,6 @@ from core.model.configuration import (
     HasExternalIntegration,
 )
 from core.testing import DatabaseTest
-from mock import MagicMock, create_autospec
-from nose.tools import assert_raises, eq_
-from parameterized import parameterized
-from requests import HTTPError
 
 BOOKS_CATALOG_SERVICE_URL = "https://proquest.com/lib/nyulibrary-ebooks/BooksCatalog"
 PARTNER_AUTH_TOKEN_SERVICE_URL = (

--- a/tests/proquest/test_credential.py
+++ b/tests/proquest/test_credential.py
@@ -1,6 +1,9 @@
 import datetime
 import json
 
+from nose.tools import eq_
+from parameterized import parameterized
+
 from api.authenticator import BaseSAMLAuthenticationProvider
 from api.proquest.credential import ProQuestCredentialManager, ProQuestCredentialType
 from api.saml.metadata.model import (
@@ -10,13 +13,8 @@ from api.saml.metadata.model import (
     SAMLSubject,
     SAMLSubjectJSONEncoder,
 )
-from nose.tools import eq_
-from parameterized import parameterized
-
 from core.model import Credential, DataSource
 from core.testing import DatabaseTest
-from nose.tools import eq_
-from parameterized import parameterized
 from tests.saml import fixtures
 
 

--- a/tests/proquest/test_identifier.py
+++ b/tests/proquest/test_identifier.py
@@ -1,7 +1,8 @@
-from api.proquest.identifier import ProQuestIdentifierParser
-from core.model import Identifier
 from nose.tools import eq_
 from parameterized import parameterized
+
+from api.proquest.identifier import ProQuestIdentifierParser
+from core.model import Identifier
 
 
 class TestProQuestIdentifierParser(object):

--- a/tests/proquest/test_scripts.py
+++ b/tests/proquest/test_scripts.py
@@ -1,0 +1,183 @@
+import json
+import sys
+
+from mock import MagicMock, create_autospec, patch
+from nose.tools import eq_
+
+from api.proquest.client import ProQuestAPIClient, ProQuestAPIClientFactory
+from api.proquest.importer import ProQuestOPDS2Importer, ProQuestOPDS2ImportMonitor
+from api.proquest.scripts import ProQuestOPDS2ImportScript
+from core.model import Collection, DataSource, ExternalIntegration, Identifier
+from core.testing import DatabaseTest
+from tests.proquest import fixtures
+
+
+class TestProQuestOPDS2ImportScript(DatabaseTest):
+    @staticmethod
+    def _get_licensepool_by_identifier(license_pools, identifier):
+        """Find and return a LicensePool object with the specified identifier.
+
+        :param license_pools: List of LicensePool objects
+        :type license_pools: List[core.model.licensing.LicensePool]
+
+        :param identifier: Identifier to look for
+        :type identifier: str
+
+        :return: LicensePool object with the specified identifier, None otherwise
+        :rtype: Optional[core.model.licensing.LicensePool]
+        """
+        for license_pool in license_pools:
+            if license_pool.identifier.identifier == identifier:
+                return license_pool
+
+        return None
+
+    def setup(self, mock_search=True):
+        super(TestProQuestOPDS2ImportScript, self).setup()
+
+        self._proquest_data_source = DataSource.lookup(
+            self._db, DataSource.PROQUEST, autocreate=True
+        )
+        self._proquest_collection = self._collection(
+            protocol=ExternalIntegration.PROQUEST
+        )
+
+        self._proquest_collection.external_integration.set_setting(
+            Collection.DATA_SOURCE_NAME_SETTING, DataSource.PROQUEST
+        )
+
+    def test_import_monitor_handles_proquest_feed_removals_correctly(self):
+        """Make sure that the ProQuest import script handles removals correctly.
+
+        If we run proquest_import_monitor with --process-removals flag,
+        it detects the items that are no longer present in the ProQuest feed
+        and makes them invisible in the CM's catalog.
+
+        This test run proquest_import_monitor twice:
+        - First time proquest_import_monitor gets the ProQuest feed containing two publications:
+            Test Book 1
+            Test Book 2.
+        - Second time we run proquest_import_monitor the ProQuest feed contains another set of publications:
+            Test Book 1
+            Test Book 3.
+          This means that Test Book 2 is no longer available in the feed and must be hidden in the CM's catalog.
+        """
+        api_client_mock = create_autospec(spec=ProQuestAPIClient)
+
+        api_client_factory_mock = create_autospec(spec=ProQuestAPIClientFactory)
+        api_client_factory_mock.create = MagicMock(return_value=api_client_mock)
+
+        # 1. First, the monitor gets PROQUEST_RAW_FEED containing two publications:
+        # - Test Book 1
+        # - Test Book 2
+        api_client_mock.download_all_feed_pages = MagicMock(
+            return_value=[
+                json.loads(fixtures.PROQUEST_RAW_FEED),
+            ]
+        )
+        # We run the importer without --process-removals flag because it's not necessary for the first run.
+        test_arguments = ["proquest_import_monitor"]
+
+        with patch.object(sys, "argv", test_arguments), patch(
+            "api.proquest.scripts.ProQuestAPIClientFactory"
+        ) as api_client_factory_constructor_mock:
+            api_client_factory_constructor_mock.return_value = api_client_factory_mock
+
+            import_script = ProQuestOPDS2ImportScript(
+                _db=self._db,
+                importer_class=ProQuestOPDS2Importer,
+                monitor_class=ProQuestOPDS2ImportMonitor,
+                protocol=ExternalIntegration.PROQUEST,
+            )
+
+            import_script.run()
+
+            # We want to make sure that the collection contains both publications.
+            eq_(2, len(self._proquest_collection.licensepools))
+
+            test_book_1_license_pool = self._get_licensepool_by_identifier(
+                self._proquest_collection.licensepools,
+                fixtures.PROQUEST_RAW_PUBLICATION_1_ID,
+            )
+            eq_(Identifier.PROQUEST_ID, test_book_1_license_pool.identifier.type)
+            eq_(
+                fixtures.PROQUEST_RAW_PUBLICATION_1_ID,
+                test_book_1_license_pool.identifier.identifier,
+            )
+            eq_(True, test_book_1_license_pool.unlimited_access)
+
+            test_book_2_license_pool = self._get_licensepool_by_identifier(
+                self._proquest_collection.licensepools,
+                fixtures.PROQUEST_RAW_PUBLICATION_2_ID,
+            )
+            eq_(Identifier.PROQUEST_ID, test_book_2_license_pool.identifier.type)
+            eq_(
+                fixtures.PROQUEST_RAW_PUBLICATION_2_ID,
+                test_book_2_license_pool.identifier.identifier,
+            )
+            eq_(True, test_book_2_license_pool.unlimited_access)
+
+        # 2. When we run the monitor for the second time it gets another feed containing:
+        # - Test Book 1
+        # - Test Book 3
+        # Note: no Test Book 2
+        api_client_mock.download_all_feed_pages = MagicMock(
+            return_value=[
+                json.loads(fixtures.PROQUEST_RAW_FEED_WITH_A_REMOVED_PUBLICATION),
+            ]
+        )
+        # We explicitly use --process-removals flag to make the importer to handle removals.
+        test_arguments = ["proquest_import_monitor", "--process-removals"]
+
+        with patch.object(sys, "argv", test_arguments), patch(
+            "api.proquest.scripts.ProQuestAPIClientFactory"
+        ) as api_client_factory_constructor_mock:
+            api_client_factory_constructor_mock.return_value = api_client_factory_mock
+
+            import_script = ProQuestOPDS2ImportScript(
+                _db=self._db,
+                importer_class=ProQuestOPDS2Importer,
+                monitor_class=ProQuestOPDS2ImportMonitor,
+                protocol=ExternalIntegration.PROQUEST,
+            )
+
+            import_script.run()
+
+            # The collection contains 3 items but only two of them are visible.
+            eq_(3, len(self._proquest_collection.licensepools))
+            test_book_1_license_pool = self._get_licensepool_by_identifier(
+                self._proquest_collection.licensepools,
+                fixtures.PROQUEST_RAW_PUBLICATION_1_ID,
+            )
+            eq_(Identifier.PROQUEST_ID, test_book_1_license_pool.identifier.type)
+            eq_(
+                fixtures.PROQUEST_RAW_PUBLICATION_1_ID,
+                test_book_1_license_pool.identifier.identifier,
+            )
+            eq_(True, test_book_1_license_pool.unlimited_access)
+
+            test_book_2_license_pool = self._get_licensepool_by_identifier(
+                self._proquest_collection.licensepools,
+                fixtures.PROQUEST_RAW_PUBLICATION_2_ID,
+            )
+            eq_(Identifier.PROQUEST_ID, test_book_2_license_pool.identifier.type)
+            eq_(
+                fixtures.PROQUEST_RAW_PUBLICATION_2_ID,
+                test_book_2_license_pool.identifier.identifier,
+            )
+            # We want to make sure that Test Book 2 is no longer visible in the CM's catalog
+            # because it doesn't have any licenses.
+            eq_(False, test_book_2_license_pool.unlimited_access)
+            eq_(0, test_book_2_license_pool.licenses_owned)
+            eq_(0, test_book_2_license_pool.licenses_available)
+
+            test_book_3_license_pool = self._get_licensepool_by_identifier(
+                self._proquest_collection.licensepools,
+                fixtures.PROQUEST_RAW_PUBLICATION_3_ID,
+            )
+            eq_(Identifier.PROQUEST_ID, test_book_3_license_pool.identifier.type)
+            eq_(
+                fixtures.PROQUEST_RAW_PUBLICATION_3_ID,
+                test_book_3_license_pool.identifier.identifier,
+            )
+            eq_(True, test_book_3_license_pool.unlimited_access)


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

The PR includes the following changes:
- it optimizes the import process and reduces the memory footprint by dumping all feed pages to a local disk
- it adds an ability to handle removals in the ProQuest feed and hide items that are no longer present there from the CM's catalog.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[SIMPLY-3421](https://jira.nypl.org/browse/SIMPLY-3421)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
