### PR TITLE
Make SAML authentication provider return 401 error in the case when a bearer token is invalid

### DIFF
--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -251,7 +251,7 @@ UNKNOWN_SAML_PROVIDER = pd(
 
 INVALID_SAML_BEARER_TOKEN = pd(
     "http://librarysimplified.org/terms/problem/credentials-invalid",
-    status_code=400,
+    status_code=401,
     title=_("Invalid SAML bearer token."),
     detail=_("The provided SAML bearer token couldn't be verified."),
 )


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR changes the error the SAML authentication provider raises when a bearer token sent by a client app to Circulation Manager is invalid (has an invalid format).

I'm not 100% sure that this is a right solution. If yes, then it would make sense to update the status code in `INVALID_OAUTH_BEARER_TOKEN` as well.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[LSSE-85](https://jira.lyrasis.org/browse/LSSE-85)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
