### PR TITLE
Fix docker builds by pinning PIP version

### DIFF
--- a/docker/simplified_app.sh
+++ b/docker/simplified_app.sh
@@ -53,7 +53,7 @@ git submodule update --init --recursive
 printf "$(git describe --tags)" > .version
 
 # Use the latest version of pip to install a virtual environment for the app.
-python /usr/lib/python2.7/dist-packages/easy_install.py pip
+python /usr/lib/python2.7/dist-packages/easy_install.py "pip<21.0"
 pip install --no-cache-dir virtualenv virtualenvwrapper
 virtualenv -p /usr/bin/python2.7 env
 


### PR DESCRIPTION
Looks like PIP 21.0 is out and it drops Python 2 support which breaks our docker builds: 
https://github.com/pypa/pip/issues/6148

This should pin PIP in the docker install by pinning pip to a version that works with Python 2.

This should fix the docker containers that didn't build on this merge: https://github.com/NYPL-Simplified/circulation/commit/a22e205812ecd9a66f9229c537f97dfd40e4a9c6