### PR TITLE
Pin urllib3 to the last 1.24 version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,8 @@ sphinxcontrib-websupport==1.1.2
 typing==3.7.4.3
 unicodecsv==0.14.1
 uritemplate==3.0.1
+# urllib3 is pinned to a pre-1.25 version to work around https://jira.nypl.org/browse/SIMPLY-3477
+urllib3==1.24.3
 uszipcode==0.2.4
 wcag-contrast-ratio==0.9
 websocket-client==0.57.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,8 +54,6 @@ sphinxcontrib-websupport==1.1.2
 typing==3.7.4.3
 unicodecsv==0.14.1
 uritemplate==3.0.1
-# urllib3 is pinned to a pre-1.25 version to work around https://jira.nypl.org/browse/SIMPLY-3477
-urllib3==1.24.3
 uszipcode==0.2.4
 wcag-contrast-ratio==0.9
 websocket-client==0.57.0


### PR DESCRIPTION
## Description

This branch pins urllib3 to the final 1.24 version as a way of avoiding https://jira.nypl.org/browse/SIMPLY-3477.

This is a temporary measure until either Axis 360 changes their ACS setup or we figure out a better long-term solution.

## How Has This Been Tested?

Axis 360 fulfillment starts succeeding once urllib3 is downgraded to a 1.24 version.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
