### PR TITLE
Add opds2_import_monitor to the crontab

### DIFF
--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -97,9 +97,13 @@ HOME=/var/www/circulation
 0 0 2 * * root core/bin/run opds_for_distributors_reaper_monitor >> /var/log/cron.log 2>&1
 0 4 * * * root core/bin/run opds_for_distributors_import_monitor >> /var/log/cron.log 2>&1
 
-# Vanilla OPDS
+# Vanilla OPDS 1.x
 #
 0 5 * * * root core/bin/run opds_import_monitor >> /var/log/cron.log 2>&1
+
+# Vanilla OPDS 2.x
+#
+30 5 * * * root core/bin/run opds2_import_monitor >> /var/log/cron.log 2>&1
 
 # OPDS import from Feedbooks
 * * */7 * * root core/bin/run feedbooks_import_monitor >> /var/log/cron.log 2>&1


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds `opds2_import_monitor` to the crontab.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

opds2_import_monitor is not added to the crontab. Because of that, the OPDS 2.x collection don't get imported automatically.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
