### PR TITLE
Use new Collection.disassociate_library method to delete unneeded ConfigurationSettings instead of clearing out their values

### DIFF
--- a/api/admin/controller/collection_settings.py
+++ b/api/admin/controller/collection_settings.py
@@ -326,11 +326,7 @@ class CollectionSettingsController(SettingsController):
                 return result
         for library in collection.libraries:
             if library.short_name not in [l.get("short_name") for l in libraries]:
-                library.collections.remove(collection)
-                for setting in protocol.get("library_settings", []):
-                    ConfigurationSetting.for_library_and_externalintegration(
-                        self._db, setting.get("key"), library, collection.external_integration,
-                    ).value = None
+                collection.disassociate_library(library)
 
     # DELETE
     def process_delete(self, collection_id):

--- a/tests/admin/controller/test_collections.py
+++ b/tests/admin/controller/test_collections.py
@@ -521,8 +521,14 @@ class TestCollectionSettings(SettingsControllerTest):
         # But the library has been removed.
         eq_([], l1.collections)
 
-        eq_(None, ConfigurationSetting.for_library_and_externalintegration(
-                self._db, "ils_name", l1, collection.external_integration).value)
+        # All ConfigurationSettings for that library and collection
+        # have been deleted.
+        qu = self._db.query(ConfigurationSetting).filter(
+            ConfigurationSetting.library==library
+        ).filter(
+            ConfigurationSetting.external_integration==collection.external_integration
+        )
+        eq_(0, qu.count())
 
         parent = self._collection(
             name="Parent",

--- a/tests/admin/controller/test_collections.py
+++ b/tests/admin/controller/test_collections.py
@@ -524,7 +524,7 @@ class TestCollectionSettings(SettingsControllerTest):
         # All ConfigurationSettings for that library and collection
         # have been deleted.
         qu = self._db.query(ConfigurationSetting).filter(
-            ConfigurationSetting.library==library
+            ConfigurationSetting.library==l1
         ).filter(
             ConfigurationSetting.external_integration==collection.external_integration
         )


### PR DESCRIPTION
## Description

This branch changes what happens when you use the admin interface to break the connection between a Library and a Collection. Previously the relevant configuration settings were cleared out but the ConfigurationSetting objects themselves were left in place. Now we delegate to the new `Collection.disassociate_library` method, which deletes the ConfigurationSetting objects totally.

## Motivation and Context

This makes the behavior around ConfigurationSettings more consistent, resolving https://jira.nypl.org/browse/SIMPLY-3504. The corresponding core branch is https://github.com/NYPL-Simplified/server_core/pull/1237.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
