### PR TITLE
Add an ability to override the default loan length for ProQuest collections

### DIFF
--- a/api/proquest/importer.py
+++ b/api/proquest/importer.py
@@ -174,6 +174,9 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
         ProQuestOPDS2ImporterConfiguration.to_settings()
         + ProQuestAPIClientConfiguration.to_settings()
     )
+    LIBRARY_SETTINGS = BaseCirculationAPI.LIBRARY_SETTINGS + [
+        BaseCirculationAPI.DEFAULT_LOAN_DURATION_SETTING
+    ]
 
     def __init__(
         self,
@@ -645,15 +648,16 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
             with self._get_configuration(self._db) as configuration:
                 self._get_or_create_proquest_token(patron, configuration)
 
-                today = datetime.datetime.utcnow()
-
+                loan_period = self.collection.default_loan_period(patron.library)
+                start_time = datetime.datetime.utcnow()
+                end_time = start_time + datetime.timedelta(days=loan_period)
                 loan = LoanInfo(
                     licensepool.collection,
                     licensepool.data_source.name,
                     identifier_type=licensepool.identifier.type,
                     identifier=licensepool.identifier.identifier,
-                    start_date=today,
-                    end_date=None,
+                    start_date=start_time,
+                    end_date=end_time,
                     fulfillment_info=None,
                     external_identifier=None,
                 )


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds standard `Default loan length` setting to the list of available ProQuest configuration settings.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

At the moment there is no way to override the default loan length for ProQuest collection. Global default value, 21, is used all the time.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
