### PR TITLE
Bugfix/simply 2913

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1359,7 +1359,7 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
         # an error. Each subsequent time this is run after the first time,
         # the timespan to check for event increases by 5 minutes until we
         # reach a 70-hour timespan to check for events.
-        if (progress.counter > 0):
+        if (progress.counter == 1):
             no_events_error = True
             timespan_to_check = timedelta(hours=70)
 
@@ -1390,7 +1390,13 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
                     self._db.commit()
             self._db.commit()
         progress.achievements = "Events handled: %d." % i
-        progress.counter = 1
+        # If we are in "catch up" mode and we encounter some events, we can
+        # reset the counter back to 0. Otherwise, keep the counter at 1. This
+        # will also set it to 1 after the initial run.
+        if progress.counter == 1:
+            progress.counter = 0
+        else:
+            progress.counter = 1
 
     def handle_event(self, bibliotheca_id, isbn, foreign_patron_id,
                      start_time, end_time, internal_event_type):

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1353,8 +1353,7 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
     def catch_up_from(self, start, cutoff, progress):
         added_books = 0
         i = 0
-        # five_minutes = timedelta(minutes=5)
-        five_minutes = timedelta(days=1)
+        five_minutes = timedelta(minutes=5)
         timestamp = self.timestamp()
 
         # If the start date is more than a month ago, then we don't consider

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -340,7 +340,8 @@ class BibliothecaAPI(BaseCirculationAPI, HasSelfTests):
             self._db.commit()
         try:
             events = EventParser().process_all(response.content, no_events_error)
-            timestamp.counter = 0
+            if (timestamp):
+                timestamp.counter = 0
         except Exception, e:
             if timestamp:
                 timestamp.counter = 1
@@ -1353,7 +1354,7 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
     def catch_up_from(self, start, cutoff, progress):
         added_books = 0
         i = 0
-        five_minutes = timedelta(minutes=5)
+        one_day = timedelta(days=1)
         timestamp = self.timestamp()
 
         # If the start date is more than a month ago, then we don't consider
@@ -1367,9 +1368,9 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
         # events as an error.
         if (timestamp.counter == 1):
             no_events_error = True
-            
+
         for slice_start, slice_cutoff, full_slice in self.slice_timespan(
-            start, cutoff, five_minutes
+            start, cutoff, one_day
         ):
             self.log.info(
                 "Asking for events between %r and %r", slice_start,

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -1009,6 +1009,8 @@ class TestBibliothecaEventMonitor(BibliothecaAPITest):
         before_timestamp = TimestampData(
             start=three_days_ago, finish=two_days_ago
         )
+        # Since this already ran once, the counter should be set to 1.
+        before_timestamp.counter = 1
 
         api = MockBibliothecaAPI(self._db, self.collection)
         api.queue_response(
@@ -1023,12 +1025,12 @@ class TestBibliothecaEventMonitor(BibliothecaAPITest):
         api.queue_response(
             200, content=self.sample_data("empty_end_date_event.xml")
         )
+
         monitor = BibliothecaEventMonitor(
             self._db, self.collection, api_class=api
         )
 
         after_timestamp = monitor.run_once(before_timestamp)
-
         # Three requests were made to the API:
         #
         # 1. Retrieving the 'slice' of events between 36 hours ago and

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -681,10 +681,19 @@ class TestEventParser(BibliothecaAPITest):
 
     def test_parse_empty_list(self):
         data = self.sample_data("empty_event_batch.xml")
+
+        # By default, we consider an empty batch of events not
+        # as an error.
+        events = list(EventParser().process_all(data))
+        eq_([], events)
+
+        # But if we consider not having events for a certain time
+        # period, then an exception should be raised.
+        no_events_error = True
         assert_raises_regexp(
             RemoteInitiatedServerError,
             "No events returned from server. This may not be an error, but treating it as one to be safe.",
-            list, EventParser().process_all(data)
+            list, EventParser().process_all(data, no_events_error)
         )
 
     def test_parse_empty_end_date_event(self):


### PR DESCRIPTION
## Description

This uses `timestamp.counter` to consider whether not getting events from Bibliotheca during a time period is an error or not. Initially, not getting any events is not considered to be an error. If a no events error is raised, the next time the script runs it'll continue past the time period the no events error occurred (assuming that no events really occurred during that time period).

## Motivation and Context

Resolves [SIMPLY-2913](https://jira.nypl.org/browse/SIMPLY-2913)

## How Has This Been Tested?

Locally. Running `./bin/bibliotheca_monitor` fetches events from 2/01/2018. Eventually, this breaks when no events were returned between 5/17/18 - 5/18/18:

<img width="1431" alt="Screen Shot 2021-02-11 at 10 33 24 AM" src="https://user-images.githubusercontent.com/1280564/107660442-45dc8800-6c56-11eb-8ad7-5b8b62a92457.png">

The next time the script runs, we don't consider no events during the time period as an error and it continues to fetch events for later time periods:

<img width="1439" alt="Screen Shot 2021-02-11 at 10 33 11 AM" src="https://user-images.githubusercontent.com/1280564/107660566-699fce00-6c56-11eb-9084-99c925f6729f.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
