### PR TITLE
Fix rendering of menu controls in the admin UI

### DIFF
--- a/api/admin/controller/collection_settings.py
+++ b/api/admin/controller/collection_settings.py
@@ -109,7 +109,7 @@ class CollectionSettingsController(SettingsController):
                         value = str(storage_integration.other_integration_id)
                     else:
                         value = self.NO_MIRROR_INTEGRATION
-                elif protocol_setting.get("type") == "list":
+                elif protocol_setting.get("type") in ("list", "menu"):
                     value = collection_object.external_integration.setting(key).json_value
                 else:
                     value = collection_object.external_integration.setting(key).value

--- a/tests/admin/controller/test_collection_settings.py
+++ b/tests/admin/controller/test_collection_settings.py
@@ -1,0 +1,50 @@
+import json
+
+from mock import PropertyMock, create_autospec
+from nose.tools import eq_
+
+from api.admin.controller.collection_settings import CollectionSettingsController
+from api.controller import CirculationManager
+from api.proquest.importer import ProQuestOPDS2ImporterConfiguration
+from api.saml.metadata.model import SAMLAttributeType
+from core.model import ConfigurationSetting
+from core.testing import DatabaseTest
+
+
+class TestCollectionSettingsController(DatabaseTest):
+    def test_load_settings_correctly_loads_menu_values(self):
+        # Arrange
+        manager = create_autospec(spec=CirculationManager)
+        manager._db = PropertyMock(return_value=self._db)
+        controller = CollectionSettingsController(manager)
+
+        # We'll be using affiliation_attributes configuration setting defined in the ProQuest integration.
+        affiliation_attributes_key = (
+            ProQuestOPDS2ImporterConfiguration.affiliation_attributes.key
+        )
+        expected_affiliation_attributes = [
+            SAMLAttributeType.eduPersonPrincipalName.name,
+            SAMLAttributeType.eduPersonScopedAffiliation.name,
+        ]
+        protocol_settings = [
+            ProQuestOPDS2ImporterConfiguration.affiliation_attributes.to_settings()
+        ]
+        collection_settings = None
+        collection = self._default_collection
+
+        # We need to explicitly set the value of "affiliation_attributes" configuration setting.
+        ConfigurationSetting.for_externalintegration(
+            affiliation_attributes_key, collection.external_integration
+        ).value = json.dumps(expected_affiliation_attributes)
+
+        # Act
+        settings = controller.load_settings(
+            protocol_settings, collection, collection_settings
+        )
+
+        # Assert
+        eq_(True, affiliation_attributes_key in settings)
+
+        # We want to make sure that the result setting array contains a correct value in a list format.
+        saved_affiliation_attributes = settings[affiliation_attributes_key]
+        eq_(expected_affiliation_attributes, saved_affiliation_attributes)


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR fixes the rendering of menu controls in the admin UI. Menu controls with multiple selected values are currently rendered like that:
![image](https://user-images.githubusercontent.com/6442436/107761150-b534a380-6d4c-11eb-8413-33a91d246c6d.png)

@tdilauro, this PR should allow you to test [PR # 1554](https://github.com/NYPL-Simplified/circulation/pull/1554).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
