### PR TITLE
Define and use a setting that controls how long authentication documents are cached.

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -37,6 +37,10 @@ class Configuration(CoreConfiguration):
     # The name of the setting that controls how long static files are cached.
     STATIC_FILE_CACHE_TIME = u"static_file_cache_time"
 
+    # The name of the setting that controls how long authentication
+    # documents are cached.
+    AUTHENTICATION_DOCUMENT_CACHE_TIME = u"authentication_document_cache_time"
+
     # A custom link to a Terms of Service document to be understood by
     # users of the administrative interface.
     #
@@ -194,6 +198,13 @@ class Configuration(CoreConfiguration):
             "label": _("Cache time for static images and JS and CSS files (in seconds)"),
             "required": True,
             "type": "number",
+        },
+        {
+            "key": AUTHENTICATION_DOCUMENT_CACHE_TIME,
+            "label": _("Cache time for authentication documents (in seconds)"),
+            "required": True,
+            "type": "number",
+            "default": 3600,
         },
         {
             "key": CUSTOM_TOS_HREF,

--- a/api/config.py
+++ b/api/config.py
@@ -37,7 +37,7 @@ class Configuration(CoreConfiguration):
     # The name of the setting that controls how long static files are cached.
     STATIC_FILE_CACHE_TIME = u"static_file_cache_time"
 
-    # The name of the setting that controls how long authentication
+    # The name of the setting controlling how long authentication
     # documents are cached.
     AUTHENTICATION_DOCUMENT_CACHE_TIME = u"authentication_document_cache_time"
 


### PR DESCRIPTION


## Description

This branch gives us the power to fine-tune or disable the caching of authentication documents. This was introduced for performance reasons but it makes certain deployment problems difficult to test, so it should be possible to disable it.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://jira.nypl.org/browse/SIMPLY-3548

## How Has This Been Tested?

In addition to the automated tests, I tested this with a local database by setting the timeout to 10 seconds, or 0 seconds, and adding a debug statement to the code to signal whenever a fresh auth document was created.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
