### PR TITLE
Fix the ProQuest ulimits issue

### DIFF
--- a/api/proquest/client.py
+++ b/api/proquest/client.py
@@ -428,6 +428,9 @@ class ProQuestAPIClient(object):
 
         :param hits_per_page: Number of publications on a single page (max = 32,767)
         :type hits_per_page: int
+
+        :return: Python dictionary object containing the feed's page
+        :rtype: dict
         """
         self._logger.info(
             "Started downloading page # {0} ({1} hits) of a paginated OPDS 2.0 feed from {2}".format(
@@ -468,6 +471,9 @@ class ProQuestAPIClient(object):
 
         :param hits_per_page: Number of publications on a single page (max = 32,766)
         :type hits_per_page: int
+
+        :return: Python dictionary object containing the feed's page
+        :rtype: dict
         """
         if not is_session(db):
             raise ValueError('"db" argument must be a valid SQLAlchemy session')
@@ -511,7 +517,7 @@ class ProQuestAPIClient(object):
         :param db: Database session
         :type db: sqlalchemy.orm.session.Session
 
-        :return: Iterable list of feed pages
+        :return: Iterable list of feed pages in a form of Python dictionaries
         :rtype: Iterable[dict]
         """
         if not is_session(db):

--- a/tests/proquest/fixtures.py
+++ b/tests/proquest/fixtures.py
@@ -1,39 +1,143 @@
+# coding=utf-8
+
 import datetime
 
-from webpub_manifest_parser.core.ast import CollectionList, PresentationMetadata
+from webpub_manifest_parser.core.ast import (
+    CollectionList,
+    CompactCollection,
+    Link,
+    LinkList,
+    Node,
+    PresentationMetadata,
+)
+from webpub_manifest_parser.core.parsers import TypeParser
+from webpub_manifest_parser.core.properties import BaseArrayProperty, PropertiesGrouping
+from webpub_manifest_parser.core.registry import RegistryItem
 from webpub_manifest_parser.opds2.ast import (
     OPDS2Feed,
     OPDS2FeedMetadata,
     OPDS2Group,
     OPDS2Publication,
 )
+from webpub_manifest_parser.opds2.registry import OPDS2LinkRelationsRegistry
+from webpub_manifest_parser.rwpm.registry import RWPMLinkRelationsRegistry
+
+
+def serialize(rwpm_item):
+    """Serialize RWPM AST node into a Python dictionary.
+
+    :param rwpm_item: RWPM AST node
+    :type rwpm_item: Node
+
+    :return: Dictionary containing properties of the serialized RWPM AST node
+    :rtype: dict
+    """
+    if isinstance(rwpm_item, list):
+        result = []
+
+        for i in rwpm_item:
+            result.append(serialize(i))
+
+        return result
+
+    result = {}
+
+    if isinstance(rwpm_item, Node):
+
+        required_properties = PropertiesGrouping.get_class_properties(
+            rwpm_item.__class__
+        )
+
+        for (property_name, property_object) in required_properties:
+            property_value = getattr(rwpm_item, property_name, None)
+
+            if property_value is None and property_object.required:
+                if property_object.default_value:
+                    property_value = property_object.default_value
+                elif isinstance(property_object, BaseArrayProperty) or (
+                    isinstance(property_object.parser, TypeParser)
+                    and issubclass(property_object.parser.type, CompactCollection)
+                ):
+                    property_value = []
+
+            if isinstance(property_value, Node):
+                property_value = serialize(property_value)
+            elif isinstance(property_value, list):
+                property_value = serialize(property_value)
+            elif isinstance(property_value, datetime.datetime):
+                property_value = property_value.isoformat() + "Z"
+            if isinstance(rwpm_item, list):
+                result.append(property_value)
+            else:
+                result[property_object.key] = property_value
+    elif isinstance(rwpm_item, RegistryItem):
+        result = rwpm_item.key
+
+    return result
+
 
 PROQUEST_PUBLICATION_1 = OPDS2Publication(
     metadata=PresentationMetadata(
         identifier="urn:proquest.com/document-id/1",
+        title="Publićation # 1",
         modified=datetime.datetime(2020, 1, 31, 0, 0, 0),
-    )
+    ),
+    links=LinkList(
+        [
+            Link(
+                href="https://feed.org/document-id/1",
+                rels=[OPDS2LinkRelationsRegistry.ACQUISITION],
+            )
+        ]
+    ),
 )
 
 PROQUEST_PUBLICATION_2 = OPDS2Publication(
     metadata=PresentationMetadata(
         identifier="urn:proquest.com/document-id/2",
+        title="Publication # 2",
         modified=datetime.datetime(2020, 1, 30, 0, 0, 0),
-    )
+    ),
+    links=LinkList(
+        [
+            Link(
+                href="https://feed.org/document-id/2",
+                rels=[OPDS2LinkRelationsRegistry.ACQUISITION],
+            )
+        ]
+    ),
 )
 
 PROQUEST_PUBLICATION_3 = OPDS2Publication(
     metadata=PresentationMetadata(
         identifier="urn:proquest.com/document-id/3",
+        title="Publication # 3",
         modified=datetime.datetime(2020, 1, 29, 0, 0, 0),
-    )
+    ),
+    links=LinkList(
+        [
+            Link(
+                href="https://feed.org/document-id/3",
+                rels=[OPDS2LinkRelationsRegistry.ACQUISITION],
+            )
+        ]
+    ),
 )
 
 PROQUEST_PUBLICATION_4 = OPDS2Publication(
     metadata=PresentationMetadata(
         identifier="urn:proquest.com/document-id/4",
+        title="Publication # 4",
         modified=datetime.datetime(2020, 1, 28, 0, 0, 0),
-    )
+    ),
+    links=LinkList(
+        [
+            Link(
+                href="https://feed.org/document-id/4",
+                rels=[OPDS2LinkRelationsRegistry.ACQUISITION],
+            )
+        ]
+    ),
 )
 
 PROQUEST_FEED_PAGE_1 = OPDS2Feed(
@@ -49,6 +153,9 @@ PROQUEST_FEED_PAGE_1 = OPDS2Feed(
             )
         ]
     ),
+    links=LinkList(
+        [Link(href="https://feed.org/pages/1", rels=[RWPMLinkRelationsRegistry.SELF])]
+    ),
 )
 
 PROQUEST_FEED_PAGE_2 = OPDS2Feed(
@@ -63,6 +170,9 @@ PROQUEST_FEED_PAGE_2 = OPDS2Feed(
                 )
             )
         ]
+    ),
+    links=LinkList(
+        [Link(href="https://feed.org/pages/2", rels=[RWPMLinkRelationsRegistry.SELF])]
     ),
 )
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR limits a number of open temporary files used during the ProQuest import to address the ulimits issue.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The ProQuest import script (`proquest_import_monitor`) fails when running through cron with `Too many open files` error.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
