### PR TITLE
Remove library manager requirement from editing library

### DIFF
--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -95,9 +95,9 @@ class LibrarySettingsController(SettingsController):
             return error
 
         if not library:
+            # Everyone can modify an existing library, but only a system admin can create a new one.
+            self.require_system_admin()
             (library, is_new) = self.create_library(short_name, library_uuid)
-        else:
-            self.require_library_manager(library)
 
         name = flask.request.form.get("name")
         if name:


### PR DESCRIPTION
This project is _so close_ to being finished.  I missed one of the no-longer-wanted admin level checks.  🤦‍♀️ 

The library settings controller's `process_post` method shouldn't check permissions if the admin is editing an existing library; everyone can do that now.  It should only check when the admin is creating a new library, since only system admins are supposed to be able to do that.  (The front end is set up such that this should never actually be an issue; the "create a new library" button is displayed only to system admins.  But might as well have a fail-safe.)
