### PR TITLE
Make basic info settings sys-admin-only

### DIFF
--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -13,6 +13,6 @@
     "npm": ">=5.0.0"
   },
   "dependencies": {
-    "simplified-circulation-web": "^0.4.34"
+    "simplified-circulation-web": "^0.4.35"
   }
 }

--- a/api/config.py
+++ b/api/config.py
@@ -232,7 +232,7 @@ class Configuration(CoreConfiguration):
             "label": _("A short description of this library"),
             "description": _("This will be shown to people who aren't sure they've chosen the right library."),
             "category": "Basic Information",
-            "level": CoreConfiguration.ALL_ACCESS
+            "level": CoreConfiguration.SYS_ADMIN_ONLY
         },
         {
             "key": Announcements.SETTING_NAME,
@@ -248,7 +248,7 @@ class Configuration(CoreConfiguration):
             "description": _("An email address a patron can use if they need help, e.g. 'simplyehelp@yourlibrary.org'."),
             "required": True,
             "format": "email",
-            "level": CoreConfiguration.ALL_ACCESS
+            "level": CoreConfiguration.SYS_ADMIN_ONLY
         },
         {
             "key": HELP_WEB,


### PR DESCRIPTION
Along with https://github.com/NYPL-Simplified/server_core/pull/1241, resolves https://jira.nypl.org/browse/SIMPLY-3556 and https://jira.nypl.org/browse/SIMPLY-3557; it turns out that librarians and library managers weren't supposed to have access to the fields in the "Basic Information" section after all.  (The "Name" and "Short Name" fields from the "Basic Information" section are taken care of on the front end.)