### PR TITLE
Pick the right licensepool for our collection.

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -1493,9 +1493,8 @@ class DirectoryImportScript(TimestampScript):
 
         edition, new = metadata.edition(self._db)
         metadata.apply(edition, collection, replace=policy)
-        data_source = metadata.data_source(self._db)
         [pool] = [x for x in edition.license_pools
-                  if x.data_source == data_source]
+                  if x.collection == collection]
         if new:
             self.log.info("Created new edition for %s", edition.title)
         else:


### PR DESCRIPTION
## Description

Fixes the case in which there is already a license pool for the same edition, which would lead to `DirectoryImportScript.work_from_metadata` crashing after we add another with our collection and try to pick just one.

## Motivation and Context

Details on https://jira.nypl.org/browse/SIMPLY-3567.

## How Has This Been Tested?

Added tests which failed before change and pass after change.

## Checklist:

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.
