### PR TITLE
Add saml_monitor to the crontab

### DIFF
--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -121,3 +121,7 @@ HOME=/var/www/circulation
 # ProQuest
 # Run proquest_import_monitor once a week on Sunday at 00:00
 0 0 * * 0 root core/bin/run proquest_import_monitor >> /var/log/cron.log 2>&1
+
+# SAML
+#
+0 5 * * * root core/bin/run saml_monitor >> /var/log/cron.log 2>&1


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds [saml_monitor](https://github.com/NYPL-Simplified/circulation/blob/develop/bin/saml_monitor), the script refreshing federated SAML metadata (at the moment, only the InCommon Federation is supported), to the crontab.

This script must update metadata of federated IdPs available in Circulation Manager at leasts once a day.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
