### PR TITLE
Update proquest_import_monitor schedule

### DIFF
--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -119,8 +119,8 @@ HOME=/var/www/circulation
 */15 * * * * root core/bin/run odilo_monitor_recent >> /var/log/cron.log 2>&1
 
 # ProQuest
-# Run proquest_import_monitor once a week on Sunday at 00:00
-0 0 * * 0 root core/bin/run proquest_import_monitor >> /var/log/cron.log 2>&1
+#
+0 7 * * 2,5 root core/bin/run proquest_import_monitor --process-removals >> /var/log/cron.log 2>&1
 
 # SAML
 #


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR updates the schedule of `proquest_import_monitor` to the following:
- Monday 11 PM PST (Tuesday 2 AM EST)
- Thursday 11 PM PST (Friday 2 AM EST)

NOTE: Both runs have `--process-removals` flag forcing `proquest_import_monitor` to sweep out removals, i.e. items that are no longer present in the ProQuest feed.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
