### PR TITLE
[WIP] SAML: migrate patrons with "old" IDs

### DIFF
--- a/api/saml/configuration/model.py
+++ b/api/saml/configuration/model.py
@@ -126,6 +126,33 @@ class SAMLConfiguration(ConfigurationGrouping):
         required=False,
     )
 
+    patron_id_migrate_patrons_with_old_ids = ConfigurationMetadata(
+        key="saml_patron_id_migrate_patrons_with_old_ids",
+        label=_("Patron ID: Migrate Patrons with \"Old\" IDs"),
+        description=_(
+            "Boolean value indicating whether Circulation Manager should migrate patrons with \"old\" IDs, "
+            "i.e. IDs that were extracted using the default <b>Patron ID</b> settings from either "
+            "eduPersonUniqueId, eduPersonTargetedID, uid attributes, or NameID without using the regular expression:"
+            "<br>"
+            "- <b>0</b> (default) means that Circulation Manager won't migrate patrons with \"old\" IDs and "
+            "after changing the <b>Patron ID</b> configuration settings some patrons "
+            "MIGHT loose their holds and loans, "
+            "<br>"
+            "- <b>1</b> means that Circulation Manager will migrate patrons with \"old\" IDs by assigning them "
+            "a new ID extracted from a SAML assertion according to new <b>Patron ID</b> configuration setting values."
+            "<br>"
+            "Please consider the following scenario as an example:"
+            "<br>"
+            "1. \"Old\" patron IDs were extracted from NameID."
+            "<br>"
+            "2. The requirements changed and now IDs have to be extracted from eduPersonalPrincipalName attribute "
+            "using a regular expression."
+        ),
+        type=ConfigurationAttributeType.NUMBER,
+        required=False,
+        default=0,
+    )
+
     non_federated_identity_provider_xml_metadata = ConfigurationMetadata(
         key="idp_xml_metadata",
         label=_("Identity Provider's XML metadata"),

--- a/tests/saml/configuration/test_validator.py
+++ b/tests/saml/configuration/test_validator.py
@@ -11,7 +11,7 @@ from api.saml.configuration.model import SAMLConfiguration
 from api.saml.configuration.validator import (
     SAML_INCORRECT_METADATA,
     SAMLSettingsValidator,
-)
+    SAML_INCORRECT_PATRON_ID_REGULAR_EXPRESSION)
 from api.saml.metadata.filter import SAMLSubjectFilter
 from api.saml.metadata.parser import SAMLMetadataParser
 from api.saml.provider import SAMLWebSSOAuthenticationProvider
@@ -35,6 +35,7 @@ class TestSAMLSettingsValidator(ControllerTest):
                 "missing_sp_metadata_and_missing_idp_metadata",
                 None,
                 None,
+                None,
                 INCOMPLETE_CONFIGURATION.detailed(
                     "Required field 'Service Provider's XML Metadata' is missing"
                 ),
@@ -43,6 +44,7 @@ class TestSAMLSettingsValidator(ControllerTest):
                 "empty_sp_metadata_and_empty_idp_metadata",
                 fixtures.INCORRECT_XML,
                 fixtures.INCORRECT_XML,
+                None,
                 INCOMPLETE_CONFIGURATION.detailed(
                     "Required field 'Service Provider's XML Metadata' is missing"
                 ),
@@ -51,6 +53,7 @@ class TestSAMLSettingsValidator(ControllerTest):
                 "incorrect_sp_metadata_and_incorrect_idp_metadata",
                 fixtures.INCORRECT_XML_WITH_ONE_SP_METADATA_WITHOUT_ACS_SERVICE,
                 fixtures.INCORRECT_XML_WITH_ONE_IDP_METADATA_WITHOUT_SSO_SERVICE,
+                None,
                 SAML_INCORRECT_METADATA.detailed(
                     "Service Provider's metadata has incorrect format: "
                     "Missing urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST AssertionConsumerService"
@@ -60,6 +63,7 @@ class TestSAMLSettingsValidator(ControllerTest):
                 "correct_sp_metadata_and_incorrect_idp_metadata",
                 fixtures.CORRECT_XML_WITH_ONE_SP,
                 fixtures.INCORRECT_XML_WITH_ONE_IDP_METADATA_WITHOUT_SSO_SERVICE,
+                None,
                 SAML_INCORRECT_METADATA.detailed(
                     "Identity Provider's metadata has incorrect format: "
                     "Missing urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect SingleSignOnService "
@@ -71,12 +75,54 @@ class TestSAMLSettingsValidator(ControllerTest):
                 fixtures.CORRECT_XML_WITH_ONE_SP,
                 fixtures.CORRECT_XML_WITH_IDP_1,
                 None,
+                None,
+            ),
+            (
+                    "correct_patron_id_regular_expression",
+                    fixtures.CORRECT_XML_WITH_ONE_SP,
+                    fixtures.CORRECT_XML_WITH_IDP_1,
+                    r"(?P<patron_id>.+)@university\.org",
+                    None,
+            ),
+            (
+                    "correct_patron_id_regular_expression_without_patron_id_named_group",
+                    fixtures.CORRECT_XML_WITH_ONE_SP,
+                    fixtures.CORRECT_XML_WITH_IDP_1,
+                    r"(?P<patron>.+)@university\.org",
+                    SAML_INCORRECT_PATRON_ID_REGULAR_EXPRESSION.detailed(
+                        u"SAML patron ID regular expression '(?P<patron>.+)@university\\.org' "
+                        u"does not have mandatory named group 'patron_id'"
+                    ),
+            ),
+            (
+                    "incorrect_patron_id_regular_expression",
+                    fixtures.CORRECT_XML_WITH_ONE_SP,
+                    fixtures.CORRECT_XML_WITH_IDP_1,
+                    r"[",
+                    SAML_INCORRECT_PATRON_ID_REGULAR_EXPRESSION.detailed(
+                        u"SAML patron ID regular expression '[' has an incorrect format: "
+                        u"unexpected end of regular expression"
+                    ),
             ),
         ]
     )
     def test_validate(
-        self, _, sp_xml_metadata, idp_xml_metadata, expected_validation_result
+        self, _, sp_xml_metadata, idp_xml_metadata, patron_id_regular_expression, expected_validation_result
     ):
+        """Ensure that SAMLSettingsValidator correctly validates the input data.
+
+        :param sp_xml_metadata: SP SAML metadata
+        :type sp_xml_metadata: str
+
+        :param idp_xml_metadata: IdP SAML metadata
+        :type idp_xml_metadata: str
+
+        :param patron_id_regular_expression: Regular expression used to extract a unique patron ID from SAML attributes
+        :type patron_id_regular_expression: str
+
+        :param expected_validation_result: Expected result: ProblemDetail object if validation must fail, None otherwise
+        :type expected_validation_result: Optional[ProblemDetail]
+        """
         # Arrange
         submitted_form_data = MultiDict()
 
@@ -88,6 +134,11 @@ class TestSAMLSettingsValidator(ControllerTest):
             submitted_form_data.add(
                 SAMLConfiguration.non_federated_identity_provider_xml_metadata.key,
                 idp_xml_metadata,
+            )
+        if patron_id_regular_expression is not None:
+            submitted_form_data.add(
+                SAMLConfiguration.patron_id_regular_expression.key,
+                patron_id_regular_expression,
             )
 
         submitted_form = {"form": submitted_form_data}

--- a/tests/saml/fixtures.py
+++ b/tests/saml/fixtures.py
@@ -992,6 +992,8 @@ xOr37hEpqz+WN/x3qM2qyBLECQFjmlJrvRLkSL15PCZiu+xFNFd/zx6btDun5DBlfDS9DG+SHCNH
 </EntitiesDescriptor>
 """
 
+PATRON_ID_REGULAR_EXPRESSION_ORG = r"(?P<patron_id>.+)@university\.org"
+PATRON_ID_REGULAR_EXPRESSION_COM = r"(?P<patron_id>.+)@university\.com"
 
 MAIL = "patron@example.com"
 GIVEN_NAME = "Rosie"

--- a/tests/saml/metadata/test_model.py
+++ b/tests/saml/metadata/test_model.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from nose.tools import eq_
 from parameterized import parameterized
 
@@ -8,8 +9,9 @@ from api.saml.metadata.model import (
     SAMLNameID,
     SAMLNameIDFormat,
     SAMLSubject,
-    SAMLSubjectUIDExtractor,
+    SAMLSubjectPatronIDExtractor,
 )
+from tests.saml import fixtures
 
 
 class TestAttributeStatement(object):
@@ -43,87 +45,369 @@ class TestAttributeStatement(object):
         )
 
 
-class TestSubjectUIDExtractor(object):
+class TestSAMLSubjectPatronIDExtractor(object):
     @parameterized.expand(
         [
-            ("subject_without_unique_id", SAMLSubject(None, None), None),
+            ("subject_without_patron_id", SAMLSubject(None, None), None),
             (
                 "subject_with_eduPersonTargetedID_attribute",
                 SAMLSubject(
-                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "12345"),
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "1"),
                     SAMLAttributeStatement(
                         [
                             SAMLAttribute(
                                 name=SAMLAttributeType.eduPersonTargetedID.name,
-                                values=["12345"],
+                                values=["2"],
                             ),
                             SAMLAttribute(
                                 name=SAMLAttributeType.eduPersonUniqueId.name,
-                                values=["12345"],
+                                values=["3"],
                             ),
                             SAMLAttribute(
-                                name=SAMLAttributeType.uid.name, values=["12345"]
+                                name=SAMLAttributeType.uid.name, values=["4"]
                             ),
                         ]
                     ),
                 ),
-                "12345",
+                "3",
             ),
             (
                 "subject_with_eduPersonUniqueId_attribute",
                 SAMLSubject(
-                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "12345"),
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "1"),
                     SAMLAttributeStatement(
                         [
                             SAMLAttribute(
                                 name=SAMLAttributeType.eduPersonUniqueId.name,
-                                values=["12345"],
+                                values=["2"],
                             ),
                             SAMLAttribute(
-                                name=SAMLAttributeType.uid.name, values=["12345"]
+                                name=SAMLAttributeType.uid.name, values=["3"]
                             ),
                         ]
                     ),
                 ),
-                "12345",
+                "2",
             ),
             (
                 "subject_with_uid_attribute",
                 SAMLSubject(
-                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "12345"),
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "1"),
                     SAMLAttributeStatement(
-                        [
-                            SAMLAttribute(
-                                name=SAMLAttributeType.uid.name, values=["12345"]
-                            )
-                        ]
+                        [SAMLAttribute(name=SAMLAttributeType.uid.name, values=["2"])]
                     ),
                 ),
-                "12345",
+                "2",
             ),
             (
                 "subject_with_name_id",
                 SAMLSubject(
-                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "12345"),
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "1"),
                     SAMLAttributeStatement(
                         [
                             SAMLAttribute(
                                 name=SAMLAttributeType.eduPersonPrincipalName.name,
-                                values=["12345"],
+                                values=["2"],
                             )
                         ]
                     ),
                 ),
-                "12345",
+                "1",
+            ),
+            (
+                "subject_with_switched_off_use_of_name_id",
+                SAMLSubject(
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "1"),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonPrincipalName.name,
+                                values=["2"],
+                            )
+                        ]
+                    ),
+                ),
+                None,
+                False,
+            ),
+            (
+                "patron_id_attributes_matching_attributes_in_subject",
+                SAMLSubject(
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "1"),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonTargetedID.name,
+                                values=["2"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["3"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.uid.name, values=["4"]
+                            ),
+                        ]
+                    ),
+                ),
+                "4",
+                False,
+                [SAMLAttributeType.uid.name],
+            ),
+            (
+                "patron_id_attributes_matching_second_saml_attribute",
+                SAMLSubject(
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "1"),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonTargetedID.name,
+                                values=[None],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["3"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.uid.name, values=["4"]
+                            ),
+                        ]
+                    ),
+                ),
+                "4",
+                True,
+                [
+                    SAMLAttributeType.eduPersonTargetedID.name,
+                    SAMLAttributeType.uid.name,
+                ],
+            ),
+            (
+                "patron_id_attributes_not_matching_attributes_in_subject",
+                SAMLSubject(
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "1"),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonTargetedID.name,
+                                values=["2"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["3"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.uid.name, values=["4"]
+                            ),
+                        ]
+                    ),
+                ),
+                None,
+                False,
+                [SAMLAttributeType.givenName.name],
+            ),
+            (
+                "patron_id_attributes_not_matching_attributes_in_subject_and_using_name_id_instead",
+                SAMLSubject(
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "1"),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonTargetedID.name,
+                                values=["2"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["3"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.uid.name, values=["4"]
+                            ),
+                        ]
+                    ),
+                ),
+                "1",
+                True,
+                [SAMLAttributeType.givenName.name],
+            ),
+            (
+                "patron_id_regular_expression_matching_saml_subject",
+                SAMLSubject(
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "1"),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonPrincipalName.name,
+                                values=["patron@university.org"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["3"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.uid.name, values=["4"]
+                            ),
+                        ]
+                    ),
+                ),
+                "patron",
+                False,
+                [
+                    SAMLAttributeType.eduPersonPrincipalName.name,
+                    SAMLAttributeType.mail.name,
+                ],
+                fixtures.PATRON_ID_REGULAR_EXPRESSION_ORG,
+            ),
+            (
+                "patron_id_regular_expression_matching_second_saml_attribute",
+                SAMLSubject(
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "1"),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonPrincipalName.name,
+                                values=["patron@university.org"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["3"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.uid.name, values=["4"]
+                            ),
+                        ]
+                    ),
+                ),
+                "patron",
+                False,
+                [
+                    SAMLAttributeType.eduPersonUniqueId.name,
+                    SAMLAttributeType.eduPersonPrincipalName.name,
+                    SAMLAttributeType.mail.name,
+                ],
+                fixtures.PATRON_ID_REGULAR_EXPRESSION_ORG,
+            ),
+            (
+                "unicode_patron_id_regular_expression_matching_saml_subject",
+                SAMLSubject(
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "1"),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonPrincipalName.name,
+                                values=[u"pątron@university.org"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["3"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.uid.name, values=["4"]
+                            ),
+                        ]
+                    ),
+                ),
+                u"pątron",
+                False,
+                [
+                    SAMLAttributeType.eduPersonPrincipalName.name,
+                    SAMLAttributeType.mail.name,
+                ],
+                fixtures.PATRON_ID_REGULAR_EXPRESSION_ORG,
+            ),
+            (
+                "patron_id_regular_expression_not_matching_saml_subject",
+                SAMLSubject(
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "1"),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonPrincipalName.name,
+                                values=["patron@university.org"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["3"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.uid.name, values=["4"]
+                            ),
+                        ]
+                    ),
+                ),
+                None,
+                False,
+                [
+                    SAMLAttributeType.eduPersonPrincipalName.name,
+                    SAMLAttributeType.mail.name,
+                ],
+                fixtures.PATRON_ID_REGULAR_EXPRESSION_COM,
+            ),
+            (
+                "patron_id_regular_expression_not_matching_saml_attributes_but_matching_name_id",
+                SAMLSubject(
+                    SAMLNameID(
+                        SAMLNameIDFormat.UNSPECIFIED, "", "", "patron@university.com"
+                    ),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonPrincipalName.name,
+                                values=["patron@university.org"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=["3"],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.uid.name, values=["4"]
+                            ),
+                        ]
+                    ),
+                ),
+                "patron",
+                True,
+                [
+                    SAMLAttributeType.eduPersonPrincipalName.name,
+                    SAMLAttributeType.mail.name,
+                ],
+                fixtures.PATRON_ID_REGULAR_EXPRESSION_COM,
             ),
         ]
     )
-    def test(self, _, subject, expected_unique_id):
+    def test(
+        self,
+        _,
+        subject,
+        expected_patron_id,
+        use_name_id=True,
+        patron_id_attributes=None,
+        patron_id_regular_expression=None,
+    ):
+        """Make sure that SAMLSubjectUIDExtractor correctly extracts a unique patron ID from the SAML subject.
+
+        :param _: Name of the test case
+        :type _: str
+
+        :param expected_patron_id: Expected patron ID
+        :type expected_patron_id: str
+
+        :param use_name_id: Boolean value indicating whether SAMLSubjectUIDExtractor
+            is allowed to search for patron IDs in NameID
+        :type use_name_id: bool
+
+        :param patron_id_attributes: List of SAML attributes used by SAMLSubjectUIDExtractor to search for a patron ID
+        :type patron_id_attributes: List[SAMLAttributeType]
+
+        :param patron_id_regular_expression: Regular expression used to extract a patron ID from SAML attributes
+        :type patron_id_regular_expression: str
+        """
         # Arrange
-        extractor = SAMLSubjectUIDExtractor()
+        extractor = SAMLSubjectPatronIDExtractor(
+            use_name_id, patron_id_attributes, patron_id_regular_expression
+        )
 
         # Act
         unique_id = extractor.extract(subject)
 
         # Assert
-        eq_(expected_unique_id, unique_id)
+        eq_(expected_patron_id, unique_id)


### PR DESCRIPTION
## Description

NOTE: This PR depends on [circulation # 1572](https://github.com/NYPL-Simplified/circulation/pull/1572).

<!--- Describe your changes -->

This PR adds a new configuration setting `Patron ID: Migrate Patrons with "Old" IDs`:
![image](https://user-images.githubusercontent.com/6442436/111102763-ae2ccb00-856e-11eb-817d-02e219cd080e.png)

This configuration setting allows to turn on the patron migration process and update patron IDs according to new **Patron ID** configuration setting values.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Please consider the following scenario as an example:
1. "Old" patron IDs were extracted from NameID.
2. The requirements have changed and now patron IDs have to be extracted from eduPersonalPrincipalName attribute using `(?P<patron_id>.+)@university\.org` regular expression.

If we don't want to loose patron's holds and loans we have to migrate them. This process includes the following steps:
1. Find a patron object with an "old" ID.
2. Find or create a patron object with a "new" ID.
3. Transfer all the holds and loans from the "old" patron object to the "new" patron object.
4. Delete the "old" patron object.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
