### PR TITLE
Fix Bibliotheca event monitor timestamp does not consider collection

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -593,12 +593,12 @@ class DummyBibliothecaAPIResponse(object):
 class MockBibliothecaAPI(BibliothecaAPI):
 
     @classmethod
-    def mock_collection(self, _db):
+    def mock_collection(self, _db, name="Test Bibliotheca Collection"):
         """Create a mock Bibliotheca collection for use in tests."""
         library = DatabaseTest.make_default_library(_db)
         collection, ignore = get_one_or_create(
             _db, Collection,
-            name="Test Bibliotheca Collection", create_method_kwargs=dict(
+            name=name, create_method_kwargs=dict(
                 external_account_id=u'c',
             )
         )

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1320,7 +1320,7 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
         # or not it exists.
         initialized = get_one(
             _db, Timestamp, service=self.service_name,
-            service_type=Timestamp.MONITOR_TYPE
+            service_type=Timestamp.MONITOR_TYPE, collection=self.collection
         )
         default_start_time = datetime.utcnow() - self.DEFAULT_START_TIME
 

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -980,17 +980,6 @@ class TestBibliothecaEventMonitor(BibliothecaAPITest):
         default_start_time = monitor.create_default_start_time(self._db, proper_args)
         assert datetime(2013, 4, 2) == default_start_time
 
-
-class TestBibliothecaEventMonitorWhenMultipleCollections(BibliothecaAPITest):
-
-    def test_when_multiple_collections(self):
-        # Now let's add a second collection and try the monitor on one of them.
-        b1 = self.collection
-        b2 = self._collection(protocol=ExternalIntegration.BIBLIOTHECA)
-        monitor = BibliothecaEventMonitor(
-            self._db, self.collection, api_class=MockBibliothecaAPI
-        )
-
     def test_run_once(self):
         # run_once() slices the time between its start date
         # and the current time into five-minute intervals, and asks for
@@ -1154,9 +1143,10 @@ class TestBibliothecaEventMonitorWhenMultipleCollections(BibliothecaAPITest):
                                     cli_date='2011-02-03')
             for c in collections
         ]
+        assert len(monitors) == len(collections)
         # Ensure that we get monitors and not an exception.
         for m in monitors:
-            isinstance(m, BibliothecaEventMonitor)
+            assert isinstance(m, BibliothecaEventMonitor)
 
 
 class TestItemListParser(BibliothecaAPITest):


### PR DESCRIPTION
## Description

This branch fixes a timestamp lookup issue when `bibliotheca_monitor` is run with a start date. It does so by including the current `collection` in the lookup.

## Motivation and Context

When `bibliotheca_monitor` is run with a start date and multiple Bibliotheca collections are configured within the circulation manager when more than one of those collections already has a `timestamp`. And, although I did not observe this, it seems possible to end up using the wrong `timestamp` if only one were present.

https://jira.nypl.org/browse/SIMPLY-3636

## How Has This Been Tested?

- Manually ran the script both with and without the fix to demonstrate that the fix resolves the situation. 
- Created new tests and verified that they fail without the fix and pass with it.

## Checklist:

- [N/A] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
