### PR TITLE
SAML: Fix the issue with missing new_patron circulation events

### DIFF
--- a/api/saml/provider.py
+++ b/api/saml/provider.py
@@ -448,7 +448,7 @@ class SAMLWebSSOAuthenticationProvider(
             return patron_data
 
         # Convert the PatronData into a Patron object
-        patron, is_new = patron_data.get_or_create_patron(db, self.library_id)
+        patron, is_new = patron_data.get_or_create_patron(db, self.library_id, self.analytics)
 
         # Create a credential for the Patron
         with self.get_configuration(db) as configuration:


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR fixes the issue related to missing `circulation_manager_new_patron` circulation events.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, Circulation Manager doesn't log new patrons because `PatronData.get_or_create_patron` is called without specifying an `Analytics` instance.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
