### PR TITLE
Issue a warning when building a Docker image if no particular version is specified

### DIFF
--- a/docker/simplified_app.sh
+++ b/docker/simplified_app.sh
@@ -6,6 +6,10 @@ set -x
 repo="$1"
 version="$2"
 
+if [ -z ${version} ]; then
+  echo "WARN: No version specified, will build default branch.";
+fi
+
 # Install the nodesource nodejs package
 # This lets us use node 10 and avoids dependency conflict between node and libxmlsec1 over the
 # version of the ssl library that we find from package managemnet


### PR DESCRIPTION
## Description

We're having a problem where an automated Docker image build is supposed to be building a particular branch, but is building develop instead. Although we're checking out the right branch, we're not passing in the branch name to the Docker build process, so the default version -- `develop` -- gets checked out and built instead.

Here's the source of my confusion: you can check out whatever branch you want to start the Docker build process, but nearly the first thing the build process does is a _fresh checkout_ that could be a completely different branch.

This small branch adds a warning for situations where simplified_app.sh is invoked without any particular version. This is actually fine in the most common case -- building whatever we merge into `develop` -- but hopefully the warning will help other people in my situation.

## How Has This Been Tested?

In the Docker directory, I executed these commands:

`sudo docker build . -f Dockerfile.webapp` - Warning issued
`sudo docker build . -f Dockerfile.webapp --build-arg version=warn-docker-build-without-version` - No warning issued

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
