### PR TITLE
Feature/bibliotheca event monitor multi collection enhancements

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1508,9 +1508,6 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
 
 class RunBibliothecaMonitorScript(RunCollectionMonitorScript):
 
-    def __init__(self, monitor_class, _db=None, cmd_args=None, **kwargs):
-        super(RunBibliothecaMonitorScript, self).__init__(monitor_class, _db, cmd_args, **kwargs)
-
     # TODO: Both '--default-start-date' and '--force-default' (or equivalents) should probably end up
     #   in a more generalized script runner superclass that is focused on Monitor or TimelineMonitor.
     @classmethod

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1,39 +1,49 @@
-import json
-from lxml import etree
-
+import base64
 from cStringIO import StringIO
-import itertools
 from datetime import datetime, timedelta
+import hashlib
+import hmac
+import itertools
+import json
+import logging
 import os
 import re
-import logging
-import base64
 import urlparse
 import time
-import hmac
-import hashlib
 
+import dateutil.parser
 from flask_babel import lazy_gettext as _
-
-
+from lxml import etree
 from sqlalchemy import or_
 from sqlalchemy.orm.session import Session
 
-from web_publication_manifest import (
-    FindawayManifest,
-    SpineItem,
-)
 from circulation import (
     FulfillmentInfo,
     HoldInfo,
     LoanInfo,
     BaseCirculationAPI,
 )
-from selftest import (
-    HasSelfTests,
-    SelfTestResult,
+from circulation_exceptions import *
+from core.analytics import Analytics
+from core.config import (
+    Configuration,
+    CannotLoadConfiguration,
+    temp_config,
 )
-
+from core.coverage import (
+    BibliographicCoverageProvider
+)
+from core.metadata_layer import (
+    ContributorData,
+    CirculationData,
+    Metadata,
+    LinkData,
+    IdentifierData,
+    FormatData,
+    MeasurementData,
+    ReplacementPolicy,
+    SubjectData,
+)
 from core.model import (
     CirculationEvent,
     Classification,
@@ -58,44 +68,27 @@ from core.model import (
     Timestamp,
     WorkCoverageRecord,
 )
-
-from core.config import (
-    Configuration,
-    CannotLoadConfiguration,
-    temp_config,
-)
-
-from core.coverage import (
-    BibliographicCoverageProvider
-)
-
 from core.monitor import (
     CollectionMonitor,
     IdentifierSweepMonitor,
     TimelineMonitor,
 )
+from core.scripts import RunCollectionMonitorScript
+from core.testing import DatabaseTest
 from core.util.xmlparser import XMLParser
 from core.util.http import (
     BadResponseException,
     HTTP
 )
-
-from circulation_exceptions import *
-from core.analytics import Analytics
-
-from core.metadata_layer import (
-    ContributorData,
-    CirculationData,
-    Metadata,
-    LinkData,
-    IdentifierData,
-    FormatData,
-    MeasurementData,
-    ReplacementPolicy,
-    SubjectData,
+from selftest import (
+    HasSelfTests,
+    SelfTestResult,
+)
+from web_publication_manifest import (
+    FindawayManifest,
+    SpineItem,
 )
 
-from core.testing import DatabaseTest
 
 class BibliothecaAPI(BaseCirculationAPI, HasSelfTests):
 

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1295,7 +1295,7 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
         :param collection: Collection for which this monitor operates.
 
         :param api_class: API class or an instance thereof for this monitor.
-        :param api-class: Union[Type[BibliothecaAPI], BibliothecaAPI]
+        :param api_class: Union[Type[BibliothecaAPI], BibliothecaAPI]
 
         :param default_start: A default date/time at which to start
             requesting events. It should be specified as a `datetime` or
@@ -1508,8 +1508,6 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
 
 class RunBibliothecaMonitorScript(RunCollectionMonitorScript):
 
-    # TODO: Both '--default-start-date' and '--force-default' (or equivalents) should probably end up
-    #   in a more generalized script runner superclass that is focused on Monitor or TimelineMonitor.
     @classmethod
     def arg_parser(cls):
         parser = super(RunBibliothecaMonitorScript, cls).arg_parser()

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1281,6 +1281,7 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
     SERVICE_NAME = "Bibliotheca Event Monitor"
     DEFAULT_START_TIME = timedelta(365*3)
     PROTOCOL = ExternalIntegration.BIBLIOTHECA
+    LOG_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
     def __init__(self, _db, collection, api_class=BibliothecaAPI,
                  cli_date=None, analytics=None):
@@ -1325,16 +1326,15 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
                     date = cli_date[0]
                 return datetime.strptime(date, "%Y-%m-%d")
             except ValueError as e:
-                # Date argument wasn't in the proper format.
                 self.log.warn(
-                    "%r. Using default date instead: %s.", e,
-                    default_start_time.strftime("%B %d, %Y")
+                    '%r. Date argument was not in a valid format. Using default date instead: %s.',
+                    e, default_start_time.strftime(self.LOG_DATE_FORMAT)
                 )
                 return default_start_time
         if not initialized:
             self.log.info(
                 "Initializing %s from date: %s.", self.service_name,
-                default_start_time.strftime("%B %d, %Y")
+                default_start_time.strftime(self.LOG_DATE_FORMAT)
             )
             return default_start_time
         return None
@@ -1369,8 +1369,9 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
             start, cutoff, timespan_to_check
         ):
             self.log.info(
-                "Asking for events between %r and %r", slice_start,
-                slice_cutoff
+                "Requesting events between %s and %s",
+                slice_start.strftime(self.LOG_DATE_FORMAT),
+                slice_cutoff.strftime(self.LOG_DATE_FORMAT)
             )
             events = self.api.get_events_between(
                 slice_start, slice_cutoff, full_slice, no_events_error
@@ -1440,7 +1441,8 @@ class BibliothecaEventMonitor(CollectionMonitor, TimelineMonitor):
                 0, 1
             )
         title = edition.title or "[no title]"
-        self.log.info("%r %s: %s", start_time, title, internal_event_type)
+        self.log.info("%s %s: %s", start_time.strftime(self.LOG_DATE_FORMAT),
+                      title, internal_event_type)
         return start_time
 
 class BibliothecaBibliographicCoverageProvider(BibliographicCoverageProvider):

--- a/bin/bibliotheca_monitor
+++ b/bin/bibliotheca_monitor
@@ -6,5 +6,8 @@ bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
 from core.scripts import RunCollectionMonitorScript
-from api.bibliotheca import BibliothecaEventMonitor
-RunCollectionMonitorScript(BibliothecaEventMonitor, cli_date=sys.argv[1:2]).run()
+from api.bibliotheca import BibliothecaEventMonitor, RunBibliothecaMonitorScript
+try:
+    RunBibliothecaMonitorScript(BibliothecaEventMonitor).run()
+except KeyboardInterrupt:
+    pass

--- a/bin/bibliotheca_monitor
+++ b/bin/bibliotheca_monitor
@@ -5,7 +5,6 @@ import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
-from core.scripts import RunCollectionMonitorScript
 from api.bibliotheca import BibliothecaEventMonitor, RunBibliothecaMonitorScript
 try:
     RunBibliothecaMonitorScript(BibliothecaEventMonitor).run()

--- a/bin/bibliotheca_monitor
+++ b/bin/bibliotheca_monitor
@@ -6,7 +6,4 @@ bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
 from api.bibliotheca import BibliothecaEventMonitor, RunBibliothecaMonitorScript
-try:
-    RunBibliothecaMonitorScript(BibliothecaEventMonitor).run()
-except KeyboardInterrupt:
-    pass
+RunBibliothecaMonitorScript(BibliothecaEventMonitor).run()


### PR DESCRIPTION
## Description

This branch:
- Adds a new script runner for Bibliotheca Event Monitor to support the following command line options.
  - `--default-date` option to override a monitor's intrinsic default date with an ISO 8601 date of arbitrary resolution.
  - `--override-timestamp` flag to allow a command line default date to override start time from timestamp.
- Support the new `CollectionArgumentsMonitor` support in `server_core.
- Improves readability of log messages by displaying dates in ISO 8601 date format.
- Renames some variables and concepts to improve clarity (I hope).
- Refactor `catch_up_from` to clarify intent.
- Add warning of potentially missed events, if 100 or more. (See [SIMPLY-3417](https://jira.nypl.org/browse/SIMPLY-3417)).
- Enhances some docstrings.

## Motivation and Context

Needed to make it easier to: 
- Run `bibliotheca_monitor` with a default start time.
- Override an existing timestamp without manually modify the datebase.
- Run the monitor for specific collection(s) and understand which log messages apply to which collection.

https://jira.nypl.org/browse/SIMPLY-3416.

## How Has This Been Tested?

Manual testing and new tests.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
