### PR TITLE
Disable the authentication document cache by default, and make it the location of optional UWSGI debugging information.

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -40,6 +40,10 @@ class Configuration(CoreConfiguration):
     # documents are cached.
     AUTHENTICATION_DOCUMENT_CACHE_TIME = u"authentication_document_cache_time"
 
+    # The name of a setting that turns UWSGI debugging information on
+    # or off.
+    UWSGI_DEBUG_KEY = u"uwsgi_debug"
+
     # A custom link to a Terms of Service document to be understood by
     # users of the administrative interface.
     #

--- a/api/config.py
+++ b/api/config.py
@@ -42,7 +42,7 @@ class Configuration(CoreConfiguration):
 
     # The name of a setting that turns UWSGI debugging information on
     # or off.
-    UWSGI_DEBUG_KEY = u"uwsgi_debug"
+    WSGI_DEBUG_KEY = u"wsgi_debug"
 
     # A custom link to a Terms of Service document to be understood by
     # users of the administrative interface.

--- a/api/config.py
+++ b/api/config.py
@@ -207,7 +207,7 @@ class Configuration(CoreConfiguration):
             "label": _("Cache time for authentication documents (in seconds)"),
             "required": True,
             "type": "number",
-            "default": 3600,
+            "default": 0,
         },
         {
             "key": CUSTOM_TOS_HREF,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -390,8 +390,8 @@ class TestCirculationManager(CirculationControllerTest):
         # max_age.
         assert 0 == manager.authentication_for_opds_documents.max_age
 
-        # UWSGI debug is off by default.
-        assert False == manager.uwsgi_debug
+        # WSGI debug is off by default.
+        assert False == manager.wsgi_debug
 
         # Now let's create a brand new library, never before seen.
         library = self._library()
@@ -428,7 +428,7 @@ class TestCirculationManager(CirculationControllerTest):
         ).value = "60"
 
         ConfigurationSetting.sitewide(
-            self._db, Configuration.UWSGI_DEBUG_KEY
+            self._db, Configuration.WSGI_DEBUG_KEY
         ).value = "true"
 
         # Then reload the CirculationManager...
@@ -473,8 +473,8 @@ class TestCirculationManager(CirculationControllerTest):
         # new max_age.
         assert 60 == manager.authentication_for_opds_documents.max_age
 
-        # The UWSGI debug setting has been changed.
-        assert True == manager.uwsgi_debug
+        # The WSGI debug setting has been changed.
+        assert True == manager.wsgi_debug
 
         # Controllers that don't depend on site configuration
         # have not been reloaded.
@@ -1531,15 +1531,15 @@ class TestIndexController(CirculationControllerTest):
             response = self.manager.index_controller.authentication_document()
             assert cached_value == response.data
 
-            # Note that UWSGI debugging data was not provided, even
-            # though we requested it, since UWSGI debugging is
+            # Note that WSGI debugging data was not provided, even
+            # though we requested it, since WSGI debugging is
             # disabled.
             assert '_debug' not in response.data
 
-        # When UWSGI debugging is enabled and requested, an
+        # When WSGI debugging is enabled and requested, an
         # authentication document includes some extra information in a
         # special '_debug' section.
-        self.manager.uwsgi_debug = True
+        self.manager.wsgi_debug = True
         with self.request_context_with_library(
                 "/?debug", headers=dict(Authorization=self.invalid_auth)):
             response = self.manager.index_controller.authentication_document()
@@ -1548,7 +1548,7 @@ class TestIndexController(CirculationControllerTest):
             debug = doc['_debug']
             assert all(x in debug for x in ('url', 'cache', 'environ'))
 
-        # UWSGI debugging is not provided unless requested.
+        # WSGI debugging is not provided unless requested.
         with self.request_context_with_library(
                 "/", headers=dict(Authorization=self.invalid_auth)):
             response = self.manager.index_controller.authentication_document()


### PR DESCRIPTION
## Description

This branch productizes two things I've learned while trying to fix SIMPLY-3346:

1. At the moment, the authentication document cache is too much trouble to justify the relatively small performance improvement it brings. I've disabled it on every site NYPL hosts and it should be disabled by default.
2. Some deployment configurations seem to send bad UWSGI data to the app server, but there's no easy way to look at that data on a running site.

I've put item #2 into QA servers as a hotfix; this productizes the hotfix so it can be turned on as necessary, to solve this problem or other problems in the future. If UWSGI debug is enabled (this is a secret site-wide setting called `uwsgi_debug`) you can get UWSGI debug information by making a request to `authentication_document` and putting `debug` in the query string, e.g. `https://qa-circulation.openebooks.us/USOEI/authentication_document?debug`.

## How Has This Been Tested?

In addition to the unit tests I tested this against a local development database.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
