### PR TITLE
Docker update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Library Simplified Circulation Manager
-[![Build Status](https://travis-ci.org/NYPL-Simplified/circulation.svg?branch=main)](https://travis-ci.org/NYPL-Simplified/circulation)
+![Build Status](https://github.com/nypl-simplified/circulation/actions/workflows/test.yml/badge.svg?branch=develop) [![GitHub Release](https://img.shields.io/github/release/tterb/PlayMusic.svg?style=flat)]()
 
-This is the Circulation Manager for [Library Simplified](http://www.librarysimplified.org/). The Circulation Manager is the main connection between a library's collection and Library Simplified's various client-side applications. It handles user authentication, combines licensed works with open access content, pulls in updated book information from the [Metadata Wrangler](https://github.com/NYPL-Simplified/metadata_wrangler), and serves up available books in appropriately organized OPDS feeds.
+Default Branch: `develop`
+
+This is the Circulation Manager for [Library Simplified](https://www.librarysimplified.org/). The Circulation Manager is the main connection between a library's collection and Library Simplified's various client-side applications. It handles user authentication, combines licensed works with open access content, pulls in updated book information from the [Metadata Wrangler](https://github.com/NYPL-Simplified/metadata_wrangler), and serves up available books in appropriately organized OPDS feeds.
 
 It depends on [Library Simplified Server Core](https://github.com/NYPL-Simplified/server_core) as a git submodule.
 
@@ -13,11 +15,15 @@ It depends on [Library Simplified Server Core](https://github.com/NYPL-Simplifie
 
 ## Generating Documentation
 
-Code documentation using Sphinx can be found on [Github Pages](http://nypl-simplified.github.io/circulation/index.html). It currently documents this repo's `api` directory, `scripts` file, and the `core` directory submodule. The configuration for the documentation can be found in `/docs`.
+Code documentation using Sphinx can be found on this repo's [Github Pages](http://nypl-simplified.github.io/circulation/index.html). It currently documents this repo's `api` directory, `scripts` file, and the `core` submodule directory. The configuration for the documentation can be found in `/docs`.
 
 Travis CI handles generating the `.rst` source files, generating the HTML static site, and deploying the build to the `gh-pages` branch.
 
 To view the documentation _locally_, go into the `/docs` directory and run `make html`. This will generate the .rst source files and build the static site in `/docs/build/html`.
+
+## Usage with Docker
+
+Check out the [Docker README](/docker/README.md) in the `/docker` directory for in-depth information on optionally running and developing the Circulation Manager locally with Docker, or for deploying the Circulation Manager with Docker.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Library Simplified Circulation Manager
 [![Build Status](https://travis-ci.org/NYPL-Simplified/circulation.svg?branch=main)](https://travis-ci.org/NYPL-Simplified/circulation)
 
-This is the Circulation Manager for [Library Simplified](http://www.librarysimplified.org/). The circulation manager is the main connection between a library's collection and Library Simplified's various client-side applications. It handles user authentication, combines licensed works with open access content, pulls in updated book information from the [Metadata Wrangler](https://github.com/NYPL-Simplified/metadata_wrangler), and serves up available books in appropriately organized OPDS feeds.
+This is the Circulation Manager for [Library Simplified](http://www.librarysimplified.org/). The Circulation Manager is the main connection between a library's collection and Library Simplified's various client-side applications. It handles user authentication, combines licensed works with open access content, pulls in updated book information from the [Metadata Wrangler](https://github.com/NYPL-Simplified/metadata_wrangler), and serves up available books in appropriately organized OPDS feeds.
 
-It depends on the [LS Server Core](https://github.com/NYPL-Simplified/server_core) as a git submodule.
+It depends on [Library Simplified Server Core](https://github.com/NYPL-Simplified/server_core) as a git submodule.
 
 ## Installation
 

--- a/docker/Dockerfile.scripts
+++ b/docker/Dockerfile.scripts
@@ -20,6 +20,7 @@ ARG version
 ARG repo="NYPL-Simplified/circulation"
 
 ENV SIMPLIFIED_DB_TASK "auto"
+# Set the local timezone in /docker/simplified_cron.sh
 ENV TZ=US/Eastern
 
 # Copy over all Library Simplified build files for this image

--- a/docker/Dockerfile.webapp
+++ b/docker/Dockerfile.webapp
@@ -1,5 +1,5 @@
 FROM phusion/baseimage:bionic-1.0.0
-MAINTAINER Library Simplified <info@librarysimplified.org>
+LABEL maintainer="Library Simplified <info@librarysimplified.org>"
 
 ARG version
 ARG repo="NYPL-Simplified/circulation"

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,13 +1,14 @@
-# circulation-docker
-These are the Docker images for Library Simplified's [Circulation Manager](https://github.com/NYPL-Simplified/circulation_manager).
+# Circulation Docker
+This directory contains `Dockerfile`s and a `docker-compose.yml` file for Library Simplified's [Circulation Manager](https://github.com/NYPL-Simplified/circulation_manager).
 
 #### Contents:
 - What is the Circulation Manager?
+- Docker Images
 - Using This Image
 - Environment Variables
-- Notes on Earlier Version
-- Additional Configuration
+- Building New Images
 - Contributing
+- License
 
 ---
 
@@ -15,23 +16,28 @@ These are the Docker images for Library Simplified's [Circulation Manager](https
 
 The Circulation Manager is the main connection between a library's collection and Library Simplified's various client-side applications. It handles user authentication, combines licensed works with open access content from the [OA Content Server](https://github.com/NYPL-Simplified/content_server), pulls in updated book information from the [Metadata Wrangler](https://github.com/NYPL-Simplified/metadata_wrangler), and serves up available books in appropriately organized OPDS feeds.
 
+## Docker Images
+
 The Dockerfiles in this directory create two distinct but necessary containers to deploy the Circulation Manager:
   - `circ-webapp` (**deprecated:** `circ-deploy`): a container that launches the API and admin interface [using Nginx and uWSGI](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Nginx-&-uWSGI)
   - `circ-scripts`: a container that schedules and runs important cron jobs at recommended intervals
+  - `circ-exec`: a container similar to `circ-scripts` but only runs one job and then stops
 
 To avoid database lockups, `circ-scripts` should be deployed as a single instance.
 
-## Using This Image
+## Using These Images
 
-You will need **a PostgreSQL instance url** in the format `postgres://[username]:[password]@[host]:[port]/[database_name]`. With this URL, you can create containers for both the web application (`circ-webapp`) and for the background cron jobs that import and update books and otherwise keep the app running smoothly (`circ-scripts`). Either container can be used to initialize or migrate the database. During the first deployment against a brand new database, the first container run can use the default `SIMPLIFIED_DB_TASK='auto'` or be run manually with `SIMPLIFIED_DB_TASK='init'`. See the "Environment Variables" section below for mroe information.
+You will need **a PostgreSQL instance URL** in the format `postgres://[username]:[password]@[host]:[port]/[database_name]`. Check the `./docker-compose.yml` file for an example. With this URL, you can create containers for both the web application (`circ-webapp`) and for the background cron jobs that import and update books and otherwise keep the app running smoothly (`circ-scripts`). Either container can be used to initialize or migrate the database. During the first deployment against a brand new database, the first container run can use the default `SIMPLIFIED_DB_TASK='auto'` or be run manually with `SIMPLIFIED_DB_TASK='init'`. See the "Environment Variables" section below for more information.
 
-### circ-webapp (**deprecated:** circ-deploy)
+### circ-webapp (**deprecated name:** circ-deploy)
 
-```
+Once the webapp Docker image is built, we can run it in a container with the following command.
+
+```sh
 # See the section "Environment Variables" below for more information
 # about the values listed here and their alternatives.
-$ docker run --name webapp \
-    -d -p 80:80 \
+$ docker run --name webapp -d \
+    --p 80:80 \
     -e SIMPLIFIED_PRODUCTION_DATABASE='postgres://[username]:[password]@[host]:[port]/[database_name]' \
     nypl/circ-webapp:2.1
 ```
@@ -42,7 +48,9 @@ For troubleshooting information and installation directions for the entire Circu
 
 ### circ-scripts
 
-```
+Once the scripts Docker image is built, we can run it in a container with the following command.
+
+```sh
 # See the section "Environment Variables" below for more information
 # about the values listed here and their alternatives.
 $ docker run --name scripts -d \
@@ -63,7 +71,7 @@ Unlike the `circ-scripts` image, which runs constantly and executes every possib
 
 Because containers based on `circ-exec` are built, run their job, and are destroyed, it's important to configure an external log aggregator to find &#42;.log files in `/var/log/simplified/${SIMPLIFIED_SCRIPT_NAME}.log`.
 
-```
+```sh
 # See the section "Environment Variables" below for more information
 # about the values listed here and their alternatives.
 $ docker run --name refresh-materialized-views -it \
@@ -76,10 +84,6 @@ $ docker run --name refresh-materialized-views -it \
 
 Environment variables can be set with the `-e VARIABLE_KEY='variable_value'` option on the `docker run` command. `SIMPLIFIED_PRODUCTION_DATABASE` is the only required environment variable.
 
-### `SIMPLIFIED_CONFIGURATION_FILE`
-
-*Optional.* The full path to a configuration file in the container. Configuration is now held in the database and accessed via an administrative interface at `/admin`, so you probably don't need this. If you do, use [this documentation](https://github.com/NYPL-Simplified/Simplified/wiki/Configuration) to create the JSON file for your particular library's configuration. If you're unfamiliar with JSON, you can use [this JSON Formatter & Validator](https://jsonformatter.curiousconcept.com/#) to validate your configuration file.
-
 ### `SIMPLIFIED_DB_TASK`
 
 *Optional.* Performs a task against the database at container runtime. Options are:
@@ -87,7 +91,6 @@ Environment variables can be set with the `-e VARIABLE_KEY='variable_value'` opt
   - `ignore` : Does nothing.
   - `init` : Initializes the app against a brand new database. If you are running a circulation manager for the first time ever, use this value to set up an Elasticsearch alias and account for the database schema for future migrations.
   - `migrate` : Migrates an existing database against a new release. Use this value when switching from one stable version to another.
-
 
 ### `SIMPLIFIED_PRODUCTION_DATABASE`
 
@@ -101,15 +104,23 @@ Environment variables can be set with the `-e VARIABLE_KEY='variable_value'` opt
 
 *Optional. Applies to `circ-scripts` only.* The time zone that cron should use to run scheduled scripts--usually the time zone of the library or libraries on the circulation manager instance. This value should be selected according to [Debian-system time zone options](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This value allows scripts to be run at ideal times.
 
+### `UWSGI_PROCESSES`
+
+*Optional.* The number of processes to use when running uWSGI. This value can be updated in `docker-compose.yml` or added directly in `Dockerfile.webapp`. Defaults to 6.
+
+### `UWSGI_THREADS`
+
+*Optional.* The number of threads to use when running uWSGI. This value can be updated in `docker-compose.yml` or added directly in `Dockerfile.webapp`. Defaults to 2.
+
 ## Building new images
 
-If you plan to work with stable versions of the Circulation Manager, we strongly recommend using the latest stable versions of circ-webapp and circ-scripts [published to Docker Hub](https://hub.docker.com/r/nypl/). However, there may come a time in development when you want to build Docker containers for a particular version of the Circulation Manager. If so, please use the instructions below.
+If you plan to work with stable versions of the Circulation Manager, we strongly recommend using the latest stable versions of circ-webapp and circ-scripts [published to Docker Hub](https://hub.docker.com/u/nypl/). However, there may come a time in development when you want to build Docker containers for a particular version of the Circulation Manager. If so, please use the instructions below.
 
 We recommend you install at least version 18.06 of the Docker engine and version 1.24 of Docker Compose.
 
-### > `.webapp` and `.scripts`
+### `.webapp` and `.scripts` images
 
-Determine which container you would like to build and update the tag and Dockerfile listed below accordingly.
+Determine which image you would like to build and update the tag and `Dockerfile` listed below accordingly.
 
 ```sh
 $ docker build --build-arg version=YOUR_DESIRED_BRANCH_OR_COMMIT \
@@ -122,17 +133,13 @@ You must run this command with the `--no-cache` option or the code in the contai
 
 That's it! Run your containers as detailed in [the Quickstart documentation](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Quickstart-with-Docker). Keep in mind that you may need to run migrations or configuration if you are using an existing version of the database.
 
-### > local testing with docker-compose
+### Local Testing With docker-compose
 
 The entirety of the setup described in [the Quickstart documentation](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Quickstart-with-Docker) can be run at once using `version=$YOUR_DESIRED_BRANCH_OR_COMMIT docker-compose up`. This can be great for locally testing feature branches and/or the success of new Docker builds.
 
 [This reference](https://docs.docker.com/compose/reference/up/) has a lot of fantastic information about options and settings for `docker-compose up`, but `-d` will run the containers in the background. [`docker-compose run`](https://docs.docker.com/compose/reference/run/) allows you to run the application with commands and settings other than those set in the Dockerfiles, to further support testing.
 
-If you're using Docker for Mac, keep an eye on the size of your /Users/courteneyervin/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/Docker.qcow2 file, which can get quite large during local testing. Regularly deleting it will remove all existing containers but also avoid slowdowns from its ballooning size.
-
-## Additional Configuration
-
-If you would like to use different tools to handle deployment for the LS Circulation Manager, you are more than welcome to do so! We would love to support more deployment configurations; feel free to contribute any changes you may make to [the official Docker build repository](https://github.com/NYPL-Simplified/circulation-docker)!
+If you're using Docker for Mac, keep an eye on the size of your /Users/[your-machine-username]/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/Docker.qcow2 file, which can get quite large during local testing. Regularly deleting it will remove all existing containers but also avoid slowdowns from its ballooning size.
 
 ## Contributing
 
@@ -146,7 +153,7 @@ Before you start to code, we recommend discussing your plans through a [GitHub i
 ## License
 
 ```
-Copyright © 2015 The New York Public Library, Astor, Lenox, and Tilden Foundations
+Copyright © 2021 The New York Public Library, Astor, Lenox, and Tilden Foundations
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,5 @@
 # circulation-docker
-These are the Docker images for Library Simplified's [Circulation Manager](https://github.com/NYPL-Simplified/circulation_manager). They are updated via [pull requests to the `NYPL-Simplified/circulation-docker` GitHub repo](https://github.com/NYPL-Simplified/circulation-docker/pulls).
+These are the Docker images for Library Simplified's [Circulation Manager](https://github.com/NYPL-Simplified/circulation_manager).
 
 #### Contents:
 - What is the Circulation Manager?
@@ -13,7 +13,7 @@ These are the Docker images for Library Simplified's [Circulation Manager](https
 
 ## What is the Circulation Manager?
 
-The circulation manager is the main connection between a library's collection and Library Simplified's various client-side applications. It handles user authentication, combines licensed works with open access content from the [OA Content Server](https://github.com/NYPL-Simplified/content_server), pulls in updated book information from the [Metadata Wrangler](https://github.com/NYPL-Simplified/metadata_wrangler), and serves up available books in appropriately organized OPDS feeds.
+The Circulation Manager is the main connection between a library's collection and Library Simplified's various client-side applications. It handles user authentication, combines licensed works with open access content from the [OA Content Server](https://github.com/NYPL-Simplified/content_server), pulls in updated book information from the [Metadata Wrangler](https://github.com/NYPL-Simplified/metadata_wrangler), and serves up available books in appropriately organized OPDS feeds.
 
 The Dockerfiles in this directory create two distinct but necessary containers to deploy the Circulation Manager:
   - `circ-webapp` (**deprecated:** `circ-deploy`): a container that launches the API and admin interface [using Nginx and uWSGI](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Nginx-&-uWSGI)
@@ -23,7 +23,7 @@ To avoid database lockups, `circ-scripts` should be deployed as a single instanc
 
 ## Using This Image
 
-You will need **a PostgreSQL instance url** in the format `postgres://[username]:[password]@[host]:[port]/[database_name]`. With this URL, you can created containers for both the web application (`circ-webapp`) and for the background cron jobs that import and update books and otherwise keep the app running smoothly (`circ-scripts`). Either container can be used to initialize or migrate the database. During the first deployment against a brand new database, the first container run can use the default `SIMPLIFIED_DB_TASK='auto'` or be run manually with `SIMPLIFIED_DB_TASK='init'`. See the "Environment Variables" section below for mroe information.
+You will need **a PostgreSQL instance url** in the format `postgres://[username]:[password]@[host]:[port]/[database_name]`. With this URL, you can create containers for both the web application (`circ-webapp`) and for the background cron jobs that import and update books and otherwise keep the app running smoothly (`circ-scripts`). Either container can be used to initialize or migrate the database. During the first deployment against a brand new database, the first container run can use the default `SIMPLIFIED_DB_TASK='auto'` or be run manually with `SIMPLIFIED_DB_TASK='init'`. See the "Environment Variables" section below for mroe information.
 
 ### circ-webapp (**deprecated:** circ-deploy)
 
@@ -36,7 +36,7 @@ $ docker run --name webapp \
     nypl/circ-webapp:2.1
 ```
 
-Navigate to `http://localhost/admin` to in your browser to input or update configuration information. If you have not yet created an admin authorization protocol before, you'll need to do that before you can set other configuration.
+Navigate to `http://localhost/admin` in your browser to visit the web admin for the Circulation Manager. In the admin, you can add or update configuration information. If you have not yet created an admin authorization protocol before, you'll need to do that before you can set other configuration.
 
 For troubleshooting information and installation directions for the entire Circulation Manager tool suite, please review [the full deployment instructions](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment:-Quickstart-with-Docker).
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -74,7 +74,7 @@ Because containers based on `circ-exec` are built, run their job, and are destro
 ```sh
 # See the section "Environment Variables" below for more information
 # about the values listed here and their alternatives.
-$ docker run --name refresh-materialized-views -it \
+$ docker run --name search_index_refresh -it \
     -e SIMPLIFIED_SCRIPT_NAME='refresh_materialized_views' \
     -e SIMPLIFIED_PRODUCTION_DATABASE='postgres://[username]:[password]@[host]:[port]/[database_name]' \
     nypl/circ-exec:2.1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,11 +1,13 @@
 version: '3.6'
 services:
   db:
-    image: "postgres:9.5"
+    image: "postgres:12.0-alpine"
     environment:
       POSTGRES_PASSWORD: "password"
       POSTGRES_USER: "simplified"
       POSTGRES_DB: "simplified_circulation_dev"
+    ports:
+      - 5432:5432/tcp
     volumes:
       - "dbdata:/var/lib/postgresql/data"
   es:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       args:
         - version
     environment:
+      UWSGI_PROCESSES: 6
+      UWSGI_THREADS: 2
       SIMPLIFIED_PRODUCTION_DATABASE: postgres://simplified:password@db:5432/simplified_circulation_dev
     ports:
       - 80:80

--- a/docker/hooks/test
+++ b/docker/hooks/test
@@ -3,8 +3,8 @@
 set -ex
 
 # Create a container with test and production postgres databases.
-docker pull postgres:9.5;
-docker run -d --env POSTGRES_HOST_AUTH_METHOD=trust --name pg postgres:9.5;
+docker pull postgres:12.0-alpine;
+docker run -d --env POSTGRES_HOST_AUTH_METHOD=trust --name pg postgres:12.0-alpine;
 
 # Sleep to let PostgreSQL start up.
 sleep 15;

--- a/docker/services/uwsgi.ini
+++ b/docker/services/uwsgi.ini
@@ -16,8 +16,24 @@ chmod-socket = 666
 logto = /var/log/uwsgi/%n.log
 log-format = %(addr) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)
 
+# The uWSGI processes and threads to use should be set as environment
+# variables in `docker-compose.yml` or in the command line when running
+# the `Dockerfile.webapp` image. The default processes used is 6 and
+# the default threads used is 2.
+if-env = UWSGI_PROCESSES
+processes = $(UWSGI_PROCESSES)
+endif =
+if-not-env = UWSGI_PROCESSES
 processes = 6
+endif =
+
+if-env = UWSGI_THREADS
+threads = $(UWSGI_THREADS)
+endif =
+if-not-env = UWSGI_THREADS
 threads = 2
+endif =
+
 harakiri = 300
 lazy-apps = true
 touch-reload = %(base)/uwsgi.ini

--- a/docker/simplified_app.sh
+++ b/docker/simplified_app.sh
@@ -47,17 +47,12 @@ mkdir /var/www && cd /var/www
 git clone https://github.com/${repo}.git circulation
 chown simplified:simplified circulation
 cd circulation
-# git checkout $version
-# temporary:
-git checkout datetime-update
+git checkout $version
 
 # Use https to access submodules.
 git submodule init
 git config submodule.core.url $(git config submodule.core.url | perl -p -e 's|git@(.*?):|https://\1/|g')
 git submodule update --init --recursive
-
-# temporary:
-cd core && git checkout datetime-update && cd ..
 
 # Add a .version file to the directory. This file
 # supplies an endpoint to check the app's current version.

--- a/docker/simplified_app.sh
+++ b/docker/simplified_app.sh
@@ -20,9 +20,12 @@ echo "deb-src https://deb.nodesource.com/node_10.x bionic main" >> /etc/apt/sour
 # Add packages we need to build the app and its dependancies
 apt-get update
 $minimal_apt_get_install --no-upgrade \
-  python-dev \
-  python2.7 \
-  python-setuptools \
+  software-properties-common \
+  python3.6 \
+  python3-dev \
+  python3-setuptools \
+  python3-venv \
+  python3-pip \
   gcc \
   git \
   libpcre3 \
@@ -44,21 +47,23 @@ mkdir /var/www && cd /var/www
 git clone https://github.com/${repo}.git circulation
 chown simplified:simplified circulation
 cd circulation
-git checkout $version
+# git checkout $version
+# temporary:
+git checkout python3
 
 # Use https to access submodules.
 git submodule init
 git config submodule.core.url $(git config submodule.core.url | perl -p -e 's|git@(.*?):|https://\1/|g')
 git submodule update --init --recursive
 
+# temporary:
+cd core && git checkout py3-base && cd ..
+
 # Add a .version file to the directory. This file
 # supplies an endpoint to check the app's current version.
 printf "$(git describe --tags)" > .version
 
-# Use the latest version of pip to install a virtual environment for the app.
-python /usr/lib/python2.7/dist-packages/easy_install.py "pip<21.0"
-pip install --no-cache-dir virtualenv virtualenvwrapper
-virtualenv -p /usr/bin/python2.7 env
+python3 -m venv env
 
 # Pass runtime environment variables to the app at runtime.
 touch environment.sh
@@ -68,12 +73,17 @@ echo "if [[ -f $SIMPLIFIED_ENVIRONMENT ]]; then \
 
 # Install required python libraries.
 set +x && source env/bin/activate && set -x
-pip install -r requirements.txt
+# Update pip and setuptools.
+python3 -m pip install -U pip setuptools
+# Install the necessary requirements.
+python3 -m pip install -r requirements.txt
 
 # Install NLTK.
-python -m textblob.download_corpora
+python3 -m textblob.download_corpora
 mv /root/nltk_data /usr/lib/
 
+# Go to the directory where the admin front-end application is located
+# and install the necessary app dependencies.
 cd api/admin
 npm install
 cd ../..

--- a/docker/simplified_app.sh
+++ b/docker/simplified_app.sh
@@ -49,7 +49,7 @@ chown simplified:simplified circulation
 cd circulation
 # git checkout $version
 # temporary:
-git checkout python3
+git checkout datetime-update
 
 # Use https to access submodules.
 git submodule init
@@ -57,7 +57,7 @@ git config submodule.core.url $(git config submodule.core.url | perl -p -e 's|gi
 git submodule update --init --recursive
 
 # temporary:
-cd core && git checkout py3-base && cd ..
+cd core && git checkout datetime-update && cd ..
 
 # Add a .version file to the directory. This file
 # supplies an endpoint to check the app's current version.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,13 +14,14 @@
 #
 import os
 import sys
+import datetime
 sys.path.insert(0, os.path.abspath('../../'))
 
 
 # -- Project information -----------------------------------------------------
-
+year = datetime.datetime.now().year
 project = 'Library Simplified Circulation Manager'
-copyright = '2019, The New York Public Library, Astor, Lenox, and Tilden Foundations'
+copyright = '%s, The New York Public Library, Astor, Lenox, and Tilden Foundations' % year
 author = 'Library Simplified'
 
 # The short X.Y version

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -34,7 +34,7 @@ pyfakefs==3.7
 Pygments==2.5.2
 PyJWT==1.4.2
 PyLD==1.0.5
-pypostalcode==0.3.4
+pypostalcode==0.3.6
 pyOpenSSL==19.1.0
 # TODO: python-Levenshtein is supposedly required for author name
 # matching, but is not a core requirement; perhaps it can be removed.

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ allowlist_externals =
     python
 
 [docker:db]
-image = postgres:9.6
+image = postgres:12
 environment =
     POSTGRES_USER=simplified_test
     POSTGRES_PASSWORD=test


### PR DESCRIPTION
## Description

This update includes:

* Updating `/docker/simplified_app.sh` so that it uses python 3 to build the environment for the app to run in (the minimum changes it needs).
* Updating the repo's README and the README in the `/docker` directory for more information regarding building/running the app with Docker. There are links to the project's wiki which can use an update as well and will do that separately.
* Updating postgres from 9.5/9.6 to 12 for usage in docker and in tox.

What this update does not include is [standardizing the build process](https://jira.nypl.org/browse/SIMPLY-3706) with the Metadata Wrangler or the Library Registry. There are tools and processes introduced that will make standardizing non-trivial and a separate PR will be easier (for me) to work with.
 
## Motivation and Context

Resolves updating this repos' docker file for the python 3 conversion update as well as [SIMPLY-3137](https://jira.nypl.org/browse/SIMPLY-3137) -- parameterizing processes and threads values for uWSGI.

## How Has This Been Tested?

Locally running the application using `docker compose`. The current main branches will fail when this is run until the python 3 PR branches are merged in.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
