### PR TITLE
Simply 3615/sphinx docs update

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+name: Build API Documentation
+on:
+  push:
+    branches:
+      - simply-3615/sphinx-docs-update
+
+jobs:
+  docs:
+    name: Build API Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "docs/"
+    # Publish built docs to gh-pages branch.
+    # ===============================
+    - name: Commit documentation changes
+      run: |
+        git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
+        cp -r docs/_build/html/* gh-pages/
+        cd gh-pages
+        touch .nojekyll
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add .
+        git commit -m "Update documentation" -a || true
+        # The above command will fail if no changes were present, so we ignore
+        # that.
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        branch: gh-pages
+        directory: gh-pages
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,9 +13,18 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
       - name: Install Apt Packages
         run: |
           sudo apt-get install --yes libxmlsec1-dev libxml2-dev libxmlsec1-openssl
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
 
       - uses: ammaraskar/sphinx-action@master
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,29 +13,17 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Install Apt Packages
-        run: |
-          sudo apt-get install --yes libxmlsec1 libxmlsec1-dev libxml2 libxml2-dev libxmlsec1-openssl
-
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip
-
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
+          pre-build-command: "sudo apt-get install --yes libxmlsec1-dev libxml2-dev libxmlsec1-openssl"
 
       # Publish built docs to gh-pages branch.
       # ===============================
       - name: Commit documentation changes
         run: |
           git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
-          cp -r docs/_build/html/* gh-pages/
+          cp -r docs/build/html/* gh-pages/
           cd gh-pages
           touch .nojekyll
           git config --local user.email "action@github.com"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
-          pre-build-command: "sudo apt-get install --yes libxmlsec1-dev libxml2-dev libxmlsec1-openssl"
+          pre-build-command: "apt-get install --yes libxmlsec1-dev libxml2-dev libxmlsec1-openssl"
 
       # Publish built docs to gh-pages branch.
       # ===============================

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,10 +13,26 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: ammaraskar/sphinx-action@master
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          docs-folder: "docs/"
-          pre-build-command: "apt-get install --yes libxmlsec1-dev libxml2-dev libxmlsec1-openssl"
+          python-version: 3.7
+
+      - name: Install Apt Packages
+        run: |
+          sudo apt-get install --yes libxmlsec1-dev libxml2-dev libxmlsec1-openssl
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Build Docs
+        run: |
+          cd docs
+          make
+
+      # - uses: ammaraskar/sphinx-action@master
+      #   with:
+      #     docs-folder: "docs/"
+          # pre-build-command: "apt-get install --yes libxmlsec1-dev libxml2-dev libxmlsec1-openssl"
 
       # Publish built docs to gh-pages branch.
       # ===============================

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,9 +12,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+
+      - name: Install Apt Packages
+        run: |
+          sudo apt-get install --yes libxmlsec1-dev libxml2-dev libxmlsec1-openssl
+
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
+
       # Publish built docs to gh-pages branch.
       # ===============================
       - name: Commit documentation changes
@@ -29,6 +35,7 @@ jobs:
           git commit -m "Update documentation" -a || true
           # The above command will fail if no changes were present, so we ignore
           # that.
+
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ name: Build API Documentation
 on:
   push:
     branches:
+      # We only want to deploy new documentation updates
+      # when there are changes in the `develop` branch.
       - simply-3615/sphinx-docs-update
 
 jobs:
@@ -18,18 +20,25 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Install Apt Packages
+      # The https://github.com/marketplace/actions/sphinx-build Github Action can
+      # run `pip install` but it fails to gather other system package
+      # requirements, even when using the `pre-build-command` hook.
+      # Instead of relying on that Github Action, let's install all the
+      # dependencies ourselves.
+      - name: Install Dependencies
         run: |
           sudo apt-get install --yes libxmlsec1-dev libxml2-dev libxmlsec1-openssl
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
+      # The `make html` command will run Sphinx to build the documentation.
       - name: Build Docs
         run: |
           cd docs
           make html
           cd ..
 
+      # Deploy to http://nypl-simplified.github.io/circulation/
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install Apt Packages
         run: |
-          sudo apt-get install --yes libxmlsec1-dev libxml2-dev libxmlsec1-openssl
+          sudo apt-get install --yes libxmlsec1 libxmlsec1-dev libxml2 libxml2-dev libxmlsec1-openssl
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,24 +15,24 @@ jobs:
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
-    # Publish built docs to gh-pages branch.
-    # ===============================
-    - name: Commit documentation changes
-      run: |
-        git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
-        cp -r docs/_build/html/* gh-pages/
-        cd gh-pages
-        touch .nojekyll
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add .
-        git commit -m "Update documentation" -a || true
-        # The above command will fail if no changes were present, so we ignore
-        # that.
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        branch: gh-pages
-        directory: gh-pages
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      # Publish built docs to gh-pages branch.
+      # ===============================
+      - name: Commit documentation changes
+        run: |
+          git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
+          cp -r docs/_build/html/* gh-pages/
+          cd gh-pages
+          touch .nojekyll
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "Update documentation" -a || true
+          # The above command will fail if no changes were present, so we ignore
+          # that.
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: gh-pages
+          directory: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,25 +30,9 @@ jobs:
           make html
           cd ..
 
-      # Publish built docs to gh-pages branch.
-      # ===============================
-      - name: Commit documentation changes
-        run: |
-          git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
-          cp -r docs/build/html/* gh-pages/
-          cd gh-pages
-          touch .nojekyll
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add .
-          git commit -m "Update documentation" -a || true
-          # The above command will fail if no changes were present, so we ignore
-          # that.
-
-      - name: Push changes
-        uses: ad-m/github-push-action@master
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.1
         with:
-          branch: gh-pages
-          directory: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages # The branch the action should deploy to.
+          folder: docs/build/html # The folder the action should deploy.
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
     branches:
       # We only want to deploy new documentation updates
       # when there are changes in the `develop` branch.
-      - simply-3615/sphinx-docs-update
+      - develop
 
 jobs:
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,12 +27,8 @@ jobs:
       - name: Build Docs
         run: |
           cd docs
-          make
-
-      # - uses: ammaraskar/sphinx-action@master
-      #   with:
-      #     docs-folder: "docs/"
-          # pre-build-command: "apt-get install --yes libxmlsec1-dev libxml2-dev libxmlsec1-openssl"
+          make html
+          cd ..
 
       # Publish built docs to gh-pages branch.
       # ===============================

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test Circulation
-on: [push, pull_request]
+# on: [push, pull_request]
 
 jobs:
   test-circulation:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test Circulation
 on: [push, pull_request]
 
 jobs:
-  test-core:
+  test-circulation:
     name: Run Circulation Tests
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test Circulation
-# on: [push, pull_request]
+on: [push, pull_request]
 
 jobs:
   test-circulation:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+-r ../core/requirements-dev.txt
+-r ../requirements-base.txt
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
--r ../core/requirements-dev.txt
--r ../requirements-base.txt
-


### PR DESCRIPTION
## Description

This adds a separate Github Actions workflow file to build and deploy Sphinx documentation to http://nypl-simplified.github.io/circulation/ . This will only run when changes have been merged/push to the `develop` branch.

I tried using an existing standard Github Action package (`sphinx-build`) but it did not install system and pip package requirements correctly, so the action file downloads all the necessary packages manually and runs the build command (`make html`) manually.

## Motivation and Context

Resolves [SIMPLY-3615](https://jira.nypl.org/browse/SIMPLY-3615), the move from Travis to Github Actions broke the way we deployed documentation to Github Pages.

## How Has This Been Tested?

While testing out the Github Action, I used this PR branch as the target branch to run on. New documentation was built and deployed to http://nypl-simplified.github.io/circulation/.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
