### PR TITLE
Py3 and flake8 updates to informational scripts

### DIFF
--- a/bin/informational/adobe-id-for-short-client-token
+++ b/bin/informational/adobe-id-for-short-client-token
@@ -1,61 +1,108 @@
-#!/usr/bin/env python
-"""Retrieve an Adobe ID from a Short Client Token."""
-# This script doesn't import any code from circulation or core. It
-# tests an integration based on HTTP.
+#!/usr/bin/env python3
 
-import requests
-import base64
 import re
 import sys
 
-base_url = "https://libraryregistry.librarysimplified.org"
+import click
+import requests
 
-if len(sys.argv) != 2:
-    print "Usage: %s [Short Client Token]" % sys.argv[0]
-    sys.exit()
+DEFAULT_REGISTRY_URL = "https://libraryregistry.librarysimplified.org"
+CLIENT_TOKEN_RE = re.compile(r'''
+                                ^
+                                (?P<library>[^|]+) \|               # Any number of characters up to a pipe
+                                (?P<timestamp>[0-9]+) \|            # Epoch timestamp, any number of digits
+                                (?P<patron_id>[-A-Za-z0-9]{36}) \|  # The patron id is a UUID, 36 characters long
+                                (?P<signature_hash>.*)              # Everything after the third pipe
+                                $
+                             ''', re.IGNORECASE | re.VERBOSE)
+REGISTRY_RESPONSE_RE = re.compile(r'''<user>(?P<user_id>[^<]+?)</user>''', re.IGNORECASE)
 
-client_token = sys.argv[1]
 
-if client_token.count("|") != 3:
-    print "%r doesn't look like a Short Client Token. It should look like this:\n[library code]|[timestamp]|[patron identifier]|[signature]" % client_token
-    sys.exit()
+class InvalidTokenException(Exception):
+    ...
 
-# If the user input the entire <drm:clientToken> tag, strip off the
-# tag and leave the token.
-if client_token.startswith("<drm:clientToken>"):
-    client_token = client_token[len("<drm:clientToken>"):]
-if client_token.endswith("</drm:clientToken>"):
-    client_token = client_token[:-len("</drm:clientToken>")]
-    
-library, timestamp, identifier, signature = client_token.split("|")
-print "This Short Client Token looks good."
-print " Library code: %s" % library
-print " Timestamp: %s" % timestamp
-print " Patron identifier: %s" % identifier
-print " Signature: %s" % signature
-print
 
-username, password = client_token.rsplit("|", 1)
-print "Dividing Short Client Token into two parts to use in the SignIn API."
-print " Username: %s" % username
-print " Password: %s" % password
-print
+def decompose_token(token):
+    if "drm:clientToken" in token:
+        token = token.replace("<drm:clientToken>", "").replace("</drm:clientToken>", "")
 
-print "Using SignIn to log in via username and password."
-login_request = """<signInRequest method="standard" xmlns="http://ns.adobe.com/adept">
-<username>%s</username>
-<password>%s</password>
-</signInRequest>""" % (username, password)
-url = base_url + "/AdobeAuth/SignIn"
-response = requests.post(url, data=login_request)
-print url
-print login_request
-print "=>"
-print response.content
-print
+    m = CLIENT_TOKEN_RE.match(token)
 
-m = re.compile("<user>([^<]+)</user>").search(response.content)
-if m:
-    print "Adobe ID for this patron is %s" % m.groups()[0]
-else:
-    print "Sorry, I couldn't turn this Short Client Token into an Adobe ID."
+    if not m:
+        raise InvalidTokenException(f"Invalid token: {token}")
+    else:
+        return m.groups()   # Tuple of library, timestamp, patron_id, signature_hash
+
+
+@click.command()
+@click.argument('token')
+@click.option('--registry-url', default=DEFAULT_REGISTRY_URL, metavar='<URL>',
+              help="URL of the library registry you're testing against")
+def main(token, registry_url):
+    """
+    Retrieve an Adobe ID from a Short Client Token.
+
+    This script doesn't import any code from circulation or core. It
+    tests an integration based on HTTP via the requests package.
+
+    A short token is a four part, pipe-separated string which follows this pattern:
+
+      \b
+      <library-code>|<epoch-timestamp>|<patron-id>|<signature-hash>
+
+    Example:
+
+      \b
+      NYNYPL|1621462513|3e0d6602-2446-4f1a-bcad-4e68bcffdfc1|xzu4JDv93sjAEzx1sSIxyWrXn;zXD62;vsR:LT1y8M0@
+    """
+    try:
+        (library, timestamp, patron_id, signature_hash) = decompose_token(token)
+    except InvalidTokenException as exc:
+        click.echo(str(exc))
+        sys.exit(1)
+
+    click.echo("\nThe supplied Short Client Token was well formed, and decomposes to:\n")
+    click.echo(f"  Library code:      {library}")
+    click.echo(f"  Timestamp:         {timestamp}")
+    click.echo(f"  Patron identifier: {patron_id}")
+    click.echo(f"  Signature:         {signature_hash}\n")
+
+    if registry_url.endswith("/"):
+        registry_url = registry_url[:-1]
+
+    signin_url = registry_url + "/AdobeAuth/SignIn"
+
+    username = "|".join([library, timestamp, patron_id])
+
+    signin_payload_lines = [
+        '<signInRequest method="standard" xmlns="http://ns.adobe.com/adept">',
+        f"    <username>{username}</username>",
+        f"    <password>{signature_hash}</password>",
+        "</signInRequest>",
+    ]
+
+    click.echo(f"\nRequesting {signin_url} with payload:\n")
+
+    for line in signin_payload_lines:
+        click.echo(f"    {line}")
+
+    response = requests.post(signin_url, data="".join(signin_payload_lines))
+
+    click.echo("\nRegistry server responded with:\n")
+    for line in response.content.decode('utf8').split("\n"):
+        click.echo(f"    {line}")
+    click.echo()
+
+    user_id_match = REGISTRY_RESPONSE_RE.search(response.content.decode('utf8'))
+    if user_id_match:
+        click.echo(click.style("SUCCESS ", fg="green", bold=True), nl=False)
+        click.echo(f"Adobe ID for this patron is {user_id_match.group('user_id')}", nl=False)
+        click.echo(click.style(" SUCCESS", fg="green", bold=True))
+    else:
+        click.echo(click.style("ERROR ", fg="red", bold=True), nl=False)
+        click.echo("Supplied token could not be turned into an Adobe ID", nl=False)
+        click.echo(click.style(" ERROR", fg="red", bold=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/informational/axis-raw-bibliographic
+++ b/bin/informational/axis-raw-bibliographic
@@ -1,30 +1,26 @@
-#!/usr/bin/env python
-import json
+#!/usr/bin/env python3
 import os
 import sys
 from xml.dom import minidom
+
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 
-from core.model import (
-    Collection,
-    ExternalIntegration,
-)
-from core.scripts import IdentifierInputScript
-from api.axis import Axis360API
+from api.axis import Axis360API                             # noqa: E402
+from core.model import (Collection, ExternalIntegration)    # noqa: E402
+from core.scripts import IdentifierInputScript              # noqa: E402
+
 
 class Axis360RawBibliographicScript(IdentifierInputScript):
     def run(self):
-        for collection in Collection.by_protocol(
-                self._db, ExternalIntegration.AXIS_360
-        ):
+        for collection in Collection.by_protocol(self._db, ExternalIntegration.AXIS_360):
             api = Axis360API(self._db, collection)
             args = self.parse_command_line(self._db)
             for identifier in args.identifiers:
                 response = api.availability(title_ids=[identifier.identifier])
                 xml = minidom.parseString(response.content)
-                print xml.toprettyxml()
-                print
+                print(xml.toprettyxml(), "\n")
+
 
 Axis360RawBibliographicScript().run()

--- a/bin/informational/bibliotheca-raw-bibliographic
+++ b/bin/informational/bibliotheca-raw-bibliographic
@@ -1,30 +1,26 @@
-#!/usr/bin/env python
-import json
+#!/usr/bin/env python3
 import os
 import sys
 from xml.dom import minidom
+
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 
-from core.model import (
-    Collection,
-    ExternalIntegration,
-)
-from core.scripts import IdentifierInputScript
-from api.bibliotheca import BibliothecaAPI
+from api.bibliotheca import BibliothecaAPI                  # noqa: E402
+from core.model import (Collection, ExternalIntegration)    # noqa: E402
+from core.scripts import IdentifierInputScript              # noqa: E402
+
 
 class BibliothecaRawBibliographicScript(IdentifierInputScript):
     def run(self):
         args = self.parse_command_line(self._db)
-        for collection in Collection.by_protocol(
-            self._db, ExternalIntegration.BIBLIOTHECA
-        ):
+        for collection in Collection.by_protocol(self._db, ExternalIntegration.BIBLIOTHECA):
             api = BibliothecaAPI(self._db, collection)
             for identifier in args.identifiers:
                 data = api.bibliographic_lookup_request([identifier.identifier])
                 xml = minidom.parseString(data)
-                print xml.toprettyxml()
-                print
+                print(xml.toprettyxml(), "\n")
+
 
 BibliothecaRawBibliographicScript().run()

--- a/bin/informational/bibliotheca-raw-patron-status
+++ b/bin/informational/bibliotheca-raw-patron-status
@@ -1,33 +1,27 @@
-#!/usr/bin/env python
-import json
+#!/usr/bin/env python3
 import os
 import sys
 from xml.dom import minidom
+
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 
-from core.model import (
-    Collection,
-    ExternalIntegration,
-    Patron,
-)
-from core.scripts import Script
-from api.bibliotheca import BibliothecaAPI
+from api.bibliotheca import BibliothecaAPI                          # noqa: E402
+from core.model import (Collection, ExternalIntegration, Patron)    # noqa: E402
+from core.scripts import Script                                     # noqa: E402
+
 
 class BibliothecaRawPatronStatusScript(Script):
     def run(self):
         for patron_identifier in sys.argv[1:]:
-            patron = self._db.query(Patron).filter(
-                Patron.authorization_identifier==patron_identifier
-            ).one()
-            for collection in Collection.by_protocol(
-                    self._db, ExternalIntegration.BIBLIOTHECA
-            ):
+            patron = self._db.query(Patron).filter(Patron.authorization_identifier == patron_identifier).one()
+
+            for collection in Collection.by_protocol(self._db, ExternalIntegration.BIBLIOTHECA):
                 api = BibliothecaAPI(self._db, collection)
                 response = api._patron_activity_request(patron)
                 xml = minidom.parseString(response.content)
-                print xml.toprettyxml()
-                print
+                print(xml.toprettyxml(), "\n")
+
 
 BibliothecaRawPatronStatusScript().run()

--- a/bin/informational/disappearing_books
+++ b/bin/informational/disappearing_books
@@ -1,9 +1,12 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 import os
 import sys
+
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 
-from scripts import DisappearingBookReportScript
+from scripts import DisappearingBookReportScript    # noqa: E402
+
 DisappearingBookReportScript().run()

--- a/bin/informational/explain
+++ b/bin/informational/explain
@@ -1,11 +1,12 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Explain what the system knows about a book."""
 import os
 import sys
+
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
-from core.scripts import (
-     Explain
-)
+
+from core.scripts import Explain   # noqa: E402
+
 Explain().run()

--- a/bin/informational/language_list
+++ b/bin/informational/language_list
@@ -1,11 +1,12 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """List languages in the collection sorted by number of non-open access works."""
 import os
 import sys
+
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
-from scripts import (
-     LanguageListScript
-)
+
+from scripts import LanguageListScript       # noqa: E402
+
 LanguageListScript().run()

--- a/bin/informational/list_collection_metadata_identifiers
+++ b/bin/informational/list_collection_metadata_identifiers
@@ -1,10 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
+
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 
-from core.scripts import ListCollectionMetadataIdentifiersScript
+from core.scripts import ListCollectionMetadataIdentifiersScript    # noqa: E402
 
 ListCollectionMetadataIdentifiersScript().run()

--- a/bin/informational/overdrive-advantage-list
+++ b/bin/informational/overdrive-advantage-list
@@ -1,9 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
+
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 
-from api.overdrive import OverdriveAdvantageAccountListScript
+from api.overdrive import OverdriveAdvantageAccountListScript   # noqa: E402
+
 OverdriveAdvantageAccountListScript().run()

--- a/bin/informational/overdrive-raw-bibliographic
+++ b/bin/informational/overdrive-raw-bibliographic
@@ -1,29 +1,25 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 import os
 import sys
+
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 
-from core.model import (
-    Collection,
-    ExternalIntegration,
-)
-from core.scripts import IdentifierInputScript
-from api.overdrive import OverdriveAPI
+from api.overdrive import OverdriveAPI                      # noqa: E402
+from core.model import (Collection, ExternalIntegration)    # noqa: E402
+from core.scripts import IdentifierInputScript              # noqa: E402
+
 
 class OverdriveRawBibliographicScript(IdentifierInputScript):
     def run(self):
         args = self.parse_command_line(self._db)
-        for collection in Collection.by_protocol(
-            self._db, ExternalIntegration.OVERDRIVE
-        ):
+        for collection in Collection.by_protocol(self._db, ExternalIntegration.OVERDRIVE):
             overdrive = OverdriveAPI(self._db, collection)
             for identifier in args.identifiers:
                 data = overdrive.metadata_lookup(identifier)
-                print json.dumps(data, sort_keys=True, indent=4,
-                                 separators=(',', ': '))
-                print
+                print(json.dumps(data, sort_keys=True, indent=4, separators=(',', ': ')), "\n")
+
 
 OverdriveRawBibliographicScript().run()

--- a/bin/informational/overdrive-raw-circulation
+++ b/bin/informational/overdrive-raw-circulation
@@ -1,33 +1,26 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 import os
 import sys
+
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 
-from core.scripts import IdentifierInputScript
-from core.model import (
-    Collection,
-    ExternalIntegration,
-)
-from api.overdrive import OverdriveAPI
+from api.overdrive import OverdriveAPI                      # noqa: E402
+from core.scripts import IdentifierInputScript              # noqa: E402
+from core.model import (Collection, ExternalIntegration)    # noqa: E402
+
 
 class OverdriveRawCirculationScript(IdentifierInputScript):
     def run(self):
         args = self.parse_command_line(self._db)
-        for collection in Collection.by_protocol(
-
-            self._db, ExternalIntegration.OVERDRIVE
-        ):
+        for collection in Collection.by_protocol(self._db, ExternalIntegration.OVERDRIVE):
             overdrive = OverdriveAPI(self._db, collection)
             for identifier in args.identifiers:
-                book_id, (status_code, headers, content) = overdrive.circulation_lookup(
-                    identifier.identifier
-                )
+                (_, _, _, content) = overdrive.circulation_lookup(identifier.identifier)
                 data = json.loads(content)
-                print json.dumps(data, sort_keys=True, indent=4,
-                                 separators=(',', ': '))
-                print
+                print(json.dumps(data, sort_keys=True, indent=4, separators=(',', ': ')), "\n")
+
 
 OverdriveRawCirculationScript().run()

--- a/bin/informational/patron_information
+++ b/bin/informational/patron_information
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
-"""Find information about a particular patron based on barcode and pin.
-"""
+#!/usr/bin/env python3
+"""Find information about a particular patron based on barcode and pin."""
 
 import os
 import sys
@@ -9,9 +8,9 @@ bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
 
-from core.scripts import LibraryInputScript
-from core.model import Library
-from api.authenticator import LibraryAuthenticator, PatronData
+from api.authenticator import LibraryAuthenticator, PatronData  # noqa: E402
+from core.scripts import LibraryInputScript                     # noqa: E402
+
 
 class PatronInformationScript(LibraryInputScript):
     @classmethod
@@ -58,5 +57,6 @@ class PatronInformationScript(LibraryInputScript):
             return "- None -"
         else:
             return data
+
 
 PatronInformationScript().run()

--- a/bin/informational/run-self-tests
+++ b/bin/informational/run-self-tests
@@ -1,11 +1,12 @@
-#!/usr/bin/env python
-"""Run self tests on every one of a library's integrations that supports
-self-tests.
-"""
+#!/usr/bin/env python3
+"""Run self tests on every one of a library's integrations that supports self-tests."""
 import os
 import sys
+
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
-from api.selftest import RunSelfTestsScript
+
+from api.selftest import RunSelfTestsScript     # noqa: E402
+
 RunSelfTestsScript().run()

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -3,7 +3,7 @@ backports.functools-lru-cache==1.6.1
 backports.ssl-match-hostname==3.7.0.1
 beautifulsoup4==4.9.1
 cffi==1.14.3
-click==8.0.1
+click==7.1.2
 contextlib2==0.6.0.post1
 cryptography==3.3.2
 # defusedxml is required for SAML authentication

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -3,6 +3,7 @@ backports.functools-lru-cache==1.6.1
 backports.ssl-match-hostname==3.7.0.1
 beautifulsoup4==4.9.1
 cffi==1.14.3
+click==8.0.1
 contextlib2==0.6.0.post1
 cryptography==3.3.2
 # defusedxml is required for SAML authentication


### PR DESCRIPTION
## Description

Two things:

* Updates the scripts in `bin/informational` to be Python3  compatible, and use `python3` in their `#!` line
* Changes the `adobe-id-for-short-client` script to be `click` based and accept a `--registry-url` CLI option

## Motivation and Context

Part of the Py3 QA process.

## How Has This Been Tested?

I've only actually tested the `adobe-id-for-short-client` script, and that was done manually. However the other changes I made were almost entirely formatting related, so shouldn't impact script functionality.

## Checklist:

- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
