### PR TITLE
Switching db task from auto to ignore

### DIFF
--- a/docker/Dockerfile.exec
+++ b/docker/Dockerfile.exec
@@ -19,7 +19,7 @@ COPY --from=builder /go/bin/lcpencrypt /go/bin/lcpencrypt
 ARG version
 ARG repo="NYPL-Simplified/circulation"
 
-ENV SIMPLIFIED_DB_TASK "auto"
+ENV SIMPLIFIED_DB_TASK "ignore"
 ENV SIMPLIFIED_SCRIPT_NAME ""
 
 # Copy over all Library Simplified build files for this image

--- a/docker/Dockerfile.webapp
+++ b/docker/Dockerfile.webapp
@@ -4,7 +4,7 @@ LABEL maintainer="Library Simplified <info@librarysimplified.org>"
 ARG version
 ARG repo="NYPL-Simplified/circulation"
 
-ENV SIMPLIFIED_DB_TASK "auto"
+ENV SIMPLIFIED_DB_TASK "ignore"
 
 # Copy over all Library Simplified build files for this image
 COPY . /ls_build


### PR DESCRIPTION
## Description

Sets the env var `SIMPLIFIED_DB_TASK` to `ignore` in both the webapp and exec dockerfiles, to keep those instances from running database migrations, which should only be run by the script runner.

## Motivation and Context

Should resolve https://jira.nypl.org/browse/SIMPLY-3745, once a new image is built and pushed.
