### PR TITLE
Change sample_data to return a bytestrings by default, to flush out discrepancies between mocked and real APIs

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -1136,6 +1136,10 @@ class DateResponseParser(BibliothecaParser):
 
     def process_all(self, string):
         parser = etree.XMLParser()
+        # If the data is an HTTP response, it is a bytestring and
+        # must be converted before it is parsed.
+        if isinstance(string, bytes):
+            string = string.decode("utf-8")
         root = etree.parse(StringIO(string), parser)
         m = root.xpath("/%s/%s" % (self.RESULT_TAG_NAME, self.DATE_TAG_NAME))
         if not m:

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -433,6 +433,8 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
 
     def _extract_text_nodes(self, content):
         """Parse the HTML representations sent by the Millenium Patron API."""
+        if isinstance(content, bytes):
+            content = content.decode("utf8")
         for line in content.split("\n"):
             if line.startswith('<HTML><BODY>'):
                 line = line[12:]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 
-def sample_data(filename, sample_data_dir, mode="r"):
+def sample_data(filename, sample_data_dir, mode="rb"):
     base_path = os.path.split(__file__)[0]
     resource_path = os.path.join(base_path, "files", sample_data_dir)
     path = os.path.join(resource_path, filename)

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -336,7 +336,7 @@ class TestAxis360API(Axis360Test):
         # Modify the data so that it appears to be talking about the
         # book we just created.
         new_identifier = pool.identifier.identifier
-        data = data.replace("0012533119", new_identifier)
+        data = data.replace(b"0012533119", new_identifier.encode("utf8"))
 
         self.api.queue_response(200, content=data)
 
@@ -408,7 +408,7 @@ class TestAxis360API(Axis360Test):
         # If we ask for AxisNow format, we get an Axis360FulfillmentInfo
         # containing an AxisNow manifest document.
         data = self.sample_data("availability_with_axisnow_fulfillment.xml")
-        data = data.replace("0016820953", pool.identifier.identifier)
+        data = data.replace(b"0016820953", pool.identifier.identifier.encode("utf8"))
         self.api.queue_response(200, content=data)
         fulfillment = fulfill("AxisNow")
         assert isinstance(fulfillment, Axis360FulfillmentInfo)
@@ -523,7 +523,7 @@ class TestAxis360API(Axis360Test):
         data = self.sample_data("availability_with_loans.xml")
         # Modify the sample data so that it appears to be talking
         # about one of the books we're going to request.
-        data = data.replace("0012533119", id1.identifier)
+        data = data.replace(b"0012533119", id1.identifier.encode("utf8"))
         self.api.queue_response(200, {}, data)
         results = [x for x in self.api._fetch_remote_availability([id1, id2])]
 
@@ -992,13 +992,13 @@ class TestParsers(Axis360Test):
         # Although the audiobook is also available in the "AxisNow"
         # format, no second delivery mechanism was created for it, the
         # way it would have been for an ebook.
-        assert '<formatName>AxisNow</formatName>' in data
+        assert b'<formatName>AxisNow</formatName>' in data
 
     def test_bibliographic_parser_blio_format(self):
         # This book is available as 'Blio' but not 'AxisNow'.
         data = self.sample_data("availability_with_audiobook_fulfillment.xml")
-        data = data.replace('Acoustik', 'Blio')
-        data = data.replace('AxisNow', 'No Such Format')
+        data = data.replace(b'Acoustik', b'Blio')
+        data = data.replace(b'AxisNow', b'No Such Format')
 
         [[bib, av]] = BibliographicParser(False, True).process_all(data)
 
@@ -1011,7 +1011,7 @@ class TestParsers(Axis360Test):
     def test_bibliographic_parser_blio_and_axisnow_format(self):
         # This book is available as both 'Blio' and 'AxisNow'.
         data = self.sample_data("availability_with_audiobook_fulfillment.xml")
-        data = data.replace('Acoustik', 'Blio')
+        data = data.replace(b'Acoustik', b'Blio')
 
         [[bib, av]] = BibliographicParser(False, True).process_all(data)
 
@@ -1023,8 +1023,8 @@ class TestParsers(Axis360Test):
 
     def test_bibliographic_parser_unsupported_format(self):
         data = self.sample_data("availability_with_audiobook_fulfillment.xml")
-        data = data.replace('Acoustik', 'No Such Format 1')
-        data = data.replace('AxisNow', 'No Such Format 2')
+        data = data.replace(b'Acoustik', b'No Such Format 1')
+        data = data.replace(b'AxisNow', b'No Such Format 2')
 
         [[bib, av]] = BibliographicParser(False, True).process_all(data)
 

--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -353,7 +353,7 @@ class TestBibliothecaAPI(BibliothecaAPITest):
         data = self.sample_data("item_metadata_single.xml")
         # Change the ID in the test data so it looks like it's talking
         # about the LicensePool we just created.
-        data = data.replace("ddf4gr9", pool.identifier.identifier)
+        data = data.replace(b"ddf4gr9", pool.identifier.identifier.encode("utf8"))
 
         # Update availability using that data.
         self.api.queue_response(200, content=data)
@@ -1276,7 +1276,7 @@ class TestBibliothecaPurchaseMonitor(BibliothecaAPITest):
 
         # Now, try the two real cases.
         [ehasb89, oock89] = parse_xml_to_array(
-            StringIO(self.sample_data("marc_records_two.xml"))
+            StringIO(self.sample_data("marc_records_two.xml").decode("utf8"))
         )
 
         # If the book is new to this collection, it's run through

--- a/tests/test_metadata_wrangler.py
+++ b/tests/test_metadata_wrangler.py
@@ -223,13 +223,13 @@ class TestMWCollectionUpdateMonitor(MonitorTest):
         self.lookup.queue_response(
             200, {'content-type' : OPDSFeed.ACQUISITION_FEED_TYPE}, data
         )
-        data = data.replace("http://next-link/", "http://different-link/")
+        data = data.replace(b"http://next-link/", b"http://different-link/")
         self.lookup.queue_response(
             200, {'content-type' : OPDSFeed.ACQUISITION_FEED_TYPE}, data
         )
 
         # This introduces a loop.
-        data = data.replace("http://next-link/", "http://next-link/")
+        data = data.replace(b"http://next-link/", b"http://next-link/")
         self.lookup.queue_response(
             200, {'content-type' : OPDSFeed.ACQUISITION_FEED_TYPE}, data
         )

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -30,7 +30,7 @@ class MockAPI(MilleniumPatronAPI):
         self.requests_made = []
 
     def sample_data(self, filename):
-        return sample_data(filename, 'millenium_patron').encode("utf8")
+        return sample_data(filename, 'millenium_patron')
 
     def enqueue(self, filename):
         data = self.sample_data(filename)

--- a/tests/test_onix.py
+++ b/tests/test_onix.py
@@ -17,7 +17,7 @@ from . import sample_data
 class TestONIXExtractor(object):
 
     def sample_data(self, filename):
-        return sample_data(filename, "onix").encode("utf-8")
+        return sample_data(filename, "onix")
 
     def test_parser(self):
         """Parse an ONIX file into Metadata objects."""


### PR DESCRIPTION
## Description

This branch changes the `sample_data` test function to return a bytestring by default. This makes tests of mocked APIs more like tests of the real APIs, since the content of an HTTP response is always a bytestring.

The problems I saw were limited to APIs that serve HTML-like markup (Millenium Patron and Bibliotheca). This is because JSON-like markup from APIs always gets run through `json.loads`, which always returns Unicode.

## Motivation and Context

This came out of our Python 3 QA process. The Millenium Patron API bug was found on the QA server; the Bibliotheca bug was found as a result of changing the test code.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
