### PR TITLE
Convert the decrypted shared secret to Unicode before storing it in the database

### DIFF
--- a/api/registry.py
+++ b/api/registry.py
@@ -478,8 +478,8 @@ class Registration(object):
         
         :param shared_secret: A byte string.
 
-        :return: The decrypted shared secret, or a ProblemDetail if
-        it could not be decrypted.
+        :return: The decrypted shared secret, as a bytestring, or
+        a ProblemDetail if it could not be decrypted.
         """
         try:
             shared_secret = cipher.decrypt(base64.b64decode(shared_secret))
@@ -529,7 +529,13 @@ class Registration(object):
                 return shared_secret
 
             setting = self.setting(ExternalIntegration.PASSWORD)
-            setting.value = shared_secret
+
+            # NOTE: we can only store Unicode data in the
+            # ConfigurationSetting.value, so this requires that the
+            # shared secret encoded as UTF-8. This works for the
+            # library registry product, which uses a long string of
+            # hex digits as its shared secret.
+            setting.value = shared_secret.decode("utf8")
 
         # We have successfully completed the registration.
         self.status_field.value = self.SUCCESS_STATUS


### PR DESCRIPTION
## Description

This branch fixes bugs found during in-person testing of qa-circulation.librarysimplified.org using the SimplyE mobile app. The corresponding core PR  is [#1262](https://github.com/NYPL-Simplified/server_core/pull/1262).

## Motivation and Context

* The shared secret between circulation manager and library registry is decrypted as a bytestring, but it's stored in ConfigurationSettings.value, which takes a Unicode string. I fixed this here, and fixed the general problem in core. 

Encryption/decryption is an area I hadn't considered as a source of bytes/Unicode confusion, so I searched through the code for other places we use the `Crypto` library or the `cipher` wrapper class. There are a couple such places but I didn't see any other errors of this type.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
