### PR TITLE
Fixed mock tests for the Firstbook API(s) to be more realistic.

### DIFF
--- a/api/firstbook.py
+++ b/api/firstbook.py
@@ -94,12 +94,13 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
                 str(e),
                 self.NAME
             )
+        content = response.content.decode("utf8")
         if response.status_code != 200:
             msg = "Got unexpected response code %d. Content: %s" % (
-                response.status_code, response.content
+                response.status_code, content
             )
             raise RemoteInitiatedServerError(msg, self.NAME)
-        if self.SUCCESS_MESSAGE in response.content:
+        if self.SUCCESS_MESSAGE in content:
             return True
         return False
 
@@ -115,6 +116,10 @@ class MockFirstBookResponse(object):
 
     def __init__(self, status_code, content):
         self.status_code = status_code
+        # Guarantee that the response content is always a bytestring,
+        # as it would be in real life.
+        if isinstance(content, str):
+            content = content.encode("utf8")
         self.content = content
 
 class MockFirstBookAuthenticationAPI(FirstBookAuthenticationAPI):

--- a/api/firstbook2.py
+++ b/api/firstbook2.py
@@ -100,12 +100,13 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
                 str(e),
                 self.NAME
             )
+        content = response.content.decode("utf8")
         if response.status_code != 200:
             msg = "Got unexpected response code %d. Content: %s" % (
-                response.status_code, response.content
+                response.status_code, content
             )
             raise RemoteInitiatedServerError(msg, self.NAME)
-        if self.SUCCESS_MESSAGE in response.content:
+        if self.SUCCESS_MESSAGE in content:
             return True
         return False
 
@@ -133,6 +134,10 @@ class MockFirstBookResponse(object):
 
     def __init__(self, status_code, content):
         self.status_code = status_code
+        # Guarantee that the response content is always a bytestring,
+        # as it would be in real life.
+        if isinstance(content, str):
+            content = content.encode("utf8")
         self.content = content
 
 class MockFirstBookAuthenticationAPI(FirstBookAuthenticationAPI):


### PR DESCRIPTION
## Description

This branch fixes the mock FirstBook APIs so `response.content` is always a bytestring, as it would be in real life. Two points in the code assumed that `response.content` would be a Unicode string; I fixed those points after fixing the mock and verifying it caused the existing tests to fail.

I changed both firstbook2.py and firstbook.py, even though firstbook.py is no longer used.