### PR TITLE
Port the SIP2 client to Python 3

### DIFF
--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -22,7 +22,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
     LOCATION_CODE = "location code"
     FIELD_SEPARATOR = "field separator"
     ENCODING = "encoding"
-    DEFAULT_ENCODING = "cp850"
+    DEFAULT_ENCODING = SIPClient.DEFAULT_ENCODING
     USE_SSL = "use_ssl"
     SSL_CERTIFICATE = "ssl_certificate"
     SSL_KEY = "ssl_key"

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -845,10 +845,10 @@ class MockSIPClient(SIPClient):
     """
 
     def __init__(self, login_user_id=None, login_password=None, separator="|",
-                 target_server=None, target_port=None, location_code=None, institution_id=''):
+                 target_server=None, target_port=None, location_code=None, institution_id='', encoding='cp850'):
         super(MockSIPClient, self).__init__(
             None, None, login_user_id=login_user_id,
-            login_password=login_password, separator=separator, institution_id=institution_id
+            login_password=login_password, separator=separator, institution_id=institution_id, encoding=encoding
         )
 
         self.read_count = 0
@@ -861,7 +861,7 @@ class MockSIPClient(SIPClient):
         if isinstance(response, str):
             # Make sure responses come in as bytestrings, as they would
             # in real life.
-            response = response.encode("utf8")
+            response = response.encode("cp850")
         self.responses.append(response)
 
     def connect(self):

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -884,3 +884,20 @@ class MockSIPClient(SIPClient):
 
     def disconnect(self):
         pass
+
+
+class MockSIPClientFactory(object):
+    """Pass this into SIP2AuthenticationProvider to instantiate a
+    MockSIPClient based on its configuration, _and_ to use that
+    MockSIPClient every single time; normally
+    SIP2AuthenticationProvider will instantiate a different client for
+    every simulated server interaction, making it impossible to queue
+    responses or look at the results.
+    """
+    def __init__(self):
+        self.client = None
+
+    def __call__(self, **kwargs):
+        if self.client is None:
+            self.client = MockSIPClient(**kwargs)
+        return self.client

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -180,6 +180,12 @@ class Constants(object):
     UNKNOWN_LANGUAGE = "000"
     ENGLISH = "001"
 
+    # By default, SIP2 messages are encoded using Code Page 850.
+    DEFAULT_ENCODING = 'cp850'
+
+    # SIP2 messages are terminated with the \r character.
+    TERMINATOR_CHAR = '\r'
+
 
 class SIPClient(Constants):
 
@@ -240,7 +246,8 @@ class SIPClient(Constants):
 
     def __init__(self, target_server, target_port, login_user_id=None,
                  login_password=None, location_code=None, institution_id='', separator=None,
-                 use_ssl=False, ssl_cert=None, ssl_key=None, encoding='cp850', dialect=GenericILS
+                 use_ssl=False, ssl_cert=None, ssl_key=None,
+                 encoding=Constants.DEFAULT_ENCODING, dialect=GenericILS
     ):
         """Initialize a client for (but do not connect to) a SIP2 server.
 
@@ -769,7 +776,7 @@ class SIPClient(Constants):
 
     def send(self, data):
         """Send a message over the socket and update the sequence index."""
-        data = data + '\r'
+        data = data + self.TERMINATOR_CHAR
         return self.do_send(data.encode(self.encoding))
 
     def do_send(self, data):
@@ -861,7 +868,7 @@ class MockSIPClient(SIPClient):
         if isinstance(response, str):
             # Make sure responses come in as bytestrings, as they would
             # in real life.
-            response = response.encode("cp850")
+            response = response.encode(Constants.DEFAULT_ENCODING)
         self.responses.append(response)
 
     def connect(self):

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -844,12 +844,12 @@ class MockSIPClient(SIPClient):
     connection.
     """
 
-    def __init__(self, login_user_id=None, login_password=None, separator="|",
-                 target_server=None, target_port=None, location_code=None, institution_id='', encoding='cp850'):
-        super(MockSIPClient, self).__init__(
-            None, None, login_user_id=login_user_id,
-            login_password=login_password, separator=separator, institution_id=institution_id, encoding=encoding
-        )
+    def __init__(self, **kwargs):
+        # Override any settings that might cause us to actually
+        # make requests.
+        kwargs['target_server'] = None
+        kwargs['target_port'] = None
+        super(MockSIPClient, self).__init__(**kwargs)
 
         self.read_count = 0
         self.write_count = 0

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -785,13 +785,13 @@ class SIPClient(Constants):
         A SIP2 message ends with a \\r character.
         """
         done = False
-        data = ""
+        data = b""
         while not done:
             tmp = self.connection.recv(4096)
             data = data + tmp
             if not tmp:
                 raise IOError("No data read from socket.")
-            if ord(data[-1]) == 13 or ord(data[-1]) == 10:
+            if data[-1] == 13 or data[-1] == 10:
                 done = True
             if len(data) > max_size:
                 raise IOError("SIP2 response too large.")

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -17,7 +17,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
     # starting point the actual (albeit redacted) SIP2 messages we
     # receive from servers.
 
-    sierra_valid_login = b"64              000201610210000142637000000000000000000000000AOnypl |AA12345|AESHELDON, ALICE|BZ0030|CA0050|CB0050|BLY|CQY|BV0|CC15.00|BEfoo@example.com|AY1AZD1B7"
+    sierra_valid_login = "64              000201610210000142637000000000000000000000000AOnypl |AA12345|AELE CARRÉ, JOHN|BZ0030|CA0050|CB0050|BLY|CQY|BV0|CC15.00|BEfoo@example.com|AY1AZD1B7".encode("cp850")
     sierra_excessive_fines = b"64              000201610210000142637000000000000000000000000AOnypl |AA12345|AESHELDON, ALICE|BZ0030|CA0050|CB0050|BLY|CQY|BV20.00|CC15.00|BEfoo@example.com|AY1AZD1B7"
     sierra_invalid_login = b"64Y  YYYYYYYYYYY000201610210000142725000000000000000000000000AOnypl |AA12345|AESHELDON, ALICE|BZ0030|CA0050|CB0050|BLY|CQN|BV0|CC15.00|BEfoo@example.com|AFInvalid PIN entered.  Please try again or see a staff member for assistance.|AFThere are unresolved issues with your account.  Please see a staff member for assistance.|AY1AZ91A8"
 
@@ -80,7 +80,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         patrondata = auth.remote_authenticate("user", "pass")
         assert "12345" == patrondata.authorization_identifier
         assert "foo@example.com" == patrondata.email_address
-        assert "SHELDON, ALICE" == patrondata.personal_name
+        assert "LE CARRÉ, JOHN" == patrondata.personal_name
         assert 0 == patrondata.fines
         assert None == patrondata.authorization_expires
         assert None == patrondata.external_type
@@ -298,7 +298,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         assert patron.__class__ == PatronData
         assert "12345" == patron.authorization_identifier
         assert "foo@example.com" == patron.email_address
-        assert "SHELDON, ALICE" == patron.personal_name
+        assert "LE CARRÉ, JOHN" == patron.personal_name
         assert 0 == patron.fines
         assert None == patron.authorization_expires
         assert None == patron.external_type
@@ -323,7 +323,7 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         assert patron.__class__ == PatronData
         assert "12345" == patron.authorization_identifier
         assert "foo@example.com" == patron.email_address
-        assert "SHELDON, ALICE" == patron.personal_name
+        assert "LE CARRÉ, JOHN" == patron.personal_name
         assert 0 == patron.fines
         assert None == patron.authorization_expires
         assert None == patron.external_type

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -251,6 +251,10 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         client.queue_response(self.sierra_valid_login_utf8)
         client.queue_response(self.end_session_response)
         patrondata = auth.remote_authenticate("user", "pass")
+
+        # We're able to parse the message from the server and parse
+        # out patron data, including the É character, with the proper
+        # encoding.
         assert "12345" == patrondata.authorization_identifier
         assert "foo@example.com" == patrondata.email_address
         assert "LE CARRÉ, JOHN" == patrondata.personal_name

--- a/tests/sip/test_authentication_provider.py
+++ b/tests/sip/test_authentication_provider.py
@@ -17,30 +17,30 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
     # starting point the actual (albeit redacted) SIP2 messages we
     # receive from servers.
 
-    sierra_valid_login = "64              000201610210000142637000000000000000000000000AOnypl |AA12345|AESHELDON, ALICE|BZ0030|CA0050|CB0050|BLY|CQY|BV0|CC15.00|BEfoo@example.com|AY1AZD1B7"
-    sierra_excessive_fines = "64              000201610210000142637000000000000000000000000AOnypl |AA12345|AESHELDON, ALICE|BZ0030|CA0050|CB0050|BLY|CQY|BV20.00|CC15.00|BEfoo@example.com|AY1AZD1B7"
-    sierra_invalid_login = "64Y  YYYYYYYYYYY000201610210000142725000000000000000000000000AOnypl |AA12345|AESHELDON, ALICE|BZ0030|CA0050|CB0050|BLY|CQN|BV0|CC15.00|BEfoo@example.com|AFInvalid PIN entered.  Please try again or see a staff member for assistance.|AFThere are unresolved issues with your account.  Please see a staff member for assistance.|AY1AZ91A8"
+    sierra_valid_login = b"64              000201610210000142637000000000000000000000000AOnypl |AA12345|AESHELDON, ALICE|BZ0030|CA0050|CB0050|BLY|CQY|BV0|CC15.00|BEfoo@example.com|AY1AZD1B7"
+    sierra_excessive_fines = b"64              000201610210000142637000000000000000000000000AOnypl |AA12345|AESHELDON, ALICE|BZ0030|CA0050|CB0050|BLY|CQY|BV20.00|CC15.00|BEfoo@example.com|AY1AZD1B7"
+    sierra_invalid_login = b"64Y  YYYYYYYYYYY000201610210000142725000000000000000000000000AOnypl |AA12345|AESHELDON, ALICE|BZ0030|CA0050|CB0050|BLY|CQN|BV0|CC15.00|BEfoo@example.com|AFInvalid PIN entered.  Please try again or see a staff member for assistance.|AFThere are unresolved issues with your account.  Please see a staff member for assistance.|AY1AZ91A8"
 
-    evergreen_active_user = "64  Y           00020161021    142851000000000000000000000000AA12345|AEBooth Active Test|BHUSD|BDAdult Circ Desk 1 Newtown, CT USA 06470|AQNEWTWN|BLY|PA20191004|PCAdult|PIAllowed|XI863715|AOBiblioTest|AY2AZ0000"
-    evergreen_expired_card = "64YYYY          00020161021    142937000000000000000000000000AA12345|AEBooth Expired Test|BHUSD|BDAdult Circ Desk #2 Newtown, CT USA 06470|AQNEWTWN|BLY|PA20080907|PCAdult|PIAllowed|XI863716|AFblocked|AOBiblioTest|AY2AZ0000"
-    evergreen_excessive_fines = "64  Y           00020161021    143002000000000000000100000000AA12345|AEBooth Excessive Fines Test|BHUSD|BV100.00|BDChildrens Circ Desk 1 Newtown, CT USA 06470|AQNEWTWN|BLY|PA20191004|PCAdult|PIAllowed|XI863718|AOBiblioTest|AY2AZ0000"
-    evergreen_hold_privileges_denied = "64   Y          00020161021    143002000000000000000100000000AA12345|AEBooth Excessive Fines Test|BHUSD|BV100.00|BDChildrens Circ Desk 1 Newtown, CT USA 06470|AQNEWTWN|BLY|PA20191004|PCAdult|PIAllowed|XI863718|AOBiblioTest|AY2AZ0000"
-    evergreen_card_reported_lost = "64    Y        00020161021    143002000000000000000100000000AA12345|AEBooth Excessive Fines Test|BHUSD|BV100.00|BDChildrens Circ Desk 1 Newtown, CT USA 06470|AQNEWTWN|BLY|PA20191004|PCAdult|PIAllowed|XI863718|AOBiblioTest|AY2AZ0000"
-    evergreen_inactive_account = "64YYYY          00020161021    143028000000000000000000000000AE|AA12345|BLN|AOBiblioTest|AY2AZ0000"
+    evergreen_active_user = b"64  Y           00020161021    142851000000000000000000000000AA12345|AEBooth Active Test|BHUSD|BDAdult Circ Desk 1 Newtown, CT USA 06470|AQNEWTWN|BLY|PA20191004|PCAdult|PIAllowed|XI863715|AOBiblioTest|AY2AZ0000"
+    evergreen_expired_card = b"64YYYY          00020161021    142937000000000000000000000000AA12345|AEBooth Expired Test|BHUSD|BDAdult Circ Desk #2 Newtown, CT USA 06470|AQNEWTWN|BLY|PA20080907|PCAdult|PIAllowed|XI863716|AFblocked|AOBiblioTest|AY2AZ0000"
+    evergreen_excessive_fines = b"64  Y           00020161021    143002000000000000000100000000AA12345|AEBooth Excessive Fines Test|BHUSD|BV100.00|BDChildrens Circ Desk 1 Newtown, CT USA 06470|AQNEWTWN|BLY|PA20191004|PCAdult|PIAllowed|XI863718|AOBiblioTest|AY2AZ0000"
+    evergreen_hold_privileges_denied = b"64   Y          00020161021    143002000000000000000100000000AA12345|AEBooth Excessive Fines Test|BHUSD|BV100.00|BDChildrens Circ Desk 1 Newtown, CT USA 06470|AQNEWTWN|BLY|PA20191004|PCAdult|PIAllowed|XI863718|AOBiblioTest|AY2AZ0000"
+    evergreen_card_reported_lost = b"64    Y        00020161021    143002000000000000000100000000AA12345|AEBooth Excessive Fines Test|BHUSD|BV100.00|BDChildrens Circ Desk 1 Newtown, CT USA 06470|AQNEWTWN|BLY|PA20191004|PCAdult|PIAllowed|XI863718|AOBiblioTest|AY2AZ0000"
+    evergreen_inactive_account = b"64YYYY          00020161021    143028000000000000000000000000AE|AA12345|BLN|AOBiblioTest|AY2AZ0000"
 
-    polaris_valid_pin = "64              00120161121    143327000000000000000000000000AO3|AA25891000331441|AEFalk, Jen|BZ0050|CA0075|CB0075|BLY|CQY|BHUSD|BV9.25|CC9.99|BD123 Charlotte Hall, MD 20622|BEfoo@bar.com|BF501-555-1212|BC19710101    000000|PA1|PEHALL|PSSt. Mary's|U1|U2|U3|U4|U5|PZ20622|PX20180609    235959|PYN|FA0.00|AFPatron status is ok.|AGPatron status is ok.|AY2AZ94F3"
+    polaris_valid_pin = b"64              00120161121    143327000000000000000000000000AO3|AA25891000331441|AEFalk, Jen|BZ0050|CA0075|CB0075|BLY|CQY|BHUSD|BV9.25|CC9.99|BD123 Charlotte Hall, MD 20622|BEfoo@bar.com|BF501-555-1212|BC19710101    000000|PA1|PEHALL|PSSt. Mary's|U1|U2|U3|U4|U5|PZ20622|PX20180609    235959|PYN|FA0.00|AFPatron status is ok.|AGPatron status is ok.|AY2AZ94F3"
 
-    polaris_wrong_pin = "64YYYY          00120161121    143157000000000000000000000000AO3|AA25891000331441|AEFalk, Jen|BZ0050|CA0075|CB0075|BLY|CQN|BHUSD|BV9.25|CC9.99|BD123 Charlotte Hall, MD 20622|BEfoo@bar.com|BF501-555-1212|BC19710101    000000|PA1|PEHALL|PSSt. Mary's|U1|U2|U3|U4|U5|PZ20622|PX20180609    235959|PYN|FA0.00|AFInvalid patron password. Passwords do not match.|AGInvalid patron password.|AY2AZ87B4"
+    polaris_wrong_pin = b"64YYYY          00120161121    143157000000000000000000000000AO3|AA25891000331441|AEFalk, Jen|BZ0050|CA0075|CB0075|BLY|CQN|BHUSD|BV9.25|CC9.99|BD123 Charlotte Hall, MD 20622|BEfoo@bar.com|BF501-555-1212|BC19710101    000000|PA1|PEHALL|PSSt. Mary's|U1|U2|U3|U4|U5|PZ20622|PX20180609    235959|PYN|FA0.00|AFInvalid patron password. Passwords do not match.|AGInvalid patron password.|AY2AZ87B4"
 
-    polaris_expired_card = "64YYYY          00120161121    143430000000000000000000000000AO3|AA25891000224613|AETester, Tess|BZ0050|CA0075|CB0075|BLY|CQY|BHUSD|BV0.00|CC9.99|BD|BEfoo@bar.com|BF|BC19710101    000000|PA1|PELEON|PSSt. Mary's|U1|U2|U3|U4|U5|PZ|PX20161025    235959|PYY|FA0.00|AFPatron has blocks.|AGPatron has blocks.|AY2AZA4F8"
+    polaris_expired_card = b"64YYYY          00120161121    143430000000000000000000000000AO3|AA25891000224613|AETester, Tess|BZ0050|CA0075|CB0075|BLY|CQY|BHUSD|BV0.00|CC9.99|BD|BEfoo@bar.com|BF|BC19710101    000000|PA1|PELEON|PSSt. Mary's|U1|U2|U3|U4|U5|PZ|PX20161025    235959|PYY|FA0.00|AFPatron has blocks.|AGPatron has blocks.|AY2AZA4F8"
 
-    polaris_excess_fines = "64YYYY      Y   00120161121    144438000000000000000000000000AO3|AA25891000115879|AEFalk, Jen|BZ0050|CA0075|CB0075|BLY|CQY|BHUSD|BV11.50|CC9.99|BD123, Charlotte Hall, MD 20622|BE|BF501-555-1212|BC20140610    000000|PA1|PEHALL|PS|U1No|U2|U3|U4|U5|PZ20622|PX20170424    235959|PYN|FA0.00|AFPatron has blocks.|AGPatron has blocks.|AY2AZA27B"
+    polaris_excess_fines = b"64YYYY      Y   00120161121    144438000000000000000000000000AO3|AA25891000115879|AEFalk, Jen|BZ0050|CA0075|CB0075|BLY|CQY|BHUSD|BV11.50|CC9.99|BD123, Charlotte Hall, MD 20622|BE|BF501-555-1212|BC20140610    000000|PA1|PEHALL|PS|U1No|U2|U3|U4|U5|PZ20622|PX20170424    235959|PYN|FA0.00|AFPatron has blocks.|AGPatron has blocks.|AY2AZA27B"
 
-    polaris_no_such_patron = "64YYYY          00120161121    143126000000000000000000000000AO3|AA1112|AE, |BZ0000|CA0000|CB0000|BLN|CQN|BHUSD|BV0.00|CC0.00|BD|BE|BF|BC|PA0|PE|PS|U1|U2|U3|U4|U5|PZ|PX|PYN|FA0.00|AFPatron does not exist.|AGPatron does not exist.|AY2AZBCF2"
+    polaris_no_such_patron = b"64YYYY          00120161121    143126000000000000000000000000AO3|AA1112|AE, |BZ0000|CA0000|CB0000|BLN|CQN|BHUSD|BV0.00|CC0.00|BD|BE|BF|BC|PA0|PE|PS|U1|U2|U3|U4|U5|PZ|PX|PYN|FA0.00|AFPatron does not exist.|AGPatron does not exist.|AY2AZBCF2"
 
-    tlc_no_such_patron = "64YYYY          00020171031    092000000000000000000000000000AOhq|AA2642|AE|BLN|AF#Unknown borrower barcode - please refer to the circulation desk.|AY1AZD46E"
+    tlc_no_such_patron = b"64YYYY          00020171031    092000000000000000000000000000AOhq|AA2642|AE|BLN|AF#Unknown borrower barcode - please refer to the circulation desk.|AY1AZD46E"
 
-    end_session_response = "36Y201610210000142637AO3|AA25891000331441|AF|AG"
+    end_session_response = b"36Y201610210000142637AO3|AA25891000331441|AF|AG"
 
     def test_initialize_from_integration(self):
         p = SIP2AuthenticationProvider
@@ -213,8 +213,8 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         patrondata = auth.remote_authenticate("user2", "some password")
         assert "12345" == patrondata.authorization_identifier
         request = client.requests[-1]
-        assert 'user2' in request
-        assert 'some password' not in request
+        assert b'user2' in request
+        assert b'some password' not in request
 
     def test_ioerror_during_connect_becomes_remoteintegrationexception(self):
         """If the IP of the circulation manager has not been whitelisted,

--- a/tests/sip/test_client.py
+++ b/tests/sip/test_client.py
@@ -179,25 +179,25 @@ class TestBasicProtocol(object):
 class TestLogin(object):
 
     def test_login_success(self):
-        sip = MockSIPClient('user_id', 'password')
+        sip = MockSIPClient(login_user_id='user_id', login_password='password')
         sip.queue_response('941')
         response = sip.login()
         assert {'login_ok': '1', '_status': '94'} == response
 
     def test_login_password_is_optional(self):
         """You can specify a login_id without specifying a login_password."""
-        sip = MockSIPClient('user_id')
+        sip = MockSIPClient(login_user_id='user_id')
         sip.queue_response('941')
         response = sip.login()
         assert {'login_ok': '1', '_status': '94'} == response
 
     def test_login_failure(self):
-        sip = MockSIPClient('user_id', 'password')
+        sip = MockSIPClient(login_user_id='user_id', login_password='password')
         sip.queue_response('940')
         pytest.raises(IOError, sip.login)
 
     def test_login_happens_when_user_id_and_password_specified(self):
-        sip = MockSIPClient('user_id', 'password')
+        sip = MockSIPClient(login_user_id='user_id', login_password='password')
         # We're not logged in, and we must log in before sending a real
         # message.
         assert True == sip.must_log_in
@@ -235,7 +235,7 @@ class TestLogin(object):
         assert '12345' == response['patron_identifier']
 
     def test_login_failure_interrupts_other_request(self):
-        sip = MockSIPClient('user_id', 'password')
+        sip = MockSIPClient(login_user_id='user_id', login_password='password')
         sip.queue_response('940')
 
         # We don't even get a chance to make the patron information request

--- a/tests/sip/test_client.py
+++ b/tests/sip/test_client.py
@@ -151,11 +151,11 @@ class TestBasicProtocol(object):
         req1, req2 = sip.requests
         # The first request includes a sequence ID field, "AY", with
         # the value "0".
-        assert '9300CNuser_id|COpassword|AY0AZF556\r' == req1
+        assert b'9300CNuser_id|COpassword|AY0AZF556\r' == req1
 
         # The second request does not include a sequence ID field. As
         # a consequence its checksum is different.
-        assert '9300CNuser_id|COpassword|AZF620\r' == req2
+        assert b'9300CNuser_id|COpassword|AZF620\r' == req2
 
         # The login request eventually succeeded.
         assert {'login_ok': '1', '_status': '94'} == response


### PR DESCRIPTION
## Description

This branch makes the SIP2 client compatible with Python 3. This required revisiting an underlying assumption in the SIP2 client code that SIP2 messages are ASCII. In point of fact, SIP2 messages are by default encoded using an old MS-DOS encoding called Code Page 850. This is now the default encoding used by our SIP2 client, but I've added a configuration setting for ILSes that use something more modern, like UTF-8.

As often happens with Python 3 work, the problems were revealed when I changed our test mocks to make sure that simulated SIP2 responses came in over the wire as bytestrings rather than Unicode strings. The problems were largely fixed by the usual trick of decoding the bytestring to Unicode immediately upon receipt. But what encoding to use? That's where Code Page 850 comes in.

## Motivation and Context

https://jira.nypl.org/browse/SIMPLY-3804

## How Has This Been Tested?

This was initially based on a reading of the SIP2 spec, but I've gotten access to a test Koha server hosted by Amigos and done basic end-to-end tests against it. Going forward we can hook qa-circulation.librarysimplified.org up to that server and use that to verify basic SIP2 support.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
