### PR TITLE
If a borrow attempt falls afoul of a vendor-specific loan limit, try placing the book on hold before giving up.

### DIFF
--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -298,6 +298,52 @@ class TestCirculationAPI(DatabaseTest):
         assert self.pool == hold.license_pool
         assert self.patron == hold.patron
 
+    def test_vendor_side_loan_limit_allows_for_hold_placement(self):
+        # Attempting to borrow a book will trigger a vendor-side loan
+        # limit.
+        self.remote.queue_checkout(PatronLoanLimitReached())
+
+        # But the point is moot because the book isn't even available.
+        # Attempting to place a hold will succeed.
+        holdinfo = HoldInfo(
+            self.pool.collection, self.pool.data_source,
+            self.identifier.type, self.identifier.identifier,
+            None, None, 10
+        )
+        self.remote.queue_hold(holdinfo)
+
+        loan, hold, is_new = self.borrow()
+
+        # No exception was raised, and the Hold looks good.
+        assert holdinfo.identifier == hold.license_pool.identifier.identifier
+        assert self.patron == hold.patron
+        assert None == loan
+        assert True == is_new
+
+    def test_loan_exception_reraised_if_hold_placement_fails(self):
+        # Attempting to borrow a book will trigger a vendor-side loan
+        # limit.
+        self.remote.queue_checkout(PatronLoanLimitReached())
+
+        # Attempting to place a hold will fail because the book is
+        # available. (As opposed to the previous test, where the book
+        # was _not_ available and hold placement succeeded.) This
+        # indicates that we should have raised PatronLoanLimitReached
+        # in the first place.
+        self.remote.queue_hold(CurrentlyAvailable())
+
+        assert len(self.remote.responses['checkout']) == 1
+        assert len(self.remote.responses['hold']) == 1
+
+        # The exception raised is PatronLoanLimitReached, the first
+        # one we encountered...
+        pytest.raises(PatronLoanLimitReached, self.borrow)
+
+        # ...but we made both requests and have no more responses
+        # queued.
+        assert not self.remote.responses['checkout']
+        assert not self.remote.responses['hold']
+
     def test_hold_sends_analytics_event(self):
         self.remote.queue_checkout(NoAvailableCopies())
         holdinfo = HoldInfo(


### PR DESCRIPTION
## Description

It's possible for `CirculationAPI.borrow` to fail at the "take out a loan" stage for a book that can't be loaned out at all. When it looks like that might be happening, we store the exception we got at the "borrow" stage and proceed to the "place a hold" stage.

If "place a hold" succeeds, there's no problem. If "place a hold" fails, we re-raise the original exception.

The specific case we've seen this is when a vendor enforces a loan limit before checking whether or not the requested book is actually loanable.

## Motivation and Context

https://jira.nypl.org/browse/SIMPLY-3750

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I used SimplyE to borrow up to my limit of Axis 360 titles. Then I ran this code against NYPL's QA database, and attempted to borrow a fourth Axis 360 title that I knew was unavailable. Without this code, the fourth borrow attempt failed with a problem detail. With this code, the fourth borrow attempts manages to put the title on hold.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
