### PR TITLE
Increased the timeout for bibliotheca requests to 60s

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -254,6 +254,7 @@ class BibliothecaAPI(BaseCirculationAPI, HasSelfTests):
                 self._db, url, extra_request_headers=headers,
                 do_get=self._simple_http_get, max_age=max_age,
                 exception_handler=Representation.reraise_exception,
+                timeout=60
             )
             content = representation.content
             return content
@@ -390,7 +391,7 @@ class BibliothecaAPI(BaseCirculationAPI, HasSelfTests):
         )
         return monitor.process_items([licensepool.identifier])
 
-    def _patron_activity_request(self, patron):
+        _activity_request(self, patron):
         patron_id = patron.authorization_identifier
         path = "circulation/patron/%s" % patron_id
         return self.request(path)

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -391,7 +391,7 @@ class BibliothecaAPI(BaseCirculationAPI, HasSelfTests):
         )
         return monitor.process_items([licensepool.identifier])
 
-        _activity_request(self, patron):
+    def _patron_activity_request(self, patron):
         patron_id = patron.authorization_identifier
         path = "circulation/patron/%s" % patron_id
         return self.request(path)


### PR DESCRIPTION
## Description

Bibliotheca API requests are increasing in time, and in some cases are passing our internal timeout limits and causing requests to `/loans` to fail. There are two methods by which an external request can be sent to Bibliotheca via the `BibliothecaAPI.request()` method:

https://github.com/NYPL-Simplified/circulation/blob/8b4f5e94f3c3cba039bc1fef38c44ed42012f7dd/api/bibliotheca.py#L252-L264

The second pathway has an explicitly defined 60s timeout, but the first does not specify, and ends up eventually relying on the default 20s timeout set here:

https://github.com/NYPL-Simplified/server_core/blob/develop/util/http.py#L223-L224

I think the change has to be in code rather than config, because:

* The uWSGI `harakiri` timer for ending long running requests is [set to 5 minutes in the config file](https://github.com/NYPL-Simplified/circulation/blob/8b4f5e94f3c3cba039bc1fef38c44ed42012f7dd/docker/services/uwsgi.ini#L37)
* Nginx has an upstream [read timeout of 120 in its config](https://github.com/NYPL-Simplified/circulation/blob/develop/docker/services/nginx.conf#L11)