### PR TITLE
An attempt to borrow a book that's already on loan is treated as success without even going to the remote API.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1406,6 +1406,9 @@ class LoanController(CirculationManagerController):
         patron = flask.request.patron
         library = flask.request.library
 
+        header = self.authorization_header()
+        credential = self.manager.auth.get_credential_from_header(header)
+
         result = self.best_lendable_pool(
             library, patron, identifier_type, identifier, mechanism_id
         )
@@ -1416,51 +1419,22 @@ class LoanController(CirculationManagerController):
                 _("I've never heard of this work.")
             )
         if isinstance(result, ProblemDetail):
+            # There was a problem determining the appropriate
+            # LicensePool to use.
             return result
-        pool, mechanism = result
 
-        header = self.authorization_header()
-        credential = self.manager.auth.get_credential_from_header(header)
-        problem_doc = None
-        try:
-            loan, hold, is_new = self.circulation.borrow(
-                patron, credential, pool, mechanism
-            )
-        except NoOpenAccessDownload as e:
-            problem_doc = NO_LICENSES.detailed(
-                _("Couldn't find an open-access download link for this book."),
-                status_code=404
-            )
-        except PatronAuthorizationFailedException as e:
-            problem_doc = INVALID_CREDENTIALS
-        except (PatronLoanLimitReached, PatronHoldLimitReached) as e:
-            problem_doc = e.as_problem_detail_document().with_debug(str(e))
-        except DeliveryMechanismError as e:
-            return BAD_DELIVERY_MECHANISM.with_debug(
-                str(e), status_code=e.status_code
-            )
-        except OutstandingFines as e:
-            problem_doc = OUTSTANDING_FINES.detailed(
-                _("You must pay your $%(fine_amount).2f outstanding fines before you can borrow more books.", fine_amount=patron.fines)
-            )
-        except AuthorizationExpired as e:
-            return e.as_problem_detail_document(debug=False)
-        except AuthorizationBlocked as e:
-            return e.as_problem_detail_document(debug=False)
-        except CannotLoan as e:
-            problem_doc = CHECKOUT_FAILED.with_debug(str(e))
-        except CannotHold as e:
-            problem_doc = HOLD_FAILED.with_debug(str(e))
-        except CannotRenew as e:
-            problem_doc = RENEW_FAILED.with_debug(str(e))
-        except NotFoundOnRemote as e:
-            problem_doc = NOT_FOUND_ON_REMOTE
-        except CirculationException as e:
-            # Generic circulation error.
-            problem_doc = CHECKOUT_FAILED.with_debug(str(e))
+        if isinstance(result, Loan):
+            # We already have a Loan, so there's no need to go to the API.
+            loan_or_hold = result
+            is_new = False
+        else:
+            # We need to actually go out to the API
+            # and try to take out a loan.
+            pool, mechanism = result
+            loan_or_hold, is_new = self._borrow(patron, credential, pool, mechanism)
 
-        if problem_doc:
-            return problem_doc
+        if isinstance(loan_or_hold, ProblemDetail):
+            return loan_or_hold
 
         # At this point we have either a loan or a hold. If a loan, serve
         # a feed that tells the patron how to fulfill the loan. If a hold,
@@ -1470,20 +1444,79 @@ class LoanController(CirculationManagerController):
             response_kwargs['status'] = 201
         else:
             response_kwargs['status'] = 200
-        item = loan or hold
-        if item:
-            return LibraryLoanAndHoldAnnotator.single_item_feed(
-                self.circulation, item, **response_kwargs
+        return LibraryLoanAndHoldAnnotator.single_item_feed(
+            self.circulation, loan_or_hold, **response_kwargs
+        )
+
+    def _borrow(self, patron, credential, pool, mechanism):
+        """Go out to the API, try to take out a loan, and handle errors as
+        problem detail documents.
+
+        :param patron: The Patron who's trying to take out the loan
+        :param credential: A Credential to use when authenticating
+           as this Patron with the external API.
+        :param pool: The LicensePool for the book the Patron wants.
+        :mechanism: The DeliveryMechanism to request when asking for
+           a loan.
+        :return: a 2-tuple (result, is_new) `result` is a Loan (if one
+           could be created or found), a Hold (if a Loan could not be
+           created but a Hold could be), or a ProblemDetail (if the
+           entire operation failed).
+        """
+        result = None
+        is_new = False
+        try:
+            loan, hold, is_new = self.circulation.borrow(
+                patron, credential, pool, mechanism
             )
-        else:
-            # This should never happen -- we should have sent a more specific
-            # error earlier.
-            return HOLD_FAILED
+            result = loan or hold
+        except NoOpenAccessDownload as e:
+            result = NO_LICENSES.detailed(
+                _("Couldn't find an open-access download link for this book."),
+                status_code=404
+            )
+        except PatronAuthorizationFailedException as e:
+            result = INVALID_CREDENTIALS
+        except (PatronLoanLimitReached, PatronHoldLimitReached) as e:
+            result = e.as_problem_detail_document().with_debug(str(e))
+        except DeliveryMechanismError as e:
+            result = BAD_DELIVERY_MECHANISM.with_debug(
+                str(e), status_code=e.status_code
+            )
+        except OutstandingFines as e:
+            result = OUTSTANDING_FINES.detailed(
+                _("You must pay your $%(fine_amount).2f outstanding fines before you can borrow more books.", fine_amount=patron.fines)
+            )
+        except AuthorizationExpired as e:
+            result = e.as_problem_detail_document(debug=False)
+        except AuthorizationBlocked as e:
+            result = e.as_problem_detail_document(debug=False)
+        except CannotLoan as e:
+            result = CHECKOUT_FAILED.with_debug(str(e))
+        except CannotHold as e:
+            result = HOLD_FAILED.with_debug(str(e))
+        except CannotRenew as e:
+            result = RENEW_FAILED.with_debug(str(e))
+        except NotFoundOnRemote as e:
+            result = NOT_FOUND_ON_REMOTE
+        except CirculationException as e:
+            # Generic circulation error.
+            result = CHECKOUT_FAILED.with_debug(str(e))
+
+        if result is None:
+            # This shouldn't happen, but if it does, it means no exception
+            # was raised but we just didn't get a loan or hold. Return a
+            # generic circulation error.
+            result = HOLD_FAILED
+        return result, is_new
 
     def best_lendable_pool(self, library, patron, identifier_type, identifier,
                            mechanism_id):
         """Of the available LicensePools for the given Identifier, return the
         one that's the best candidate for loaning out right now.
+
+        :return: A Loan if this patron already has an active loan, otherwise
+        a LicensePool.
         """
         # Turn source + identifier into a set of LicensePools
         pools = self.load_licensepools(
@@ -1502,7 +1535,10 @@ class LoanController(CirculationManagerController):
             Loan.patron==patron
         ).all()
         if existing_loans:
-            return ALREADY_CHECKED_OUT
+            # The patron already has at least one loan on this book already.
+            # To make the "borrow" operation idempotent, return one of
+            # those loans instead of an error.
+            return existing_loans[0]
 
         # We found a number of LicensePools. Try to locate one that
         # we can actually loan to the patron.


### PR DESCRIPTION
## Description

This branch makes the "checkout" operation idempotent. If you try to borrow a book and we know you already have the book on loan, we send an OPDS entry that explains how to fulfill the book, rather than sending a problem detail document.

## Motivation and Context

https://jira.nypl.org/browse/SIMPLY-3831

If looks like SimplyE sometimes loses track of a book's fulfillment links, or possibly all information about its current state. When that happens, it may attempt to borrow the book again, either to get a copy of the fulfillment links or because it doesn't know there's already a loan.

This may or may not represent a problem on the client side, but there's no reason we can't accommodate a client that forgets whether a book is on loan.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I set up the new branch against the QA database and tried to "borrow" a book I already had on loan.

```
curl http://leonardr:xxxx@localhost:6500/QANYPL/works/Overdrive%20ID/b95e6c49-0d9d-4670-92b8-1d788f72f730/borrow
```

This got me an OPDS entry with fulfillment links.

Then I tried the same request on the real QA server running the old code:

```
curl https://leonardr:xxxx@qa-circulation.librarysimplified.org/QANYPL/works/Overdrive%20ID/b95e6c49-0d9d-4670-92b8-1d788f72f730/borrow
```

This got me a problem detail document saying that I've already checked out the book.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
