### PR TITLE
Simply 2102/update version number

### DIFF
--- a/api/admin/CHANGELOG.md
+++ b/api/admin/CHANGELOG.md
@@ -1,3 +1,6 @@
+This document is used only to track changes to the simplified-circulation-web
+version number, and is separate from the CHANGELOG at this repository's root.
+
 ## Changelog
 
 ### v0.1.0

--- a/api/admin/CHANGELOG.md
+++ b/api/admin/CHANGELOG.md
@@ -1,0 +1,7 @@
+## Changelog
+
+### v0.1.0
+
+#### Updated
+
+- Updated simplified-circulation-web version number to v0.5.3.

--- a/api/admin/package-lock.json
+++ b/api/admin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/api/admin/package-lock.json
+++ b/api/admin/package-lock.json
@@ -5,17 +5,17 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
-      "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
+      "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.14.8.tgz",
-      "integrity": "sha512-Jj4fkQPFp73ia9y6BctEX5ypA1icbOVPtc9l0T1VnAv8EmzaN/Lm/WvnKNve1610VvHV69SLihpu9tHnVziBvw==",
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.15.3.tgz",
+      "integrity": "sha512-iG7ypZmrdoKP1ckFurS8z97TR+Bqd6KaDsLQ9DiC/Rdxmrvy1nsCDlgfLNKfalbg9sFWdmIdNf+Hg+19XysSFg==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -58,9 +58,9 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
-      "version": "17.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.14.tgz",
-      "integrity": "sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.17.tgz",
+      "integrity": "sha512-nrfi7I13cAmrd0wje8czYpf5SFbryczCtPzFc6ijqvdjKcyA3tCvGxwchOUlxb2ucBPuJ9Y3oUqKrRqZvrz0lw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -252,9 +252,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-js": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
-      "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q=="
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.1.tgz",
+      "integrity": "sha512-AAkP8i35EbefU+JddyWi12AWE9f2N/qr/pwnDtWz4nyUIBGMJPX99ANFFRSw6FefM374lDujdtLDyhN2A/btHw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -450,9 +450,9 @@
       "integrity": "sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw="
     },
     "draft-convert": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/draft-convert/-/draft-convert-2.1.11.tgz",
-      "integrity": "sha512-8jLuhXmx5h5jiGi7thqdqV8O3aOmT7D5Q4OvCmT5tJWyMXWhKcJCktgqnwvEVGrHGxYJwfkfU4F/3fhGP2Dljw==",
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/draft-convert/-/draft-convert-2.1.12.tgz",
+      "integrity": "sha512-6Bt338J+ZA00OLlzHipd0ZcQCCrVEM0vCyXb/eDlLdY89mmQ4XWkflSD9vql8TzVJ5ENk4s8cywMO9YTaTnZyg==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "immutable": "~3.7.4",
@@ -737,9 +737,9 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
-      "integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
       "requires": {
         "abab": "^2.0.5",
         "acorn": "^8.2.4",
@@ -766,7 +766,7 @@
         "whatwg-encoding": "^1.0.5",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.5.0",
-        "ws": "^7.4.5",
+        "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
       }
     },
@@ -872,16 +872,16 @@
       "integrity": "sha512-YqVh744GsMlZu6xkhGslPSqSurOv6P+kLN2J3ysBZfagLcL5FdRK/0UpgLoL8hwjjEvvAVkjJZyFP+1T6p1vgA=="
     },
     "mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
+      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
     },
     "mime-types": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+      "version": "2.1.32",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
+      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
       "requires": {
-        "mime-db": "1.48.0"
+        "mime-db": "1.49.0"
       }
     },
     "minimatch": {
@@ -1367,9 +1367,9 @@
       }
     },
     "redux": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.0.tgz",
-      "integrity": "sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
+      "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
@@ -1390,9 +1390,9 @@
       "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "request": {
       "version": "2.88.2",
@@ -1528,9 +1528,9 @@
       }
     },
     "simplified-circulation-web": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.2.tgz",
-      "integrity": "sha512-9t1DfPWI94lFCjoNGhv4Sn4Yy2yD/dR61idqUN7SX/hQCOmWjEzlfEZ0FXsaqL80LRu+WMy1CuxbARCZfCwq6Q==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.3.tgz",
+      "integrity": "sha512-4DqhbAyE7uCNYzRN7O2ga9UMsPuY7F07IG7bM6KLNASUEXZ2XB8chFdM7QSIs9eohMPYHmUR7A8hKUxhc6bsaw==",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.4",
         "bootstrap": "^3.3.6",

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -13,6 +13,6 @@
     "npm": ">=5.0.0"
   },
   "dependencies": {
-    "simplified-circulation-web": "^0.5.2"
+    "simplified-circulation-web": "^0.5.3"
   }
 }

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Library Simplified Circulation Manager",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

- Updated simplified-circulation-web version number to v0.5.3.
- Updated simplified-circulation version number to v0.1.0.
- Added new CHANGELOG in api/admin to track updates to simplified-circulation-web version numbers.

## Motivation and Context

- Need to pull most recent circulation-web changes through to QA.

## How Has This Been Tested?

- No testing necessary.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
