### PR TITLE
Simply 3412/make-https-with-local-host-possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,6 @@ docs/**/
 docs/source/*
 !docs/source/conf.py
 !docs/source/index.rst
+
+# For SSL
 certificates

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,3 @@ docs/**/
 docs/source/*
 !docs/source/conf.py
 !docs/source/index.rst
-
-# For SSL
-certificates

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ docs/**/
 docs/source/*
 !docs/source/conf.py
 !docs/source/index.rst
+certificates

--- a/README.md
+++ b/README.md
@@ -57,10 +57,6 @@ While you're at it, go ahead and install the following required dependencies:
 - `$ brew install libxmlsec1`
 - `$ brew install libjpeg`
 
-Please note: only certain versions of Python 3 will work with this application. One such version is Python 3.6.5. Check to see which version you currently have installed by running `$ python -V`.
-
-If you're using a version of Python that doesn't work, install [pyenv](https://github.com/pyenv/pyenv-installer) using command `$ curl https://pyenv.run | bash`, then install the version of Python you want to work with, ie `$ pyenv install python3.6.5`, and then run `$ pyenv global 3.6.5`. Check the current version again with `$ python -V` to make sure it's correct before proceeding.
-
 You will need to set up a local virtual environment to install packages and run the project. If you haven't done so before, use pip to install virtualenv – `$ pip install virtualenv` – before creating the virtual environment in the root of the circulation repository:
 
 ```sh
@@ -71,6 +67,12 @@ As mentioned above, this application depends on [Library Simplified Server Core]
 
 - `$ git submodule init`
 - `$ git submodule update`
+
+### Python Version
+
+It is important to know that only certain versions of Python 3 will work with this application. One such version is Python 3.6.5. Check to see which version you currently have installed by running `$ python -V`.
+
+If you're using a version of Python that doesn't work, install [pyenv](https://github.com/pyenv/pyenv-installer) using command `$ curl https://pyenv.run | bash`, then install the version of Python you want to work with, ie `$ pyenv install python3.6.5`, and then run `$ pyenv global 3.6.5`. Check the current version again with `$ python -V` to make sure it's correct before proceeding.
 
 ### Elasticsearch Set Up
 
@@ -129,13 +131,19 @@ And install the dependencies:
 $ pip install -r requirements-dev.txt
 ```
 
-Run the application with:
+Generally, you should run the application with:
 
 ```sh
 $ python app.py
 ```
 
 And visit `http://localhost:6500/`.
+
+But, if you need to run the application over https, explicitly state that in the command:
+
+```sh
+$ python app.py https://localhost:6500/
+```
 
 ### Python Installation Issues
 
@@ -144,7 +152,7 @@ When running the `pip install ...` command, you may run into installation issues
 ```sh
 error: command '/usr/bin/clang' failed with exit code 1
   ----------------------------------------
-  ERROR: Failed building wheel for xmlsec
+ERROR: Failed building wheel for xmlsec
 Failed to build dm.xmlsec.binding xmlsec
 ERROR: Could not build wheels for xmlsec which use PEP 517 and cannot be installed directly
 ```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ And install the dependencies:
 $ pip install -r requirements-dev.txt
 ```
 
-Generally, you can run the application with:
+Run the application with:
 
 ```sh
 $ python app.py
@@ -139,11 +139,17 @@ $ python app.py
 
 Then, navigate to `http://localhost:6500/`.
 
-But, if you need to run the application over https, explicitly state that in the command:
+### Note on HTTP/S in development
+
+When deployed, the application should be run behind a secure proxy responsible for SSL termination. While developing locally, if it becomes necessary to observe app code serving HTTP/S requests, it is possible to start the Flask/Werkzeug development server with an ad-hoc SSL context (see [werkzeug.serving.run_simple()](https://werkzeug.palletsprojects.com/en/2.0.x/serving/#werkzeug.serving.run_simple) for more details). These ad-hoc certs work because of the pyopenssl package.
+
+To have the server listen for HTTP/S requests, supply an https:// URL on start:
 
 ```sh
 $ python app.py https://localhost:6500/
 ```
+
+Also note that this does not fully replicate secure requests as they would appear on a deployed app instance. In particular, the X-Forwarded-* headers may be different, since you are hitting the application server directly rather than through one or more proxy layers.
 
 ### Python Installation Issues
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ Then, navigate to `http://localhost:6500/`.
 
 ### Note on HTTP/S in development
 
-When deployed, the application should be run behind a secure proxy responsible for SSL termination. While developing locally, if it becomes necessary to observe app code serving HTTP/S requests, it is possible to start the Flask/Werkzeug development server with an ad-hoc SSL context (see [werkzeug.serving.run_simple()](https://werkzeug.palletsprojects.com/en/2.0.x/serving/#werkzeug.serving.run_simple) for more details). These ad-hoc certs work because of the pyopenssl package.
+When deployed, the application should be run behind a secure proxy responsible for SSL termination. 
+
+While developing locally, if it becomes necessary to observe app code serving HTTP/S requests, it is possible to start the Flask/Werkzeug development server with an ad-hoc SSL context (see [werkzeug.serving.run_simple()](https://werkzeug.palletsprojects.com/en/2.0.x/serving/#werkzeug.serving.run_simple) for more details). These ad-hoc certs work because of the pyopenssl package.
 
 To have the server listen for HTTP/S requests, supply an https:// URL on start:
 

--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ And install the dependencies:
 $ pip install -r requirements-dev.txt
 ```
 
-Generally, you should run the application with:
+Generally, you can run the application with:
 
 ```sh
 $ python app.py
 ```
 
-And visit `http://localhost:6500/`.
+Then, navigate to `http://localhost:6500/`.
 
 But, if you need to run the application over https, explicitly state that in the command:
 

--- a/api/app.py
+++ b/api/app.py
@@ -69,6 +69,5 @@ def run(url=None):
         socket.setdefaulttimeout(None)
 
     logging.info("Starting app on %s:%s", host, port)
-    app.run(debug=debug, host=host, port=port, threaded=True)
-
-
+    sslContext = 'adhoc' if scheme == 'https' else None
+    app.run(debug=debug, host=host, port=port, threaded=True, ssl_context=sslContext)


### PR DESCRIPTION
## Description

- Updated api/app.py run function so that app can be run over https when given the proper scheme.
- Updated the README to include this information.
- Updated the README to make it more clear that the app only works with certain Python versions (per feedback from Mike).

## Motivation and Context

- Originally configured to investigate a redirect issue.
- The above issue will be resolved outside of the app code (in AWS), but it will still be useful to have the ability to run localhost over https in future.

## How Has This Been Tested?

- Running `python app.py` will start the app locally on http.
- Running `python app.py https://localhost:6500/` will start the app locally on https.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
