### PR TITLE
Switching feedbooks_import_monitor to 1x weekly

### DIFF
--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -107,7 +107,7 @@ HOME=/var/www/circulation
 30 5 * * * root core/bin/run opds2_import_monitor >> /var/log/cron.log 2>&1
 
 # OPDS import from Feedbooks
-* * */7 * * root core/bin/run feedbooks_import_monitor >> /var/log/cron.log 2>&1
+0 0 */7 * * root core/bin/run feedbooks_import_monitor >> /var/log/cron.log 2>&1
 
 # ODL import
 #


### PR DESCRIPTION
## Description

The scheduled job `feedbooks_import_monitor` is supposed to run weekly. The crontab entry for it was `* * */7 * *`, which means [every minute on every 7th day-of-month](https://crontab.guru/#*_*_*/7_*_*). It's been that way for 4 years so I don't think this fix is _hugely_ urgent, but probably it'll make the script runner instance faster on every 7th day if we update it.