### PR TITLE
Updating circulation-web version number

### DIFF
--- a/api/admin/CHANGELOG.md
+++ b/api/admin/CHANGELOG.md
@@ -3,6 +3,12 @@ version number, and is separate from the CHANGELOG at this repository's root.
 
 ## Changelog
 
+### v0.1.1
+
+#### Updated
+
+- Updated simplified-circulation-web version number to v0.5.4-test.
+
 ### v0.1.0
 
 #### Updated

--- a/api/admin/package-lock.json
+++ b/api/admin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -58,9 +58,9 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
-      "version": "17.0.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.17.tgz",
-      "integrity": "sha512-nrfi7I13cAmrd0wje8czYpf5SFbryczCtPzFc6ijqvdjKcyA3tCvGxwchOUlxb2ucBPuJ9Y3oUqKrRqZvrz0lw==",
+      "version": "17.0.19",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.19.tgz",
+      "integrity": "sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -252,9 +252,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-js": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.1.tgz",
-      "integrity": "sha512-AAkP8i35EbefU+JddyWi12AWE9f2N/qr/pwnDtWz4nyUIBGMJPX99ANFFRSw6FefM374lDujdtLDyhN2A/btHw=="
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
+      "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -950,9 +950,9 @@
       }
     },
     "opds-web-client": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.6.2.tgz",
-      "integrity": "sha512-0soQCzAD83Fu7Zhb3oNnc26S5YdB5ef82Ab5PDxMXVsaPdsWlh3m7/XYFd7GpOnEGgoXjyVUk5MZw3Z0grUrGA==",
+      "version": "0.6.3-test",
+      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.6.3-test.tgz",
+      "integrity": "sha512-H+20qmJfzlfdtMMRra7IuQZadQH0Y5DD+VD5dIVddIL2bSCvGZlX3xkuDTUbynckjnlGgLGQn8ZQ4GBRWjQLDw==",
       "requires": {
         "@nypl/dgx-svg-icons": "^0.3.4",
         "dompurify": "2.2.8",
@@ -1528,9 +1528,9 @@
       }
     },
     "simplified-circulation-web": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.3.tgz",
-      "integrity": "sha512-4DqhbAyE7uCNYzRN7O2ga9UMsPuY7F07IG7bM6KLNASUEXZ2XB8chFdM7QSIs9eohMPYHmUR7A8hKUxhc6bsaw==",
+      "version": "0.5.4-test",
+      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.4-test.tgz",
+      "integrity": "sha512-2sY2X30XiP10Jx/A99CfcmiI1gRfsLzc+G60ugVz0gIsQ+GRimsOmb0l4Fr4U2XpikvycfzWmSoAU1Iz3YO2xQ==",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.4",
         "bootstrap": "^3.3.6",
@@ -1541,7 +1541,7 @@
         "library-simplified-reusable-components": "1.3.18",
         "numeral": "^2.0.6",
         "opds-feed-parser": "0.0.17",
-        "opds-web-client": "^0.6.2",
+        "opds-web-client": "0.6.3-test",
         "prop-types": "^15.7.2",
         "qs": "^6.2.0",
         "react": "^16.8.6",

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Library Simplified Circulation Manager",
   "repository": {
     "type": "git",
@@ -13,6 +13,6 @@
     "npm": ">=5.0.0"
   },
   "dependencies": {
-    "simplified-circulation-web": "^0.5.3"
+    "simplified-circulation-web": "0.5.4-test"
   }
 }


### PR DESCRIPTION
## Description

- Updated circulation-web version number to v0.5.4-test.

## Motivation and Context

- Testing changes made in the opds-web-client that potentially fix a bug in the List Manager (see [SIMPLY-3869](https://jira.nypl.org/browse/SIMPLY-3869))

