### PR TITLE
Updates circulation-web version

### DIFF
--- a/api/admin/CHANGELOG.md
+++ b/api/admin/CHANGELOG.md
@@ -3,6 +3,13 @@ version number, and is separate from the CHANGELOG at this repository's root.
 
 ## Changelog
 
+### v0.1.2
+
+#### Updated
+
+- Updated simplified-circulation-web version number to v0.5.4 after successfully
+  testing the previous version.
+
 ### v0.1.1
 
 #### Updated

--- a/api/admin/package-lock.json
+++ b/api/admin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -950,9 +950,9 @@
       }
     },
     "opds-web-client": {
-      "version": "0.6.3-test",
-      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.6.3-test.tgz",
-      "integrity": "sha512-H+20qmJfzlfdtMMRra7IuQZadQH0Y5DD+VD5dIVddIL2bSCvGZlX3xkuDTUbynckjnlGgLGQn8ZQ4GBRWjQLDw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.6.3.tgz",
+      "integrity": "sha512-FxtsNRTLf7avUnJ4RyTQggZpvfDGJzxDvTXl8VB/YNMoPp+WWERq5YIE3Dtho22XPi2kQM3vjB7A2aecdNoHVA==",
       "requires": {
         "@nypl/dgx-svg-icons": "^0.3.4",
         "dompurify": "2.2.8",
@@ -1528,9 +1528,9 @@
       }
     },
     "simplified-circulation-web": {
-      "version": "0.5.4-test",
-      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.4-test.tgz",
-      "integrity": "sha512-2sY2X30XiP10Jx/A99CfcmiI1gRfsLzc+G60ugVz0gIsQ+GRimsOmb0l4Fr4U2XpikvycfzWmSoAU1Iz3YO2xQ==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.4.tgz",
+      "integrity": "sha512-KydLDHIA9zReSdNyT3F7E8XWNKHRuXkd8xK3ipl6G6eIj4ijKAbsVOFVV4xKTd2Nj6lpvbljfev3Qv9lqk4bbQ==",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.4",
         "bootstrap": "^3.3.6",
@@ -1541,7 +1541,7 @@
         "library-simplified-reusable-components": "1.3.18",
         "numeral": "^2.0.6",
         "opds-feed-parser": "0.0.17",
-        "opds-web-client": "0.6.3-test",
+        "opds-web-client": "0.6.3",
         "prop-types": "^15.7.2",
         "qs": "^6.2.0",
         "react": "^16.8.6",

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Library Simplified Circulation Manager",
   "repository": {
     "type": "git",
@@ -13,6 +13,6 @@
     "npm": ">=5.0.0"
   },
   "dependencies": {
-    "simplified-circulation-web": "0.5.4-test"
+    "simplified-circulation-web": "0.5.4"
   }
 }


### PR DESCRIPTION
## Description

- Updated circulation-web dependency version number to v0.5.4.

## Motivation and Context

- Needed to pull through updates to opds-web-client that solved [SIMPLY-3869](https://jira.nypl.org/browse/SIMPLY-3869).

