### PR TITLE
Update how we process external type from Clever grade level

### DIFF
--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -299,7 +299,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
                 self.log.info(msg)
 
             # If we can't determine a type from the grade level, set to "A"
-            external_type = external_type_from_clever_grade(student_grade) or "A"
+            external_type = external_type_from_clever_grade(student_grade)
         else:
             external_type = "A"     # Non-students get content level "A"
 

--- a/tests/clever/test_clever.py
+++ b/tests/clever/test_clever.py
@@ -141,6 +141,14 @@ class TestCleverAuthenticationAPI(DatabaseTest):
         token = self.api.remote_patron_lookup("")
         assert CLEVER_UNKNOWN_SCHOOL == token
 
+    def test_remote_patron_unknown_student_grade(self):
+        self.api.queue_response(dict(type='student', data=dict(id='2'), links=[dict(rel='canonical', uri='test')]))
+        self.api.queue_response(dict(data=dict(school='1234', district='1234', name='Abcd', grade="")))
+        self.api.queue_response(dict(data=dict(nces_id='44270647')))
+
+        patrondata = self.api.remote_patron_lookup("token")
+        assert patrondata.external_type is None
+
     def test_remote_patron_lookup_title_i(self):
         self.api.queue_response(dict(type='student', data=dict(id='5678'), links=[dict(rel='canonical', uri='test')]))
         self.api.queue_response(dict(data=dict(school='1234', district='1234', name='Abcd', grade="10")))


### PR DESCRIPTION
## Description

Per OE-24, we need to update how we're parsing the grade level information we get from the Clever API. This updates the Clever module to use v3.0 of their API, and account for all possible values for a student user's grade.

## How Has This Been Tested?

Added a test for the case where we cannot determine a grade level, so we return a problem detail document.

## Checklist:

- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
