### PR TITLE
URL-encode passwords going into the Millenium Patron API.

### DIFF
--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -1,8 +1,7 @@
 import dateutil
 import logging
 from lxml import etree
-from urllib.parse import urljoin
-from urllib.parse import urlencode
+from urllib import parse
 import datetime
 import requests
 from money import Money
@@ -212,8 +211,13 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
 
         if self.auth_mode == self.PIN_AUTHENTICATION_MODE:
             # Patrons are authenticated with a secret PIN.
+            #
+            # The PIN is URL-encoded. The username is not: as far as
+            # we can tell Millenium Patron doesn't even try to decode
+            # it.
+            quoted_password = parse.quote(password) if password else password
             path = "%(barcode)s/%(pin)s/pintest" % dict(
-                barcode=username, pin=password
+                barcode=username, pin=quoted_password
             )
             url = self.root + path
             response = self.request(url)


### PR DESCRIPTION
## Description

This branch fixes https://jira.nypl.org/browse/SIMPLY-3876.

## How Has This Been Tested?

I used direct experimentation with curl and a running instance of the Millenium Patron API to determine that URL-encoding of passwords solves the problem we're seeing (and that URL-encoding of usernames is useless). Due to IP address limitations we won't be able to test this code against a real Millenium Patron API without deploying a Docker image somewhere.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
