### PR TITLE
URL-escape the slash character when it appears in a password.

### DIFF
--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -215,7 +215,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
             # The PIN is URL-encoded. The username is not: as far as
             # we can tell Millenium Patron doesn't even try to decode
             # it.
-            quoted_password = parse.quote(password) if password else password
+            quoted_password = parse.quote(password, safe='') if password else password
             path = "%(barcode)s/%(pin)s/pintest" % dict(
                 barcode=username, pin=quoted_password
             )

--- a/tests/test_millenium_patron.py
+++ b/tests/test_millenium_patron.py
@@ -186,7 +186,7 @@ class TestMilleniumPatronAPI(DatabaseTest):
     def test_remote_authenticate_correct_pin(self):
         self.api.enqueue("pintest.good.html")
         barcode = "barcode1234567!"
-        pin = "!correct pin<>@"
+        pin = "!correct pin<>@/"
         patrondata = self.api.remote_authenticate(barcode, pin)
         # The return value includes everything we know about the
         # authenticated patron, which isn't much.
@@ -196,7 +196,11 @@ class TestMilleniumPatronAPI(DatabaseTest):
         [args, kwargs] = self.api.requests_made.pop()
         [url] = args
         assert kwargs == {}
-        assert url == 'http://url/%s/%s/pintest' % (barcode, parse.quote(pin))
+        assert url == 'http://url/%s/%s/pintest' % (barcode, parse.quote(pin, safe=''))
+
+        # In particular, verify that the slash character in the PIN was encoded;
+        # by default, parse.quote leaves it alone.
+        assert '%2F' in url
 
     def test_authentication_updates_patron_authorization_identifier(self):
         """Verify that Patron.authorization_identifier is updated when


### PR DESCRIPTION
## Description

This is a follow-up from https://github.com/NYPL-Simplified/circulation/pull/1634 which I found while running QA on https://jira.nypl.org/browse/SIMPLY-3876. 

Characters like "+" get escaped correctly, but the slash character doesn't because [urllib.parse.quote](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote) considers it 'safe' by default. In this context it's definitely not safe, so I changed the call to `quote`.

## How Has This Been Tested?

As before, not possible to test this for real without deploying due to the IP restrictions on NYPL's ILS; otherwise I would have caught this problem earlier.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
