### PR TITLE
Add volumes for es service in Docker Compose setup

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,9 @@ services:
   es:
     # Use the latest version of Elasticsearch supported by Amazon AWS ES.
     image: docker.elastic.co/elasticsearch/elasticsearch:6.7.2
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+      - elasticsearch-plugins:/usr/share/elasticsearch/plugins
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -22,7 +25,8 @@ services:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     command: >
       /bin/sh -c "./bin/elasticsearch-plugin list | grep -q analysis-icu 
-      || ./bin/elasticsearch-plugin install analysis-icu; tail -f /dev/null"
+      || ./bin/elasticsearch-plugin install analysis-icu;
+      /usr/local/bin/docker-entrypoint.sh"
   webapp:
     build:
       context: .
@@ -57,3 +61,7 @@ volumes:
   dbdata:
   uwsgi_log:
   script_logs:
+  elasticsearch-data:
+    driver: local
+  elasticsearch-plugins:
+    driver: local


### PR DESCRIPTION
## Description

Adds two volumes to the docker compose setup for Elastic Search. 

## Motivation and Context

Based on a [suggestion ](https://github.com/NYPL-Simplified/circulation/pull/1642#discussion_r717693597) by @nballenger