### PR TITLE
Update from Palace for ODL reaper improvements

### DIFF
--- a/bin/odl_reaper
+++ b/bin/odl_reaper
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Remove all expired licenses from ODL 1.x collections."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.scripts import RunCollectionMonitorScript
+from api.odl import ODLExpiredItemsReaper
+RunCollectionMonitorScript(ODLExpiredItemsReaper).run()

--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -113,6 +113,7 @@ HOME=/var/www/circulation
 #
 0 6 * * * root core/bin/run odl_import_monitor >> /var/log/cron.log 2>&1
 0 */8 * * * root core/bin/run odl_hold_reaper >> /var/log/cron.log 2>&1
+0 */14 * * * root core/bin/run odl_reaper >> /var/log/cron.log 2>&1
 5 */6 * * * root core/bin/run shared_odl_import_monitor >> /var/log/cron.log 2>&1
 
 # Odilo

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+# jinja2 is used to fill out templated files for testing parsers.
+jinja2
 -r core/requirements-dev.txt
 -r requirements-base.txt
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,3 @@
-# jinja2 is used to fill out templated files for testing parsers.
-jinja2
 -r core/requirements-dev.txt
 -r requirements-base.txt
 

--- a/tests/files/odl/feed_template.xml.jinja
+++ b/tests/files/odl/feed_template.xml.jinja
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:dcterms="http://purl.org/dc/terms/" xmlns:thr="http://purl.org/syndication/thread/1.0" xmlns:app="http://www.w3.org/2007/app" xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/" xmlns="http://www.w3.org/2005/Atom" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:lang="en" xmlns:odl="http://opds-spec.org/odl" xmlns:schema="http://schema.org/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <id>https://market.feedbooks.com/api/libraries/harvest.atom</id>
+    <title>Feedbooks</title>
+    <updated>2021-08-16T09:07:14Z</updated>
+    <icon>/favicon.ico</icon>
+    <author>
+        <name>Feedbooks</name>
+        <uri>https://market.feedbooks.com</uri>
+        <email>support@feedbooks.zendesk.com</email>
+    </author>
+    <link rel="self" type="application/atom+xml;profile=odl; charset=utf-8" href="https://market.feedbooks.com/api/libraries/harvest.atom"/>
+    <opensearch:totalResults>481</opensearch:totalResults>
+    <opensearch:itemsPerPage>100</opensearch:itemsPerPage>
+    <link rel="next" title="Next" type="application/atom+xml;profile=odl" href="https://market.feedbooks.com/api/libraries/harvest?page=2&amp;token=4xrc0mlxgc6xn6kl9xc"/>
+    <entry schema:additionalType="http://schema.org/Ebook">
+        <title>The Golden State</title>
+        <id>https://www.feedbooks.com/item/2895246</id>
+        <dcterms:identifier xsi:type="dcterms:URI">urn:ISBN:9780374718060</dcterms:identifier>
+        <dcterms:source xsi:type="dcterms:URI">urn:ISBN:9780374164836</dcterms:source>
+        <author>
+            <name>Lydia Kiesling</name>
+            <uri>https://market.feedbooks.com/store/browse/recent.atom?author_id=954566&amp;lang=en</uri>
+        </author>
+        <published>2018-08-12T00:16:43Z</published>
+        <updated>2020-05-21T11:13:26Z</updated>
+        <dcterms:language>en</dcterms:language>
+        <dcterms:publisher>Mcd</dcterms:publisher>
+        <dcterms:issued>2018-09-03</dcterms:issued>
+        <summary>NATIONAL BOOK FOUNDATION 5 UNDER 35 PICK. LONGLISTED FOR THE CENTER FOR FICTION'S FIRST NOVEL PRIZE. Named one of the Best Books of 2018 by NPR, Bookforum and Bustle. One of Entertainment Weekly's 10 Best Debut Novels of 2018. An Amazon Best Book of the Month and named a fall read by Buzzfeed, Nylon, Entertainment Weekly, Elle, Vanity Fair, Vulture, Refinery29 and Mind Body GreenA gorgeous, raw debut novel about a young woman braving the ups and downs of motherhood in a fractured AmericaIn Lydia Kiesling's razor-sharp debut novel, The Golden State, we accompany Daphne, a young mother on the edge of a breakdown, as she flees her sensible but strained life in San Francisco for the high desert of Altavista with her toddler, Honey. Bucking under the weight of being a single parent--her Turkish husband is unable to return to the United States because of a "processing error"--Daphne takes refuge in a mobile home left to her by her grandparents in hopes that the quiet will bring clarity. But clarity proves elusive. Over the next ten days Daphne is anxious, she behaves a little erratically, she drinks too much. She wanders the town looking for anyone and anything to punctuate the long hours alone with the baby. Among others, she meets Cindy, a neighbor who is active in a secessionist movement, and befriends the elderly Alice, who has traveled to Altavista as she approaches the end of her life. When her relationships with these women culminate in a dangerous standoff, Daphne must reconcile her inner narrative with the reality of a deeply divided world. Keenly observed, bristling with humor, and set against the beauty of a little-known part of California, The Golden State is about class and cultural breakdowns, and desperate attempts to bridge old and new worlds. But more than anything, it is about motherhood: its voracious worry, frequent tedium, and enthralling, wondrous love.</summary>
+        <dcterms:extent>4 MB</dcterms:extent>
+        <category label="Fiction" term="FBFIC000000" scheme="http://www.feedbooks.com/categories"/>
+        <category label="Literary" term="FBFIC019000" scheme="http://www.feedbooks.com/categories"/>
+        <category label="English literature" term="INFEN000" scheme="http://www.feedbooks.com/categories"/>
+        <category label="American and Canadian literature" term="INFENUSA" scheme="http://www.feedbooks.com/categories"/>
+        <link type="text/html" rel="alternate" title="View on Feedbooks" href="http://www.feedbooks.com/item/2895246"/>
+        <link type="image/jpeg" rel="http://opds-spec.org/image" href="https://covers.feedbooks.net/item/2895246.jpg?size=large&amp;t=1575076522"/>
+        <link type="image/jpeg" rel="http://opds-spec.org/image/thumbnail" href="https://covers.feedbooks.net/item/2895246.jpg?t=1575076522"/>
+        <link type="text/html" rel="http://opds-spec.org/acquisition/buy" href="https://market.feedbooks.com/item/2895246/buy">
+            <opds:price currencycode="USD">40.00</opds:price>
+            <opds:indirectAcquisition type="application/vnd.adobe.adept+xml">
+                <opds:indirectAcquisition type="application/epub+zip"/></opds:indirectAcquisition>
+            <opds:indirectAcquisition type="application/vnd.readium.lcp.license.v1.0+json">
+                <opds:indirectAcquisition type="application/epub+zip"/></opds:indirectAcquisition>
+        </link>
+        <link type="application/epub+zip" rel="http://opds-spec.org/acquisition/sample" href="https://market.feedbooks.com/item/2895246/preview"/>
+        <link type="text/html" rel="http://opds-spec.org/acquisition/sample" href="https://www.cantook.net/p/9780374718060"/>
+
+        {% for license in licenses %}
+            <odl:license>
+                <dcterms:identifier xsi:type="dcterms:URI">urn:uuid:{{ license.identifier }}</dcterms:identifier>
+                <dcterms:format>application/epub+zip</dcterms:format>
+                <dcterms:format>text/html</dcterms:format>
+                <dcterms:source>http://www.cantook.net/</dcterms:source>
+                <opds:price currencycode="USD">40.00</opds:price>
+                <dcterms:source>cant-2461538-24501117858552614-libraries</dcterms:source>
+                <created>2020-03-02T20:20:17+01:00</created>
+                <odl:terms>
+                    {% if license.total_checkouts is not none %}
+                        <odl:total_checkouts>{{ license.total_checkouts }}</odl:total_checkouts>
+                    {% endif %}
+
+                    {% if license.concurrent_checkouts is not none %}
+                        <odl:concurrent_checkouts>{{ license.concurrent_checkouts }}</odl:concurrent_checkouts>
+                    {% endif %}
+
+                    {% if license.expires is not none %}
+                        <odl:expires>{{ license.expires.isoformat() }}</odl:expires>
+                    {% endif %}
+
+                    <odl:maximum_checkout_length>5097600</odl:maximum_checkout_length>
+                </odl:terms>
+                <odl:protection>
+                    <dcterms:format>application/vnd.adobe.adept+xml</dcterms:format>
+                    <odl:max_devices>6</odl:max_devices>
+                    <odl:copy>true</odl:copy>
+                    <odl:print>false</odl:print>
+                    <odl:tts>false</odl:tts>
+                </odl:protection>
+                <odl:protection>
+                    <dcterms:format>application/vnd.readium.lcp.license.v1.0+json</dcterms:format>
+                    <odl:max_devices>6</odl:max_devices>
+                    <odl:copy>true</odl:copy>
+                    <odl:print>false</odl:print>
+                    <odl:tts>false</odl:tts>
+                </odl:protection>
+                <odl:tlink href="https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url,passphrase,hint,hint_url}" rel="http://opds-spec.org/acquisition/borrow" type="application/vnd.readium.license.status.v1.0+json"/>
+                <link href="https://license.feedbooks.net/copy/status/?uuid=c981d61e-26f4-4070-aaa8-83df952cf61b" rel="self" type="application/vnd.odl.info+json"/>
+            </odl:license>
+        {% endfor %}
+    </entry>
+</feed>

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -1,49 +1,51 @@
-import pytest
-import os
-import json
 import datetime
-import dateutil
-import re
+import json
+import os
 import urllib.parse
-from pdb import set_trace
-from core.testing import DatabaseTest
-from core.metadata_layer import TimestampData
+import uuid
+from typing import List, Optional, Tuple
+
+import dateutil
+import pytest
+from api.circulation_exceptions import *
+from api.odl import (
+    ODLAPI,
+    MockODLAPI,
+    MockSharedODLAPI,
+    ODLExpiredItemsReaper,
+    ODLHoldReaper,
+    ODLImporter,
+    SharedODLAPI,
+    SharedODLImporter,
+)
+from freezegun import freeze_time
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from mock import MagicMock, PropertyMock, patch
+from parameterized import parameterized
+
 from core.model import (
     Collection,
     ConfigurationSetting,
-    Credential,
     DataSource,
     DeliveryMechanism,
     Edition,
     ExternalIntegration,
     Hold,
     Hyperlink,
-    Identifier,
+    LicensePool,
     Loan,
     MediaTypes,
     Representation,
     RightsStatus,
-    get_one,
+    Work,
 )
-from api.odl import (
-    ODLImporter,
-    ODLHoldReaper,
-    MockODLAPI,
-    SharedODLAPI,
-    MockSharedODLAPI,
-    SharedODLImporter,
-)
-from api.circulation_exceptions import *
-from core.util.datetime_helpers import (
-    datetime_utc,
-    strptime_utc,
-    utc_now,
-)
-from core.util.http import (
-    BadResponseException,
-    RemoteIntegrationException,
-)
+from core.scripts import RunCollectionMonitorScript
+from core.testing import DatabaseTest
+from core.util import datetime_helpers
+from core.util.datetime_helpers import datetime_utc, utc_now
+from core.util.http import BadResponseException, RemoteIntegrationException
 from core.util.string_helpers import base64
+
 
 class BaseODLTest(object):
     base_path = os.path.split(__file__)[0]
@@ -52,7 +54,8 @@ class BaseODLTest(object):
     @classmethod
     def get_data(cls, filename):
         path = os.path.join(cls.resource_path, filename)
-        return open(path, "rb").read()
+        return open(path, "r").read()
+
 
 class TestODLAPI(DatabaseTest, BaseODLTest):
 
@@ -1290,8 +1293,12 @@ class TestODLAPI(DatabaseTest, BaseODLTest):
 
 
 class TestODLImporter(DatabaseTest, BaseODLTest):
-
+    @freeze_time("2019-01-01T00:00:00+00:00")
     def test_import(self):
+        """Ensure that ODLImporter correctly processes and imports the ODL feed encoded using OPDS 1.x.
+
+        NOTE: `freeze_time` decorator is required to treat the licenses in the ODL feed as non-expired.
+        """
         feed = self.get_data("feedbooks_bibliographic.atom")
         data_source = DataSource.lookup(self._db, "Feedbooks", autocreate=True)
         collection = MockODLAPI.mock_collection(self._db)
@@ -1305,7 +1312,7 @@ class TestODLImporter(DatabaseTest, BaseODLTest):
                 return working_display_name
         metadata_client = MockMetadataClient()
 
-        warrior_time_limited = dict(checkouts=dict(available=1))
+        warrior_time_limited = dict(checkouts=dict(left=52, available=1))
         canadianity_loan_limited = dict(checkouts=dict(left=40, available=10))
         canadianity_perpetual = dict(checkouts=dict(available=1))
         midnight_loan_limited_1 = dict(checkouts=dict(left=20, available=1))
@@ -1365,7 +1372,7 @@ class TestODLImporter(DatabaseTest, BaseODLTest):
         assert Representation.EPUB_MEDIA_TYPE == lpdm.delivery_mechanism.content_type
         assert DeliveryMechanism.ADOBE_DRM == lpdm.delivery_mechanism.drm_scheme
         assert RightsStatus.IN_COPYRIGHT == lpdm.rights_status.uri
-        assert 1 == warrior_pool.licenses_owned
+        assert 52 == warrior_pool.licenses_owned  # 52 remaining checkouts in the License Info Document
         assert 1 == warrior_pool.licenses_available
         [license] = warrior_pool.licenses
         assert "1" == license.identifier
@@ -1382,7 +1389,7 @@ class TestODLImporter(DatabaseTest, BaseODLTest):
         assert datetime.datetime(
             2019, 3, 31, 3, 13, 35, tzinfo=dateutil.tz.tzoffset("", 3600*2)
         ) == license.expires
-        assert None == license.remaining_checkouts
+        assert 52 == license.remaining_checkouts  # 52 remaining checkouts in the License Info Document
         assert 1 == license.concurrent_checkouts
 
         # This item is an open access audiobook.
@@ -1416,7 +1423,7 @@ class TestODLImporter(DatabaseTest, BaseODLTest):
         assert Representation.EPUB_MEDIA_TYPE == lpdm.delivery_mechanism.content_type
         assert DeliveryMechanism.ADOBE_DRM == lpdm.delivery_mechanism.drm_scheme
         assert RightsStatus.IN_COPYRIGHT == lpdm.rights_status.uri
-        assert 11 == canadianity_pool.licenses_owned
+        assert 40 == canadianity_pool.licenses_owned  # 40 remaining checkouts in the License Info Document
         assert 11 == canadianity_pool.licenses_available
         [license1, license2] = sorted(canadianity_pool.licenses, key=lambda x: x.identifier)
         assert "2" == license1.identifier
@@ -1448,7 +1455,7 @@ class TestODLImporter(DatabaseTest, BaseODLTest):
             [lpdm.delivery_mechanism.drm_scheme for lpdm in lpdms])
         assert ([RightsStatus.IN_COPYRIGHT, RightsStatus.IN_COPYRIGHT] ==
             [lpdm.rights_status.uri for lpdm in lpdms])
-        assert 2 == midnight_pool.licenses_owned
+        assert 72 == midnight_pool.licenses_owned  # 20 + 52 remaining checkouts in corresponding License Info Documents
         assert 2 == midnight_pool.licenses_available
         [license1, license2] = sorted(midnight_pool.licenses, key=lambda x: x.identifier)
         assert "4" == license1.identifier
@@ -1515,7 +1522,6 @@ class TestODLHoldReaper(DatabaseTest, BaseODLTest):
         # that will be applied by run().
         assert None == progress.start
         assert None == progress.finish
-
 
 
 class TestSharedODLAPI(DatabaseTest, BaseODLTest):
@@ -1847,6 +1853,7 @@ class TestSharedODLAPI(DatabaseTest, BaseODLTest):
         pytest.raises(RemoteIntegrationException, self.api.patron_activity, self.patron, "pin")
         assert [hold.external_identifier] == self.api.requests[1:]
 
+
 class TestSharedODLImporter(DatabaseTest, BaseODLTest):
 
     def test_get_fulfill_url(self):
@@ -1925,7 +1932,493 @@ class TestSharedODLImporter(DatabaseTest, BaseODLTest):
         assert Representation.EPUB_MEDIA_TYPE == lpdm.delivery_mechanism.content_type
         assert DeliveryMechanism.ADOBE_DRM == lpdm.delivery_mechanism.drm_scheme
         assert RightsStatus.IN_COPYRIGHT == lpdm.rights_status.uri
-        [borrow_link] = [l for l in essex_pool.identifier.links if l.rel == Hyperlink.BORROW]
-        assert 'http://localhost:6500/AL/works/URI/http://www.feedbooks.com/item/1946289/borrow' == borrow_link.resource.url
+        [borrow_link] = [
+            l for l in essex_pool.identifier.links if l.rel == Hyperlink.BORROW
+        ]
+        assert (
+            "http://localhost:6500/AL/works/URI/http://www.feedbooks.com/item/1946289/borrow"
+            == borrow_link.resource.url
+        )
 
 
+class TestLicense:
+    """Represents an ODL license."""
+
+    def __init__(
+        self,
+        identifier: Optional[str] = None,
+        total_checkouts: Optional[int] = None,
+        concurrent_checkouts: Optional[int] = None,
+        expires: Optional[datetime.datetime] = None,
+    ) -> None:
+        """Initialize a new instance of TestLicense class.
+
+        :param identifier: License's identifier
+        :param total_checkouts: Total number of checkouts before a license expires
+        :param concurrent_checkouts: Number of concurrent checkouts allowed
+        :param expires: Date & time when a license expires
+        """
+        self._identifier: str = identifier if identifier else str(uuid.uuid1())
+        self._total_checkouts: Optional[int] = total_checkouts
+        self._concurrent_checkouts: Optional[int] = concurrent_checkouts
+        self._expires: Optional[datetime.datetime] = expires
+
+    @property
+    def identifier(self) -> str:
+        """Return the license's identifier.
+
+        :return: License's identifier
+        """
+        return self._identifier
+
+    @property
+    def total_checkouts(self) -> Optional[int]:
+        """Return the total number of checkouts before a license expires.
+
+        :return: Total number of checkouts before a license expires
+        """
+        return self._total_checkouts
+
+    @property
+    def concurrent_checkouts(self) -> Optional[int]:
+        """Return the number of concurrent checkouts allowed.
+
+        :return: Number of concurrent checkouts allowed
+        """
+        return self._concurrent_checkouts
+
+    @property
+    def expires(self) -> Optional[datetime.datetime]:
+        """Return the date & time when a license expires.
+
+        :return: Date & time when a license expires
+        """
+        return self._expires
+
+
+class TestLicenseInfo:
+    """Represents information about the current state of a license stored in the License Info Document."""
+
+    def __init__(
+        self, remaining_checkouts: int, available_concurrent_checkouts: int
+    ) -> None:
+        """Initialize a new instance of TestLicenseInfo class.
+
+        :param remaining_checkouts: Total number of checkouts left for a License
+        :param available_concurrent_checkouts: Number of concurrent checkouts currently available
+        """
+        self._remaining_checkouts: int = remaining_checkouts
+        self._available_concurrent_checkouts: int = available_concurrent_checkouts
+
+    @property
+    def remaining_checkouts(self) -> int:
+        """Return the total number of checkouts left for a License.
+
+        :return: Total number of checkouts left for a License
+        """
+        return self._remaining_checkouts
+
+    @property
+    def available_concurrent_checkouts(self) -> int:
+        """Return the number of concurrent checkouts currently available.
+
+        :return: Number of concurrent checkouts currently available
+        """
+        return self._available_concurrent_checkouts
+
+    def __str__(self) -> str:
+        """Return a JSON representation of a part of the License Info Document."""
+        return json.dumps(
+            {
+                "checkouts": {
+                    "left": self.remaining_checkouts,
+                    "available": self.available_concurrent_checkouts,
+                }
+            }
+        )
+
+
+class TestODLExpiredItemsReaper(DatabaseTest, BaseODLTest):
+    """Base class for all ODL reaper tests."""
+
+    ODL_PROTOCOL = ODLAPI.NAME
+    ODL_TEMPLATE_DIR = os.path.join(BaseODLTest.base_path, "files", "odl")
+    ODL_TEMPLATE_FILENAME = "feed_template.xml.jinja"
+    ODL_REAPER_CLASS = ODLExpiredItemsReaper
+
+    def _create_importer(self, collection, http_get):
+        """Create a new ODL importer with the specified parameters.
+
+        :param collection: Collection object
+        :param http_get: Use this method to make an HTTP GET request.
+            This can be replaced with a stub method for testing purposes.
+
+        :return: ODLImporter object
+        """
+        importer = ODLImporter(
+            self._db,
+            collection=collection,
+            http_get=http_get,
+        )
+
+        return importer
+
+    def _get_test_feed(self, licenses: List[TestLicense]) -> str:
+        """Get the test ODL feed with specific licensing information.
+
+        :param licenses: List of ODL licenses
+
+        :return: Test ODL feed
+        """
+        env = Environment(
+            loader=FileSystemLoader(self.ODL_TEMPLATE_DIR), autoescape=select_autoescape()
+        )
+        template = env.get_template(self.ODL_TEMPLATE_FILENAME)
+        feed = template.render(licenses=licenses)
+
+        return feed
+
+    def _import_test_feed(
+        self,
+        licenses: List[TestLicense],
+        license_infos: Optional[List[Optional[TestLicenseInfo]]] = None,
+    ) -> Tuple[List[Edition], List[LicensePool], List[Work]]:
+        """Import the test ODL feed with specific licensing information.
+
+        :param licenses: List of ODL licenses
+        :param license_infos: List of License Info Documents
+
+        :return: 3-tuple containing imported editions, license pools and works
+        """
+        feed = self._get_test_feed(licenses)
+        data_source = DataSource.lookup(self._db, "Feedbooks", autocreate=True)
+        collection = MockODLAPI.mock_collection(self._db, protocol=self.ODL_PROTOCOL)
+        collection.external_integration.set_setting(
+            Collection.DATA_SOURCE_NAME_SETTING, data_source.name
+        )
+        license_status_response = MagicMock(
+            side_effect=[
+                (200, {}, str(license_status) if license_status else "{}") for license_status in license_infos
+            ]
+            if license_infos
+            else [(200, {}, {})]
+        )
+        importer = self._create_importer(collection, license_status_response)
+
+        (
+            imported_editions,
+            imported_pools,
+            imported_works,
+            _,
+        ) = importer.import_from_feed(feed)
+
+        return imported_editions, imported_pools, imported_works
+
+
+class TestODLExpiredItemsReaperSingleLicense(TestODLExpiredItemsReaper):
+    """Class testing that the ODL 1.x reaper correctly processes publications with a single license."""
+
+    @parameterized.expand([
+        (
+            "expiration_date_in_the_past",
+            # The license expires 2021-01-01T00:01:00+01:00 that equals to 2010-01-01T00:00:00+00:00, the current time.
+            # It means the license had already expired at the time of the import.
+            TestLicense(expires=dateutil.parser.isoparse("2021-01-01T00:01:00+01:00"))
+        ),
+        (
+            "total_checkouts_is_zero",
+            TestLicense(total_checkouts=0)
+        ),
+        (
+            "remaining_checkouts_is_zero",
+            TestLicense(total_checkouts=10, concurrent_checkouts=5),
+            TestLicenseInfo(remaining_checkouts=0, available_concurrent_checkouts=0)
+        )
+    ])
+    @freeze_time("2021-01-01T00:00:00+00:00")
+    def test_odl_importer_skips_expired_licenses(
+        self,
+        _,
+        test_license: TestLicense,
+        test_license_info: Optional[TestLicenseInfo] = None
+    ) -> None:
+        """Ensure ODLImporter skips expired licenses
+        and does not count them in the total number of available licenses.
+
+        :param test_license: An example of an expired ODL license
+        :param test_license_info: An example of an ODL License Info Document belonging to an expired ODL license
+            (if required)
+        """
+        # 1.1. Import the test feed with an expired ODL license.
+        imported_editions, imported_pools, imported_works = self._import_test_feed(
+            [test_license],
+            [test_license_info]
+        )
+
+        # Commit to expire the SQLAlchemy cache.
+        self._db.commit()
+
+        # 1.2. Ensure that the license pool was successfully created but it does not have any available licenses.
+        assert len(imported_pools) == 1
+
+        [imported_pool] = imported_pools
+        assert imported_pool.licenses_owned == 0
+        assert imported_pool.licenses_available == 0
+        assert len(imported_pool.licenses) == 0
+
+    @freeze_time("2021-01-01T00:00:00+00:00")
+    def test_odl_reaper_removes_expired_licenses(self):
+        """Ensure ODLExpiredItemsReaper removes expired licenses."""
+        patron = self._patron()
+
+        # 1.1. Import the test feed with an ODL license that is still valid.
+        # The license will be valid for one more day since this very moment.
+        # The feed declares that there 10 checkouts available in total
+        # but the License Info Document shows that there are only 9 available at the moment of import.
+        total_checkouts = 10
+        available_concurrent_checkouts = 5
+        remaining_checkouts = 9
+        license_expiration_date = datetime_helpers.utc_now() + datetime.timedelta(
+            days=1
+        )
+        imported_editions, imported_pools, imported_works = self._import_test_feed(
+            [
+                TestLicense(
+                    expires=license_expiration_date,
+                    total_checkouts=total_checkouts,
+                    concurrent_checkouts=available_concurrent_checkouts,
+                )
+            ],
+            [
+                TestLicenseInfo(
+                    remaining_checkouts=remaining_checkouts,
+                    available_concurrent_checkouts=available_concurrent_checkouts,
+                )
+            ],
+        )
+
+        # Commit to expire the SQLAlchemy cache.
+        self._db.commit()
+
+        # 1.2. Ensure that there is a license pool with available license.
+        assert len(imported_pools) == 1
+
+        [imported_pool] = imported_pools
+        assert imported_pool.licenses_owned == remaining_checkouts
+        assert imported_pool.licenses_available == available_concurrent_checkouts
+
+        assert len(imported_pool.licenses) == 1
+        [license] = imported_pool.licenses
+        assert license.expires == license_expiration_date
+
+        # 2. Create a loan to ensure that the licence with active loan can also be removed (hidden).
+        loan, _ = license.loan_to(patron)
+
+        # 3.1. Run ODLExpiredItemsReaper. This time nothing should happen since the license is still valid.
+        script = RunCollectionMonitorScript(
+            self.ODL_REAPER_CLASS, _db=self._db, cmd_args=["Test ODL Collection"]
+        )
+        script.run()
+
+        # Commit to expire the SQLAlchemy cache.
+        self._db.commit()
+
+        # 3.2. Ensure that availability of the license pool didn't change.
+        assert imported_pool.licenses_owned == remaining_checkouts
+        assert imported_pool.licenses_available == available_concurrent_checkouts
+
+        # 4. Expire the license.
+        with patch("core.model.License.is_expired", new_callable=PropertyMock) as is_expired:
+            is_expired.return_value = True
+
+            # 5.1. Run ODLExpiredItemsReaper again. This time it should remove the expired license.
+            script.run()
+
+            # Commit to expire the SQLAlchemy cache.
+            self._db.commit()
+
+            # 5.2. Ensure that availability of the license pool was updated
+            # and now it doesn't have any available licenses.
+            assert imported_pool.licenses_owned == 0
+            assert imported_pool.licenses_available == 0
+
+            # 6.1. Run ODLExpiredItemsReaper again to ensure that number of licenses won't become negative.
+            script.run()
+
+            # Commit to expire the SQLAlchemy cache.
+            self._db.commit()
+
+            # 6.2. Ensure that number of licenses is still 0.
+            assert imported_pool.licenses_owned == 0
+            assert imported_pool.licenses_available == 0
+
+
+class TestODLExpiredItemsReaperMultipleLicense(TestODLExpiredItemsReaper):
+    """Class testing that the ODL 1.x reaper correctly processes publications with multiple licenses."""
+
+    @freeze_time("2021-01-01T00:00:00+00:00")
+    def test_odl_importer_skips_expired_licenses(self):
+        """Ensure ODLImporter skips expired licenses
+        and does not count them in the total number of available licenses."""
+        # 1.1. Import the test feed with three expired ODL licenses and two valid licenses.
+        remaining_checkouts = 9
+        available_concurrent_checkouts = 5
+        imported_editions, imported_pools, imported_works = self._import_test_feed(
+            [
+                TestLicense(                                                            # Expired
+                    total_checkouts=10,                                                 # (expiry date in the past)
+                    concurrent_checkouts=5,
+                    expires=datetime_helpers.utc_now() - datetime.timedelta(days=1),
+                ),
+                TestLicense(                                                            # Expired
+                    total_checkouts=0,                                                  # (total_checkouts is 0)
+                    concurrent_checkouts=0,
+                    expires=datetime_helpers.utc_now() + datetime.timedelta(days=1),
+                ),
+                TestLicense(                                                            # Expired
+                    total_checkouts=10,                                                 # (remaining_checkout is 0)
+                    concurrent_checkouts=5,
+                    expires=datetime_helpers.utc_now() + datetime.timedelta(days=1),
+                ),
+                TestLicense(                                                            # Valid
+                    total_checkouts=10,
+                    concurrent_checkouts=5,
+                    expires=datetime_helpers.utc_now() + datetime.timedelta(days=2),
+                ),
+                TestLicense(                                                            # Valid
+                    total_checkouts=10,
+                    concurrent_checkouts=5,
+                    expires=datetime_helpers.utc_now() + datetime.timedelta(weeks=12),
+                ),
+            ],
+            [
+                TestLicenseInfo(
+                    remaining_checkouts=0,
+                    available_concurrent_checkouts=0
+                ),
+                TestLicenseInfo(
+                    remaining_checkouts=remaining_checkouts,
+                    available_concurrent_checkouts=available_concurrent_checkouts
+                ),
+                TestLicenseInfo(
+                    remaining_checkouts=remaining_checkouts,
+                    available_concurrent_checkouts=available_concurrent_checkouts
+                )
+            ],
+        )
+
+        # Commit to expire the SQLAlchemy cache.
+        self._db.commit()
+
+        # 1.2. Ensure that the license pool was successfully created
+        assert len(imported_pools) == 1
+        [imported_pool] = imported_pools
+
+        # 1.3. Ensure that the two valid licenses were imported.
+        assert len(imported_pool.licenses) == 2
+
+        # 1.4 Make sure that the license statistics is correct and include only checkouts owned by two valid licenses.
+        assert imported_pool.licenses_owned == remaining_checkouts * 2
+        assert imported_pool.licenses_available == available_concurrent_checkouts * 2
+
+    @freeze_time("2021-01-01T00:00:00+00:00")
+    def test_odl_reaper_removes_expired_licenses(self):
+        """Ensure ODLExpiredItemsReaper removes expired licenses."""
+        # 1.1. Import the test feed with ODL licenses that are not expired.
+        total_checkouts = 10
+        remaining_checkouts = 9
+        available_concurrent_checkouts = 5
+        imported_editions, imported_pools, imported_works = self._import_test_feed(
+            [
+                TestLicense(
+                    total_checkouts=total_checkouts,
+                    concurrent_checkouts=available_concurrent_checkouts,
+                    expires=datetime_helpers.utc_now() + datetime.timedelta(days=1),
+                ),
+                TestLicense(
+                    total_checkouts=total_checkouts,
+                    concurrent_checkouts=available_concurrent_checkouts,
+                    expires=datetime_helpers.utc_now() + datetime.timedelta(days=2),
+                ),
+                TestLicense(
+                    total_checkouts=total_checkouts,
+                    concurrent_checkouts=available_concurrent_checkouts,
+                    expires=datetime_helpers.utc_now() + datetime.timedelta(weeks=12),
+                ),
+            ],
+            [
+                TestLicenseInfo(
+                    remaining_checkouts=total_checkouts,
+                    available_concurrent_checkouts=available_concurrent_checkouts
+                ),
+                TestLicenseInfo(
+                    remaining_checkouts=remaining_checkouts,
+                    available_concurrent_checkouts=available_concurrent_checkouts
+                ),
+                TestLicenseInfo(
+                    remaining_checkouts=remaining_checkouts,
+                    available_concurrent_checkouts=available_concurrent_checkouts
+                )
+            ],
+        )
+
+        # Commit to expire the SQLAlchemy cache.
+        self._db.commit()
+
+        # 1.2. Ensure that there is a license pool with available license.
+        assert len(imported_pools) == 1
+
+        [imported_pool] = imported_pools
+        assert len(imported_pool.licenses) == 3
+
+        [license1, license2, license3] = imported_pool.licenses
+        assert license1.remaining_checkouts == total_checkouts
+        assert license1.concurrent_checkouts == available_concurrent_checkouts
+
+        assert license2.remaining_checkouts == remaining_checkouts
+        assert license2.concurrent_checkouts == available_concurrent_checkouts
+
+        assert license3.remaining_checkouts == remaining_checkouts
+        assert license3.concurrent_checkouts == available_concurrent_checkouts
+
+        assert imported_pool.licenses_owned == total_checkouts + 2 * remaining_checkouts
+        assert imported_pool.licenses_available == 3 * available_concurrent_checkouts
+
+        # 2.1. Run ODLExpiredItemsReaper. This time nothing should happen since the license is still valid.
+        script = RunCollectionMonitorScript(
+            self.ODL_REAPER_CLASS, _db=self._db, cmd_args=["Test ODL Collection"]
+        )
+        script.run()
+
+        # Commit to expire the SQLAlchemy cache.
+        self._db.commit()
+
+        # 2.2. Ensure that availability of the license pool didn't change.
+        assert len(imported_pool.licenses) == 3
+        assert imported_pool.licenses_owned == total_checkouts + 2 * remaining_checkouts
+        assert imported_pool.licenses_available == 3 * available_concurrent_checkouts
+
+        # 3. Expire the license.
+        license1.expires = datetime_helpers.utc_now() - datetime.timedelta(days=1)
+
+        # 3.1. Run ODLExpiredItemsReaper again. This time it should remove the expired license.
+        script.run()
+
+        # Commit to expire the SQLAlchemy cache.
+        self._db.commit()
+
+        # 3.2. Ensure that availability of the license pool was updated.
+        assert len(imported_pool.licenses) == 3
+        assert imported_pool.licenses_owned == 2 * remaining_checkouts
+        assert imported_pool.licenses_available == 2 * available_concurrent_checkouts
+
+        # 4.1. Run ODLExpiredItemsReaper again to make sure that licenses are not expired twice.
+        script.run()
+
+        # Commit to expire the SQLAlchemy cache.
+        self._db.commit()
+
+        # 4.2. Ensure that number of licenses remains the same as in step 3.2.
+        assert len(imported_pool.licenses) == 3
+        assert imported_pool.licenses_owned == 2 * remaining_checkouts
+        assert imported_pool.licenses_available == 2 * available_concurrent_checkouts


### PR DESCRIPTION
## Description

This branch copies in code from the Palace project -- specifically these two PRs [1](https://github.com/ThePalaceProject/circulation/pull/39) [2](https://github.com/ThePalaceProject/circulation/pull/25) -- to address https://jira.nypl.org/browse/SIMPLY-3868.

There are two main goals:
1. Add a reaper for ODL licenses, so that books disappear from the collection once all loans have been used up.
2. Change the ODL importer so that books aren't imported in the first place if there aren't actually any licenses.

## Motivation and Context

In my review of the original branch I noticed that the algorithm for determining whether an ODL license _had_ expired only handled the most simple use cases, so Tim and Viacheslav from Lyrasis added some more complex test cases and make them work.

To make this particular PR I just copied the api/odl.py and tests/test_odl.py files over from the second Palace PR. We haven't done any development on those files for a long time, so there should have been no divergence. The Palace repo has a lot of new code in odl2.py and test_odl2.py, but that's for the JSON flavor of ODL based on OPDS 2, which is a new flavor of ODL that we don't currently support.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
