### PR TITLE
Go back to the old versions of the Clever URLs.

### DIFF
--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -251,7 +251,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
 
         """
         bearer_headers = {'Authorization': 'Bearer %s' % token}
-        result = self._get(self.CLEVER_API_VERSIONED_URL + '/me', bearer_headers)
+        result = self._get(self.CLEVER_API_BASE_URL + '/me', bearer_headers)
         data = result.get('data', {}) or {}
 
         identifier = data.get('id', None)
@@ -270,8 +270,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
 
         user_data = user['data']
         school_id = user_data['school']
-        school = self._get(f"{self.CLEVER_API_VERSIONED_URL}/schools/{school_id}", bearer_headers)
-
+        school = self._get(f"{self.CLEVER_API_BASE_URL}/v1.1/schools/{school_id}", bearer_headers)
         school_nces_id = school['data'].get('nces_id')
 
         # TODO: check student free and reduced lunch status as well


### PR DESCRIPTION
## Description

This branch changes the Clever API URLs we use to the URLs we were using as of revision df1e6be325caeff8a456d28292a3f9722ab0a6e8. The Clever API documentation says the URLs we switched to should work fine, but in real life they're not working for us.

## Motivation and Context

https://jira.nypl.org/browse/SIMPLY-3936

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested this by hooking up my local install to the QA Open eBooks database and visiting `https://localhost:6500/USOEI/oauth_authenticate?provider=Clever`. After going through the Clever dance I was eventually redirected to `#access_token=[token]`, which indicates a successful completion.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
