### PR TITLE
Updates version of circulation-web to 0.5.11

### DIFF
--- a/api/admin/CHANGELOG.md
+++ b/api/admin/CHANGELOG.md
@@ -3,6 +3,12 @@ version number, and is separate from the CHANGELOG at this repository's root.
 
 ## Changelog
 
+### v0.1.9
+
+#### Updated
+
+- Updated simplified-circulation-web version number to v0.5.11.
+
 ### v0.1.8
 
 #### Updated

--- a/api/admin/package-lock.json
+++ b/api/admin/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "simplified-circulation",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "version": "7.16.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+      "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.16.3.tgz",
-      "integrity": "sha512-VrmNH31CEUoR7kIel005qFMVUJpJm1VxfM7YUzVVc2jrxHCi/I6lBEJuqAcP9u9nEzmTD2RnSPhzfdupcSbnPQ==",
+      "version": "7.16.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.16.5.tgz",
+      "integrity": "sha512-GHejyoK+JQqna9rUTkybaGahZOOM+EDcUsbWaLye1g4ZOQMotrMiY8VTBbX1gycZTMNG/YiWTo4WTABvyPUgOg==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -252,9 +252,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.3.tgz",
-      "integrity": "sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g=="
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.0.tgz",
+      "integrity": "sha512-KjbKU7UEfg4YPpskMtMXPhUKn7m/1OdTHTVjy09ScR2LVaoUXe8Jh0UdvN2EKUR6iKTJph52SJP95mAB0MnVLQ=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -928,9 +928,9 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
-      "integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
     },
     "opds-feed-parser": {
       "version": "0.0.17",
@@ -1535,9 +1535,9 @@
       }
     },
     "simplified-circulation-web": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.10.tgz",
-      "integrity": "sha512-5LkLv80dUWQJ4L8u+ynVF/FdmNWUBlvEeePEL9xnIZyVz6133StxNN5m2i7EutA5tDdd1gn8WXY1OZeYDb5nSw==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.11.tgz",
+      "integrity": "sha512-/3HHHxaPXICQDWWWB88fl/kVTFCvpPQIvx6JxWTXDEu294RD5wIGNUxfPl3MZso0i9YBiMMKhR7YpBu+9UYa+w==",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.4",
         "bootstrap": "^3.3.6",

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Library Simplified Circulation Manager",
   "repository": {
     "type": "git",
@@ -13,6 +13,6 @@
     "npm": ">=5.0.0"
   },
   "dependencies": {
-    "simplified-circulation-web": "0.5.10"
+    "simplified-circulation-web": "0.5.11"
   }
 }


### PR DESCRIPTION
## Description

- Updates simplified-circulation-web dependency from 0.5.10 to 0.5.11.

## Motivation and Context

- This update was made in order to incorporate recent bug fixes:
- Fixed issue where the "View Details" button in the List Manager caused an error.
- Fixed bug wherein if a user added or deleted books from a list, then navigated to a new list without saving, the deletedListEntries and addedListEntries would not be reset to empty and therefore would cause the displayed number of books in a list to be wrong.

## How Has This Been Tested?

- These changes have been tested locally.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
