### PR TITLE
SIMPLY-3929: Fix comma + space issue in access-control-allow-origin headers

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -128,7 +128,7 @@ def allows_cors(allowed_domain_type):
 
             if web_domains:
                 options = get_cors_options(
-                    app, dict(origins=" ,".join(web_domains),
+                    app, dict(origins=", ".join(web_domains),
                             supports_credentials=True)
                 )
                 set_cors_headers(resp, options)


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
- Just a small fix to the access-control-allow-origin header that was erroneously adding a space before the comma in the list instead of after.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://jira.nypl.org/browse/SIMPLY-3929

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
