### PR TITLE
OE-317 Advertise OAuth endpoint for HTTP Basic Auth

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2177,10 +2177,12 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
         basic_doc = self._generate_authentication_flow_document(_db, type="http://opds-spec.org/auth/basic")
         oauth_doc = self._generate_authentication_flow_document(_db, type="http://librarysimplified.org/authtype/OAuth-Client-Credentials")
         oauth_doc.update(dict(
-            links=dict(
-                rel="authenticate",
-                href=url_for("http_basic_auth_token", _external=True)
-            )
+            links=[
+                dict(
+                    rel="authenticate",
+                    href=url_for("http_basic_auth_token", _external=True)
+                )
+            ]
         ))
 
         return [basic_doc, oauth_doc]

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2666,4 +2666,10 @@ class BasicAuthTempTokenController(object):
             # Wrap the inner token with the provider name
             outer_token = self.authenticator.create_bearer_token(provider, inner_token.credential)
 
-            return flask.Response(outer_token, 200, {"Content-Type": "text/plain"})
+            data = dict(
+                access_token=outer_token,
+                token_type="bearer",
+                expires_in=duration.seconds
+            )
+
+            return flask.jsonify(data)

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1591,6 +1591,8 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
     NAME = 'Generic Basic Authentication provider'
     BEARER_TOKEN_PROVIDER_NAME = 'HTTPBasicBearerToken'
     TOKEN_TYPE = 'HTTP Basic'
+    FLOW_TYPE_BASIC = 'http://opds-spec.org/auth/basic'
+    FLOW_TYPE_OAUTH = 'http://librarysimplified.org/authtype/OAuth-Client-Credentials'
 
     # By default, patron identifiers can only contain alphanumerics and
     # a few other characters. By default, there are no restrictions on
@@ -2174,8 +2176,8 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
         OPDS document.
         """
 
-        basic_doc = self._generate_authentication_flow_document(_db, type="http://opds-spec.org/auth/basic")
-        oauth_doc = self._generate_authentication_flow_document(_db, type="http://librarysimplified.org/authtype/OAuth-Client-Credentials")
+        basic_doc = self._generate_authentication_flow_document(_db, type=self.FLOW_TYPE_BASIC)
+        oauth_doc = self._generate_authentication_flow_document(_db, type=self.FLOW_TYPE_OAUTH)
         oauth_doc.update(dict(
             links=[
                 dict(

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2167,8 +2167,6 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         provider.identifier_maximum_length=22
         provider.password_maximum_length=7
         provider.identifier_barcode_format = provider.BARCODE_FORMAT_CODABAR
-        FLOW_TYPE_BASIC = 'http://opds-spec.org/auth/basic'
-        FLOW_TYPE_OAUTH = 'http://librarysimplified.org/authtype/OAuth-Client-Credentials'
 
         # We're about to call url_for, so we must create an
         # application context.
@@ -2184,7 +2182,7 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
 
             for doc in docs:
                 assert _(provider.DISPLAY_NAME) == doc['description']
-                assert doc['type'] in [FLOW_TYPE_BASIC, FLOW_TYPE_OAUTH]
+                assert doc['type'] in [provider.FLOW_TYPE_BASIC, provider.FLOW_TYPE_OAUTH]
 
                 labels = doc['labels']
                 assert provider.identifier_label == labels['login']
@@ -2203,12 +2201,12 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
                 assert (provider.password_maximum_length ==
                     inputs['password']['maximum_length'])
 
-                if doc.get('type') == FLOW_TYPE_BASIC:
+                if doc.get('type') == provider.FLOW_TYPE_BASIC:
                     [logo_link] = doc['links']
                     assert "logo" == logo_link["rel"]
                     assert "http://localhost/images/" + MockBasic.LOGIN_BUTTON_IMAGE == logo_link["href"]
 
-                if doc.get('type') == FLOW_TYPE_OAUTH:
+                if doc.get('type') == provider.FLOW_TYPE_OAUTH:
                     [links] = doc['links']
                     assert 'authenticate' == links['rel']
                     assert url_for('http_basic_auth_token', _external=True) == links['href']

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2177,7 +2177,8 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         self.app = app
         del os.environ['AUTOINITIALIZE']
         with self.app.test_request_context("/"):
-            # This will start returning 2 documents, check both of them.
+            # BasicAuthenticationProvider returns 2 authentication flow documents.
+            # One is for Basic Auth and one is for OAuth, we need to check both.
             docs = provider.authentication_flow_document(self._db)
             assert len(docs) == 2
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2179,6 +2179,8 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         with self.app.test_request_context("/"):
             # This will start returning 2 documents, check both of them.
             docs = provider.authentication_flow_document(self._db)
+            assert len(docs) == 2
+
             for doc in docs:
                 assert _(provider.DISPLAY_NAME) == doc['description']
                 assert doc['type'] in [FLOW_TYPE_BASIC, FLOW_TYPE_OAUTH]

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2881,7 +2881,7 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
             response = self.controller.basic_auth_temp_token({}, self._db)
             assert 200 == response.status_code
 
-            token = response.data.decode('utf-8')
+            token = response.json.get('access_token')
             assert token
 
             # Ensure the token is valid

--- a/tests/test_firstbook.py
+++ b/tests/test_firstbook.py
@@ -103,8 +103,6 @@ class TestFirstBook(DatabaseTest):
         del os.environ['AUTOINITIALIZE']
         with self.app.test_request_context("/"):
             docs = self.api.authentication_flow_document(self._db)
-            FLOW_TYPE_BASIC = 'http://opds-spec.org/auth/basic'
-            FLOW_TYPE_OAUTH = 'http://librarysimplified.org/authtype/OAuth-Client-Credentials'
             for doc in docs:
                 assert self.api.DISPLAY_NAME == doc['description']
-                assert doc['type'] in [FLOW_TYPE_BASIC, FLOW_TYPE_OAUTH]
+                assert doc['type'] in [self.api.FLOW_TYPE_BASIC, self.api.FLOW_TYPE_OAUTH]

--- a/tests/test_firstbook.py
+++ b/tests/test_firstbook.py
@@ -102,6 +102,9 @@ class TestFirstBook(DatabaseTest):
         self.app = app
         del os.environ['AUTOINITIALIZE']
         with self.app.test_request_context("/"):
-            doc = self.api.authentication_flow_document(self._db)
-            assert self.api.DISPLAY_NAME == doc['description']
-            assert self.api.FLOW_TYPE == doc['type']
+            docs = self.api.authentication_flow_document(self._db)
+            FLOW_TYPE_BASIC = 'http://opds-spec.org/auth/basic'
+            FLOW_TYPE_OAUTH = 'http://librarysimplified.org/authtype/OAuth-Client-Credentials'
+            for doc in docs:
+                assert self.api.DISPLAY_NAME == doc['description']
+                assert doc['type'] in [FLOW_TYPE_BASIC, FLOW_TYPE_OAUTH]

--- a/tests/test_firstbook2.py
+++ b/tests/test_firstbook2.py
@@ -113,9 +113,13 @@ class TestFirstBook(DatabaseTest):
         self.app = app
         del os.environ['AUTOINITIALIZE']
         with self.app.test_request_context("/"):
-            doc = self.api.authentication_flow_document(self._db)
-            assert self.api.DISPLAY_NAME == doc['description']
-            assert self.api.FLOW_TYPE == doc['type']
+            docs = self.api.authentication_flow_document(self._db)
+            FLOW_TYPE_BASIC = 'http://opds-spec.org/auth/basic'
+            FLOW_TYPE_OAUTH = 'http://librarysimplified.org/authtype/OAuth-Client-Credentials'
+            for doc in docs:
+                assert self.api.DISPLAY_NAME == doc['description']
+                assert doc['type'] in [FLOW_TYPE_BASIC, FLOW_TYPE_OAUTH]
+
 
     def test_jwt(self):
         # Test the code that generates and signs JWTs.

--- a/tests/test_firstbook2.py
+++ b/tests/test_firstbook2.py
@@ -114,11 +114,9 @@ class TestFirstBook(DatabaseTest):
         del os.environ['AUTOINITIALIZE']
         with self.app.test_request_context("/"):
             docs = self.api.authentication_flow_document(self._db)
-            FLOW_TYPE_BASIC = 'http://opds-spec.org/auth/basic'
-            FLOW_TYPE_OAUTH = 'http://librarysimplified.org/authtype/OAuth-Client-Credentials'
             for doc in docs:
                 assert self.api.DISPLAY_NAME == doc['description']
-                assert doc['type'] in [FLOW_TYPE_BASIC, FLOW_TYPE_OAUTH]
+                assert doc['type'] in [self.api.FLOW_TYPE_BASIC, self.api.FLOW_TYPE_OAUTH]
 
 
     def test_jwt(self):


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Advertises the new basic auth bearer token URL in the authentication document.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses [OE-317](https://jira.nypl.org/browse/OE-317). This was something that I missed while working on [OE-162](https://jira.nypl.org/browse/OE-162).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add a Simple Authentication Provider to the Patron Authentication. Ensure that the new endpoint is being advertised in the authentication document. Additional asserts have been added `test_authentication_flow_document` to check that both documents are present and contains the correct attributes.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
