### PR TITLE
Simply 3984 incorrect url scheme on redirect

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -17,6 +17,7 @@ from core.model import (
     Library,
     SessionManager,
     create,
+    get_one_or_create,
 )
 from core.external_search import ExternalSearchIndex
 from core.log import LogConfiguration
@@ -56,8 +57,8 @@ def initialize_database(autoinitialize=True):
     ).filter(Library.id==None).all()
     es_url_from_env = os.environ.get('SIMPLIFIED_ELASTICSEARCH_URL')
 
-    if not es_integrations and not testing and es_url_from_env:        
-        (es_integration, _) = create(
+    if not es_integrations and not testing and es_url_from_env:
+        (es_integration, _) = get_one_or_create(
             _db,
             ExternalIntegration,
             name="LocalDevElasticSearch",

--- a/docker/gunicorn.conf.py
+++ b/docker/gunicorn.conf.py
@@ -32,3 +32,4 @@ if os.environ.get('FLASK_ENV', None) == 'development':
     reload = True       # restart workers when app code changes
     loglevel = "debug"  # default loglevel is 'info'
     workers = 1         # single worker for local dev
+    threads = 1         # single thread for local dev

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -20,10 +20,11 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    access_log /var/log/nginx/access.log;
-    error_log /var/log/nginx/error.log;
+    log_format extended '[$time_local] $status REQUEST: "$request" REFERER: "$http_referer" '
+        'FWD_FOR "$http_x_forwarded_for" PROXY_HOST: "$proxy_host" UPSTREAM_ADDR: "$upstream_addr"';
+    access_log /var/log/nginx/access.log extended;
+    error_log /var/log/nginx/error.log error;
 
-    log_format main '[$time_local] $status REQUEST: "$request" REFERER: "$http_referer" FWD_FOR "$http_x_forwarded_for" PROXY_HOST: "$proxy_host" UPSTREAM_ADDR: "$upstream_addr"';
     gzip on;
 
     upstream circ_mngr_server {
@@ -47,7 +48,7 @@ http {
 
         location @proxy_to_app {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
             proxy_set_header Host $http_host;
             proxy_redirect off;
             proxy_pass http://circ_mngr_server;


### PR DESCRIPTION
## Description

Active Ingredient: changing the Nginx config file so that the value of the `X-Forwarded-Proto` header passed upstream to the WSGI app in Gunicorn is based on the received value of that header, not on the scheme of the inbound request.

Inactive Ingredients:

* Updates the log format for Nginx, and sets the error logging level to `error`
* Updates the gunicorn config for local installs to run single threaded, in addition to single worker

## Motivation and Context

In AWS the app operates behind an application load balancer that handles SSL termination. Consequently requests reach Nginx on the container as HTTP only. Nginx was set up to supply a value to the WSGI server for the `X-Forwarded-Proto` header, but was basing the value of that header on the scheme of the inbound request (from the ALB, so always HTTP), and NOT on the `X-Forwarded-Proto` header supplied by the ALB, which would be the scheme of the original request (always HTTPS).

Because that header was always giving a value of `http` to the upstream WSGI server, the app code's use of `url_for()` would produce new URLs based on that scheme, so the value of redirects and the URLs supplied in feeds had the incorrect scheme prepended. By passing on the received header value instead of inferring that header from the inbound request, we'll get the original scheme value from the ALB passed into the WSGI app environ correctly.

## How Has This Been Tested?

Since it involves both Gunicorn and Nginx, it's not a great fit for our current test suite. I tested manually by logging into the QA instance, changing the Nginx config and restarting, then observing the correct URLs in subsequent curl calls.
