### PR TITLE
Simply 3984 incorrect url scheme on redirect

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -17,6 +17,7 @@ from core.model import (
     Library,
     SessionManager,
     create,
+    get_one_or_create,
 )
 from core.external_search import ExternalSearchIndex
 from core.log import LogConfiguration
@@ -56,8 +57,8 @@ def initialize_database(autoinitialize=True):
     ).filter(Library.id==None).all()
     es_url_from_env = os.environ.get('SIMPLIFIED_ELASTICSEARCH_URL')
 
-    if not es_integrations and not testing and es_url_from_env:        
-        (es_integration, _) = create(
+    if not es_integrations and not testing and es_url_from_env:
+        (es_integration, _) = get_one_or_create(
             _db,
             ExternalIntegration,
             name="LocalDevElasticSearch",

--- a/docker/gunicorn.conf.py
+++ b/docker/gunicorn.conf.py
@@ -32,3 +32,4 @@ if os.environ.get('FLASK_ENV', None) == 'development':
     reload = True       # restart workers when app code changes
     loglevel = "debug"  # default loglevel is 'info'
     workers = 1         # single worker for local dev
+    threads = 1         # single thread for local dev

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -20,10 +20,11 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    access_log /var/log/nginx/access.log;
-    error_log /var/log/nginx/error.log;
+    log_format extended '[$time_local] $status REQUEST: "$request" REFERER: "$http_referer" '
+        'FWD_FOR "$http_x_forwarded_for" PROXY_HOST: "$proxy_host" UPSTREAM_ADDR: "$upstream_addr"';
+    access_log /var/log/nginx/access.log extended;
+    error_log /var/log/nginx/error.log error;
 
-    log_format main '[$time_local] $status REQUEST: "$request" REFERER: "$http_referer" FWD_FOR "$http_x_forwarded_for" PROXY_HOST: "$proxy_host" UPSTREAM_ADDR: "$upstream_addr"';
     gzip on;
 
     upstream circ_mngr_server {
@@ -47,7 +48,7 @@ http {
 
         location @proxy_to_app {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
             proxy_set_header Host $http_host;
             proxy_redirect off;
             proxy_pass http://circ_mngr_server;


### PR DESCRIPTION
## Description

Should resolve SIMPLY-3984, by passing the `X-Forwarded-Proto` header from the AWS application load balancer to Nginx correctly.
