### PR TITLE
OE 318 Require OAuth flow to be explicitly enabled

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1822,6 +1822,13 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
             or self.DEFAULT_PASSWORD_LABEL
         )
 
+        self.oauth_enabled = self.HTTP_BASIC_OAUTH_ENABLED_DEFAULT
+        oauth_enabled = list(
+            filter(lambda setting: setting.key == self.HTTP_BASIC_OAUTH_ENABLED, library.settings)) \
+            or self.HTTP_BASIC_OAUTH_ENABLED_DEFAULT
+        if oauth_enabled:
+            self.oauth_enabled = oauth_enabled[0].bool_value or self.HTTP_BASIC_OAUTH_ENABLED_DEFAULT
+
     def remote_patron_lookup(self, patron_or_patrondata):
         """Ask the remote for information about this patron, and then make sure
         the patron belongs to the library associated with thie BasicAuthenticationProvider."""

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1679,6 +1679,19 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
     TEST_PASSWORD_DESCRIPTION_REQUIRED = _("The password for the Test Identifier.")
     TEST_PASSWORD_DESCRIPTION_OPTIONAL = _("The password for the Test Identifier (above, in previous section).")
 
+    LIBRARY_SETTINGS = [
+        { "key": HTTP_BASIC_OAUTH_ENABLED,
+          "label": _("Enable OAuth for HTTP Basic Auth"),
+          "description": _("Enable authentication with bearer tokens generated via basic auth credentials"),
+          "type": "select",
+          "options": [
+              { "key": "false", "label": _("Disabled") },
+              { "key": "true", "label": _("Enabled") },
+          ],
+          "default": "false",
+        },
+    ] + AuthenticationProvider.LIBRARY_SETTINGS
+
     SETTINGS = [
         { "key": TEST_IDENTIFIER,
           "label": _("Test Identifier"),

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1589,10 +1589,6 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
     DISPLAY_NAME = _("Library Barcode")
     AUTHENTICATION_REALM = _("Library card")
     NAME = 'Generic Basic Authentication provider'
-    BEARER_TOKEN_PROVIDER_NAME = 'HTTPBasicBearerToken'
-    TOKEN_TYPE = 'HTTP Basic'
-    FLOW_TYPE_BASIC = 'http://opds-spec.org/auth/basic'
-    FLOW_TYPE_OAUTH = 'http://librarysimplified.org/authtype/OAuth-Client-Credentials'
 
     # By default, patron identifiers can only contain alphanumerics and
     # a few other characters. By default, there are no restrictions on
@@ -1604,6 +1600,15 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
     # Configuration settings that are common to all Basic Auth-type
     # authentication techniques.
     #
+
+    # Settings for basic auth bearer tokens
+    BEARER_TOKEN_PROVIDER_NAME = 'HTTPBasicBearerToken'
+    TOKEN_TYPE = 'HTTP Basic'
+    HTTP_BASIC_OAUTH_ENABLED = "http_basic_oauth_enabled"
+    HTTP_BASIC_OAUTH_ENABLED_DEFAULT = False
+    FLOW_TYPE_BASIC = 'http://opds-spec.org/auth/basic'
+    FLOW_TYPE_OAUTH = 'http://librarysimplified.org/authtype/OAuth-Client-Credentials'
+
 
     # Identifiers can be presumed invalid if they don't match
     # this regular expression.

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2195,17 +2195,12 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
         """
 
         basic_doc = self._generate_authentication_flow_document(_db, type=self.FLOW_TYPE_BASIC)
-        oauth_doc = self._generate_authentication_flow_document(_db, type=self.FLOW_TYPE_OAUTH)
-        oauth_doc.update(dict(
-            links=[
-                dict(
-                    rel="authenticate",
-                    href=url_for("http_basic_auth_token", _external=True)
-                )
-            ]
-        ))
+        docs = [basic_doc, ]
+        if self.oauth_enabled:
+            oauth_doc = self._generate_authentication_flow_document(_db, type=self.FLOW_TYPE_OAUTH)
+            docs.append(oauth_doc)
 
-        return [basic_doc, oauth_doc]
+        return docs
 
     def _generate_authentication_flow_document(self, _db, type):
 
@@ -2241,6 +2236,9 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
             # logos instead.
             flow_doc["links"] = [dict(rel="logo", href=url_for("static_image", filename=self.LOGIN_BUTTON_IMAGE, _external=True))]
         flow_doc["type"] = type
+        if type == self.FLOW_TYPE_OAUTH:
+            flow_doc["links"] = [dict(rel="authenticate", href=url_for("http_basic_auth_token", _external=True))]
+
         return flow_doc
 
 

--- a/tests/admin/controller/test_patron_auth.py
+++ b/tests/admin/controller/test_patron_auth.py
@@ -329,6 +329,7 @@ class TestPatronAuth(SettingsControllerTest):
                     "short_name": library.short_name,
                     AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_NONE,
                     AuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
+                    BasicAuthenticationProvider.HTTP_BASIC_OAUTH_ENABLED: "false",
                 }])),
             ] + common_args)
             response = self.manager.admin_patron_auth_services_controller.process_patron_auth_services()
@@ -343,6 +344,7 @@ class TestPatronAuth(SettingsControllerTest):
                     AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_NONE,
                     AuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
                     AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION: "(invalid re",
+                    BasicAuthenticationProvider.HTTP_BASIC_OAUTH_ENABLED: "false",
                 }])),
             ] + common_args)
             response = self.manager.admin_patron_auth_services_controller.process_patron_auth_services()
@@ -356,6 +358,7 @@ class TestPatronAuth(SettingsControllerTest):
                     AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
                     AuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
                     AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION: "(invalid re",
+                    BasicAuthenticationProvider.HTTP_BASIC_OAUTH_ENABLED: "false",
                 }])),
             ] + common_args)
             response = self.manager.admin_patron_auth_services_controller.process_patron_auth_services()
@@ -401,6 +404,7 @@ class TestPatronAuth(SettingsControllerTest):
                     AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
                     AuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
                     AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION: "^1234",
+                    BasicAuthenticationProvider.HTTP_BASIC_OAUTH_ENABLED: "false",
                 }])),
             ] + self._common_basic_auth_arguments())
 
@@ -472,6 +476,7 @@ class TestPatronAuth(SettingsControllerTest):
                     AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION: "^(.)",
                     AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_NONE,
                     AuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
+                    BasicAuthenticationProvider.HTTP_BASIC_OAUTH_ENABLED: "false",
                 }])),
             ] + self._common_basic_auth_arguments())
             response = self.manager.admin_patron_auth_services_controller.process_patron_auth_services()

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1130,6 +1130,11 @@ class TestLibraryAuthenticator(AuthenticatorTest):
 
         integration = self._external_integration(self._str)
         library = self._default_library
+
+        # Enable Basic Auth OAuth before passing into authenticators
+        ConfigurationSetting.for_library(
+            BasicAuthenticationProvider.HTTP_BASIC_OAUTH_ENABLED, library).value = "true"
+
         basic = MockBasicAuthenticationProvider(library, integration)
         oauth = MockOAuthAuthenticationProvider(library, "oauth")
         oauth.URI = "http://example.org/"
@@ -2166,6 +2171,7 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
         provider.identifier_maximum_length=22
         provider.password_maximum_length=7
         provider.identifier_barcode_format = provider.BARCODE_FORMAT_CODABAR
+        provider.oauth_enabled = True
 
         # We're about to call url_for, so we must create an
         # application context.


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Adds a `LIBRARY_SETTINGS` configuration to `BasicAuthenticationProvider` that allows libraries to opt in to the new OAuth flow.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[OE-318](https://jira.nypl.org/browse/OE-318). Allows libraries to opt in to the new flow, with the default being opted out.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
