### PR TITLE
Updates version number of circ-web from 0.5.12 to 0.5.13

### DIFF
--- a/api/admin/CHANGELOG.md
+++ b/api/admin/CHANGELOG.md
@@ -2,6 +2,11 @@ This document is used only to track changes to the simplified-circulation-web
 version number, and is separate from the CHANGELOG at this repository's root.
 
 ## Changelog
+### v0.1.11
+
+#### Updated
+
+- Updated simplified-circulation-web version number to v0.5.13.
 ### v0.1.10
 
 #### Updated

--- a/api/admin/package-lock.json
+++ b/api/admin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1466,9 +1466,9 @@
       }
     },
     "simplified-circulation-web": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.12.tgz",
-      "integrity": "sha512-KCLF8Vo0REYDehRyUzYhG9RowrhBZtV9/SthVb+hdGvm7HrdAaawlsW1RfnIeCj1yQOvW8vVecasPvCcT2Obug==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.13.tgz",
+      "integrity": "sha512-F+SBb9H1rIqbtgj/o7Deike6WD4AI4RcSexJsH1ZVax021EHeQckMaLleVVTYI32bbCmSWYa0yrVOltEts7fMg==",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.4",
         "bootstrap": "^3.3.6",

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Library Simplified Circulation Manager",
   "repository": {
     "type": "git",
@@ -13,6 +13,6 @@
     "npm": ">=5.0.0"
   },
   "dependencies": {
-    "simplified-circulation-web": "0.5.12"
+    "simplified-circulation-web": "0.5.13"
   }
 }


### PR DESCRIPTION
## Description

- Updated simplified-circulation-web version from 0.5.12 to 0.5.13.

## Motivation and Context

- This update was needed to pull in recent work (including [SIMPLY-3974](https://jira.nypl.org/browse/SIMPLY-3974)) into circulation so it can be deployed to the QA server and tested.

## How Has This Been Tested?

- The updated code has been tested locally.
- Server-side unit tests pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
