### PR TITLE
Updates simplified-circulation-web version number

### DIFF
--- a/api/admin/CHANGELOG.md
+++ b/api/admin/CHANGELOG.md
@@ -2,6 +2,12 @@ This document is used only to track changes to the simplified-circulation-web
 version number, and is separate from the CHANGELOG at this repository's root.
 
 ## Changelog
+
+### v0.1.12
+
+#### Updated
+
+- Updated simplified-circulation-web version number to v0.5.14.
 ### v0.1.11
 
 #### Updated

--- a/api/admin/package-lock.json
+++ b/api/admin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -250,11 +250,11 @@
       }
     },
     "cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "requires": {
-        "node-fetch": "2.6.1"
+        "node-fetch": "2.6.7"
       }
     },
     "css-box-model": {
@@ -373,6 +373,31 @@
         "abab": "^2.0.3",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+          "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+        },
+        "whatwg-url": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+          "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+          "requires": {
+            "lodash": "^4.7.0",
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          }
+        }
       }
     },
     "debug": {
@@ -755,6 +780,31 @@
         "whatwg-url": "^8.5.0",
         "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+          "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+        },
+        "whatwg-url": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+          "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+          "requires": {
+            "lodash": "^4.7.0",
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          }
+        }
       }
     },
     "json-schema": {
@@ -890,9 +940,12 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "numeral": {
       "version": "2.0.6",
@@ -1466,9 +1519,9 @@
       }
     },
     "simplified-circulation-web": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.13.tgz",
-      "integrity": "sha512-F+SBb9H1rIqbtgj/o7Deike6WD4AI4RcSexJsH1ZVax021EHeQckMaLleVVTYI32bbCmSWYa0yrVOltEts7fMg==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.14.tgz",
+      "integrity": "sha512-yb+a4JZgVO2KJbV80eI3b/FcuFLpTNYiE1vGJMK1b0s8VBl5j6abFwX/iwb8V3aZ36P9D3BmRP+BGTU4xcgSVw==",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.4",
         "bootstrap": "^3.3.6",
@@ -1558,12 +1611,9 @@
       }
     },
     "tr46": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
-      "requires": {
-        "punycode": "^2.1.1"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -1657,9 +1707,9 @@
       }
     },
     "webidl-conversions": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -1680,13 +1730,12 @@
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
     },
     "whatwg-url": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
-      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "requires": {
-        "lodash": "^4.7.0",
-        "tr46": "^2.1.0",
-        "webidl-conversions": "^6.1.0"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "word-wrap": {

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Library Simplified Circulation Manager",
   "repository": {
     "type": "git",
@@ -13,6 +13,6 @@
     "npm": ">=5.0.0"
   },
   "dependencies": {
-    "simplified-circulation-web": "0.5.13"
+    "simplified-circulation-web": "0.5.14"
   }
 }


### PR DESCRIPTION
## Description

- Updated version number of simplified-circulation-web from 0.5.13 to 0.5.14.

## Motivation and Context

- Needed to incorporate recent changes to the QA server, including a bug fix impacting deleting books in the List Manager.

## How Has This Been Tested?

- This change has been tested locally.
- All current unit tests pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
