### PR TITLE
Fix LOGIN_BUTTON_IMAGE link not appearing in authentication_document for basic oauth

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2235,14 +2235,21 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
             inputs = dict(login=login_inputs,
                           password=password_inputs)
         )
+
+        flow_doc["links"] = []
         if self.LOGIN_BUTTON_IMAGE:
             # TODO: I'm not sure if logo is appropriate for this, since it's a button
             # with the logo on it rather than a plain logo. Perhaps we should use plain
             # logos instead.
-            flow_doc["links"] = [dict(rel="logo", href=url_for("static_image", filename=self.LOGIN_BUTTON_IMAGE, _external=True))]
+            flow_doc["links"].append(
+                dict(rel="logo", href=url_for("static_image", filename=self.LOGIN_BUTTON_IMAGE, _external=True))
+            )
+
         flow_doc["type"] = type
         if type == self.FLOW_TYPE_OAUTH:
-            flow_doc["links"] = [dict(rel="authenticate", href=url_for("http_basic_auth_token", _external=True))]
+            flow_doc["links"].append(
+                dict(rel="authenticate", href=url_for("http_basic_auth_token", _external=True))
+            )
 
         return flow_doc
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2251,9 +2251,11 @@ class TestBasicAuthenticationProvider(AuthenticatorTest):
                     assert "http://localhost/images/" + MockBasic.LOGIN_BUTTON_IMAGE == logo_link["href"]
 
                 if doc.get('type') == provider.FLOW_TYPE_OAUTH:
-                    [links] = doc['links']
-                    assert 'authenticate' == links['rel']
-                    assert url_for('http_basic_auth_token', _external=True) == links['href']
+                    logo_link, authenticate_link = doc['links']
+                    assert 'authenticate' == authenticate_link['rel']
+                    assert url_for('http_basic_auth_token', _external=True) == authenticate_link['href']
+                    assert "logo" == logo_link["rel"]
+                    assert "http://localhost/images/" + MockBasic.LOGIN_BUTTON_IMAGE == logo_link["href"]
 
     def test_remote_patron_lookup(self):
         #remote_patron_lookup does the lookup by calling _remote_patron_lookup,


### PR DESCRIPTION
## Description

Fixes the FirstBook logo link in the authentication_document. The "authenticate" link was re-defining the "links" dict thus overwriting the logo.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The mobile clients use the LOGIN_BUTTON_IMAGE (logo) from the authentication_document and it was missing with the new Basic OAuth implementation.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated `test_authentication_flow_document` to ensure that the logo and authenticate dicts are in the links dict. Also tested manually by checking the authentication_document to ensure the logo appears alongside authenticate.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
