### PR TITLE
Add MinIO to docker-compose

### DIFF
--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -37,8 +37,6 @@ services:
     ports:
       - "9000:9000"
       - "9001:9001"
-    volumes:
-      - cm_local_minio:/data
 
   scripts:
     container_name: cm_local_scripts
@@ -90,4 +88,3 @@ volumes:
   cm_local_gunicorn_log:
   cm_local_script_logs:
   es_data:
-  cm_local_minio:

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -27,7 +27,19 @@ services:
     ports:
       - "9200:9200"
       - "9300:9300"
-    
+
+  minio:
+    container_name: minio
+    image: bitnami/minio:latest
+    environment:
+      MINIO_ROOT_USER: simplified
+      MINIO_ROOT_PASSWORD: 12345678901234567890
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - cm_local_minio:/data
+
   scripts:
     container_name: cm_local_scripts
     depends_on:
@@ -52,6 +64,7 @@ services:
     depends_on:
       - database
       - elasticsearch
+      - minio
     build:
       context: .
       target: cm_webapp_local
@@ -60,6 +73,9 @@ services:
       SIMPLIFIED_TEST_DATABASE: postgres://simplified_test:simplified_test@cm_local_db:5434/simplified_circulation_test
       SIMPLIFIED_ELASTICSEARCH_URL: http://cm_local_es:9200
       SIMPLIFIED_TEST_ELASTICSEARCH: http://cm_local_es:9200
+      SIMPLIFIED_TEST_MINIO_ENDPOINT_URL: http://minio:9000
+      SIMPLIFIED_TEST_MINIO_USER: simplified
+      SIMPLIFIED_TEST_MINIO_PASSWORD: 12345678901234567890
     ports:
       - 80:80
     volumes:
@@ -74,3 +90,4 @@ volumes:
   cm_local_gunicorn_log:
   cm_local_script_logs:
   es_data:
+  cm_local_minio:

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -59,6 +59,7 @@ services:
       SIMPLIFIED_PRODUCTION_DATABASE: postgres://simplified:simplified@cm_local_db:5434/simplified_circulation_dev
       SIMPLIFIED_TEST_DATABASE: postgres://simplified_test:simplified_test@cm_local_db:5434/simplified_circulation_test
       SIMPLIFIED_ELASTICSEARCH_URL: http://cm_local_es:9200
+      SIMPLIFIED_TEST_ELASTICSEARCH: http://cm_local_es:9200
     ports:
       - 80:80
     volumes:

--- a/docker-compose.cicd.yml
+++ b/docker-compose.cicd.yml
@@ -27,6 +27,16 @@ services:
       /bin/sh -c "./bin/elasticsearch-plugin list | grep -q analysis-icu 
       || ./bin/elasticsearch-plugin install analysis-icu; tail -f /dev/null"
 
+  minio:
+    container_name: minio
+    image: bitnami/minio:latest
+    environment:
+      MINIO_ROOT_USER: simplified
+      MINIO_ROOT_PASSWORD: 12345678901234567890
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
   scripts:
     container_name: cm_active_scripts
     depends_on:
@@ -46,6 +56,7 @@ services:
     depends_on:
       - database
       - elasticsearch
+      - minio
     build:
       context: .
       target: cm_webapp_active
@@ -55,5 +66,8 @@ services:
       SIMPLIFIED_PRODUCTION_DATABASE: postgres://simplified:simplified@cm_active_db:5434/simplified_circulation_dev
       SIMPLIFIED_TEST_DATABASE: postgres://simplified_test:simplified_test@cm_active_db:5434/simplified_circulation_test
       SIMPLIFIED_TEST_ELASTICSEARCH: http://cm_local_es:9200
+      SIMPLIFIED_TEST_MINIO_ENDPOINT_URL: http://minio:9000
+      SIMPLIFIED_TEST_MINIO_USER: simplified
+      SIMPLIFIED_TEST_MINIO_PASSWORD: 12345678901234567890
     ports:
       - 80:80

--- a/docker-compose.cicd.yml
+++ b/docker-compose.cicd.yml
@@ -54,5 +54,6 @@ services:
     environment:
       SIMPLIFIED_PRODUCTION_DATABASE: postgres://simplified:simplified@cm_active_db:5434/simplified_circulation_dev
       SIMPLIFIED_TEST_DATABASE: postgres://simplified_test:simplified_test@cm_active_db:5434/simplified_circulation_test
+      SIMPLIFIED_TEST_ELASTICSEARCH: http://cm_local_es:9200
     ports:
       - 80:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,18 @@ services:
       /bin/sh -c "./bin/elasticsearch-plugin list | grep -q analysis-icu 
       || ./bin/elasticsearch-plugin install analysis-icu; tail -f /dev/null"
 
+  minio:
+    container_name: minio
+    image: bitnami/minio:latest
+    environment:
+      MINIO_ROOT_USER: simplified
+      MINIO_ROOT_PASSWORD: 12345678901234567890
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - cm_local_minio:/data
+
   scripts:
     container_name: cm_local_scripts
     depends_on:
@@ -53,6 +65,7 @@ services:
     depends_on:
       - database
       - elasticsearch
+      - minio
     build:
       context: .
       target: cm_webapp_local
@@ -61,6 +74,9 @@ services:
       SIMPLIFIED_TEST_DATABASE: postgres://simplified_test:simplified_test@cm_local_db:5434/simplified_circulation_test
       SIMPLIFIED_ELASTICSEARCH_URL: http://cm_local_es:9200
       SIMPLIFIED_TEST_ELASTICSEARCH: http://cm_local_es:9200
+      SIMPLIFIED_TEST_MINIO_ENDPOINT_URL: http://minio:9000
+      SIMPLIFIED_TEST_MINIO_USER: simplified
+      SIMPLIFIED_TEST_MINIO_PASSWORD: 12345678901234567890
     ports:
       - 80:80
     volumes:
@@ -74,3 +90,4 @@ volumes:
   cm_local_dbdata:
   cm_local_gunicorn_log:
   cm_local_script_logs:
+  cm_local_minio:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       SIMPLIFIED_PRODUCTION_DATABASE: postgres://simplified:simplified@cm_local_db:5434/simplified_circulation_dev
       SIMPLIFIED_TEST_DATABASE: postgres://simplified_test:simplified_test@cm_local_db:5434/simplified_circulation_test
       SIMPLIFIED_ELASTICSEARCH_URL: http://cm_local_es:9200
+      SIMPLIFIED_TEST_ELASTICSEARCH: http://cm_local_es:9200
     ports:
       - 80:80
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,6 @@ services:
     ports:
       - "9000:9000"
       - "9001:9001"
-    volumes:
-      - cm_local_minio:/data
 
   scripts:
     container_name: cm_local_scripts
@@ -90,4 +88,3 @@ volumes:
   cm_local_dbdata:
   cm_local_gunicorn_log:
   cm_local_script_logs:
-  cm_local_minio:

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ commands_pre =
     docker: docker restart es
     python -m textblob.download_corpora
 commands =
-    pytest --disable-warnings {posargs:"tests core/tests"}
+    pytest --disable-warnings {posargs:["tests", "core/tests"]}
 passenv = SIMPLIFIED_*
 setenv =
     docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9005/simplified_circulation_test

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ commands_pre =
     docker: docker restart es
     python -m textblob.download_corpora
 commands =
-    pytest --disable-warnings {posargs:["tests", "core/tests"]}
+    pytest --disable-warnings {posargs: "tests", "core/tests"}
 passenv = SIMPLIFIED_*
 setenv =
     docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9005/simplified_circulation_test

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ commands_pre =
     docker: docker restart es
     python -m textblob.download_corpora
 commands =
-    pytest --disable-warnings {posargs:"tests"}
+    pytest --disable-warnings {posargs:"tests core/tests"}
 passenv = SIMPLIFIED_*
 setenv =
     docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9005/simplified_circulation_test

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ commands_pre =
     docker: docker restart es
     python -m textblob.download_corpora
 commands =
-    pytest --disable-warnings {posargs: "tests", "core/tests"}
+    pytest --disable-warnings {posargs: "tests" "core/tests"}
 passenv = SIMPLIFIED_*
 setenv =
     docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9005/simplified_circulation_test

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,13 @@ passenv = SIMPLIFIED_*
 setenv =
     docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9005/simplified_circulation_test
     docker: SIMPLIFIED_TEST_ELASTICSEARCH=http://localhost:9006
+    docker: SIMPLIFIED_TEST_MINIO_ENDPOINT_URL=http://localhost:9007
+    docker: SIMPLIFIED_TEST_MINIO_USER=simplified
+    docker: SIMPLIFIED_TEST_MINIO_PASSWORD=12345678901234567890
 docker =
     docker: es
     docker: db
+    docker: minio
 allowlist_externals =
     docker: docker
     python
@@ -36,6 +40,14 @@ environment =
     discovery.type=single-node
 ports =
     9006:9200/tcp
+
+[docker:minio]
+image = bitnami/minio:latest
+environment =
+    MINIO_ROOT_USER=simplified
+    MINIO_ROOT_PASSWORD=12345678901234567890
+ports =
+    9007:9000/tcp
 
 [gh-actions]
 python =


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Adds a MinIO container and fixes test Elasticsearch endpoint.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adds a MinIO container for S3 tests in `core` and fixes the Elasticsearch test endpoint.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with `make up` and running the tests separately via `docker exec -it --env TESTING=1 cm_local_webapp /usr/local/bin/runinvenv /simplified_venv pytest tests --disable-pytest-warnings` and `docker exec -it --env TESTING=1 cm_local_webapp /usr/local/bin/runinvenv /simplified_venv pytest core/tests/ --disable-pytest-warnings`.

There are four tests that fail for me locally from `core`. Two deal with read-only settings and two that have some sort of mismatched exceptions from `core/tests/test_app_server.py`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
