### PR TITLE
Return an existing HTTP Basic Auth token if requested within a minute since creation

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -30,7 +30,6 @@ from .config import (
     IntegrationException,
 )
 from core.model import (
-    credential,
     get_one,
     get_one_or_create,
     CirculationEvent,

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -30,6 +30,7 @@ from .config import (
     IntegrationException,
 )
 from core.model import (
+    credential,
     get_one,
     get_one_or_create,
     CirculationEvent,
@@ -2685,9 +2686,38 @@ class BasicAuthTempTokenController(object):
     """A controller that handles requests for issuing temporary tokens
     to HTTP Basic Auth credentials.
     """
+    DO_NOT_GENERATE_NEW_TOKEN_PERIOD = 60 * 59
+    TOKEN_DURATION = datetime.timedelta(seconds=3600)
 
     def __init__(self, authenticator):
         self.authenticator = authenticator
+
+    def get_or_create_token(self, _db, patron):
+        """
+        Retrieve a patron's Credential or create a new one.
+        """
+        data_source = None
+        token_type = BasicAuthenticationProvider.TOKEN_TYPE
+        refesher_method = None
+        token_time_remaining = 0
+
+        credential = Credential.lookup(_db, data_source, token_type, patron, refesher_method)
+        if credential.expires:
+            # The Credential's expiration time is stored and the lifetime of the Credential (one hour) is known,
+            # so the creation time can be calculated
+            token_time_remaining = (credential.expires - utc_now()).seconds
+
+            if token_time_remaining >= BasicAuthTempTokenController.DO_NOT_GENERATE_NEW_TOKEN_PERIOD:
+                # Use the existing token if it's been requested within a minute since creation
+                inner_token = credential
+        else:
+            # Patron didn't have an existing token or is requesting a new one,
+            # create a temporary inner token with a lifetime of 1 hour
+            inner_token, _ = Credential.temporary_token_create(
+                _db, data_source, token_type, patron, BasicAuthTempTokenController.TOKEN_DURATION
+            )
+
+        return inner_token
 
     def basic_auth_temp_token(self, params, _db):
         """Generate and return a temporary token from HTTP Basic Auth credentials.
@@ -2695,27 +2725,22 @@ class BasicAuthTempTokenController(object):
         patron = self.authenticator.authenticated_patron(_db, flask.request.authorization)
 
         if isinstance(patron, ProblemDetail):
-            # There was a problem turning the authorization header
-            # into a valid patron.
+            # There was a problem turning the authorization header into a valid patron.
             return patron
 
         if isinstance(patron, Patron):
-            # Create a temporary inner token with a lifetime of 1 hour
-            duration = datetime.timedelta(seconds=3600)
-            data_source = None
-            provider = BasicAuthenticationProvider.BEARER_TOKEN_PROVIDER_NAME
-            token_type = BasicAuthenticationProvider.TOKEN_TYPE
-            inner_token, _ = Credential.temporary_token_create(
-                _db, data_source, token_type, patron, duration
-            )
-
+            inner_token = self.get_or_create_token(_db, patron)
+            
             # Wrap the inner token with the provider name
-            outer_token = self.authenticator.create_bearer_token(provider, inner_token.credential)
+            outer_token = self.authenticator.create_bearer_token(
+                BasicAuthenticationProvider.BEARER_TOKEN_PROVIDER_NAME,
+                inner_token.credential
+            )
 
             data = dict(
                 access_token=outer_token,
                 token_type="bearer",
-                expires_in=duration.seconds
+                expires_in=BasicAuthTempTokenController.TOKEN_DURATION.seconds
             )
 
             return flask.jsonify(data)

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2685,8 +2685,8 @@ class BasicAuthTempTokenController(object):
     """A controller that handles requests for issuing temporary tokens
     to HTTP Basic Auth credentials.
     """
-    DO_NOT_GENERATE_NEW_TOKEN_PERIOD = 60 * 59
     TOKEN_DURATION = datetime.timedelta(seconds=3600)
+    DO_NOT_GENERATE_NEW_TOKEN_PERIOD = TOKEN_DURATION.seconds - 60
 
     def __init__(self, authenticator):
         self.authenticator = authenticator

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2706,9 +2706,9 @@ class BasicAuthTempTokenController(object):
             # so the creation time can be calculated
             token_time_remaining = (credential.expires - utc_now()).seconds
 
-            if token_time_remaining >= BasicAuthTempTokenController.DO_NOT_GENERATE_NEW_TOKEN_PERIOD:
-                # Use the existing token if it's been requested within a minute since creation
-                inner_token = credential
+        if token_time_remaining >= BasicAuthTempTokenController.DO_NOT_GENERATE_NEW_TOKEN_PERIOD:
+            # Use the existing token if it's been requested within a minute since creation
+            inner_token = credential
         else:
             # Patron didn't have an existing token or is requesting a new one,
             # create a temporary inner token with a lifetime of 1 hour

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2958,15 +2958,17 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
         """
         valid_credentials = base64.b64encode(b"unittestuser:unittestpassword").decode("utf-8")
         headers_basic = dict(Authorization=f"Basic {valid_credentials}")
+        start_datetime = datetime.datetime(2022, 1, 1, 0, 0, 0)
 
-        with app.test_request_context("/http_basic_auth_token", headers=headers_basic):
-            response = self.controller.basic_auth_temp_token({}, self._db)
-            assert 200 == response.status_code
+        with freeze_time(start_datetime) as frozen_time:
+            with app.test_request_context("/http_basic_auth_token", headers=headers_basic):
+                response = self.controller.basic_auth_temp_token({}, self._db)
+                assert 200 == response.status_code
 
-            token = response.json.get('access_token')
-            assert token
+                token = response.json.get('access_token')
+                assert token
 
-            with freeze_time(lambda: utc_now() + datetime.timedelta(seconds=59)):
+                frozen_time.move_to(start_datetime + datetime.timedelta(seconds=59))
                 another_response = self.controller.basic_auth_temp_token({}, self._db)
                 assert another_response.status_code == 200
 
@@ -2981,15 +2983,17 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
         """
         valid_credentials = base64.b64encode(b"unittestuser:unittestpassword").decode("utf-8")
         headers_basic = dict(Authorization=f"Basic {valid_credentials}")
+        start_datetime = datetime.datetime(2022, 1, 1, 0, 0, 0)
 
-        with app.test_request_context("/http_basic_auth_token", headers=headers_basic):
-            response = self.controller.basic_auth_temp_token({}, self._db)
-            assert 200 == response.status_code
+        with freeze_time(start_datetime) as frozen_time:
+            with app.test_request_context("/http_basic_auth_token", headers=headers_basic):
+                response = self.controller.basic_auth_temp_token({}, self._db)
+                assert 200 == response.status_code
 
-            token = response.json.get('access_token')
-            assert token
+                token = response.json.get('access_token')
+                assert token
 
-            with freeze_time(lambda: utc_now() + datetime.timedelta(seconds=61)):
+                frozen_time.move_to(start_datetime + datetime.timedelta(seconds=61))
                 another_response = self.controller.basic_auth_temp_token({}, self._db)
                 assert another_response.status_code == 200
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2966,11 +2966,12 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
             token = response.json.get('access_token')
             assert token
 
-            another_response = self.controller.basic_auth_temp_token({}, self._db)
-            assert another_response.status_code == 200
+            with freeze_time(lambda: utc_now() + datetime.timedelta(seconds=59)):
+                another_response = self.controller.basic_auth_temp_token({}, self._db)
+                assert another_response.status_code == 200
 
-            another_token = another_response.json.get('access_token')
-            assert another_token == token
+                another_token = another_response.json.get('access_token')
+                assert another_token == token
 
     def test_basic_auth_temp_token_returns_new_token(self):
         """

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2950,7 +2950,7 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
     def test_basic_auth_temp_token_returns_existing(self):
         """"
         GIVEN: A request to authenticate a patron with a base64 encoded username:password to recieve a token
-        WHEN:  Re-requesting authentication with the same credentials
+        WHEN:  Re-requesting authentication with the same credentials within a minute of the token's creation
         THEN:  The same token is returned
         """
         valid_credentials = base64.b64encode(b"unittestuser:unittestpassword").decode("utf-8")

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2969,7 +2969,7 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
             another_token = another_response.json.get('access_token')
             assert another_token == token
 
-    def test_basic_auth_temp_tokoen_problem_detail(self):
+    def test_basic_auth_temp_token_problem_detail(self):
         """
         GIVEN: An invalid Authorization header
         WHEN:  Requesting a token

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2989,7 +2989,7 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
             token = response.json.get('access_token')
             assert token
 
-            with freeze_time(lambda: utc_now() + datetime.timedelta(seconds=120)):
+            with freeze_time(lambda: utc_now() + datetime.timedelta(seconds=61)):
                 another_response = self.controller.basic_auth_temp_token({}, self._db)
                 assert another_response.status_code == 200
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Return a patron's existing HTTP Basic temp token if it was requested within a minute since the token's creation. Otherwise a new token is generated and returned.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[[SIMPLY-4057](https://jira.nypl.org/browse/SIMPLY-4057)] Returning an existing token if it was requested within a minute of the token's creation rather than generating a new one will help avoid race conditions for the consuming clients.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test to confirm that the same token is returned when authenticating with HTTP Basic within a minute of the initial token's creation.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
