### PR TITLE
Run coverage and generate reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test-circulation:
     name: Run Circulation Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,4 @@ jobs:
         with:
           name: coverage-report
           path: htmlcov
+          retention-days: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,9 @@ jobs:
         run: |
           export SIMPLIFIED_STATIC_DIR="$(pwd)/resources"
           tox
+
+      - name: Coverage HTML Report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: htmlcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,8 @@ jobs:
           export SIMPLIFIED_STATIC_DIR="$(pwd)/resources"
           tox
 
-      - name: Coverage HTML Report
-        uses: actions/upload-artifact@v3
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
         with:
-          name: coverage-report
-          path: htmlcov
-          retention-days: 30
+          files: ./coverage.xml
+          verbose: true

--- a/core/requirements-base.txt
+++ b/core/requirements-base.txt
@@ -66,6 +66,7 @@ webpub-manifest-parser==0.0.4
 # Theses dependencies are only used in our tests. Ideally they would get moved out to
 # the dev requirements file, but the mock classes for our tests are included alongside
 # the production classes, so these have to be installed all the time for now.
+coverage==6.2
 mock==3.0.5
 parameterized==0.7.4
 pytest<7.0

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,7 @@ commands =
     coverage erase
     coverage run -m pytest tests core/tests --disable-warnings
 commands_post =
-    coverage report --omit="*test*"
-    coverage html --omit="*test*"
+    coverage xml --omit="*test*"
 passenv = SIMPLIFIED_*
 setenv =
     docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9005/simplified_circulation_test

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,11 @@ commands_pre =
     docker: docker restart es
     python -m textblob.download_corpora
 commands =
-    pytest --disable-warnings {posargs: "tests" "core/tests"}
+    coverage erase
+    coverage run -m pytest tests core/tests --disable-warnings
+commands_post =
+    coverage report --omit="*test*"
+    coverage html --omit="*test*"
 passenv = SIMPLIFIED_*
 setenv =
     docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9005/simplified_circulation_test
@@ -24,6 +28,7 @@ docker =
 allowlist_externals =
     docker: docker
     python
+    coverage
 
 [docker:db]
 image = postgres:12


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Update tox commands to run pytest through coverage and generate a command line report and an HTML report. The HTML report is uploaded as an artifact which can be downloaded and viewed. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[SIMPLY-4051](https://jira.nypl.org/browse/SIMPLY-4051)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Through GitHub Actions.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
