### PR TITLE
OE-259 Store transaction_id in loans.external_identifier

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -435,6 +435,19 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasCollectionSelfTests):
             )
 
         identifier = licensepool.identifier
+        if isinstance(patron, Patron):
+            # Check if the Patron's Loan has
+            # a transaction ID as an external_identifier
+            loan, _ = licensepool.loan_to(patron)
+            if loan and loan.external_identifier:
+                # Skip the availability API call and return fulfillment
+                return Axis360FulfillmentInfo(
+                    api=self, key=loan.external_identifier,
+                    data_source_name=DataSource.AXIS_360,
+                    identifier_type=Identifier.AXIS_360_ID,
+                    identifier=identifier.identifier
+                )
+
         # This should include only one 'activity'.
         activities = self.patron_activity(patron, pin, licensepool.identifier, internal_format)
         for loan in activities:

--- a/api/axis.py
+++ b/api/axis.py
@@ -53,6 +53,7 @@ from core.model import (
     Library,
     LicensePool,
     LinkRelations,
+    Loan,
     MediaTypes,
     Patron,
     Representation,
@@ -438,7 +439,7 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasCollectionSelfTests):
         if isinstance(patron, Patron):
             # Check if the Patron's Loan has
             # a transaction ID as an external_identifier
-            loan, _ = licensepool.loan_to(patron)
+            loan = get_one(self._db, Loan, patron=patron, license_pool=licensepool)
             if loan and loan.external_identifier:
                 # Skip the availability API call and return fulfillment
                 return Axis360FulfillmentInfo(
@@ -464,7 +465,9 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasCollectionSelfTests):
 
             if isinstance(patron, Patron) and loan.external_identifier:
                 # Save the external_identifier to the Patron's Loan for future retrieval
-                licensepool.loan_to(patron, external_identifier=loan.external_identifier)
+                patron_loan = get_one(self._db, Loan, patron=patron, license_pool=licensepool)
+                if patron_loan:
+                    patron_loan.external_identifier = loan.external_identifier
 
             return fulfillment
         # If we made it to this point, the patron does not have this

--- a/api/axis.py
+++ b/api/axis.py
@@ -1553,7 +1553,8 @@ class AvailabilityResponseParser(ResponseParser):
                 identifier_type=self.id_type,
                 identifier=axis_identifier,
                 start_date=start_date, end_date=end_date,
-                fulfillment_info=fulfillment
+                fulfillment_info=fulfillment,
+                external_identifier=transaction_id,
             )
 
         elif reserved:

--- a/api/axis.py
+++ b/api/axis.py
@@ -448,6 +448,11 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasCollectionSelfTests):
             fulfillment = loan.fulfillment_info
             if not fulfillment or not isinstance(fulfillment, FulfillmentInfo):
                 raise CannotFulfill()
+
+            if isinstance(patron, Patron) and loan.external_identifier:
+                # Save the external_identifier to the Patron's Loan for future retrieval
+                licensepool.loan_to(patron, external_identifier=loan.external_identifier)
+
             return fulfillment
         # If we made it to this point, the patron does not have this
         # book checked out.


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
When parsing the availability response, store the `transaction_id` as `external_identifier` in `LoanInfo`. Saves this information to the patron's `Loan` so it can be retrieved in future fulfillments, skipping a call to the availability API.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[OE-259](https://jira.nypl.org/browse/OE-259)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a new test to verify that what is stored in `loan.external_identifier` matches the `transaction_id`. The test also checks that only 1 request was made (to the availability endpoint).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
