### PR TITLE
OE-260 Cache result of "getFulfillmentInfo" call

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -442,12 +442,14 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasCollectionSelfTests):
             loan = get_one(self._db, Loan, patron=patron, license_pool=licensepool)
             if loan and loan.external_identifier:
                 # Skip the availability API call and return fulfillment
-                return Axis360FulfillmentInfo(
+                fulfillment = Axis360FulfillmentInfo(
                     api=self, key=loan.external_identifier,
                     data_source_name=DataSource.AXIS_360,
                     identifier_type=Identifier.AXIS_360_ID,
                     identifier=identifier.identifier
                 )
+                fulfillment.can_cache_manifest = True
+                return fulfillment
 
         # This should include only one 'activity'.
         activities = self.patron_activity(patron, pin, licensepool.identifier, internal_format)
@@ -469,6 +471,7 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasCollectionSelfTests):
                 if patron_loan:
                     patron_loan.external_identifier = loan.external_identifier
 
+            fulfillment.can_cache_manifest = True
             return fulfillment
         # If we made it to this point, the patron does not have this
         # book checked out.

--- a/api/axis.py
+++ b/api/axis.py
@@ -448,7 +448,6 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasCollectionSelfTests):
                     identifier_type=Identifier.AXIS_360_ID,
                     identifier=identifier.identifier
                 )
-                fulfillment.can_cache_manifest = True
                 return fulfillment
 
         # This should include only one 'activity'.
@@ -471,7 +470,6 @@ class Axis360API(Authenticator, BaseCirculationAPI, HasCollectionSelfTests):
                 if patron_loan:
                     patron_loan.external_identifier = loan.external_identifier
 
-            fulfillment.can_cache_manifest = True
             return fulfillment
         # If we made it to this point, the patron does not have this
         # book checked out.
@@ -1813,3 +1811,6 @@ class Axis360FulfillmentInfo(APIAwareFulfillmentInfo):
         self._content = str(manifest)
         self._content_type = manifest.MEDIA_TYPE
         self._content_expires = expires
+
+        if manifest.MEDIA_TYPE == AxisNowManifest.MEDIA_TYPE:
+            self.can_cache_manifest = True

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -993,7 +993,7 @@ class CirculationAPI(object):
                     part=part, fulfill_part_url=fulfill_part_url
                 )
 
-                if getattr(fulfillment, "can_cache_manifest", False):
+                if fulfillment.can_cache_manifest:
                     loan.cached_manifest = fulfillment.content.encode("raw_unicode_escape")
                     loan.cached_content_type = fulfillment.content_type
 

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -993,14 +993,16 @@ class CirculationAPI(object):
                     part=part, fulfill_part_url=fulfill_part_url
                 )
 
-                if loan and fulfillment.can_cache_manifest:
-                    loan.cached_manifest = fulfillment.content.encode("raw_unicode_escape")
-                    loan.cached_content_type = fulfillment.content_type
-
             if not fulfillment or not (
                 fulfillment.content_link or fulfillment.content
             ):
                 raise NoAcceptableFormat()
+
+            # Now that the additional API calls have been made,
+            # fulfillment data can be saved to the loan for future retrieval
+            if loan and fulfillment.can_cache_manifest:
+                loan.cached_manifest = fulfillment.content.encode("raw_unicode_escape")
+                loan.cached_content_type = fulfillment.content_type
 
         # Send out an analytics event to record the fact that
         # a fulfillment was initiated through the circulation

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -993,7 +993,7 @@ class CirculationAPI(object):
                     part=part, fulfill_part_url=fulfill_part_url
                 )
 
-                if fulfillment.can_cache_manifest:
+                if loan and fulfillment.can_cache_manifest:
                     loan.cached_manifest = fulfillment.content.encode("raw_unicode_escape")
                     loan.cached_content_type = fulfillment.content_type
 

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -163,6 +163,7 @@ class FulfillmentInfo(CirculationInfo):
     """A record of a technique that can be used *right now* to fulfill
     a loan.
     """
+    can_cache_manifest = False
 
     def __init__(self, collection, data_source_name, identifier_type,
                  identifier, content_link, content_type, content,
@@ -200,7 +201,6 @@ class FulfillmentInfo(CirculationInfo):
         self.content_type = content_type
         self.content = content
         self.content_expires = content_expires
-        self.can_cache_manifest = False
 
     def __repr__(self):
         if self.content:

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -977,7 +977,7 @@ class CirculationAPI(object):
                     identifier=licensepool.identifier.identifier,
                     content_link=None,
                     content_type=loan.cached_content_type,
-                    content=loan.cached_manifest,
+                    content=loan.cached_manifest.decode("utf-8"),
                     content_expires=loan.end
                 )
             else:
@@ -994,7 +994,7 @@ class CirculationAPI(object):
                 )
 
                 if getattr(fulfillment, "can_cache_manifest", False):
-                    loan.cached_manifest = fulfillment.content
+                    loan.cached_manifest = fulfillment.content.encode("raw_unicode_escape")
                     loan.cached_content_type = fulfillment.content_type
 
             if not fulfillment or not (

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -200,6 +200,7 @@ class FulfillmentInfo(CirculationInfo):
         self.content_type = content_type
         self.content = content
         self.content_expires = content_expires
+        self.can_cache_manifest = False
 
     def __repr__(self):
         if self.content:

--- a/core/migration/20220427-add-loan-cached-manifest-content-type.sql
+++ b/core/migration/20220427-add-loan-cached-manifest-content-type.sql
@@ -1,7 +1,7 @@
  BEGIN
   -- Add the 'cached_manifest' column
   BEGIN
-   ALTER TABLE loans ADD COLUMN cached_manifest varchar;
+   ALTER TABLE loans ADD COLUMN cached_manifest bytea;
   EXCEPTION
    WHEN duplicate_column THEN RAISE NOTICE 'column loans.cached_manifest already exists, not creating it.';
   END;

--- a/core/migration/20220427-add-loan-cached-manifest-content-type.sql
+++ b/core/migration/20220427-add-loan-cached-manifest-content-type.sql
@@ -1,0 +1,17 @@
+ BEGIN
+  -- Add the 'cached_manifest' column
+  BEGIN
+   ALTER TABLE loans ADD COLUMN cached_manifest varchar;
+  EXCEPTION
+   WHEN duplicate_column THEN RAISE NOTICE 'column loans.cached_manifest already exists, not creating it.';
+  END;
+
+  -- Add the 'cached_content_type' column'
+  BEGIN
+   ALTER TABLE loans ADD COLUMN cached_content_type varchar;
+  EXCEPTION
+   WHEN duplicate_column THEN RAISE NOTICE 'column loans.cached_content_type already exists, not creating it.';
+  END;
+
+ END;
+$$;

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    LargeBinary,
     String,
     Unicode,
     UniqueConstraint,
@@ -511,7 +512,7 @@ class Loan(Base, LoanAndHoldMixin):
     # Some distributors (e.g. Feedbooks) may have an identifier that can
     # be used to check the status of a specific Loan.
     external_identifier = Column(Unicode, unique=True, nullable=True)
-    cached_manifest = Column(Unicode, nullable=True)
+    cached_manifest = Column(LargeBinary, nullable=True)
     cached_content_type = Column(Unicode, nullable=True)
 
     __table_args__ = (

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -511,13 +511,13 @@ class Loan(Base, LoanAndHoldMixin):
     # Some distributors (e.g. Feedbooks) may have an identifier that can
     # be used to check the status of a specific Loan.
     external_identifier = Column(Unicode, unique=True, nullable=True)
-    cached_manifest = Column(Unicode, unique=True, nullable=True)
-    cached_content_type = Column(Unicode, unique=True, nullable=True)
+    cached_manifest = Column(Unicode, nullable=True)
+    cached_content_type = Column(Unicode, nullable=True)
 
     __table_args__ = (
         UniqueConstraint('patron_id', 'license_pool_id'),
     )
-    
+
     def __lt__(self, other):
         return self.id < other.id
 

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -511,6 +511,8 @@ class Loan(Base, LoanAndHoldMixin):
     # Some distributors (e.g. Feedbooks) may have an identifier that can
     # be used to check the status of a specific Loan.
     external_identifier = Column(Unicode, unique=True, nullable=True)
+    cached_manifest = Column(Unicode, unique=True, nullable=True)
+    cached_content_type = Column(Unicode, unique=True, nullable=True)
 
     __table_args__ = (
         UniqueConstraint('patron_id', 'license_pool_id'),

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -1820,6 +1820,9 @@ class TestAxis360FulfillmentInfo(Axis360Test):
         assert DeliveryMechanism.FINDAWAY_DRM == fulfillment.content_type
         assert isinstance(fulfillment.content, str)
 
+        # Findaway manifests can't be cached
+        assert fulfillment.can_cache_manifest is False
+
         # The manifest document combines information from the
         # fulfillment document and the metadata document.
         for required in (
@@ -1859,6 +1862,9 @@ class TestAxis360FulfillmentInfo(Axis360Test):
         assert (
             '{"book_vault_uuid": "1c11c31f-81c2-41bb-9179-491114c3f121", "isbn": "9780547351551"}' ==
             fulfillment.content)
+
+        # AxisNow manifests can be cached
+        assert fulfillment.can_cache_manifest is True
 
         # The content expiration date also comes from the fulfillment
         # document.

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -890,10 +890,16 @@ class TestCirculationAPI(DatabaseTest):
 
     def test_fulfill(self):
         self.pool.loan_to(self.patron)
-
-        fulfillment = self.pool.delivery_mechanisms[0]
-        fulfillment.content = "Fulfilled."
-        fulfillment.content_link = None
+        fulfillment = FulfillmentInfo(
+            self.collection,
+            data_source_name=DataSource.BIBBLIO,
+            identifier_type=self.identifier,
+            identifier=self.identifier.identifier,
+            content_link=None,
+            content_type=self.pool.delivery_mechanisms[0].delivery_mechanism.content_type,
+            content="Fulfilled.",
+            content_expires=None,
+        )
         self.remote.queue_fulfill(fulfillment)
 
         result = self.circulation.fulfill(self.patron, '1234', self.pool,
@@ -910,9 +916,16 @@ class TestCirculationAPI(DatabaseTest):
     def test_fulfill_without_loan(self):
         # By default, a title cannot be fulfilled unless there is an active
         # loan for the title (tested above, in test_fulfill).
-        fulfillment = self.pool.delivery_mechanisms[0]
-        fulfillment.content = "Fulfilled."
-        fulfillment.content_link = None
+        fulfillment = FulfillmentInfo(
+            self.collection,
+            data_source_name=DataSource.BIBBLIO,
+            identifier_type=self.identifier,
+            identifier=self.identifier.identifier,
+            content_link=None,
+            content_type=self.pool.delivery_mechanisms[0].delivery_mechanism.content_type,
+            content="Fulfilled.",
+            content_expires=None,
+        )
         self.remote.queue_fulfill(fulfillment)
 
         def try_to_fulfill():

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -1,4 +1,5 @@
 """Test the CirculationAPI."""
+from datetime import datetime
 from datetime import timedelta
 
 import flask
@@ -7,6 +8,7 @@ from flask import Flask
 from parameterized import parameterized
 
 from api.authenticator import LibraryAuthenticator, PatronData
+from api.axis import MockAxis360API
 from api.bibliotheca import MockBibliothecaAPI
 from api.circulation import (
     APIAwareFulfillmentInfo,
@@ -928,6 +930,45 @@ class TestCirculationAPI(DatabaseTest):
         self.circulation.can_fulfill_without_loan = yes_we_can
         result = try_to_fulfill()
         assert fulfillment == result
+
+    def test_fulfill_cached_manifest_axis_ebook(self):
+        """
+        GIVEN: 
+        WHEN:  
+        THEN:  
+        """
+        self.collection = MockAxis360API.mock_collection(self._db)
+        self.patron = self._patron()
+        _, self.pool = self._edition(
+            data_source_name=DataSource.AXIS_360,
+            identifier_id='0016820953',
+            identifier_type=Identifier.AXIS_360_ID,
+            with_license_pool=True
+        )
+        loan, _ = self.pool.loan_to(self.patron, end=datetime(2018, 9, 29, 18, 34))
+
+        def mock_axis_api(licensepool):
+            api = MockAxis360API(self._db, self.collection)
+            api.queue_response(
+                200, {}, sample_data("availability_with_axisnow_fulfillment.xml", "axis"))
+            api.queue_response(
+                200, {}, sample_data("ebook_fulfillment_info.json", "axis"))
+            return api
+
+        self.circulation.api_for_license_pool = mock_axis_api
+
+        first_fulfillment = self.circulation.fulfill(
+            self.patron, '1234', self.pool, self.pool.delivery_mechanisms[0])
+        assert first_fulfillment.content == loan.cached_manifest
+        assert first_fulfillment.content_type == loan.cached_content_type
+        assert first_fulfillment.can_cache_manifest is True
+
+        second_fulfillment = self.circulation.fulfill(
+            self.patron, '1234', self.pool, self.pool.delivery_mechanisms[0])
+        # The second fulfillment request won't have can_cache_manifest set to True
+        # since it created a FulfillmentInfo from the Loan information
+        assert second_fulfillment.can_cache_manifest is False
+        assert second_fulfillment.content_expires == loan.end
 
     @parameterized.expand([
         ('open_access', True, False),

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -36,6 +36,7 @@ from core.model import (
     Loan,
     Representation,
     RightsStatus,
+    get_one,
 )
 
 from core.testing import DatabaseTest
@@ -907,6 +908,12 @@ class TestCirculationAPI(DatabaseTest):
 
         # The fulfillment looks good.
         assert fulfillment == result
+
+        # Since the fulfillment did not allow for manifest caching it is not present
+        loan = get_one(self._db, Loan, patron=self.patron, license_pool=self.pool)
+        assert fulfillment.can_cache_manifest is False
+        assert loan.cached_manifest is None
+        assert loan.cached_content_type is None
 
         # An analytics event was created.
         assert 1 == self.analytics.count

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -959,7 +959,7 @@ class TestCirculationAPI(DatabaseTest):
 
         first_fulfillment = self.circulation.fulfill(
             self.patron, '1234', self.pool, self.pool.delivery_mechanisms[0])
-        assert first_fulfillment.content == loan.cached_manifest
+        assert first_fulfillment.content == loan.cached_manifest.decode("utf-8")
         assert first_fulfillment.content_type == loan.cached_content_type
         assert first_fulfillment.can_cache_manifest is True
 
@@ -967,8 +967,9 @@ class TestCirculationAPI(DatabaseTest):
             self.patron, '1234', self.pool, self.pool.delivery_mechanisms[0])
         # The second fulfillment request won't have can_cache_manifest set to True
         # since it created a FulfillmentInfo from the Loan information
-        assert second_fulfillment.can_cache_manifest is False
+        assert second_fulfillment.content == loan.cached_manifest.decode("utf-8")
         assert second_fulfillment.content_expires == loan.end
+        assert second_fulfillment.can_cache_manifest is False
 
     @parameterized.expand([
         ('open_access', True, False),


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
This adds two new fields to the Loans table, `cached_manifest` and `cached_content_type`. A `can_cache_manifest` flag has been added to `FulfillmentInfo` and is set to `False` by default. Axis360 fulfillments have this flag enabled, allowing for the manifest and content_type to be stored in the patron's loan.

When fulfilling a loan in `CirculationAPI.fulfill()`, a `FulfillmentInfo` will be created with the cached manifest and content_type if available, skipping additional API calls.  If there is no cached manifest then fulfillment will as proceed to make those API calls as it did before.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[OE-260](https://jira.nypl.org/browse/OE-260)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Two new tests have been added. A test to fulfill a loan when the loan has a cached manifest. A test to fulfill a loan that does not currently have a cached manifest, but the manifest is allowed to be cached. Additionally, new assertions have been added to ensure that only AxisNow manifests can be cached.

I have also tested this manually by setting up an Axis 360 collection locally, borrowing a book, then fulfilling the (AxisNow) book. Checking the database after fulfillment shows that the transaction ID was cached to the loan's external_identifier, the manifest was cached to cached_manifest, and the content_type was cached to cached_content_type.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
