### PR TITLE
Add missing `DO $$` statement to loan migration

### DIFF
--- a/core/migration/20220427-add-loan-cached-manifest-content-type.sql
+++ b/core/migration/20220427-add-loan-cached-manifest-content-type.sql
@@ -1,4 +1,5 @@
- BEGIN
+DO $$
+  BEGIN
   -- Add the 'cached_manifest' column
   BEGIN
    ALTER TABLE loans ADD COLUMN cached_manifest bytea;


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Fixes the migration added in #1704.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adds a missing `DO $$` statement at the start of the migration. Without this the migration failed.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested this locally by running the migration script in `core/bin`. First I had to run the initialize database script with `./core/bin/initialize_database` then ran the migrate script with `./core/bin/migrate_database -d 2021-06-04`, which was the date for the previous migration. After running this I am now able to see the two new columns in the loans table.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
