### PR TITLE
Add logging for `initialize_database` and `migrate_database` scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -256,7 +256,7 @@ RUN chmod 664 /etc/cron.d/circulation \
  && crontab /etc/cron.d/circulation \
  && touch /var/log/cron.log
 
-CMD ["scripts"]
+CMD ["scripts", "|& tee -a /var/log/cron.log 2>$1"]
 
 ###############################################################################
 ## cm_scripts_local - local dev version of scripts, relies on host mounted code

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -97,7 +97,7 @@ while [[ $# -gt 0 ]]; do
         scripts)
             # Check for migrations to run, then make cron the foreground process
             source ${SIMPLIFIED_VENV}/bin/activate
-            db_init_script="${CM_BIN_DIR}/util/initialize_database"
+            db_init_script="${CORE_BIN_DIR}/initialize_database"
             migrate_script="${CORE_BIN_DIR}/migrate_database"
             if [[ -x $db_init_script && -x $migrate_script ]]; then
                 ${db_init_script} && ${migrate_script}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -100,7 +100,9 @@ while [[ $# -gt 0 ]]; do
             db_init_script="${CORE_BIN_DIR}/initialize_database"
             migrate_script="${CORE_BIN_DIR}/migrate_database"
             if [[ -x $db_init_script && -x $migrate_script ]]; then
-                ${db_init_script} && ${migrate_script}
+                PID1_STDOUT=/proc/1/fd/1
+                PID1_STDERR=/proc/1/fd/2
+                core/bin/run initialize_database |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR && core/bin/run migrate_database |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR
             fi
             cron -f
             ;;

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -100,9 +100,7 @@ while [[ $# -gt 0 ]]; do
             db_init_script="${CORE_BIN_DIR}/initialize_database"
             migrate_script="${CORE_BIN_DIR}/migrate_database"
             if [[ -x $db_init_script && -x $migrate_script ]]; then
-                PID1_STDOUT=/proc/1/fd/1
-                PID1_STDERR=/proc/1/fd/2
-                core/bin/run initialize_database |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR && core/bin/run migrate_database |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR
+                core/bin/run initialize_database && core/bin/run migrate_database
             fi
             cron -f
             ;;


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Fixes the path for `db_init_script` to point to the core bin dir where the `initialize_database` script currently resides. Runs `initialize_database` and `migrate_database` with `core/bin/run` which does a bunch of stuff but mainly interested in the logging format that it establishes.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[SIMPLY-4071](https://jira.nypl.org/browse/SIMPLY-4071) During a recent deploy the migrations failed but there was no logged output for the failure. This adds logging for the `docker-entrypoint.sh` script.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested this locally by doing `make full-clean` then `make up` and monitoring the logging output in docker desktop. I can see log entries for `initialize_database` and `migrate_database`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
