### PR TITLE
Fix docker elasticsearch for non-arm64 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ The following shell commands will clone this repo and build Docker images for th
 ```shell
 git clone https://github.com/NYPL-Simplified/circulation.git
 cd ./circulation
-make setup
 make build
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Branches whose name follows the pattern `<organization>-deploy-<env>` are protec
 * `nypl-deploy-qa`
 * `nypl-deploy-production`
 * `openebooks-deploy-qa`
-* `openebooks-deploy-qa`
+* `openebooks-deploy-production`
 * `bpl-deploy-qa`
 * `bpl-deploy-production`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     ports:
       - "9200:9200"
       - "9300:9300"
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
@@ -88,3 +90,4 @@ volumes:
   cm_local_dbdata:
   cm_local_gunicorn_log:
   cm_local_script_logs:
+  es_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     command: >
       /bin/sh -c "./bin/elasticsearch-plugin list | grep -q analysis-icu 
-      || ./bin/elasticsearch-plugin install analysis-icu; tail -f /dev/null"
+      || ./bin/elasticsearch-plugin install analysis-icu; /usr/local/bin/docker-entrypoint.sh && tail -f /dev/null"
 
   minio:
     container_name: minio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,19 +17,17 @@ services:
   elasticsearch:
     # Use the latest version of Elasticsearch supported by Amazon AWS ES.
     container_name: cm_local_es
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.7.2
+    image: bitnami/elasticsearch:6.7.2
     ports:
       - "9200:9200"
       - "9300:9300"
-    volumes:
-      - es_data:/usr/share/elasticsearch/data
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    command: >
-      /bin/sh -c "./bin/elasticsearch-plugin list | grep -q analysis-icu 
-      || ./bin/elasticsearch-plugin install analysis-icu; /usr/local/bin/docker-entrypoint.sh && tail -f /dev/null"
+      - ELASTICSEARCH_HEAP_SIZE=512m
+      - ELASTICSEARCH_PLUGINS=analysis-icu
+    volumes:
+      - cm_local_esdata:/bitnami/elasticsearch/data
 
   minio:
     container_name: minio
@@ -90,4 +88,4 @@ volumes:
   cm_local_dbdata:
   cm_local_gunicorn_log:
   cm_local_script_logs:
-  es_data:
+  cm_local_esdata:


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Manually run `/usr/local/bin/docker-entrypoint.sh` in the `command:` section in `docker-comopse.yml`. Also includes some `README.md` cleanup.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Due to the differences between arm64 and amd64, the elasticsearch container needed to be handled differently. The arm64 builds uses `docker/Dockerfile-es654.arm64` to build the image while amd64 pulls the elasticsearch image from dockerhub. Due to this the arm64 Dockerfile can install elasticsearch plugins, but the amd64 version uses a command in `docker-compose.yml` to install the plugin. It seems like the entrypoint script wasn't getting ran so I've added it to the command. I'm not sure if it also needs to be added to `docker-compose.cicd.yml`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my windows machine and @oliviawongnyc tested on her non-m1 mac.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
