### PR TITLE
Don't return expired HTTP Basic tokens

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2704,7 +2704,7 @@ class BasicAuthTempTokenController(object):
         if credential.expires:
             # The Credential's expiration time is stored and the lifetime of the Credential (one hour) is known,
             # so the creation time can be calculated
-            token_time_remaining = (credential.expires - utc_now()).seconds
+            token_time_remaining = (credential.expires - utc_now()).total_seconds()
 
         if (
             BasicAuthTempTokenController.TOKEN_DURATION.seconds

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2706,7 +2706,11 @@ class BasicAuthTempTokenController(object):
             # so the creation time can be calculated
             token_time_remaining = (credential.expires - utc_now()).seconds
 
-        if token_time_remaining >= BasicAuthTempTokenController.DO_NOT_GENERATE_NEW_TOKEN_PERIOD:
+        if (
+            BasicAuthTempTokenController.TOKEN_DURATION.seconds
+            >= token_time_remaining >=
+            BasicAuthTempTokenController.DO_NOT_GENERATE_NEW_TOKEN_PERIOD
+        ):
             # Use the existing token if it's been requested within a minute since creation
             inner_token = credential
         else:

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2950,7 +2950,15 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
             patron = self.controller.authenticator.authenticated_patron(self._db, headers_bearer)
             assert 'unittestuser' == patron.username
 
-    def test_basic_auth_temp_token_returns_existing(self):
+    @pytest.mark.parametrize(
+        'delta',
+        [
+            pytest.param(1, id="after_1_second"),
+            pytest.param(59, id="after_59_seconds"),
+            pytest.param(60, id="after_60_seconds"),
+        ]
+    )
+    def test_basic_auth_temp_token_returns_existing(self, delta):
         """"
         GIVEN: A request to authenticate a patron with a base64 encoded username:password to recieve a token
         WHEN:  Re-requesting authentication with the same credentials within a minute of the token's creation
@@ -2968,14 +2976,22 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
                 token = response.json.get('access_token')
                 assert token
 
-                frozen_time.move_to(start_datetime + datetime.timedelta(seconds=59))
+                frozen_time.move_to(start_datetime + datetime.timedelta(seconds=delta))
                 another_response = self.controller.basic_auth_temp_token({}, self._db)
                 assert another_response.status_code == 200
 
                 another_token = another_response.json.get('access_token')
                 assert another_token == token
 
-    def test_basic_auth_temp_token_returns_new_token(self):
+    @pytest.mark.parametrize(
+        'delta',
+        [
+            pytest.param(61, id="after_1_minute_and_1_second"),
+            pytest.param(3601, id="after_1_hour_and_1_second"),
+            pytest.param(86401, id="after_1_day_and_1_second")
+        ]
+    )
+    def test_basic_auth_temp_token_returns_new_token(self, delta):
         """
         GIVEN: A request to authenticate a patron with a base64 encoded username:password to recieve a token
         WHEN:  Re-requesting authentication with the same credentials after a minute of the token's creation
@@ -2993,7 +3009,7 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
                 token = response.json.get('access_token')
                 assert token
 
-                frozen_time.move_to(start_datetime + datetime.timedelta(seconds=61))
+                frozen_time.move_to(start_datetime + datetime.timedelta(seconds=delta))
                 another_response = self.controller.basic_auth_temp_token({}, self._db)
                 assert another_response.status_code == 200
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2975,7 +2975,15 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
                 another_token = another_response.json.get('access_token')
                 assert another_token == token
 
-    def test_basic_auth_temp_token_returns_new_token(self):
+
+    @pytest.mark.parametrize(
+        'delta',
+        [
+            pytest.param(61, id='after_one_minute'),
+            pytest.param(3601, id='after_one_hour')
+        ]
+    )
+    def test_basic_auth_temp_token_returns_new_token(self, delta):
         """
         GIVEN: A request to authenticate a patron with a base64 encoded username:password to recieve a token
         WHEN:  Re-requesting authentication with the same credentials after a minute of the token's creation
@@ -2993,7 +3001,7 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
                 token = response.json.get('access_token')
                 assert token
 
-                frozen_time.move_to(start_datetime + datetime.timedelta(seconds=61))
+                frozen_time.move_to(start_datetime + datetime.timedelta(seconds=delta))
                 another_response = self.controller.basic_auth_temp_token({}, self._db)
                 assert another_response.status_code == 200
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2975,15 +2975,7 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
                 another_token = another_response.json.get('access_token')
                 assert another_token == token
 
-
-    @pytest.mark.parametrize(
-        'delta',
-        [
-            pytest.param(61, id='after_one_minute'),
-            pytest.param(3601, id='after_one_hour')
-        ]
-    )
-    def test_basic_auth_temp_token_returns_new_token(self, delta):
+    def test_basic_auth_temp_token_returns_new_token(self):
         """
         GIVEN: A request to authenticate a patron with a base64 encoded username:password to recieve a token
         WHEN:  Re-requesting authentication with the same credentials after a minute of the token's creation
@@ -3001,7 +2993,7 @@ class TestBasicAuthTempTokenController(AuthenticatorTest):
                 token = response.json.get('access_token')
                 assert token
 
-                frozen_time.move_to(start_datetime + datetime.timedelta(seconds=delta))
+                frozen_time.move_to(start_datetime + datetime.timedelta(seconds=61))
                 another_response = self.controller.basic_auth_temp_token({}, self._db)
                 assert another_response.status_code == 200
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
When returning an existing HTTP Basic token, ensure that the remaining token time is between the upper boundary of 1 hour and lower boundary of 59 minutes. Use `.total_seconds()` instead of `.seconds` to get a proper duration that takes days into account.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Expired HTTP Basic tokens were being returned in QA, this fix will now properly generate new tokens. When using `.seconds` days were not taken into account when checking whether to return an existing token or generate a new one.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Parametrized an existing test that returns new tokens to include a request at a time beyond the lifespan of a token. Test was failing locally before changes were implemented and passed afterwards.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
