### PR TITLE
Fixed misplaced parentheses in a bin/informational script.

### DIFF
--- a/bin/informational/overdrive-raw-circulation
+++ b/bin/informational/overdrive-raw-circulation
@@ -19,7 +19,7 @@ class OverdriveRawCirculationScript(IdentifierInputScript):
         for collection in Collection.by_protocol(self._db, ExternalIntegration.OVERDRIVE):
             overdrive = OverdriveAPI(self._db, collection)
             for identifier in args.identifiers:
-                (_, _, _, content) = overdrive.circulation_lookup(identifier.identifier)
+                (_, (_, _, content)) = overdrive.circulation_lookup(identifier.identifier)
                 data = json.loads(content)
                 print(json.dumps(data, sort_keys=True, indent=4, separators=(',', ': ')), "\n")
 


### PR DESCRIPTION
## Description

A minor change to fix a script I plan to use in a demo.

## Motivation and Context

Nick changed this script in May to fix it, but it looks like he missed some parentheses. The parentheses are used to extract the part of the Overdrive API call we actually need -- the JSON document sent by the server.

## How Has This Been Tested?

Manually tested. Since this is a utility script we don't have good test coverage for it. You can test this by hooking up the branch to NYPL's QA circulation manager database and issuing a command like this:

```
bin/informational/overdrive-raw-circulation --identifier-type="Overdrive ID" 1dc5b1c1-79f8-42ad-8e1e-912a37a8f835
```

For the record, the ignored variables are an ID mapping, the HTTP response code, and the HTTP response headers.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
