### PR TITLE
Revert "Fixed misplaced parentheses in a bin/informational script."

### DIFF
--- a/bin/informational/overdrive-raw-circulation
+++ b/bin/informational/overdrive-raw-circulation
@@ -19,7 +19,7 @@ class OverdriveRawCirculationScript(IdentifierInputScript):
         for collection in Collection.by_protocol(self._db, ExternalIntegration.OVERDRIVE):
             overdrive = OverdriveAPI(self._db, collection)
             for identifier in args.identifiers:
-                (_, (_, _, content)) = overdrive.circulation_lookup(identifier.identifier)
+                (_, _, _, content) = overdrive.circulation_lookup(identifier.identifier)
                 data = json.loads(content)
                 print(json.dumps(data, sort_keys=True, indent=4, separators=(',', ': ')), "\n")
 


### PR DESCRIPTION
Reverts NYPL-Simplified/circulation#1711

Build API documentation failed. This may be because warnings as errors are flagged, but I didn't want to leave dev in its current state until we discussed.

Warning, treated as error:
autodoc: failed to import module 'app' from module 'api'; the following exception was raised:
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/sphinx/ext/autodoc/importer.py", line 154, in import_module
    __import__(modname)
  File "/home/runner/work/circulation/circulation/api/app.py", line 30, in <module>
    app.static_resources_dir = Configuration.static_resources_dir()
  File "/home/runner/work/circulation/circulation/core/config.py", line 494, in static_resources_dir
    raise CannotLoadConfiguration(' '.join(warning_msgs + error_msgs))
core.config.CannotLoadConfiguration: Env var SIMPLIFIED_STATIC_DIR unset or empty, defaulted to '/simplified_static'. Static resources directory path '/simplified_static' does not exist.