### PR TITLE
SIMPLY-4089 Add Unsubscribe link option

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -989,6 +989,13 @@ class LibraryAuthenticator(object):
                 )
             )
 
+        # If there is an unsubscribe link, add it here
+        unsubscribe_uri = Configuration.unsubscribe_email_uri(library)
+        if unsubscribe_uri:
+            links.append(
+                dict(rel=Configuration.HELP_UNSUBSCRIBE_URI, href=unsubscribe_uri)
+            )
+
         # Add a rel="help" link for every type of URL scheme that
         # leads to library-specific help.
         for type, uri in Configuration.help_uris(library):

--- a/api/config.py
+++ b/api/config.py
@@ -678,7 +678,7 @@ class Configuration(CoreConfiguration):
 
     @classmethod
     def unsubscribe_email_uri(cls, library):
-        return cls._help_uri_with_fallback(library, cls.HELP_UNSUBSCRIBE_URI)
+        return ConfigurationSetting.for_library(cls.HELP_UNSUBSCRIBE_URI, library).value
 
     @classmethod
     def _email_uri_with_fallback(cls, library, key):

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1246,6 +1246,8 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             Configuration.HELP_WEB, library).value = "http://library.help/"
         ConfigurationSetting.for_library(
             Configuration.HELP_URI, library).value = "custom:uri"
+        ConfigurationSetting.for_library(
+            Configuration.HELP_UNSUBSCRIBE_URI, library).value = 'http://library.unsubscribe/'
 
         base_url = ConfigurationSetting.sitewide(self._db, Configuration.BASE_URL_KEY)
         base_url.value = 'http://circulation-manager/'
@@ -1315,10 +1317,9 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             # We also need to test that the links got pulled in
             # from the configuration.
             (about, alternate, copyright, help_uri, help_web, help_email,
-             copyright_agent, profile, loans, license, logo, privacy_policy, register, start,
-             stylesheet, terms_of_service) = sorted(
-                 doc['links'], key=lambda x: (x['rel'], x['href'])
-             )
+             copyright_agent, unsubscribe_link, profile, loans, license, logo,
+             privacy_policy, register, start, stylesheet, terms_of_service)\
+                 = sorted(doc['links'], key=lambda x: (x['rel'], x['href']))
             assert "http://terms" == terms_of_service['href']
             assert "http://privacy" == privacy_policy['href']
             assert "http://copyright" == copyright['href']
@@ -1360,6 +1361,9 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             assert "http://library.help/" == help_web['href']
             assert "text/html" == help_web['type']
             assert "mailto:help@library" == help_email['href']
+
+            # We also have an unsubscribe link
+            assert 'http://library.unsubscribe/' == unsubscribe_link['href']
 
             # Since no special address was given for the copyright
             # designated agent, the help address was reused.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -181,3 +181,48 @@ class TestConfiguration(DatabaseTest):
         # Initializing the Configuration object modifies the corresponding
         # object in core, so that core code will behave appropriately.
         assert Configuration.DEFAULT_OPDS_FORMAT == CoreConfiguration.DEFAULT_OPDS_FORMAT
+
+    def test__help_uri_with_fallback_provided_key_success(self):
+        unsubscribe_value = 'http://example.org/unsubscribe'
+
+        ConfigurationSetting.for_library(
+            Configuration.HELP_UNSUBSCRIBE_URI, self._default_library).value\
+                = unsubscribe_value
+
+        assert Configuration._help_uri_with_fallback(
+            self._default_library, Configuration.HELP_UNSUBSCRIBE_URI)\
+                == unsubscribe_value
+
+    def test__help_uri_with_fallback_missing_key(self):
+        help_value = 'http://example.org/help'
+
+        ConfigurationSetting.for_library(
+            Configuration.HELP_WEB, self._default_library).value\
+                = help_value
+
+        assert Configuration._help_uri_with_fallback(
+            self._default_library, Configuration.HELP_UNSUBSCRIBE_URI)\
+            == help_value
+
+    def test__email_uri_with_fallback_provided_key_success(self):
+        contact_email = 'contact@example.org'
+
+        ConfigurationSetting.for_library(
+            Configuration.CONFIGURATION_CONTACT_EMAIL, self._default_library).value\
+                = contact_email
+
+        assert Configuration._email_uri_with_fallback(
+            self._default_library, Configuration.CONFIGURATION_CONTACT_EMAIL)\
+                == f'mailto:{contact_email}'
+
+    def test__email_uri_with_fallback_missing_key(self):
+        help_email = 'help@example.org'
+
+        ConfigurationSetting.for_library(
+            Configuration.HELP_EMAIL, self._default_library).value\
+                = help_email
+
+        assert Configuration._email_uri_with_fallback(
+            self._default_library, Configuration.CONFIGURATION_CONTACT_EMAIL)\
+            == f'mailto:{help_email}'
+


### PR DESCRIPTION
## Description

This adds an option for a library to have an (optional) link to unsubscribe to email notifications/communications. This is part of the `Patron Support` page and returns the URI as part of the `links` array as part of the `authentication_document`.

In addition this adds a new convenience method `_help_uri_with_fallback` that will return a help URI, falling back to the general help link configured for the library. This compliments the `_email_uri_with_fallback` method.

In addition one test is updated to reflect the new state of the `authentication_document`.
## Motivation and Context

This change is necessary to meet new iOS requirements for email subscription management as described in [SIMPLY-4089](https://jira.nypl.org/browse/SIMPLY-4089)

## How Has This Been Tested?

I updated the test suite to validate that the output appears as desired and updated this variable for my local testing configuration, validating it can be created in the circ admin and returned in an authentication document.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
