### PR TITLE
Adds library short name to url_for function

### DIFF
--- a/api/admin/opds.py
+++ b/api/admin/opds.py
@@ -72,6 +72,7 @@ class AdminAnnotator(LibraryAnnotator):
             href=self.url_for(
                 "edit",
                 identifier_type=identifier.type,
+                library_short_name=self.library.short_name,
                 identifier=identifier.identifier, _external=True)
         )
 

--- a/tests/admin/test_opds.py
+++ b/tests/admin/test_opds.py
@@ -96,6 +96,7 @@ class TestOPDS(DatabaseTest):
         feed = AcquisitionFeed(self._db, "test", "url", [work], AdminAnnotator(None, self._default_library, test_mode=True))
         [entry] = feedparser.parse(str(feed))['entries']
         [edit_link] = [x for x in entry['links'] if x['rel'] == "edit"]
+        assert self._default_library.short_name in edit_link["href"]
         assert lp.identifier.identifier in edit_link["href"]
 
     def test_feed_includes_change_cover_link(self):


### PR DESCRIPTION
## Description

- Adds library_short_name as argument to url_for function that creates the edit url.

## Motivation and Context

- Fixes issue where metadata for books cannot be edited if part of library that is not default library, described in [SIMPLY-4061](https://jira.nypl.org/browse/SIMPLY-4061).

## How Has This Been Tested?

- Not tested yet (will meet with Keith and Leonard to discuss).

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
