### PR TITLE
Remove check for http/https scheme in cors domain header

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,16 +137,16 @@ That gives you access to all of the standard options to `pytest`, allowing varia
 
 ```shell
 # Fail fast with -x
-docker exec -it --env TESTING=1 cm_local_webapp pipenv run pytest -x tests
+docker exec -it --env TESTING=1 cm_local_webapp /usr/local/bin/runinvenv /simplified_venv pytest -x tests
 
 # Run a particular test class
-docker exec -it --env TESTING=1 cm_local_webapp pipenv \run pytest tests/test_decorators.py::TestDecorators
+docker exec -it --env TESTING=1 cm_local_webapp /usr/local/bin/runinvenv /simplified_venv pytest tests/test_controller.py::TestCirculationManager
 
 # Run a specific test method
-docker exec -it --env TESTING=1 cm_local_webapp pipenv run pytest tests/test_decorators.py::TestDecorators::test_uses_location_from_ip
+docker exec -it --env TESTING=1 cm_local_webapp /usr/local/bin/runinvenv /simplified_venv pytest tests/test_controller.py::TestCirculationManager::test_exception_during_external_search_initialization_is_stored
 
 # Turn off the warnings output
-docker exec -it --env TESTING=1 cm_local_webapp pipenv run pytest --disable-warnings tests
+docker exec -it --env TESTING=1 cm_local_webapp /usr/local/bin/runinvenv /simplified_venv pytest --disable-warnings tests
 ```
 
 The full set of options to the `pytest` executable is available at [https://docs.pytest.org/en/6.2.x/usage.html](https://docs.pytest.org/en/6.2.x/usage.html)

--- a/api/util/url.py
+++ b/api/util/url.py
@@ -47,6 +47,7 @@ class URLUtility(object):
             https://*.librarysimplified.org
             https://alpha.bravo.charlie.librarysimplified.org
             https://*.charlie.librarysimplified.org
+            capacitor://*.vercel.app
 
         Note that the entry `http://*.librarysimplified.org` WILL NOT match
         the URL of the root domain `http://librarysimplified.org`. To match the root
@@ -56,9 +57,6 @@ class URLUtility(object):
             url_parsed = urlparse(url)
         except AttributeError:
             return False    # origin value was not a string
-
-        if not url_parsed.netloc or url_parsed.scheme not in ('http', 'https'):
-            return False    # CORS concerns are for HTTP requests with real domains
 
         url_match_in_list = False
 

--- a/tests/api/util/test_url.py
+++ b/tests/api/util/test_url.py
@@ -14,6 +14,18 @@ class TestURLUtility:
                 id="simplest_full_match"
             ),
             pytest.param(
+                "capacitor://localhost",
+                ["capacitor://localhost"],
+                True,
+                id="simplest_full_match"
+            ),
+            pytest.param(
+                "capacitor://test.vercel.app",
+                ["capacitor://*.vercel.app"],
+                True,
+                id="wildcard_subdomains"
+            ),
+            pytest.param(
                 "http://librarysimplified.org",
                 ["https://librarysimplified.org"],
                 False,

--- a/tests/api/util/test_url.py
+++ b/tests/api/util/test_url.py
@@ -26,6 +26,12 @@ class TestURLUtility:
                 id="wildcard_subdomains"
             ),
             pytest.param(
+                "capacitor://test.vercel.app",
+                ["capacitor://*.vercel.app", "capacitor://localhost"],
+                True,
+                id="multiple_patterns"
+            ),
+            pytest.param(
                 "http://librarysimplified.org",
                 ["https://librarysimplified.org"],
                 False,


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Allows any url scheme to be returned an allowable Access-Control-Allow-Origin header, not just `http` or `https`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@kristojorg is working on a proof of concept hybrid web app that makes requests from `capacitor://<something>` which were previously being blocked by CORS access-control-allow-origin headers. This makes it so that any scheme is allowed, not just `http` or `https`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added a couple new test cases to `test_url.py::URLUtiliity::url_match_in_domain_list`. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
