### PR TITLE
NOREF Reduce SAML test file and update tests

### DIFF
--- a/tests/saml/metadata/federations/test_validator.py
+++ b/tests/saml/metadata/federations/test_validator.py
@@ -1,8 +1,10 @@
 import datetime
 import os
 
+from mock import patch
 import pytest
 from freezegun import freeze_time
+from onelogin.saml2.utils import OneLogin_Saml2_Utils
 from parameterized import parameterized
 
 import tests.saml.fixtures
@@ -13,89 +15,141 @@ from api.saml.metadata.federations.validator import (
     SAMLFederatedMetadataValidationError,
     SAMLMetadataSignatureValidator,
 )
-from core.util.datetime_helpers import (
-    datetime_utc,
-    from_timestamp,
-    utc_now
-)
+from core.util.datetime_helpers import datetime_utc, utc_now
 
 
-class TestSAMLFederatedMetadataExpirationValidator(object):
-    @parameterized.expand(
+INCOMMON_METADATA_FREEZE_TIME = datetime_utc(2020, 11, 26, 14, 32, 42)
+
+
+@pytest.fixture(scope="session")
+def incommon_metadata():
+    incommon_metadata_file = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "../../../files/saml/incommon-metadata-idp-only.xml",
+    )
+    with open(incommon_metadata_file, mode='r') as f:
+        yield f.read()
+
+
+@pytest.fixture(scope="class")
+def metadata_expiration_validator():
+    validator = SAMLFederatedMetadataExpirationValidator()
+    yield validator
+
+
+@pytest.fixture(scope="class")
+def metadata_signature_validator():
+    validator = SAMLMetadataSignatureValidator()
+    yield validator
+
+
+@pytest.fixture(scope="module")
+def incommon_federation():
+    federation = SAMLFederation(incommon.FEDERATION_TYPE, incommon.IDP_METADATA_SERVICE_URL)
+    yield federation
+
+
+class TestSAMLFederatedMetadataExpirationValidator:
+    def test_validate_with_real_incommon_metadata(
+        self, metadata_expiration_validator, incommon_federation, incommon_metadata
+    ):
+        """
+        GIVEN:
+        WHEN:
+        THEN:
+        """
+        with freeze_time(INCOMMON_METADATA_FREEZE_TIME):
+            validation_result = metadata_expiration_validator.validate(
+                incommon_federation,
+                incommon_metadata
+            )
+            assert validation_result is None
+
+    @pytest.mark.parametrize(
+        "time_to_freeze,metadata,expected_exception",
         [
-            (
-                "incorrect_xml",
+            pytest.param(
                 utc_now(),
                 tests.saml.fixtures.INCORRECT_XML,
                 SAMLFederatedMetadataValidationError,
+                id="incorrect_xml"
             ),
-            (
-                "without_valid_until_attribute",
+            pytest.param(
                 utc_now(),
                 tests.saml.fixtures.FEDERATED_METADATA_WITHOUT_VALID_UNTIL_ATTRIBUTE,
                 SAMLFederatedMetadataValidationError,
+                id="without_valid_until_attribute"
             ),
-            (
-                "with_expired_valid_until_attribute",
-                tests.saml.fixtures.FEDERATED_METADATA_VALID_UNTIL
-                + SAMLFederatedMetadataExpirationValidator.MAX_CLOCK_SKEW
-                + datetime.timedelta(minutes=1),
+            pytest.param(
+                (
+                    tests.saml.fixtures.FEDERATED_METADATA_VALID_UNTIL
+                    + SAMLFederatedMetadataExpirationValidator.MAX_CLOCK_SKEW
+                    + datetime.timedelta(minutes=1)
+                ),
                 tests.saml.fixtures.FEDERATED_METADATA_WITH_VALID_UNTIL_ATTRIBUTE,
                 SAMLFederatedMetadataValidationError,
+                id="with_expired_valid_until_attribute",
             ),
-            (
-                "with_valid_until_attribute_too_far_in_the_future",
-                tests.saml.fixtures.FEDERATED_METADATA_VALID_UNTIL
-                - SAMLFederatedMetadataExpirationValidator.MAX_VALID_TIME
-                - datetime.timedelta(minutes=1),
+            pytest.param(
+                (
+                    tests.saml.fixtures.FEDERATED_METADATA_VALID_UNTIL
+                    - SAMLFederatedMetadataExpirationValidator.MAX_VALID_TIME
+                    - datetime.timedelta(minutes=1)
+                ),
                 tests.saml.fixtures.FEDERATED_METADATA_WITH_VALID_UNTIL_ATTRIBUTE,
                 SAMLFederatedMetadataValidationError,
+                id="with_valid_until_attribute_too_far_in_the_future",
             ),
-            (
-                "with_valid_until_attribute_less_than_current_time_and_less_than_max_clock_skew",
-                tests.saml.fixtures.FEDERATED_METADATA_VALID_UNTIL
-                + SAMLFederatedMetadataExpirationValidator.MAX_CLOCK_SKEW,
+            pytest.param(
+                (
+                    tests.saml.fixtures.FEDERATED_METADATA_VALID_UNTIL
+                    + SAMLFederatedMetadataExpirationValidator.MAX_CLOCK_SKEW
+                ),
                 tests.saml.fixtures.FEDERATED_METADATA_WITH_VALID_UNTIL_ATTRIBUTE,
                 None,
+                id="with_valid_until_attribute_less_than_current_time_and_less_than_max_clock_skew",
             ),
-            (
-                "with_valid_until_attribute_greater_than_current_time_and_less_than_max_valid_time",
-                tests.saml.fixtures.FEDERATED_METADATA_VALID_UNTIL
-                - SAMLFederatedMetadataExpirationValidator.MAX_VALID_TIME
-                + datetime.timedelta(minutes=1),
+            pytest.param(
+                (
+                    tests.saml.fixtures.FEDERATED_METADATA_VALID_UNTIL
+                    - SAMLFederatedMetadataExpirationValidator.MAX_VALID_TIME
+                    + datetime.timedelta(minutes=1)
+                ),
                 tests.saml.fixtures.FEDERATED_METADATA_WITH_VALID_UNTIL_ATTRIBUTE,
                 None,
-            ),
-            (
-                "with_real_incommon_metadata",
-                datetime_utc(2020, 11, 26, 14, 32, 42),
-                open(
-                    os.path.join(
-                        os.path.dirname(os.path.abspath(__file__)),
-                        "../../../files/saml/incommon-metadata-idp-only.xml",
-                    )
-                ).read(),
-                None,
+                id="with_valid_until_attribute_greater_than_current_time_and_less_than_max_valid_time",
             ),
         ]
     )
-    def test_validate(self, _, current_time, metadata, expected_exception):
-        # Arrange
-        validator = SAMLFederatedMetadataExpirationValidator()
-        federation = SAMLFederation(
-            incommon.FEDERATION_TYPE, incommon.IDP_METADATA_SERVICE_URL
-        )
-
-        # Act, assert
-        with freeze_time(current_time):
+    def test_validate(
+        self, metadata_expiration_validator, incommon_federation,
+        time_to_freeze, metadata, expected_exception
+    ):
+        with freeze_time(time_to_freeze):
             if expected_exception:
                 with pytest.raises(expected_exception):
-                    validator.validate(federation, metadata)
+                    metadata_expiration_validator.validate(incommon_federation, metadata)
             else:
-                validator.validate(federation, metadata)
+                metadata_expiration_validator.validate(incommon_federation, metadata)
 
 
 class TestSAMLMetadataSignatureValidator(object):
+    @pytest.mark.skip(reason="TODO: Needs new signature for shortened version of metadata file.")
+    def test_validate_with_real_incommon_metadata(
+        self, metadata_signature_validator, incommon_federation, incommon_metadata
+    ):
+        """
+        GIVEN:
+        WHEN:
+        THEN:
+        """
+        incommon_federation.certificate = tests.saml.fixtures.FEDERATED_METADATA_CERTIFICATE.strip()
+        validation_result = metadata_signature_validator.validate(
+            incommon_federation,
+            incommon_metadata
+        )
+        assert validation_result is None
+
     @parameterized.expand(
         [
             (
@@ -131,9 +185,12 @@ class TestSAMLMetadataSignatureValidator(object):
         )
         federation.certificate = certificate
 
-        # Act, assert
-        if expected_exception:
-            with pytest.raises(expected_exception):
+        with patch.object(OneLogin_Saml2_Utils, 'validate_metadata_sign') as mockOneLoginValidate:
+            # Act, assert
+            if expected_exception:
+                mockOneLoginValidate.side_effect = expected_exception
+
+                with pytest.raises(expected_exception):
+                    validator.validate(federation, metadata)
+            else:
                 validator.validate(federation, metadata)
-        else:
-            validator.validate(federation, metadata)

--- a/tests/saml/metadata/federations/test_validator.py
+++ b/tests/saml/metadata/federations/test_validator.py
@@ -134,7 +134,6 @@ class TestSAMLFederatedMetadataExpirationValidator:
 
 
 class TestSAMLMetadataSignatureValidator(object):
-    @pytest.mark.skip(reason="TODO: Needs new signature for shortened version of metadata file.")
     def test_validate_with_real_incommon_metadata(
         self, metadata_signature_validator, incommon_federation, incommon_metadata
     ):
@@ -144,11 +143,20 @@ class TestSAMLMetadataSignatureValidator(object):
         THEN:
         """
         incommon_federation.certificate = tests.saml.fixtures.FEDERATED_METADATA_CERTIFICATE.strip()
-        validation_result = metadata_signature_validator.validate(
-            incommon_federation,
-            incommon_metadata
-        )
-        assert validation_result is None
+
+        with patch.object(OneLogin_Saml2_Utils, 'validate_metadata_sign') as mockOneLoginValidate:
+            validation_result = metadata_signature_validator.validate(
+                incommon_federation,
+                incommon_metadata
+            )
+
+            mockOneLoginValidate.assert_called_once_with(
+                incommon_metadata,
+                incommon_federation.certificate,
+                raise_exceptions=True
+            )
+
+            assert validation_result is None
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Description

This is a clone of Nick Ballenger's PR #1686 which reduces the SAML test fixture size and updates tests to match. It is being re-opened here based off the latest develop code, which importantly includes the merged core module.

To ensure that this appropriately tests the validator class we mock out the signature calculation method, as this is an external dependency.

## Motivation and Context

This helps simplify and streamline our unit test suite, with a side-effect benefit of slimming down a 37M file by 99%.

## How Has This Been Tested?
The test suite has been run to ensure that the tests pass as expected and should exercise all relevant parts of the code.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
