### PR TITLE
NOREF Fix docstring

### DIFF
--- a/api/util/url.py
+++ b/api/util/url.py
@@ -41,6 +41,7 @@ class URLUtility(object):
 
         Examples of valid domain_list entries:
 
+            ```
             http://librarysimplified.org
             https://librarysimplified.org
             https://www.librarysimplified.org
@@ -48,6 +49,7 @@ class URLUtility(object):
             https://alpha.bravo.charlie.librarysimplified.org
             https://*.charlie.librarysimplified.org
             capacitor://*.vercel.app
+            ```
 
         Note that the entry `http://*.librarysimplified.org` WILL NOT match
         the URL of the root domain `http://librarysimplified.org`. To match the root


### PR DESCRIPTION
## Description

A syntax error in a docstring is causing the GHA docs build action. This resolves that issue.

## Motivation and Context

This impacts the GHA build, which is not fatal, but annoying in that it largely causes a false positive on merges to long-lived branches.

## How Has This Been Tested?

I ran `make html` locally and confirmed that the sphinx documentation built successfully.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
