### PR TITLE
NOREF Add Missing import line

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -81,6 +81,7 @@ def initialize_database(autoinitialize=True):
 
 from . import routes
 from .admin import routes
+from .documentation import routes
 
 def run(url=None):
     base_url = url or 'http://localhost:6500/'


### PR DESCRIPTION
## Description

A line in the main Flask app was dropped and prevented the `/documentation` endpoint from functioning as intended. This shoud restore that functionality.

## Motivation and Context

When deployed the current app is unable to find the documentation endpoints. This re-adds this functionality to the application.

## How Has This Been Tested?

This has been verified to work on my local machine.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
