### PR TITLE
Fix missing day for axis_reaper

### DIFF
--- a/docker/simplified_crontab
+++ b/docker/simplified_crontab
@@ -171,7 +171,7 @@ PID1_STDERR=/proc/1/fd/2
 
 # axis_reaper - Monitor the Axis collection by looking for books that have been removed.
 #   Frequency: Every 30th minute
-*/30 * * * core/bin/run axis_reaper |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR
+*/30 * * * * core/bin/run axis_reaper |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR
 
 #--- Bibliotheca -------------------------------------------------------------
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Fixes a missing day for `axis_reaper` in the crontab

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes the following error
```
"/etc/cron.d/circulation":173: bad day-of-week
errors in crontab file, can't install.
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
[crontab.guru with the correct timing](https://crontab.guru/#*/30_*_*_*)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
