### PR TITLE
Fix missing day for enki_reaper

### DIFF
--- a/docker/simplified_crontab
+++ b/docker/simplified_crontab
@@ -209,7 +209,7 @@ PID1_STDERR=/proc/1/fd/2
 
 # enki_reaper - Monitor the Enki collection by looking for books with lost licenses.
 #   Frequency: Minute 30 of every 6th hour
-30 */6 * * core/bin/run enki_reaper |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR
+30 */6 * * * core/bin/run enki_reaper |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR
 
 # enki_import - monitor the Enki collection by asking about recently changed books.
 #   Frequency: Minute 0 of every 6th hour


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Fixes a missing day for `enki_reaper` in the crontab

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes the following error
```
"/etc/cron.d/circulation":211: bad day-of-week
errors in crontab file, can't install.
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
[crontab.guru with the correct timing](https://crontab.guru/#30_*/6_*_*_*)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
