### PR TITLE
SIMPLY-4101_3 Improve Documentation

### DIFF
--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -344,7 +344,15 @@ def work_details(identifier_type, identifier):
           description: An identifier for a work record
       responses:
         200:
-          description: A single OPDS record describing the requested work
+          description: |
+            A single OPDS record describing the requested work
+
+            The link object is repeatable and can contain the following link relations:
+              - `self`: Used in the context of a pURL
+              - `alternate`: An alternate identifier, distinct from the `atom:id` value
+              - `collection`: A URL to a collection containing the current item
+              - `http://opds-spec.org/image`: A URL to a full-size cover image
+              - `http://opds-spec.org/image/thumbnail`: A URL to a thumbnail-size cover image
           content:
             application/atom+xml;type=entry;profile=opds-catalog:
               schema: OPDSEntry
@@ -1291,7 +1299,18 @@ def lanes():
             type: string
       responses:
         200:
-          description: An array of lane objects
+          description: |
+            An array of lane objects
+
+            The lane `count` attribute is retrieved from the `size` column of the `lanes` table. This value is updated by a script once daily, 
+            and is also updated when a lane or list is edited. The value is ultimately retrieved in all cases from a count query executed in ElasticSearch.
+
+            Additional size values for each lane are stored in the `size_by_entrypoint` field which records lane size by schema.org types: `CreativeWork`, `EBook` and `Audiobook`,
+            this endpoint returns only the generic `count` value representing all works in the current lane.
+
+            The `size` attribute does _not_ reflect the contents of any sub-lanes, and is independent of the `size` value calculated for constituent lists.
+
+            The `sublanes` array will contain identical `Lane` objects, which can be deeply nested.
           content:
             application/json:
               schema: LaneListResponse

--- a/api/documentation/controller.py
+++ b/api/documentation/controller.py
@@ -65,7 +65,7 @@ class OpenAPIController:
             'schema', 'AdminRole', 'object',
             {
                 'library': {'type': 'string'},
-                'role': {'$ref': '#/components/schemas/SiteAdminroles'}
+                'role': {'$ref': '#/components/schemas/SiteAdminRoles'}
             }
         )
 
@@ -120,7 +120,7 @@ class OpenAPIController:
         self.addComponent(
             'schema', 'AtomCategory', 'object',
             {
-                'schema': {'type': 'string'},
+                'scheme': {'type': 'string'},
                 'term': {'type': 'string'},
                 'label': {'type': 'string'}
             },
@@ -156,22 +156,72 @@ class OpenAPIController:
         )
 
         self.addComponent(
+            'schema', 'AtomAuthor', 'object',
+            {
+                'atom:name': {'type': 'string'},
+                'atom:sort_name': {'type': 'string'},
+                'atom:family_name': {'type': 'string'},
+                'simplified:wikipedia_name': {'type': 'string'},
+                'atom:sameas': {
+                    'type': 'string',
+                    'enum': ['http://viaf.org/viaf/[VIAF_ID]', 'http://id.loc.gov/authorities/names/[LCNAF_ID]'],
+                    'description': 'A resolvable VIAF or LCNAF URI for the current author'
+                }
+            }
+        )
+
+        self.addComponent(
+            'schema', 'AtomSeries', 'object',
+            {
+                'atom:name': {'type': 'string'},
+                'atom:position': {'type': 'integer'},
+            }
+        )
+
+        self.addComponent(
+            'schema', 'BibframeProvider', 'object',
+            {
+                'bibframe:ProviderName': {'type': 'string'}
+            }
+        )
+
+        self.addComponent(
             'schema', 'OPDSEntry', 'object',
             {
                 'atom:id': {'type': 'string'},
                 'dc:identifier': {'type': 'string'},
                 'atom:updated': {'type': 'string'},
-                'dc:issued': {'type': 'string'},
+                'dcterms:issued': {'type': 'string'},
                 'atom:title': {'type': 'string'},
-                'atom:author': {'type': 'string',},
+                'atom:author': {
+                    'type': 'array',
+                    'items': {'$ref': '#/components/schemas/AtomAuthor'}
+                },    
                 'atom:rights': {'type': 'string'},
                 'atom:summary': {'type': 'string'},
                 'atom:content': {'type': 'string'},
                 'atom:contributor': {'type': 'string'},
                 'atom:published': {'type': 'string'},
                 'opds:price': {'type': 'string'},
-                'atom:category': {'$ref': '#/components/schemas/AtomCategory'},
-                'opds:link': {'$ref': '#/components/schemas/OPDSLink'}
+                'atom:category': {
+                    'type': 'array',
+                    'items': {'$ref': '#/components/schemas/AtomCategory'}
+                },
+                'opds:link': {
+                    'type': 'array',
+                    'items': {'$ref': '#/components/schemas/OPDSLink'}
+                },
+                'schema:alternativeHeadline': {'type': 'string'},
+                'simplified:pwid': {'type': 'string'},
+                'atom:additionalType': {'type': 'string'},
+                'atom:series': {
+                    'type': 'array', 
+                    'items': {'$ref': '#/components/schemas/AtomSeries'}
+                },
+                'dcterms:language': {'type': 'string'},
+                'dcterms:publisher': {'type': 'string'},
+                'dcterms:publisherImprint': {'type': 'string'},
+                'bibframe:distribution': {'$ref': '#/components/schemas/BibframeProvider'}
             },
             requiredFields=['atom:id', 'atom:updated', 'atom:title']
         )
@@ -302,7 +352,10 @@ class OpenAPIController:
                 'id': {'type': 'string'},
                 'display_name': {'type': 'string'},
                 'visible': {'type': 'boolean'},
-                'count': {'type': 'integer'},
+                'count': {
+                    'type': 'integer',
+                    'description': 'Count is determined by the `update_lane_size` script and is stored in the lane model in the circulation database in the `size` column. This counts only works in the current lane, and not sublanes'
+                },
                 'sublanes': {
                     'description': 'A nested array of Lane objects',
                     'type': 'array',


### PR DESCRIPTION
## Description

This makes two updates to the CM OpenAPI documentation:

1. Extends the description of the OPDS Work object returned to include all potential fields
2. Improves description of the `count` attribute of the `lanes` endpoint to describe the source/control of this data

## Motivation and Context

This addresses some comments from users of the documentation that additional details are needed

## How Has This Been Tested?

Validated that all new documentation updates appear on the Swagger UI page.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
