### PR TITLE
Set docker-compose version to 3.8

### DIFF
--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: '3.8'
 
 services:
 

--- a/docker-compose.cicd.yml
+++ b/docker-compose.cicd.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: '3.8'
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: '3.8'
 
 services:
 


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Set docker-compose version to 3.8.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bamboo failed to build with 3.9, version is unsupported in our instance.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
