### PR TITLE
Set docker-compose version to 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,8 @@ ARG DEBIAN_FRONTEND="noninteractive"
 ARG NODESOURCE_KEYFILE="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
 
 # Install system level dependencies
-RUN apt-get update \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 871920D1991BC93C \
+ && apt-get update \
  && apt-get install --yes --no-install-recommends \
     curl \
     ca-certificates \

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.7'
 
 services:
 

--- a/docker-compose.cicd.yml
+++ b/docker-compose.cicd.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.7'
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.7'
 
 services:
 


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Our instance of Bamboo does not support docker-compose versions 3.9 or 3.8. This sets the version back to 3.7 and adds an apt-key.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The added apt-key attempts to fix build errors in Bamboo.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
