### PR TITLE
Switch the order of apt-key after installing gnupg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,12 +68,12 @@ FROM ubuntu:22.04 as circulation_base
 ARG DEBIAN_FRONTEND="noninteractive"
 
 # Install system level dependencies
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 871920D1991BC93C
 RUN apt-get update \
  && apt-get install --yes --no-install-recommends \
     curl \
     ca-certificates \
     gnupg
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 871920D1991BC93C
 RUN apt-get update \
  && apt-get install --yes --no-install-recommends \
     build-essential \


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Move `apt-key add` to after installing gnupg

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Logs didn't seem to like this line even though it fixed the pubkey errors. Maybe it needs to be installed after gnupg.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
