### PR TITLE
Clean up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,16 +69,16 @@ ARG DEBIAN_FRONTEND="noninteractive"
 ARG NODESOURCE_KEYFILE="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
 
 # Install system level dependencies
-RUN apt-get update
-RUN apt-get install --yes --no-install-recommends \
+RUN apt-get update \
+ && apt-get install --yes --no-install-recommends \
     curl \
     ca-certificates \
-    gnupg
-RUN curl -sSL ${NODESOURCE_KEYFILE} | apt-key add - \
- && echo "deb https://deb.nodesource.com/node_14.x jammy main" >> /etc/apt/sources.list.d/nodesource.list \
- && echo "deb-src https://deb.nodesource.com/node_14.x jammy main" >> /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update
-RUN apt-get install --yes --no-install-recommends \
+    gnupg \
+ && curl -sSL ${NODESOURCE_KEYFILE} | apt-key add - \
+ && echo "deb https://deb.nodesource.com/node_14.x focal main" >> /etc/apt/sources.list.d/nodesource.list \
+ && echo "deb-src https://deb.nodesource.com/node_14.x focal main" >> /etc/apt/sources.list.d/nodesource.list \
+ && apt-get update \
+ && apt-get install --yes --no-install-recommends \
     build-essential \
     pkg-config \
     software-properties-common \
@@ -101,9 +101,9 @@ RUN apt-get install --yes --no-install-recommends \
     libxmlsec1-openssl \
     libxml2-dev \
  && locale-gen en_US \
- && update-locale LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8
-RUN apt-get clean --yes
-RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ && update-locale LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 \
+ && apt-get clean --yes \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV LANG="en_US.UTF-8"
 ENV LC_CTYPE="en_US.UTF-8"


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Cleans up the Dockerfile to run multiple commands in one `RUN` command.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Revert the Dockerfile back to how it previously worked now that debugging on bamboo is completed. Resolution was to downgrade from Ubuntu 22.04 to Ubuntu 20.04.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
