### PR TITLE
Simply-3972 Re-enable DockerHub builds

### DIFF
--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -10,6 +10,7 @@ fi
 # Clone the right version of the circulation code.
 docker build \
   --build-arg version=${SOURCE_BRANCH} \
-  -f "Dockerfile.$image_branch" \
+  -f Dockerfile \
+  --target ${image_branch} \
   -t ${IMAGE_NAME} \
   --no-cache .

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -4,7 +4,7 @@ set -ex
 image_branch="$IMAGE_BRANCH"
 
 if [[ -z "$image_branch" ]]; then
-  image_branch=`echo "${DOCKER_REPO}" | sed "s/.*circ-//"`;
+  image_branch=`echo "cm_${DOCKER_REPO}_active" | sed "s/circ-//"`;
 fi
 
 # Clone the right version of the circulation code.


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Updates the docker build hook to use targets in a multi-stage build Dockerfile.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Builds on DockerHub started to fail after migrating to a multi-stage Dockerfile from three separate Dockerfiles.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Can't test this before merge. To test either try a manual build on DockerHub or merge something into develop after this pull request is merged.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
