### PR TITLE
SIMPLY-4161 Remove references to adobe_drm_devices

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -502,12 +502,6 @@ class CirculationPatronProfileStorage(PatronProfileStorage):
             adobe_drm['drm:scheme'] = "http://librarysimplified.org/terms/drm/scheme/ACS"
             drm.append(adobe_drm)
 
-            device_link['rel'] = 'http://librarysimplified.org/terms/drm/rel/devices'
-            device_link['href'] = self.url_for(
-                "adobe_drm_devices", library_short_name=self.patron.library.short_name, _external=True
-            )
-            links.append(device_link)
-
             annotations_link = dict(
                 rel="http://www.w3.org/ns/oa#annotationService",
                 type=AnnotationWriter.CONTENT_TYPE,

--- a/api/opds.py
+++ b/api/opds.py
@@ -1207,15 +1207,6 @@ class LibraryAnnotator(CirculationManagerAnnotator):
                 patron_key.text = token
                 drm_licensor.append(patron_key)
 
-                # Add the link to the DRM Device Management Protocol
-                # endpoint. See:
-                # https://github.com/NYPL-Simplified/Simplified/wiki/DRM-Device-Management
-                device_list_link = OPDSFeed.makeelement("link")
-                device_list_link.attrib['rel'] = 'http://librarysimplified.org/terms/drm/rel/devices'
-                device_list_link.attrib['href'] = self.url_for(
-                    "adobe_drm_devices", library_short_name=self.library.short_name, _external=True
-                )
-                drm_licensor.append(device_list_link)
                 cached = [drm_licensor]
 
             self._adobe_id_tags[cache_key] = cached

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -467,9 +467,7 @@ class TestCirculationPatronProfileStorage(ControllerTest):
             patron.library.short_name.upper() + "TOKEN"
         )
         assert adobe["drm:scheme"] == "http://librarysimplified.org/terms/drm/scheme/ACS"
-        [device_link, annotations_link] = doc['links']
-        assert device_link['rel'] == "http://librarysimplified.org/terms/drm/rel/devices"
-        assert device_link['href'] == "http://host/adobe_drm_devices?library_short_name=default"
+        [annotations_link] = doc['links']
         assert annotations_link['rel'] == "http://www.w3.org/ns/oa#annotationService"
         assert annotations_link['href'] == "http://host/annotations?library_short_name=default"
         assert annotations_link['type'] == AnnotationWriter.CONTENT_TYPE

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -553,8 +553,7 @@ class TestLibraryAnnotator(VendorIDTest):
 
         key = '{http://librarysimplified.org/terms/drm}vendor'
         assert self.adobe_vendor_id.username == element.attrib[key]
-
-        [token, device_management_link] = element
+        [token] = element
 
         assert '{http://librarysimplified.org/terms/drm}clientToken' == token.tag
         # token.text is a token which we can decode, since we know
@@ -566,15 +565,6 @@ class TestLibraryAnnotator(VendorIDTest):
             Configuration.WEBSITE_URL, library
         ).value
         assert (expected_url, patron_identifier) == decoded
-
-        assert "link" == device_management_link.tag
-        assert ("http://librarysimplified.org/terms/drm/rel/devices" ==
-            device_management_link.attrib['rel'])
-        expect_url = self.annotator.url_for(
-            'adobe_drm_devices', library_short_name=library.short_name,
-            _external=True
-        )
-        assert expect_url == device_management_link.attrib['href']
 
         # If we call adobe_id_tags again we'll get a distinct tag
         # object that renders to the same XML.
@@ -1047,16 +1037,12 @@ class TestLibraryAnnotator(VendorIDTest):
         # and the patron's patron identifier for Adobe purposes.
         assert (self.adobe_vendor_id.username ==
             licensor.attrib['{http://librarysimplified.org/terms/drm}vendor'])
-        [client_token, device_management_link] = licensor
+        [client_token] = licensor
         expected = ConfigurationSetting.for_library_and_externalintegration(
             self._db, ExternalIntegration.USERNAME, self._default_library, self.registry
         ).value.upper()
         assert client_token.text.startswith(expected)
         assert adobe_patron_identifier in client_token.text
-        assert ("{http://www.w3.org/2005/Atom}link" ==
-            device_management_link.tag)
-        assert ("http://librarysimplified.org/terms/drm/rel/devices" ==
-            device_management_link.attrib['rel'])
 
         # Unlike other places this tag shows up, we use the
         # 'scheme' attribute to explicitly state that this


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Remove references to adobe drm devices.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[SIMPLY-4161](https://jira.nypl.org/browse/SIMPLY-4161) This removes some remaining adobe drm device logic that was worked on in #1736 and #1740. Currently patron authentication fails due to calls to `adobe_drm_devices` that was removed in #1736. Completing the removal of the drm device logic fixes patron authentication.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Automated tests. I also tried this locally with a test user/password through the Simple Authentication Provider.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
