### PR TITLE
HOTFIX Disable PatronRecordReaper

### DIFF
--- a/core/monitor.py
+++ b/core/monitor.py
@@ -884,7 +884,10 @@ class PatronRecordReaper(ReaperMonitor):
     MODEL_CLASS = Patron
     TIMESTAMP_FIELD = 'authorization_expires'
     MAX_AGE = 60
-ReaperMonitor.REGISTRY.append(PatronRecordReaper)
+
+# NOTE: This reaper does not correlate to our current policy and is being paused
+#       It may be renabled at any time by un-commenting the line below
+# ReaperMonitor.REGISTRY.append(PatronRecordReaper)
 
 
 class WorkReaper(ReaperMonitor):


### PR DESCRIPTION


## Description

After review and consultation with our Product team it was concluded that this reaper (which deletes inactive patron accounts) does not match our understanding of library policy. As such this fix disables this reaper from being run as part of the daily `database_reaper` script package. It is not being removed entirely if it needs to be re-enabled in this format or a modified one in the future.

## Motivation and Context

This is motivated by the need to update our policy when it comes to this process

## How Has This Been Tested?

This has not been tested, but simply removes a process from a cron task. This changes no functionality and no complications are anticipated

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
