### PR TITLE
Halt Cron jobs between 01:00 and 03:00 on wednesdays

### DIFF
--- a/core/bin/run
+++ b/core/bin/run
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 #### Housekeeping functions and variables ####################################
+# This is to halt the script runner create a manual database maintenance window between 01:00 and 03:00 on Wendesdays.
 
 if [[ $(date +%u) -eq 3 && $(date +%H) -eq 1 ]]; then
   echo "I don't run at this time"
-  exit 1
+  exit 0
 elif [[ $(date +%u) -eq 3 && $(date +%H) -eq 2 ]]; then
   echo "I don't run at this time"
-  exit 1
+  exit 0
 fi
 
 THIS_SCRIPTS_NAME="$(basename $0)"

--- a/core/bin/run
+++ b/core/bin/run
@@ -2,6 +2,14 @@
 
 #### Housekeeping functions and variables ####################################
 
+if [[ $(date +%u) -eq 3 && $(date +%H) -eq 1 ]]; then
+  echo "I don't run at this time"
+  exit 1
+elif [[ $(date +%u) -eq 3 && $(date +%H) -eq 2 ]]; then
+  echo "I don't run at this time"
+  exit 1
+fi
+
 THIS_SCRIPTS_NAME="$(basename $0)"
 
 function display_help () {

--- a/docker/simplified_crontab
+++ b/docker/simplified_crontab
@@ -82,7 +82,7 @@
 if [[ $(date +%u) -eq 3 && $(date +%H) -eq 1 ]]; then
   echo "I don't run at this time"
   exit 1
-elif [[ $(date +%u) -eq 3 && $(date +%H) -eq 1 ]]; then
+elif [[ $(date +%u) -eq 3 && $(date +%H) -eq 2 ]]; then
   echo "I don't run at this time"
   exit 1
 fi

--- a/docker/simplified_crontab
+++ b/docker/simplified_crontab
@@ -78,7 +78,14 @@
 #   /var/log/simplified that's named after the script it was asked to run. Those
 #   messages will typically NOT appear in the container output or the cron.log file.
 #
-##############################################################################
+############################################################################### # A database maintenance window is needed between 01:00 and 03:00 on Wednesdays
+if [[ $(date +%u) -eq 3 && $(date +%H) -eq 1 ]]; then
+  echo "I don't run at this time"
+  exit 1
+elif [[ $(date +%u) -eq 3 && $(date +%H) -eq 1 ]]; then
+  echo "I don't run at this time"
+  exit 1
+fi
 
 ## Environment Variables for Cron Shells #####################################
 

--- a/docker/simplified_crontab
+++ b/docker/simplified_crontab
@@ -78,15 +78,8 @@
 #   /var/log/simplified that's named after the script it was asked to run. Those
 #   messages will typically NOT appear in the container output or the cron.log file.
 #
-############################################################################### # A database maintenance window is needed between 01:00 and 03:00 on Wednesdays
-if [[ $(date +%u) -eq 3 && $(date +%H) -eq 1 ]]; then
-  echo "I don't run at this time"
-  exit 1
-elif [[ $(date +%u) -eq 3 && $(date +%H) -eq 2 ]]; then
-  echo "I don't run at this time"
-  exit 1
-fi
-
+###############################################################################
+#
 ## Environment Variables for Cron Shells #####################################
 
 SHELL=/bin/bash
@@ -106,6 +99,7 @@ PID1_STDERR=/proc/1/fd/2
 #   https://github.com/NYPL-Simplified/Simplified/wiki/Circulation-Manager-Scripts
 #
 ##############################################################################
+
 
 #### Updates to caches and indexes ###########################################
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Added an if elif bash statement to check for date and time of the server and exit the cron job if it is between 01:00 and 03:00 server time on Wednesdays.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A manual maintenance window is needed for the database between 01:00 and 03:00 on Wednesdays.  This requires cron jobs to be halted for clean handling. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
