### PR TITLE
SIMPLY-4163 GitHub Action to push QA images to ECR

### DIFF
--- a/.github/workflows/publishQA.yml
+++ b/.github/workflows/publishQA.yml
@@ -29,7 +29,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SE_AWS_SECRET_ACCESS_KEY }}
         - stage: cm_scripts_active
           container_tag: qa-cron-latest
-        - stage: cm_webapp_active:
+        - stage: cm_webapp_active
           container_tag: qa-latest
     steps:
       - name: checkout

--- a/.github/workflows/publishQA.yml
+++ b/.github/workflows/publishQA.yml
@@ -16,17 +16,17 @@ jobs:
         stage: [cm_scripts_active, cm_webapp_active, cm_exec_active]
         include:
         - project: BPL
-            ECR_REPOSITORY: ${{ secrets.BPL_ECR_REPOSITORY }}
-            AWS_ACCESS_KEY_ID: ${{ secrets.SE_AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.SE_AWS_SECRET_ACCESS_KEY }}
+          ECR_REPOSITORY: ${{ secrets.BPL_ECR_REPOSITORY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.SE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SE_AWS_SECRET_ACCESS_KEY }}
         - project: OE
-            ECR_REPOSITORY: ${{ secrets.OE_ECR_REPOSITORY }}
-            AWS_ACCESS_KEY_ID: ${{ secrets.OE_AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.OE_AWS_SECRET_ACCESS_KEY }}
+          ECR_REPOSITORY: ${{ secrets.OE_ECR_REPOSITORY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.OE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OE_AWS_SECRET_ACCESS_KEY }}
         - project: SE
-            ECR_REPOSITORY: ${{ secrets.SE_ECR_REPOSITORY }}
-            AWS_ACCESS_KEY_ID: ${{ secrets.SE_AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.SE_AWS_SECRET_ACCESS_KEY }}
+          ECR_REPOSITORY: ${{ secrets.SE_ECR_REPOSITORY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.SE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SE_AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publishQA.yml
+++ b/.github/workflows/publishQA.yml
@@ -10,21 +10,21 @@ jobs:
     name: Publish image to ECR
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-		strategy:
-			matrix:
-				project: [BPL, OE, SE]
+    strategy:
+      matrix:
+        project: [BPL, OE, SE]
         stage: [cm_scripts_active, cm_webapp_active, cm_exec_active]
-				include:
-					- project: BPL
-						ECR_REPOSITORY: ${{ secrets.BPL_ECR_REPOSITORY }}
+        include:
+        - project: BPL
+            ECR_REPOSITORY: ${{ secrets.BPL_ECR_REPOSITORY }}
             AWS_ACCESS_KEY_ID: ${{ secrets.SE_AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.SE_AWS_SECRET_ACCESS_KEY }}
-					- project: OE
-						ECR_REPOSITORY: ${{ secrets.OE_ECR_REPOSITORY }}
+          - project: OE
+            ECR_REPOSITORY: ${{ secrets.OE_ECR_REPOSITORY }}
             AWS_ACCESS_KEY_ID: ${{ secrets.OE_AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.OE_AWS_SECRET_ACCESS_KEY }}
-					- project: SE
-						ECR_REPOSITORY: ${{ secrets.SE_ECR_REPOSITORY }}
+          - project: SE
+            ECR_REPOSITORY: ${{ secrets.SE_ECR_REPOSITORY }}
             AWS_ACCESS_KEY_ID: ${{ secrets.SE_AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.SE_AWS_SECRET_ACCESS_KEY }}
     steps:

--- a/.github/workflows/publishQA.yml
+++ b/.github/workflows/publishQA.yml
@@ -31,6 +31,24 @@ jobs:
           container_tag: qa-cron-latest
         - stage: cm_webapp_active
           container_tag: qa-latest
+        - project: BPL
+          stage: cm_scripts_active
+          cluster_service: ${{ secrets.BPL_SCRIPTS_CLUSTER_SERVICE }}
+        - project: BPL
+          stage: cm_webapp_active
+          cluster_service: ${{ secrets.BPL_WEBAPP_CLUSTER_SERVICE }}
+        - project: OE
+          stage: cm_scripts_active
+          cluster_service: ${{ secrets.OE_SCRIPTS_CLUSTER_SERVICE }}
+        - project: OE
+          stage: cm_webapp_active
+          cluster_service: ${{ secrets.OE_WEBAPP_CLUSTER_SERVICE }}
+        - project: SE
+          stage: cm_scripts_active
+          cluster_service: ${{ secrets.SE_SCRIPTS_CLUSTER_SERVICE }}
+        - project: SE
+          stage: cm_webapp_active
+          cluster_service: ${{ secrets.SE_WEBAPP_CLUSTER_SERVICE }}
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -63,4 +81,4 @@ jobs:
 
       - name: Force ECS Update
         run: |
-          aws ecs update-service --cluster ${{ matrix.ECR_REPOSITORY }} --service ${{ matrix.ECR_REPOSITORY }} --force-new-deployment
+          aws ecs update-service --cluster ${{ matrix.cluster_service }} --service ${{ matrix.cluster_service }} --force-new-deployment

--- a/.github/workflows/publishQA.yml
+++ b/.github/workflows/publishQA.yml
@@ -19,11 +19,11 @@ jobs:
             ECR_REPOSITORY: ${{ secrets.BPL_ECR_REPOSITORY }}
             AWS_ACCESS_KEY_ID: ${{ secrets.SE_AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.SE_AWS_SECRET_ACCESS_KEY }}
-          - project: OE
+        - project: OE
             ECR_REPOSITORY: ${{ secrets.OE_ECR_REPOSITORY }}
             AWS_ACCESS_KEY_ID: ${{ secrets.OE_AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.OE_AWS_SECRET_ACCESS_KEY }}
-          - project: SE
+        - project: SE
             ECR_REPOSITORY: ${{ secrets.SE_ECR_REPOSITORY }}
             AWS_ACCESS_KEY_ID: ${{ secrets.SE_AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.SE_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publishQA.yml
+++ b/.github/workflows/publishQA.yml
@@ -1,0 +1,61 @@
+# On merge to qa, build a container and deploy to ECR
+name: Publish QA
+on:
+  pull_request:
+    branches: [qa]
+    types: [closed]
+
+jobs:
+  publish_and_deploy_qa:
+    name: Publish image to ECR
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+		strategy:
+			matrix:
+				project: [BPL, OE, SE]
+        stage: [cm_scripts_active, cm_webapp_active, cm_exec_active]
+				include:
+					- project: BPL
+						ECR_REPOSITORY: ${{ secrets.BPL_ECR_REPOSITORY }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.SE_AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.SE_AWS_SECRET_ACCESS_KEY }}
+					- project: OE
+						ECR_REPOSITORY: ${{ secrets.OE_ECR_REPOSITORY }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.OE_AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.OE_AWS_SECRET_ACCESS_KEY }}
+					- project: SE
+						ECR_REPOSITORY: ${{ secrets.SE_ECR_REPOSITORY }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.SE_AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.SE_AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Configure QA AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        env:
+          AWS_ACCESS_KEY_ID: ${{ matrix.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ matrix.AWS_SECRET_ACCESS_KEY }}
+        with:
+          aws-access-key-id: $AWS_ACCESS_KEY_ID
+          aws-secret-access-key: $AWS_SECRET_ACCESS_KEY
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ matrix.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG . --target ${{ matrix.stage }}
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:qa-latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:qa-latest
+
+      - name: Force ECS Update
+        run: |
+          aws ecs update-service --cluster ${{ matrix.ECR_REPOSITORY }} --service <service_name> --force-new-deployment

--- a/.github/workflows/publishQA.yml
+++ b/.github/workflows/publishQA.yml
@@ -27,6 +27,10 @@ jobs:
           ECR_REPOSITORY: ${{ secrets.SE_ECR_REPOSITORY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.SE_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SE_AWS_SECRET_ACCESS_KEY }}
+        - stage: cm_scripts_active
+          container_tag: qa-cron-latest
+        - stage: cm_webapp_active:
+          container_tag: qa-latest
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -50,11 +54,12 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ matrix.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
+          CONTAINER_TAG: ${{ matrix.container_tag }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG . --target ${{ matrix.stage }}
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:qa-latest
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:qa-latest
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$CONTAINER_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$CONTAINER_TAG
 
       - name: Force ECS Update
         run: |

--- a/.github/workflows/publishQA.yml
+++ b/.github/workflows/publishQA.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         project: [BPL, OE, SE]
-        stage: [cm_scripts_active, cm_webapp_active, cm_exec_active]
+        stage: [cm_scripts_active, cm_webapp_active]
         include:
         - project: BPL
           ECR_REPOSITORY: ${{ secrets.BPL_ECR_REPOSITORY }}

--- a/.github/workflows/publishQA.yml
+++ b/.github/workflows/publishQA.yml
@@ -63,4 +63,4 @@ jobs:
 
       - name: Force ECS Update
         run: |
-          aws ecs update-service --cluster ${{ matrix.ECR_REPOSITORY }} --service <service_name> --force-new-deployment
+          aws ecs update-service --cluster ${{ matrix.ECR_REPOSITORY }} --service ${{ matrix.ECR_REPOSITORY }} --force-new-deployment


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Add a new Action to build and publish QA images to ECR.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[SIMPLY-4163](https://jira.nypl.org/browse/SIMPLY-4163) Moving forward with a single QA branch helps the overhead of maintaining three branches and removes the dependency on Bamboo to manage deployments.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has not been tested yet, but will be on merged pull requests into the new `qa` branch.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
