### PR TITLE
Increase default pool_size and max_overflow

### DIFF
--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -309,7 +309,8 @@ class SessionManager(object):
     @classmethod
     def engine(cls, url=None):
         url = url or Configuration.database_url()
-        return create_engine(url, echo=DEBUG)
+        # Default sqlalchemy QueuePool pool_size is 10 and max_overflow is 20. This triples it.
+        return create_engine(url, echo=DEBUG, pool_size=30, max_overflow=60)
 
     @classmethod
     def sessionmaker(cls, url=None, session=None):


### PR DESCRIPTION
## Description

In an effort to address the SQLAlchemy QueuePoolError where the default number of database connections is being exhausted, this triples the total number of available connections.

## Motivation and Context

The QueuePoolError has been a persistent error that we have attributed to a number of issues, namely disappearing books, disappearing checkouts, and failing API calls. We have tried another approach to solve this problem involving fixing dangling connections. That approach did not work, and SQLAlchemy recommends increasing connections as a possible fix. This PR attempts that fix. 

## How Has This Been Tested?

`make test`

## Checklist:

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
