### PR TITLE
Simply-4215 Fix Docker Hub builds [hooks/test]

### DIFF
--- a/hooks/test
+++ b/hooks/test
@@ -3,8 +3,8 @@
 set -ex
 
 # Create a container with test and production postgres databases.
-docker pull postgres:12.0-alpine;
-docker run -d --env POSTGRES_HOST_AUTH_METHOD=trust --name pg postgres:12.0-alpine;
+docker pull postgres:12.8-alpine;
+docker run -d --env POSTGRES_HOST_AUTH_METHOD=trust --name pg postgres:12.8-alpine;
 
 # Sleep to let PostgreSQL start up.
 sleep 15;

--- a/hooks/test
+++ b/hooks/test
@@ -27,19 +27,23 @@ docker run -d -p 80:80 \
   -e SIMPLIFIED_PRODUCTION_DATABASE="postgresql://simplified:test@${pghost}:5432/docker_prod" \
   --name circ --rm "$IMAGE_NAME"
 
-# A method to check that runit services are running inside the container
+# A method to check that services are running inside the container
 function check_service_status()
 {
-  # The location of the runit service should be passed.
+  # The service name should be passed.
   service="$1"
 
   # Check the status of the service.
-  service_status=`docker exec circ /bin/bash -c "sv status $service"`
+  if [[ "$service" == "gunicorn" ]]; then
+    service_status=$(docker exec circ /bin/bash -c "supervisorctl status ${service}")
+  else
+    service_status=$(docker exec circ /bin/bash -c "service $service status")
+  fi
 
-  # Get the exit code for the sv call.
-  sv_status=$?
+  # Get the exit code for the service call.
+  svc_status=$?
 
-  if [[ "$sv_status" != 0 || "$service_status" =~ down ]]; then
+  if [[ "$svc_status" != 0 ]]; then
     echo "  FAIL: $service is not running"
     exit 1
   else
@@ -57,13 +61,16 @@ fi
 
 # If this is a scripts container, check that cron is running.
 if [[ ${IMAGE_NAME} == *"scripts"* ]]; then
-  check_service_status /etc/service/cron
+  check_service_status cron
   exit 0
 fi
 
-# In a webapp container, check that nginx and uwsgi are running.
-check_service_status /etc/service/nginx
-check_service_status /home/simplified/service/uwsgi
+# If this is a webapp container, check that nginx and gunicorn are running
+if [[ ${IMAGE_NAME} == *"webapp"* ]]; then
+  check_service_status nginx
+  check_service_status gunicorn
+  exit 0
+fi
 
 # Make sure the web server is running.
 healthcheck=$(docker exec circ /bin/bash -c "curl --write-out \"%{http_code}\" --silent --output /dev/null http://localhost/healthcheck.html")

--- a/hooks/test
+++ b/hooks/test
@@ -65,12 +65,9 @@ if [[ ${IMAGE_NAME} == *"scripts"* ]]; then
   exit 0
 fi
 
-# If this is a webapp container, check that nginx and gunicorn are running
-if [[ ${IMAGE_NAME} == *"webapp"* ]]; then
-  check_service_status nginx
-  check_service_status gunicorn
-  exit 0
-fi
+# In a webapp container, check that nginx and uwsgi are running.
+check_service_status nginx
+check_service_status gunicorn
 
 # Make sure the web server is running.
 healthcheck=$(docker exec circ /bin/bash -c "curl --write-out \"%{http_code}\" --silent --output /dev/null http://localhost/healthcheck.html")


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Update `hooks/test` to match the version of postgres that we currently use. Also updates the service status check commands to reflect the current architecture.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[SIMPLY-4215](https://jira.nypl.org/browse/SIMPLY-4215). Docker Hub is now picking up the hooks and the test hook was not updated which caused the builds to fail. The test hook has been updated to reflect the current state of services.

`nginx` and `cron` can be checked through `service <nginx|cron> status`, but `gunicorn` has to be checked through `supervisorctl`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I couldn't find a way to run the test hook, so I tested it piece by piece. The `check_service_status` function with `cron`, `nginx`, and `gunicorn` all reported the expected status. I also curled the healthcheck endpoints and the output looks unchanged.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
