### PR TITLE
Fix Build API Documentation action

### DIFF
--- a/api/lcp/collection.py
+++ b/api/lcp/collection.py
@@ -124,7 +124,7 @@ class LCPAPI(BaseCirculationAPI, HasExternalIntegration):
         """Returns an associated Collection object
 
         :return: Associated Collection object
-        :rtype: Collection
+        :rtype: core.model.collection.Collection
         """
         return Collection.by_id(self._db, id=self._collection_id)
 

--- a/api/lcp/mirror.py
+++ b/api/lcp/mirror.py
@@ -128,7 +128,7 @@ class LCPMirror(MinIOUploader, HasExternalIntegrationPerCollection):
         :type mirror_to: string
 
         :param collection: Collection
-        :type collection: Optional[Collection]
+        :type collection: Optional[core.model.collection.Collection]
         """
         db = Session.object_session(representation)
         bucket = self.get_bucket(S3UploaderConfiguration.PROTECTED_CONTENT_BUCKET_KEY)

--- a/core/mirror.py
+++ b/core/mirror.py
@@ -118,7 +118,7 @@ class MirrorUploader(metaclass=ABCMeta):
         :type mirror_to: string
 
         :param collection: Collection
-        :type collection: Optional[Collection]
+        :type collection: Optional[core.model.collection.Collection]
         """
         now = utc_now()
         exception = self.do_upload(representation)

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -374,7 +374,7 @@ class CollectionMonitor(Monitor):
         :param _db: Database session object.
         :param collections: An optional list of collections. If None,
             we'll process all collections.
-        :type collections: List[Collection]
+        :type collections: List[core.model.collection.Collection]
         :param constructor_kwargs: These keyword arguments will be passed
             into the CollectionMonitor constructor.
 

--- a/core/opds_import.py
+++ b/core/opds_import.py
@@ -664,7 +664,7 @@ class OPDSImporter(object):
         """Returns an associated Collection object
 
         :return: Associated Collection object
-        :rtype: Optional[Collection]
+        :rtype: Optional[core.model.collection.Collection]
         """
         if self._collection_id:
             return Collection.by_id(self._db, id=self._collection_id)

--- a/core/s3.py
+++ b/core/s3.py
@@ -615,7 +615,7 @@ class S3Uploader(MirrorUploader):
         :type mirror_to: string
 
         :param collection: Collection
-        :type collection: Optional[Collection]
+        :type collection: Optional[core.model.collection.Collection]
         """
         # Turn the original URL into an s3.amazonaws.com URL.
         media_type = representation.external_media_type

--- a/core/util/webpub_manifest_parser/core/ast.py
+++ b/core/util/webpub_manifest_parser/core/ast.py
@@ -445,7 +445,8 @@ class Contributor(Node):
 class ArrayOfContributorsProperty(BaseArrayProperty):
     """Property containing information about contributors.
 
-    For example:
+    For example::
+
         - "Herman Melville"
         - {
             name: "Herman Melville"
@@ -522,7 +523,8 @@ class Subject(Node, PropertiesGrouping):
 class ArrayOfSubjectsProperty(BaseArrayProperty):
     """Property containing information about subjects.
 
-    For example:
+    For example::
+
         - "Juvenile Fiction"
         - {
             name: "Juvenile Fiction"

--- a/core/util/webpub_manifest_parser/core/properties.py
+++ b/core/util/webpub_manifest_parser/core/properties.py
@@ -563,7 +563,8 @@ class ArrayOfStringsProperty(BaseArrayProperty):
 class ListOfLanguagesProperty(BaseArrayProperty):
     """Property allowing localizable strings.
 
-    For example:
+    For example::
+
         - "en"
         - [
             "eng",
@@ -599,12 +600,13 @@ class ListOfLanguagesProperty(BaseArrayProperty):
 class LocalizableStringProperty(ParsableProperty):
     """Property allowing either only string/localizable string values.
 
-    For example:
-    - "plain string"
-    - {
-        "eng": "Hello",
-        "esp": "Hola"
-      }
+    For example::
+
+        - "plain string"
+        - {
+            "eng": "Hello",
+            "esp": "Hola"
+        }
     """
 
     PARSER = AnyOfParser([LocalizableStringParser(), StringParser()])

--- a/scripts.py
+++ b/scripts.py
@@ -1420,7 +1420,7 @@ class DirectoryImportScript(TimestampScript):
         :type data_source_name: string
 
         :return: A 2-tuple (Collection, list of MirrorUploader instances)
-        :rtype: Tuple[Collection, List[MirrorUploader]]
+        :rtype: Tuple[core.model.collection.Collection, List[MirrorUploader]]
         """
         collection, is_new = Collection.by_name_and_protocol(
             self._db, collection_name, ExternalIntegration.LCP if collection_type == CollectionType.LCP else ExternalIntegration.MANUAL
@@ -1476,7 +1476,7 @@ class DirectoryImportScript(TimestampScript):
         """Creates a Work instance from metadata
 
         :param collection: Target collection
-        :type collection: Collection
+        :type collection: core.model.collection.Collection
 
         :param collection_type: Collection's type: open access/protected access
         :type collection_type: CollectionType

--- a/scripts.py
+++ b/scripts.py
@@ -1482,7 +1482,7 @@ class DirectoryImportScript(TimestampScript):
         :type collection_type: CollectionType
 
         :param metadata: Book's metadata
-        :type metadata: Metadata
+        :type metadata: core.metadata_layer.Metadata
 
         :param policy: Replacement policy
         :type policy: ReplacementPolicy
@@ -1528,7 +1528,7 @@ class DirectoryImportScript(TimestampScript):
         :type collection_type: CollectionType
 
         :param metadata: Book's metadata
-        :type metadata: Metadata
+        :type metadata: core.metadata_layer.Metadata
 
         :param policy: Replacement policy
         :type policy: ReplacementPolicy


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Fix errors that cause the `Build API Documentation` action to fail.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When `webpub_manifest_parser` was folded into `core/util` this caused the API documentation builds to fail.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In the webapp container in the `docs` folder running `make clean && make html` until build succeeded.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
