### PR TITLE
Defaults visibility of lane to false

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1134,6 +1134,9 @@ class LanesController(AdminCirculationManagerController):
                 (lane, is_new) = create(self._db, Lane,
                                         display_name=display_name, parent=parent, library=library)
 
+                if is_new:
+                    lane.visible = False
+
                 # Make a new lane the first child of its parent and bump all the siblings down in priority.
                 siblings = self._db.query(Lane).filter(
                     Lane.library == library

--- a/core/lane.py
+++ b/core/lane.py
@@ -2595,7 +2595,7 @@ class Lane(Base, DatabaseBackedWorkList, HierarchyWorkList):
 
     # Only a visible lane will show up in the user interface.  The
     # admin interface can see all the lanes, visible or not.
-    _visible = Column(Boolean, default=True, nullable=False, name="visible")
+    _visible = Column(Boolean, default=False, nullable=False, name="visible")
 
     # A Lane may have many CachedFeeds.
     cachedfeeds = relationship(

--- a/core/lane.py
+++ b/core/lane.py
@@ -2595,7 +2595,7 @@ class Lane(Base, DatabaseBackedWorkList, HierarchyWorkList):
 
     # Only a visible lane will show up in the user interface.  The
     # admin interface can see all the lanes, visible or not.
-    _visible = Column(Boolean, default=False, nullable=False, name="visible")
+    _visible = Column(Boolean, default=True, nullable=False, name="visible")
 
     # A Lane may have many CachedFeeds.
     cachedfeeds = relationship(

--- a/tests/admin/controller/test_controller.py
+++ b/tests/admin/controller/test_controller.py
@@ -1565,6 +1565,7 @@ class TestLanesController(AdminControllerTest):
             assert list == lane.customlists[0]
             assert lane.inherit_parent_restrictions is False
             assert 0 == lane.priority
+            assert False == lane.visible
 
             # The sibling's priority has been shifted down to put the new lane at the top.
             assert 1 == sibling.priority


### PR DESCRIPTION
## Description

- Changed lane's default visibility to hidden.

## Motivation and Context

- As described in [SIMPLY-4218](https://jira.nypl.org/browse/SIMPLY-4218), we should ensure new lanes start off with their visibility set to hidden, so that any mistakes aren't propagated to patrons.

## How Has This Been Tested?

- This has been tested locally.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
