### PR TITLE
Update code and tests for clever v3 change

### DIFF
--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -264,7 +264,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
         if not identifier:
             return INVALID_CREDENTIALS.detailed(lgt("A valid Clever login is required."))
 
-        if result.get('user_type') not in self.SUPPORTED_USER_TYPES:
+        if result.get('type') not in self.SUPPORTED_USER_TYPES:
             return UNSUPPORTED_CLEVER_USER_TYPE
 
         links = result['links']
@@ -293,7 +293,7 @@ class CleverAuthenticationAPI(OAuthAuthenticationProvider):
 
         external_type = None
 
-        if result['user_type'] == 'student':
+        if result['type'] == 'student':
             # We need to be able to assign an external_type to students, so that they
             # get the correct content level. To do so we rely on the grade field in the
             # user data we get back from Clever. Their API doesn't guarantee that the

--- a/tests/clever/test_clever.py
+++ b/tests/clever/test_clever.py
@@ -80,7 +80,8 @@ class TestCleverAuthenticationAPI(DatabaseTest):
 
     def test_authenticated_patron(self):
         """An end-to-end test of authenticated_patron()."""
-        assert self.api.authenticated_patron(self._db, "not a valid token") is None
+        assert self.api.authenticated_patron(
+            self._db, "not a valid token") is None
 
         # This patron has a valid clever token.
         patron = self._patron()
@@ -95,17 +96,20 @@ class TestCleverAuthenticationAPI(DatabaseTest):
         # Test success.
         self.api.queue_response(dict(access_token="a token"))
         with self.app.test_request_context("/"):
-            assert self.api.remote_exchange_code_for_bearer_token(self._db, "code") == "a token"
+            assert self.api.remote_exchange_code_for_bearer_token(
+                self._db, "code") == "a token"
 
         # Test failure.
         self.api.queue_response(None)
         with self.app.test_request_context("/"):
-            problem = self.api.remote_exchange_code_for_bearer_token(self._db, "code")
+            problem = self.api.remote_exchange_code_for_bearer_token(
+                self._db, "code")
         assert INVALID_CREDENTIALS.uri == problem.uri
 
         self.api.queue_response(dict(something_else="not a token"))
         with self.app.test_request_context("/"):
-            problem = self.api.remote_exchange_code_for_bearer_token(self._db, "code")
+            problem = self.api.remote_exchange_code_for_bearer_token(
+                self._db, "code")
         assert INVALID_CREDENTIALS.uri == problem.uri
 
     def test_remote_exchange_payload(self):
@@ -121,37 +125,46 @@ class TestCleverAuthenticationAPI(DatabaseTest):
             assert 'a code' == payload['code']
 
     def test_remote_patron_lookup_unsupported_user_type(self):
-        self.api.queue_response(dict(type='district_admin', data=dict(id='1234')))
+        self.api.queue_response(
+            dict(user_type='district_admin', data=dict(id='1234')))
         token = self.api.remote_patron_lookup("token")
         assert UNSUPPORTED_CLEVER_USER_TYPE == token
 
     def test_remote_patron_lookup_ineligible(self):
-        self.api.queue_response(dict(type='student', data=dict(id='1234'), links=[dict(rel='canonical', uri='test')]))
-        self.api.queue_response(dict(data=dict(school='1234', district='1234')))
+        self.api.queue_response(dict(user_type='student', data=dict(
+            id='1234'), links=[dict(rel='canonical', uri='test')]))
+        self.api.queue_response(
+            dict(data=dict(school='1234', district='1234')))
         self.api.queue_response(dict(data=dict(nces_id='I am not Title I')))
 
         token = self.api.remote_patron_lookup("")
         assert CLEVER_NOT_ELIGIBLE == token
 
     def test_remote_patron_lookup_missing_nces_id(self):
-        self.api.queue_response(dict(type='student', data=dict(id='1234'), links=[dict(rel='canonical', uri='test')]))
-        self.api.queue_response(dict(data=dict(school='1234', district='1234')))
+        self.api.queue_response(dict(user_type='student', data=dict(
+            id='1234'), links=[dict(rel='canonical', uri='test')]))
+        self.api.queue_response(
+            dict(data=dict(school='1234', district='1234')))
         self.api.queue_response(dict(data=dict()))
 
         token = self.api.remote_patron_lookup("")
         assert CLEVER_UNKNOWN_SCHOOL == token
 
     def test_remote_patron_unknown_student_grade(self):
-        self.api.queue_response(dict(type='student', data=dict(id='2'), links=[dict(rel='canonical', uri='test')]))
-        self.api.queue_response(dict(data=dict(school='1234', district='1234', name='Abcd', grade="")))
+        self.api.queue_response(dict(user_type='student', data=dict(
+            id='2'), links=[dict(rel='canonical', uri='test')]))
+        self.api.queue_response(
+            dict(data=dict(school='1234', district='1234', name='Abcd', grade="")))
         self.api.queue_response(dict(data=dict(nces_id='44270647')))
 
         patrondata = self.api.remote_patron_lookup("token")
         assert patrondata.external_type is None
 
     def test_remote_patron_lookup_title_i(self):
-        self.api.queue_response(dict(type='student', data=dict(id='5678'), links=[dict(rel='canonical', uri='test')]))
-        self.api.queue_response(dict(data=dict(school='1234', district='1234', name='Abcd', grade="10")))
+        self.api.queue_response(dict(user_type='student', data=dict(
+            id='5678'), links=[dict(rel='canonical', uri='test')]))
+        self.api.queue_response(
+            dict(data=dict(school='1234', district='1234', name='Abcd', grade="10")))
         self.api.queue_response(dict(data=dict(nces_id='44270647')))
 
         patrondata = self.api.remote_patron_lookup("token")
@@ -164,8 +177,10 @@ class TestCleverAuthenticationAPI(DatabaseTest):
 
     def test_remote_patron_lookup_external_type(self):
         # Teachers have an external type of 'A' indicating all access.
-        self.api.queue_response(dict(type='teacher', data=dict(id='1'), links=[dict(rel='canonical', uri='test')]))
-        self.api.queue_response(dict(data=dict(school='1234', district='1234', name='Abcd')))
+        self.api.queue_response(dict(user_type='teacher', data=dict(
+            id='1'), links=[dict(rel='canonical', uri='test')]))
+        self.api.queue_response(
+            dict(data=dict(school='1234', district='1234', name='Abcd')))
         self.api.queue_response(dict(data=dict(nces_id='44270647')))
 
         patrondata = self.api.remote_patron_lookup("teacher token")
@@ -173,8 +188,10 @@ class TestCleverAuthenticationAPI(DatabaseTest):
 
         # Student type is based on grade
         def queue_student(grade):
-            self.api.queue_response(dict(type='student', data=dict(id='2'), links=[dict(rel='canonical', uri='test')]))
-            self.api.queue_response(dict(data=dict(school='1234', district='1234', name='Abcd', grade=grade)))
+            self.api.queue_response(dict(user_type='student', data=dict(
+                id='2'), links=[dict(rel='canonical', uri='test')]))
+            self.api.queue_response(
+                dict(data=dict(school='1234', district='1234', name='Abcd', grade=grade)))
             self.api.queue_response(dict(data=dict(nces_id='44270647')))
 
         queue_student(grade="1")
@@ -192,16 +209,20 @@ class TestCleverAuthenticationAPI(DatabaseTest):
     def test_oauth_callback_creates_patron(self):
         """Test a successful run of oauth_callback."""
         self.api.queue_response(dict(access_token="bearer token"))
-        self.api.queue_response(dict(type='teacher', data=dict(id='1'), links=[dict(rel='canonical', uri='test')]))
-        self.api.queue_response(dict(data=dict(school='1234', district='1234', name='Abcd')))
+        self.api.queue_response(dict(user_type='teacher', data=dict(
+            id='1'), links=[dict(rel='canonical', uri='test')]))
+        self.api.queue_response(
+            dict(data=dict(school='1234', district='1234', name='Abcd')))
         self.api.queue_response(dict(data=dict(nces_id='44270647')))
 
         with self.app.test_request_context("/"):
-            response = self.api.oauth_callback(self._db, dict(code="teacher code"))
+            response = self.api.oauth_callback(
+                self._db, dict(code="teacher code"))
             credential, patron, patrondata = response
 
         # The bearer token was turned into a Credential.
-        expect_credential, ignore = self.api.create_token(self._db, patron, "bearer token")
+        expect_credential, ignore = self.api.create_token(
+            self._db, patron, "bearer token")
         assert credential == expect_credential
 
         # Since the patron is a teacher, their external_type was set to 'A'.
@@ -213,7 +234,8 @@ class TestCleverAuthenticationAPI(DatabaseTest):
     def test_oauth_callback_problem_detail_if_bad_token(self):
         self.api.queue_response(dict(something_else="not a token"))
         with self.app.test_request_context("/"):
-            response = self.api.oauth_callback(self._db, dict(code="teacher code"))
+            response = self.api.oauth_callback(
+                self._db, dict(code="teacher code"))
         assert isinstance(response, ProblemDetail)
         assert INVALID_CREDENTIALS.uri == response.uri
 
@@ -222,7 +244,8 @@ class TestCleverAuthenticationAPI(DatabaseTest):
         self.api.queue_response(dict())
 
         with self.app.test_request_context("/"):
-            response = self.api.oauth_callback(self._db, dict(code="teacher code"))
+            response = self.api.oauth_callback(
+                self._db, dict(code="teacher code"))
 
         assert isinstance(response, ProblemDetail)
         assert INVALID_CREDENTIALS.uri == response.uri
@@ -230,7 +253,8 @@ class TestCleverAuthenticationAPI(DatabaseTest):
     def test_external_authenticate_url(self):
         """Verify that external_authenticate_url is generated properly"""
         # We're about to call url_for, so we must create an application context.
-        my_api = CleverAuthenticationAPI(self._default_library, self.mock_integration)
+        my_api = CleverAuthenticationAPI(
+            self._default_library, self.mock_integration)
 
         with self.app.test_request_context("/"):
             request.library = self._default_library

--- a/tests/clever/test_clever.py
+++ b/tests/clever/test_clever.py
@@ -126,12 +126,12 @@ class TestCleverAuthenticationAPI(DatabaseTest):
 
     def test_remote_patron_lookup_unsupported_user_type(self):
         self.api.queue_response(
-            dict(user_type='district_admin', data=dict(id='1234')))
+            dict(type='district_admin', data=dict(id='1234')))
         token = self.api.remote_patron_lookup("token")
         assert UNSUPPORTED_CLEVER_USER_TYPE == token
 
     def test_remote_patron_lookup_ineligible(self):
-        self.api.queue_response(dict(user_type='student', data=dict(
+        self.api.queue_response(dict(type='student', data=dict(
             id='1234'), links=[dict(rel='canonical', uri='test')]))
         self.api.queue_response(
             dict(data=dict(school='1234', district='1234')))
@@ -141,7 +141,7 @@ class TestCleverAuthenticationAPI(DatabaseTest):
         assert CLEVER_NOT_ELIGIBLE == token
 
     def test_remote_patron_lookup_missing_nces_id(self):
-        self.api.queue_response(dict(user_type='student', data=dict(
+        self.api.queue_response(dict(type='student', data=dict(
             id='1234'), links=[dict(rel='canonical', uri='test')]))
         self.api.queue_response(
             dict(data=dict(school='1234', district='1234')))
@@ -151,7 +151,7 @@ class TestCleverAuthenticationAPI(DatabaseTest):
         assert CLEVER_UNKNOWN_SCHOOL == token
 
     def test_remote_patron_unknown_student_grade(self):
-        self.api.queue_response(dict(user_type='student', data=dict(
+        self.api.queue_response(dict(type='student', data=dict(
             id='2'), links=[dict(rel='canonical', uri='test')]))
         self.api.queue_response(
             dict(data=dict(school='1234', district='1234', name='Abcd', grade="")))
@@ -161,7 +161,7 @@ class TestCleverAuthenticationAPI(DatabaseTest):
         assert patrondata.external_type is None
 
     def test_remote_patron_lookup_title_i(self):
-        self.api.queue_response(dict(user_type='student', data=dict(
+        self.api.queue_response(dict(type='student', data=dict(
             id='5678'), links=[dict(rel='canonical', uri='test')]))
         self.api.queue_response(
             dict(data=dict(school='1234', district='1234', name='Abcd', grade="10")))
@@ -177,7 +177,7 @@ class TestCleverAuthenticationAPI(DatabaseTest):
 
     def test_remote_patron_lookup_external_type(self):
         # Teachers have an external type of 'A' indicating all access.
-        self.api.queue_response(dict(user_type='teacher', data=dict(
+        self.api.queue_response(dict(type='teacher', data=dict(
             id='1'), links=[dict(rel='canonical', uri='test')]))
         self.api.queue_response(
             dict(data=dict(school='1234', district='1234', name='Abcd')))
@@ -188,7 +188,7 @@ class TestCleverAuthenticationAPI(DatabaseTest):
 
         # Student type is based on grade
         def queue_student(grade):
-            self.api.queue_response(dict(user_type='student', data=dict(
+            self.api.queue_response(dict(type='student', data=dict(
                 id='2'), links=[dict(rel='canonical', uri='test')]))
             self.api.queue_response(
                 dict(data=dict(school='1234', district='1234', name='Abcd', grade=grade)))
@@ -209,7 +209,7 @@ class TestCleverAuthenticationAPI(DatabaseTest):
     def test_oauth_callback_creates_patron(self):
         """Test a successful run of oauth_callback."""
         self.api.queue_response(dict(access_token="bearer token"))
-        self.api.queue_response(dict(user_type='teacher', data=dict(
+        self.api.queue_response(dict(type='teacher', data=dict(
             id='1'), links=[dict(rel='canonical', uri='test')]))
         self.api.queue_response(
             dict(data=dict(school='1234', district='1234', name='Abcd')))


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Update clever api calls and tests to v3.0 accommodate for the deprecation of clever v1.1 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Clever API is deprecating their v1.1 API we are updating to v3.0.  This required sending requests to versioned end points and updating the fields we are searching to their new titles.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Our test suite has been updated to send and reflect the changes to the Clever data model and extracting new multi_role_user_id and user_type.  The real test will come upon merging into QA and actually testing the Clever login functionality as this would require setting up Docker HTTPS to test locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
