### PR TITLE
Return 405 error for POST to index

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -811,6 +811,8 @@ class IndexController(CirculationManagerController):
 
     def __call__(self):
         # If this library provides a custom index view, use that.
+        if flask.request.method == 'POST':
+            return Response('Method not allowed', 405)
         library = flask.request.library
         custom = self.manager.custom_index_views.get(library.id)
         if custom is not None:

--- a/api/routes.py
+++ b/api/routes.py
@@ -267,7 +267,8 @@ def library_dir_route(path, *args, **kwargs):
         return default_library_no_slash
     return decorator
 
-@library_route("/", strict_slashes=False)
+
+@library_route("/", strict_slashes=False, methods=['GET', 'POST'])
 @has_library
 @allows_cors(allowed_domain_type=set({"admin", "patron"}))
 @returns_problem_detail

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1422,6 +1422,12 @@ class TestIndexController(CirculationControllerTest):
             assert 302 == response.status_code
             assert "http://cdn/default/groups/" == response.headers['location']
 
+    def test_post_to_root(self):
+        with self.app.test_request_context('/', method='POST'):
+            flask.request.library = self.library
+            response = self.manager.index_controller()
+            assert 405 == response.status_code
+
     def test_custom_index_view(self):
         """If a custom index view is registered for a library,
         it is called instead of the normal IndexController code.


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Explicit handling of 405 error for POST requests to `/`. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is the most common error that is reported by New Relic across all instances of the CM. The associated ticket is [4223](https://jira.nypl.org/browse/SIMPLY-4223)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The tests have been expanded to include POST requests to `/` and expect an explicit 405 Method not allowed error.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
