### PR TITLE
SIMPLY-4216 Fix: Use the library from the patron's root_lane

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2639,13 +2639,10 @@ class OAuthController(object):
 
         patron_info = json.dumps(patrondata.to_response_parameters)
         try:
-            library = self.authenticator.library_authenticators.get(
-                self.authenticator.current_library_name
-            ).library
             root_lane = cdn_url_for(
                 'acquisition_groups',
                 _external=True,
-                library_short_name=library.short_name,
+                library_short_name=patron.root_lane.library.short_name,
                 lane_identifier=patron.root_lane.id,
             )
         except AttributeError:
@@ -2760,7 +2757,7 @@ class BasicAuthTempTokenController(object):
                 root_lane = cdn_url_for(
                     'acquisition_groups',
                     _external=True,
-                    library_short_name=self.authenticator.library.short_name,
+                    library_short_name=patron.root_lane.library.short_name,
                     lane_identifier=patron.root_lane.id,
                 )
             except AttributeError:


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Use the library from the patron's root_lane instead of getting it from the authenticator. This is more reliable and cleaner than getting it from the authenticator since the library is already tied to the root_lane if one exists.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[SIMPLY-4216](https://jira.nypl.org/browse/SIMPLY-4216)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
