### PR TITLE
Remove delete method from endpoint

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1821,9 +1821,6 @@ class LoanController(CirculationManagerController):
         return AcquisitionFeed.single_entry(self._db, work, annotator)
 
     def detail(self, identifier_type, identifier):
-        if flask.request.method == 'DELETE':
-            return self.revoke_loan_or_hold(identifier_type, identifier)
-
         patron = flask.request.patron
         library = flask.request.library
         pools = self.load_licensepools(library, identifier_type, identifier)

--- a/api/routes.py
+++ b/api/routes.py
@@ -529,7 +529,8 @@ def fulfill(license_pool_id, mechanism_id=None, part=None):
 def revoke_loan_or_hold(license_pool_id):
     return app.manager.loans.revoke(license_pool_id)
 
-@library_route('/loans/<identifier_type>/<path:identifier>', methods=['GET', 'DELETE'])
+
+@library_route('/loans/<identifier_type>/<path:identifier>')
 @has_library
 @allows_cors(allowed_domain_type=set({"admin", "patron"}))
 @requires_auth
@@ -573,28 +574,6 @@ def loan_or_hold_detail(identifier_type, identifier):
                 content:
                     application/json:
                         schema: ProblemResponse 
-    delete:
-        tags:
-            -  loans
-        summary: Revoke a loan or hold
-        security:
-            - BasicAuth: []
-        parameters:
-            - in: path
-              name: library_short_name
-              schema:
-                  type: string
-              description: The short code of a library that holds the requested work
-            - in: path
-              name: identifier_type
-              schema:
-                type: string
-              description: The type of the identifier being used to retrieve a work
-            - in: path
-              name: identifier
-              schema:
-                type: string
-              description: An identifier for a work record
     """
     return app.manager.loans.detail(identifier_type, identifier)
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Remove deprecated DELETE method to `/loans/<identifier_type>/<path:identifier>` end point.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Found a method that has not been declared and removed it.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No testing required.  The method was never declared in the code.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
