### PR TITLE
Remove unused turtle import from update_lane_size script

### DIFF
--- a/bin/update_lane_size
+++ b/bin/update_lane_size
@@ -3,7 +3,6 @@
 
 import os
 import sys
-from turtle import update
 from newrelic import agent
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Removes an unused import which causes a `ModuleNotFoundError: No module named 'tkinter'` from the `update_lane_size` script.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While investigating [SIMPLY-4229](https://jira.nypl.org/browse/SIMPLY-4229) it was discovered that `update_lane_size` does not run due to the error described above.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally, script now runs.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
