### PR TITLE
Reverts circ-web package version

### DIFF
--- a/api/admin/CHANGELOG.md
+++ b/api/admin/CHANGELOG.md
@@ -3,6 +3,13 @@ version number, and is separate from the CHANGELOG at this repository's root.
 
 ## Changelog
 
+### v0.1.15
+
+#### Reverted
+
+- Reverted simplified-circulation-web version number to v0.5.16 due to
+  unresolved bugs.
+
 ### v0.1.14
 
 #### Updated

--- a/api/admin/package-lock.json
+++ b/api/admin/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "simplified-circulation",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "simplified-circulation",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "Apache-2.0",
       "dependencies": {
-        "simplified-circulation-web": "0.5.17"
+        "simplified-circulation-web": "0.5.16"
       },
       "engines": {
         "node": ">=8.0.0",
@@ -1932,9 +1932,9 @@
       }
     },
     "node_modules/simplified-circulation-web": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.17.tgz",
-      "integrity": "sha512-8WEAlA+fAFPSrxXvkrE8JwznR/Bfp3PdyQ+mCAgFJoWlCGR8TG0mmrksAx09f+IHEMRzR2wF0oJgPqmCaVNPTA==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.16.tgz",
+      "integrity": "sha512-JQ7QpFw/UPA5MIkHr3/0i77wZHvbJEGXvpedvqsaS+jiEbiky3I8ki9/hkGA1bHVOT6Ou03Ta2k9k4SQo/S6kQ==",
       "dependencies": {
         "@nypl/dgx-svg-icons": "0.3.4",
         "bootstrap": "^3.3.6",
@@ -3927,9 +3927,9 @@
       }
     },
     "simplified-circulation-web": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.17.tgz",
-      "integrity": "sha512-8WEAlA+fAFPSrxXvkrE8JwznR/Bfp3PdyQ+mCAgFJoWlCGR8TG0mmrksAx09f+IHEMRzR2wF0oJgPqmCaVNPTA==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/simplified-circulation-web/-/simplified-circulation-web-0.5.16.tgz",
+      "integrity": "sha512-JQ7QpFw/UPA5MIkHr3/0i77wZHvbJEGXvpedvqsaS+jiEbiky3I8ki9/hkGA1bHVOT6Ou03Ta2k9k4SQo/S6kQ==",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.4",
         "bootstrap": "^3.3.6",

--- a/api/admin/package.json
+++ b/api/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Library Simplified Circulation Manager",
   "repository": {
     "type": "git",
@@ -13,6 +13,6 @@
     "npm": ">=5.0.0"
   },
   "dependencies": {
-    "simplified-circulation-web": "0.5.17"
+    "simplified-circulation-web": "0.5.16"
   }
 }


### PR DESCRIPTION
## Description

- Reverts simplified-circulation-web package to version 0.5.16.

## Motivation and Context

- Bugs in the updated version, found on QA, that we do not want to introduce to production
- See conversation in [SIMPLY-4198](https://jira.nypl.org/browse/SIMPLY-4198) for more context
