### PR TITLE
SIMPLY-4238 HTTPS images

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -1125,6 +1125,8 @@ class BibliographicParser(Axis360Parser):
             element, 'axis:imageUrl', ns
         )
         if thumbnail_url:
+            # Switch out http for https
+            thumbnail_url = thumbnail_url.replace('http://', 'https://')
             # We presume all images from this service are JPEGs.
             media_type = MediaTypes.JPEG_MEDIA_TYPE
             if '/Medium/' in thumbnail_url:

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -1153,12 +1153,12 @@ class TestParsers(Axis360Test):
         # Axis 360 API response and we can hack the URL to get the
         # full-sized image URL.
         assert LinkRelations.IMAGE == cover.rel
-        assert ("http://contentcafecloud.baker-taylor.com/Jacket.svc/D65D0665-050A-487B-9908-16E6D8FF5C3E/9780375504587/Large/Empty" ==
+        assert ("https://contentcafecloud.baker-taylor.com/Jacket.svc/D65D0665-050A-487B-9908-16E6D8FF5C3E/9780375504587/Large/Empty" ==
             cover.href)
         assert MediaTypes.JPEG_MEDIA_TYPE == cover.media_type
 
         assert LinkRelations.THUMBNAIL_IMAGE == cover.thumbnail.rel
-        assert ("http://contentcafecloud.baker-taylor.com/Jacket.svc/D65D0665-050A-487B-9908-16E6D8FF5C3E/9780375504587/Medium/Empty" ==
+        assert ("https://contentcafecloud.baker-taylor.com/Jacket.svc/D65D0665-050A-487B-9908-16E6D8FF5C3E/9780375504587/Medium/Empty" ==
             cover.thumbnail.href)
         assert MediaTypes.JPEG_MEDIA_TYPE == cover.thumbnail.media_type
 
@@ -1209,11 +1209,11 @@ class TestParsers(Axis360Test):
         # thumbnail.
         [cover] = bib2.links
         assert LinkRelations.IMAGE == cover.rel
-        assert "http://some-other-server/image.jpg" == cover.href
+        assert "https://some-other-server/image.jpg" == cover.href
         assert MediaTypes.JPEG_MEDIA_TYPE == cover.media_type
 
         assert LinkRelations.THUMBNAIL_IMAGE == cover.thumbnail.rel
-        assert "http://some-other-server/image.jpg" == cover.thumbnail.href
+        assert "https://some-other-server/image.jpg" == cover.thumbnail.href
         assert MediaTypes.JPEG_MEDIA_TYPE == cover.thumbnail.media_type
 
         # The first book is available in two formats -- "ePub" and "AxisNow"


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Force images from the Axis360 API to be `https` instead of `http`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[SIMPLY-4238](https://jira.nypl.org/browse/SIMPLY-4238) This forces images from the Axis360 API to https for the Open eBooks project.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Automated tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
