### PR TITLE
Simply-4243

### DIFF
--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -310,7 +310,7 @@ class SessionManager(object):
     def engine(cls, url=None):
         url = url or Configuration.database_url()
         # Default sqlalchemy QueuePool pool_size is 10 and max_overflow is 20. This triples it.
-        return create_engine(url, echo=DEBUG, pool_size=30, max_overflow=60)
+        return create_engine(url, echo=DEBUG, pool_size=30, max_overflow=60, pool_recycle=60*30)
 
     @classmethod
     def sessionmaker(cls, url=None, session=None):

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -99,7 +99,7 @@ soupsieve==1.9.6
 # Sphinx is for code documentation
 Sphinx==5.0.0b1
 sphinxcontrib-websupport==1.2.4
-SQLAlchemy==1.4.36
+SQLAlchemy==1.4.46
 strict-rfc3339==0.7
 textblob==0.15.3
 typing==3.7.4.3


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Add `pool_recycle` that invalidates connections older than 30 minutes upon checking out a connection (open to any value for this if we feel 30 minutes isn't a good fit). [SQLAlchemy docs](https://docs.sqlalchemy.org/en/20/core/pooling.html#setting-pool-recycle).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[SIMPLY-4243](https://jira.nypl.org/browse/SIMPLY-4243) Implement a potential solution from [SIMPLY-4221](https://jira.nypl.org/browse/SIMPLY-4221) and monitor for any changes.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with tests, but to see any real impact this will need to be deployed.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
