### PR TITLE
Comment out cron tab call of NYT_Best_seller script

### DIFF
--- a/docker/simplified_crontab
+++ b/docker/simplified_crontab
@@ -129,8 +129,9 @@ CRON_TZ=$TZ
 #### Bibliographic metadata maintenance ######################################
 
 # update_nyt_best_seller_lists - Bring in the entire history of all NYT best-seller lists.
+# TODO This script does not run correctly in a Docker container. It needs to be updated before reused.
 #   Frequency: Minute 30 of hour 3 (once daily)
-30 3 * * * core/bin/run update_nyt_best_seller_lists |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR
+# 30 3 * * * core/bin/run update_nyt_best_seller_lists |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR
 
 # work_presentation_editions - Re-generate presentation editions of any Works that need it.
 #   Frequency: Minute 7 of every 3rd hour from 1 through 23


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Prevent nyt_best_sellers script from running in cron tab

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The NYT best seller list script has been non-functional for some time, but is still run on a daily basis at 10am. Due to the nature of this script it still consumes significant resources and causes a daily spike in response times while its running.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
