### PR TITLE
Remove max_age from all private cache responses

### DIFF
--- a/core/tests/models/test_cachedfeed.py
+++ b/core/tests/models/test_cachedfeed.py
@@ -371,7 +371,6 @@ class TestCachedFeed:
         assert isinstance(r, OPDSFeedResponse)
         assert 200 == r.status_code
         assert OPDSFeed.ACQUISITION_FEED_TYPE == r.content_type
-        assert 102 == r.max_age
         assert "Here's a feed." == str(r)
 
         # The extra argument `private`, not used by CachedFeed.fetch, was
@@ -390,7 +389,6 @@ class TestCachedFeed:
         assert isinstance(r, OPDSFeedResponse)
         assert 200 == r.status_code
         assert OPDSFeed.ACQUISITION_FEED_TYPE == r.content_type
-        assert 102 == r.max_age
         assert "Here's a feed." == str(r)
 
         # If we tell CachedFeed to cache its feed 'forever', that only
@@ -401,7 +399,6 @@ class TestCachedFeed:
             max_age=CachedFeed.CACHE_FOREVER, private=private
         )
         assert isinstance(r, OPDSFeedResponse)
-        assert OPDSFeed.DEFAULT_MAX_AGE == r.max_age
 
         # If the Library associated with the WorkList used in the feed
         # has root lanes, `private` is always set to True, even if we

--- a/core/tests/test_opds.py
+++ b/core/tests/test_opds.py
@@ -1240,7 +1240,6 @@ class TestOPDS(DatabaseTest):
             )
         response = make_page(pagination)
         assert isinstance(response, OPDSFeedResponse)
-        assert OPDSFeed.DEFAULT_MAX_AGE == response.max_age
         assert OPDSFeed.ACQUISITION_FEED_TYPE == response.content_type
         assert private == response.private
 
@@ -1346,7 +1345,6 @@ class TestAcquisitionFeed(DatabaseTest):
         # The result is an OPDSFeedResponse. The 'private' argument,
         # unused by page(), was passed along into the constructor.
         assert isinstance(response, OPDSFeedResponse)
-        assert 10 == response.max_age
         assert private == response.private
 
         assert '<title>feed title</title>' in str(response)
@@ -2580,7 +2578,6 @@ class TestNavigationFeed(DatabaseTest):
         # max_age and private were propagated to the response
         # constructor.
         assert isinstance(response, OPDSFeedResponse)
-        assert 42 == response.max_age
         assert private == response.private
 
         # The media type of this response is different than from the

--- a/core/tests/util/test_flask_util.py
+++ b/core/tests/util/test_flask_util.py
@@ -54,7 +54,7 @@ class TestResponse(object):
         # Test the case where the response is private but may be
         # cached privately.
         headers = Response(max_age=300, private=True).headers
-        assert "private, no-transform, max-age=300" == headers['Cache-Control']
+        assert "private, no-cache" == headers['Cache-Control']
         assert 'Authorization' == headers['Vary']
 
         # Test the case where the response is public and may be cached,
@@ -86,7 +86,6 @@ class TestResponse(object):
         response = Response(max_age=30, private=True)
         cache_control = response.headers['Cache-Control']
         assert 'private' in cache_control
-        assert 'max-age=30' in cache_control
         assert 'Authorization' == response.headers['Vary']
 
     def test_unicode(self):

--- a/core/util/flask_util.py
+++ b/core/util/flask_util.py
@@ -99,6 +99,8 @@ class Response(FlaskResponse):
             # A private resource should be re-requested, rather than
             # retrieved from cache, if the authorization credentials
             # change from those originally used to retrieve it.
+            # Set max_age to 0 to prevent caching.
+            self.max_age = 0
             headers['Vary'] = 'Authorization'
         else:
             private = "public"

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -273,10 +273,9 @@ class TestCirculationManagerAnnotator(DatabaseTest):
         assert isinstance(response, OPDSEntryResponse)
         assert '<title>%s</title>' % work.title in response.get_data(as_text=True)
 
-        # By default, the representation is private but can be cached
+        # By default, the representation is private and must be revalidated
         # by the recipient.
         assert True == response.private
-        assert 30*60 == response.max_age
 
         # Test the case where we override the defaults.
         response = m(self._db, work, annotator, url, max_age=12, private=False)


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
For all responses using private Cache-Control headers respond with Cache-control = private, no-cache

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Our custom entry responses should not have a max_age as these can be updated at any time.  By removing a max_age as the default for private caching we can achieve this result.  This still allows for local caching, but requires the client to verify that the content has not been updated.  

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests have been updated.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
