### PR TITLE
Simply 4255 builtin type error

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1141,7 +1141,7 @@ class OPDSFeedController(CirculationManagerController):
 
         facets = self._load_search_facets(lane)
         if isinstance(facets, ProblemDetail):
-            return lane
+            return facets
 
         search_engine = self.search_engine
         if isinstance(search_engine, ProblemDetail):

--- a/tests/documentation/test_admin_controller.py
+++ b/tests/documentation/test_admin_controller.py
@@ -1,4 +1,3 @@
-from lib2to3.pgen2.token import OP
 from apispec import APISpec
 import pytest
 

--- a/tests/documentation/test_public_controller.py
+++ b/tests/documentation/test_public_controller.py
@@ -1,4 +1,3 @@
-from lib2to3.pgen2.token import OP
 from apispec import APISpec
 import pytest
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
When there is a problem loading facets in the search function, that should return a ProblemDetail of the facet and not a lane.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A bug was reported for [this](https://jira.nypl.org/browse/SIMPLY-4255) ticket.  The New relic logs gave a stack trace to this change.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
