### PR TITLE
NOREF Close session from Config.cdns method

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -403,8 +403,12 @@ class Configuration(ConfigurationConstants):
             # information now.
             from .model import SessionManager
             url = cls.database_url()
-            _db = SessionManager.session(url)
+
+            _db = SessionManager.session(
+                url, initialize_data=False, initialize_schema=False)
+
             cls.load_cdns(_db)
+
             _db.close()
 
         from .model import ExternalIntegration

--- a/core/config.py
+++ b/core/config.py
@@ -405,6 +405,7 @@ class Configuration(ConfigurationConstants):
             url = cls.database_url()
             _db = SessionManager.session(url)
             cls.load_cdns(_db)
+            _db.close()
 
         from .model import ExternalIntegration
         return cls.integration(ExternalIntegration.CDN)

--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -373,6 +373,7 @@ class SessionManager(object):
         if initialize_data:
             session = Session(connection)
             cls.initialize_data(session)
+            session.close()
 
         if connection:
             connection.close()
@@ -409,10 +410,8 @@ class SessionManager(object):
                 url, initialize_data=initialize_data,
                 initialize_schema=initialize_schema
             )
-        session = Session(engine)
-        if initialize_data:
-            session = cls.initialize_data(session)
-        return session
+
+        return Session(engine)
 
     @classmethod
     def initialize_data(cls, session, set_site_configuration=True):


### PR DESCRIPTION
## Description

In the Config module there is a specific method that generates its own database session in local scope. This is used to check for and load CDN configuration and is potentially called for non-cached XML feeds for cover image fetching.

This session object is never closed/removed, which could be contributing to persistent database connection issues. These have been found across CM instances. This may or may not be implicated, regardless database sessions should be explicitly closed after opening.
