### PR TITLE
NOREF Update Error Code from Overdrive

### DIFF
--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -889,7 +889,7 @@ class OverdriveRepresentationExtractor(object):
         # The current behavior will respond to errors other than
         # NotFound by leaving the book alone, but this might not be
         # the right behavior.
-        if error_code == 'NotFound':
+        if error_code in ['NotFound', 'TitleNotFoundError']:
             licenses_owned = 0
             licenses_available = 0
             patrons_in_hold_queue = 0


### PR DESCRIPTION
Following an error report from a partner, it has come to our attention that an error returned from the Overdrive API is not handled correctly. This update simply adds the correct error code, which will result in responses containing that error setting available copies to zero. This should have no other effects