### PR TITLE
NOREF Update update_lane_size script schedule

### DIFF
--- a/docker/simplified_crontab
+++ b/docker/simplified_crontab
@@ -123,7 +123,7 @@ CRON_TZ=$TZ
 0 0 * * * core/bin/run update_custom_list_size |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR
 
 # update_lane_size - Update the cached sizes of all lanes.
-#   Frequency: Minute 2 of hour 10 (once daily)
+#   Frequency: Minute 2 of hour 7 (once daily)
 2 7 * * * core/bin/run update_lane_size |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR
 
 #### Bibliographic metadata maintenance ######################################

--- a/docker/simplified_crontab
+++ b/docker/simplified_crontab
@@ -124,7 +124,7 @@ CRON_TZ=$TZ
 
 # update_lane_size - Update the cached sizes of all lanes.
 #   Frequency: Minute 2 of hour 10 (once daily)
-2 10 * * * core/bin/run update_lane_size |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR
+2 7 * * * core/bin/run update_lane_size |& tee -a /var/log/cron.log > $PID1_STDOUT 2>$PID1_STDERR
 
 #### Bibliographic metadata maintenance ######################################
 


### PR DESCRIPTION
This is an expensive operation which can be taxing on the database, it should be run earlier in the day when there is less patron activity. This should have a two-fold impact: 1) It should improve the script's speed and 2) it should reduce the impact of any associated performance issues as we see lower traffic at that time.

@keithbauer As you last worked on this file, do you know of any potential side effects to this rescheduling?