### PR TITLE
Add facet links to search

### DIFF
--- a/core/opds.py
+++ b/core/opds.py
@@ -1019,6 +1019,10 @@ class AcquisitionFeed(OPDSFeed):
         # Add "up" link.
         AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, rel="up", href=annotator.lane_url(lane), title=str(lane.display_name))
 
+        # Add URLs to change faceted views
+        for args in cls.facet_links(annotator, facets):
+            AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, **args)
+
         # We do not add breadcrumbs to this feed since you're not
         # technically searching the this lane; you are searching the
         # library's entire collection, using _some_ of the constraints

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 
 [docker:es]
 image = elasticsearch:6.8.6
+container_name = es
 environment =
     discovery.type=single-node
 ports =

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,13 @@
 envlist = py{310}-docker
 skipsdist = true
 
+[docker:es]
+image = elasticsearch:6.8.6
+environment =
+    discovery.type=single-node
+ports =
+    9006:9200/tcp
+
 [testenv]
 deps = -r requirements-dev.txt
 commands_pre =
@@ -37,13 +44,6 @@ environment =
     POSTGRES_DB=simplified_circulation_test
 ports =
     9005:5432/tcp
-
-[docker:es]
-image = elasticsearch:6.8.6
-environment =
-    discovery.type=single-node
-ports =
-    9006:9200/tcp
 
 [docker:minio]
 image = bitnami/minio:latest

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,6 @@
 envlist = py{310}-docker
 skipsdist = true
 
-[docker:es]
-image = elasticsearch:6.8.6
-container_name = es
-environment =
-    discovery.type=single-node
-ports =
-    9006:9200/tcp
-
 [testenv]
 deps = -r requirements-dev.txt
 commands_pre =
@@ -45,6 +37,13 @@ environment =
     POSTGRES_DB=simplified_circulation_test
 ports =
     9005:5432/tcp
+
+[docker:es]
+image = elasticsearch:6.8.6
+environment =
+    discovery.type=single-node
+ports =
+    9006:9200/tcp
 
 [docker:minio]
 image = bitnami/minio:latest


### PR DESCRIPTION
## Description
Adds facet links to the search response which will allow for sorting by title and author.

## Motivation and Context
[OE-927 Add facet links to search](https://jira.nypl.org/browse/OE-927)

## How Has This Been Tested?
Modified `test_search_feed` test to also look for the ordering facet links. The `Facets.available_facets` class method needed to be monkeypatched to return the supported order facets since `config` is set to `None` along the way causing it to error out.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
