### PR TITLE
OE-929 patron is_new (OAuth)

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2520,6 +2520,7 @@ class OAuthAuthenticationProvider(AuthenticationProvider, BearerTokenSigner):
         patron, is_new = patrondata.get_or_create_patron(
             _db, self.library_id, analytics=self.analytics
         )
+        patrondata.is_new = is_new
 
         # Create a credential for the Patron.
         credential, is_new = self.create_token(_db, patron, token)
@@ -2701,6 +2702,7 @@ class OAuthController(object):
             access_token=simplified_token,
             patron_info=patron_info,
             root_lane=root_lane,
+            is_new=patrondata.is_new,
         )
         return redirect(client_redirect_uri + "#" + urllib.parse.urlencode(params))
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2781,7 +2781,7 @@ class TestOAuthController(AuthenticatorTest):
     def setup_method(self):
         super(TestOAuthController, self).setup_method()
         class MockOAuthWithExternalAuthenticateURL(MockOAuth):
-            def __init__(self, library, _db, external_authenticate_url, patron, root_lane=None):
+            def __init__(self, library, _db, external_authenticate_url, patron, root_lane=None, is_new=False):
                 super(MockOAuthWithExternalAuthenticateURL, self).__init__(
                     library,
                 )
@@ -2790,8 +2790,9 @@ class TestOAuthController(AuthenticatorTest):
                 self.token, ignore = self.create_token(
                     _db, self.patron, "a token"
                 )
-                self.patrondata = PatronData(personal_name="Abcd")
+                self.patrondata = PatronData(personal_name="Abcd", is_new=is_new)
                 self.root_lane = root_lane
+                self.is_new = self.patrondata.is_new
 
             def external_authenticate_url(self, state, _db):
                 return self.url + "?state=" + state
@@ -2876,6 +2877,7 @@ class TestOAuthController(AuthenticatorTest):
             assert self.oauth1.NAME == provider_name
             assert self.oauth1.token.credential == provider_token
             assert str(self.oauth1.root_lane) in fragments.get('root_lane')[0]
+            assert str(self.oauth1.is_new) == fragments.get('is_new')[0]
 
         # Successful callback through OAuth provider 2.
         params = dict(code="foo", state=json.dumps(dict(provider=self.oauth2.NAME)))


### PR DESCRIPTION
## Description
Explicitly passes along the url parameter`is_new=<true|false>` for Clever/OAuth.

## Motivation and Context
[OE-929](https://jira.nypl.org/browse/OE-929) Fixes the `is_new` parameter missing for Clever

## How Has This Been Tested?
Updated `test_oauth_authentication_callback` to check that `is_new` is in the url which pulls from `PatronData.is_new`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
