### PR TITLE
MULTIREF OE Enhancements

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -2703,6 +2703,7 @@ class OAuthController(object):
             patron_info=patron_info,
             root_lane=root_lane,
             is_new=patrondata.is_new,
+            age_group=patron.external_type,
         )
         return redirect(client_redirect_uri + "#" + urllib.parse.urlencode(params))
 
@@ -2828,6 +2829,7 @@ class BasicAuthTempTokenController(object):
                 expires_in=BasicAuthTempTokenController.TOKEN_DURATION.seconds,
                 root_lane=root_lane,
                 is_new=is_new,
+                age_group=patron.external_type,
             )
 
             return flask.jsonify(data)

--- a/core/facets.py
+++ b/core/facets.py
@@ -42,6 +42,7 @@ class FacetConstants(object):
     ORDER_SERIES_POSITION = 'series'
     ORDER_WORK_ID = 'work_id'
     ORDER_RANDOM = 'random'
+    ORDER_RELEVANCE = 'relevance'
     # Some order facets, like series and work id,
     # only make sense in certain contexts.
     # These are the options that can be enabled
@@ -51,6 +52,7 @@ class FacetConstants(object):
         ORDER_AUTHOR,
         ORDER_ADDED_TO_COLLECTION,
         ORDER_RANDOM,
+        ORDER_RELEVANCE,
     ]
 
     ORDER_ASCENDING = "asc"
@@ -88,6 +90,7 @@ class FacetConstants(object):
         ORDER_SERIES_POSITION: _('Series Position'),
         ORDER_WORK_ID : _('Work ID'),
         ORDER_RANDOM : _('Random'),
+        ORDER_RELEVANCE : _('Relevance'),
 
         AVAILABLE_NOW : _("Available now"),
         AVAILABLE_ALL : _("All"),

--- a/core/opds.py
+++ b/core/opds.py
@@ -1021,6 +1021,8 @@ class AcquisitionFeed(OPDSFeed):
 
         # Add URLs to change faceted views
         for args in cls.facet_links(annotator, facets):
+            # Put the query parameter into the url
+            args["href"] += f"&q={query}"
             AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, **args)
 
         # We do not add breadcrumbs to this feed since you're not

--- a/core/tests/test_facets.py
+++ b/core/tests/test_facets.py
@@ -38,3 +38,6 @@ class TestFacetConfig(DatabaseTest):
         config.enable_facet(order_by, Facets.ORDER_RANDOM)
         assert Facets.ORDER_RANDOM in config.enabled_facets(order_by)
         assert config.default_facet(order_by) != Facets.ORDER_RANDOM
+
+        config.enable_facet(order_by, Facets.ORDER_RELEVANCE)
+        assert Facets.ORDER_RELEVANCE in config.enabled_facets(order_by)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -2474,6 +2474,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
             permanent_id=self._str,
             authorization_identifier=self._str,
             fines=Money(1, "USD"),
+            external_type='H',
         )
 
         library = self._library()
@@ -2490,6 +2491,7 @@ class TestBasicAuthenticationProviderAuthenticate(AuthenticatorTest):
         assert (patrondata.authorization_identifier ==
             patron.authorization_identifier)
         assert provider.patron_is_new is True
+        assert patron.external_type == patrondata.external_type
 
         # Information not relevant to the patron's identity was stored
         # in the Patron object after it was created.
@@ -2793,6 +2795,7 @@ class TestOAuthController(AuthenticatorTest):
                 self.patrondata = PatronData(personal_name="Abcd", is_new=is_new)
                 self.root_lane = root_lane
                 self.is_new = self.patrondata.is_new
+                self.age_group = self.patron.external_type
 
             def external_authenticate_url(self, state, _db):
                 return self.url + "?state=" + state
@@ -2878,6 +2881,7 @@ class TestOAuthController(AuthenticatorTest):
             assert self.oauth1.token.credential == provider_token
             assert str(self.oauth1.root_lane) in fragments.get('root_lane')[0]
             assert str(self.oauth1.is_new) == fragments.get('is_new')[0]
+            assert str(self.oauth1.age_group) == fragments.get('age_group')[0]
 
         # Successful callback through OAuth provider 2.
         params = dict(code="foo", state=json.dumps(dict(provider=self.oauth2.NAME)))


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
* Add a new url parameter, `age_group`, to pass to the client on login
* Add a `relevance` ordering facet
* Add the query parameter `q` to the facet urls

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* [OE-940 Pass a user's age group to the client on login](https://jira.nypl.org/browse/OE-940)
* [OE-965 Add query parameter to search facetLinks](https://jira.nypl.org/browse/OE-965)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and unit tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
