### PR TITLE
Add search faceted urls to search results

### DIFF
--- a/core/opds.py
+++ b/core/opds.py
@@ -1029,9 +1029,9 @@ class AcquisitionFeed(OPDSFeed):
         for facet in all_order_facets:
             order = dict(parse_qsl(facet["href"])).get('order')
             if order in enabled_order_facets:
-                # search_url uses facets.order to generate a /feed/ url,
-                # but we want to generate a /search/ url for this given
-                # ordering facet instead of the the original facet.
+                # cls.facet_links generates a /feed/ url, but we want to use
+                # search_url to generate a /search/ url. We also want to generate
+                # the facet url for this given ordering facet instead of the original facet.
                 facets.order = order
                 facet["href"] = annotator.search_url(lane, query, pagination=None, facets=facets)
                 AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, **facet)

--- a/core/opds.py
+++ b/core/opds.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from urllib.parse import quote
+from urllib.parse import quote, parse_qsl
 from collections import (
     defaultdict,
 )
@@ -1027,7 +1027,7 @@ class AcquisitionFeed(OPDSFeed):
         )
         original_facet = facets.order
         for facet in all_order_facets:
-            order = facet["title"].lower()
+            order = dict(parse_qsl(facet["href"])).get('order')
             if order in enabled_order_facets:
                 # search_url uses facets.order to generate a /feed/ url,
                 # but we want to generate a /search/ url for this given


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Adds ordering facet links to search results for enabled facets.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a refactor of [OE-927](https://jira.nypl.org/browse/OE-927)/#1883. This now returns only the ordering facets which was the original intent rather than all the facet links. Only enabled ordering facet links are generated (which is done via the admin).

The initial implementation built out links that pointed to `/feed/`, but the links should've been pointing to `/search/`. This caused some unexpected behavior since `/feed/` wasn't handling some of the parameters that `/search/` supported.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
