### PR TITLE
NOREF Limit requests handled by workers

### DIFF
--- a/docker/gunicorn.conf.py
+++ b/docker/gunicorn.conf.py
@@ -21,8 +21,8 @@ group = "simplified"
 bind = ["127.0.0.1:8000"]     # listen on 8000, only on the loopback address
 workers = (2 * multiprocessing.cpu_count()) + 1
 threads = 2
-max_requests = 2000
-max_requests_jitter = 100
+max_requests = 500
+max_requests_jitter = 50
 pythonpath = ",".join([
     str(VENV_ACTUAL),
     SIMPLIFIED_HOME,

--- a/docker/gunicorn.conf.py
+++ b/docker/gunicorn.conf.py
@@ -21,6 +21,8 @@ group = "simplified"
 bind = ["127.0.0.1:8000"]     # listen on 8000, only on the loopback address
 workers = (2 * multiprocessing.cpu_count()) + 1
 threads = 2
+max_requests = 2000
+max_requests_jitter = 100
 pythonpath = ",".join([
     str(VENV_ACTUAL),
     SIMPLIFIED_HOME,


### PR DESCRIPTION
This update introduces two configuration settings for our gunicorn server:

- `max_requests` Limits the number of total requests that can be handled by a single gunicorn worker. The gunicorn docs state this is intended to help limit effects of memory leaks
- `max_requests_jitter` This randomizes the exact number of requests to prevent multiple workers from being restarted simultaneously

The goal of this work is to hopefully limit memory consumption (which tends to run at 90% or greater in production) and to reduce the effect of `QueuePool` errors that result from long-running workers. At the current setting of 500 this should result in workers being restarted roughly every 45-60 minutes. This can be adjusted after review of effects on performance in QA (and production if no issues are raised in QA).

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
