### PR TITLE
OE-917 [fix] Set the original facet to active

### DIFF
--- a/core/opds.py
+++ b/core/opds.py
@@ -1034,6 +1034,8 @@ class AcquisitionFeed(OPDSFeed):
                 # the facet url for this given ordering facet instead of the original facet.
                 facets.order = order
                 facet["href"] = annotator.search_url(lane, query, pagination=None, facets=facets)
+                if order == original_facet:
+                    facet["href"] += "&active=true"
                 AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, **facet)
         facets.order = original_facet
 

--- a/core/tests/test_opds.py
+++ b/core/tests/test_opds.py
@@ -1296,6 +1296,9 @@ class TestOPDS(DatabaseTest):
         assert 'Title' in sort_by_facets
         assert 'Author' in sort_by_facets
 
+        [active_facet] = [facet['title'] for facet in facets if getattr(facet, "activefacet", False) == 'true']
+        assert active_facet == 'Author'
+
         # The feed has no breadcrumb links, since we're not
         # searching the lane -- just using some aspects of the lane
         # to guide the search.


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Set the current search sorting facet to be active.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While sorting facets are now included in the search feed there was no active facet set which caused the search results / client applications to experience unexpected behavior attempting to display the active facet. This now sets the active search sorting facet to be the one the patron has specified (or falls back to the default which must be defined somewhere). This feels a bit hacky to set the active facet on its `href`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually in the CM admin and a basic test that checks for the `activefacet`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
