### PR TITLE
Correctly set active search facet

### DIFF
--- a/core/opds.py
+++ b/core/opds.py
@@ -1029,13 +1029,15 @@ class AcquisitionFeed(OPDSFeed):
         for facet in all_order_facets:
             order = dict(parse_qsl(facet["href"])).get('order')
             if order in enabled_order_facets:
+                facets.order = order
+                if order == original_facet:
+                    facet = cls.facet_link(href=facet["href"], title=facet["title"], facet_group_name="Sort by", is_active=True)
+                else:
+                    facet = cls.facet_link(href=facet["href"], title=facet["title"], facet_group_name="Sort by", is_active=False)
                 # cls.facet_links generates a /feed/ url, but we want to use
                 # search_url to generate a /search/ url. We also want to generate
                 # the facet url for this given ordering facet instead of the original facet.
-                facets.order = order
                 facet["href"] = annotator.search_url(lane, query, pagination=None, facets=facets)
-                if order == original_facet:
-                    facet["href"] += "&active=true"
                 AcquisitionFeed.add_link_to_feed(feed=opds_feed.feed, **facet)
         facets.order = original_facet
 


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Correctly set the active search facet

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
My previous hacky attempt didn't actually set the `@opds:activeFacet` in the OPDS feed. I thought the URL would pick up on it and do some background magic, but it didn't look like it did.

This now builds out a facet link by using `cls.facet_link` to ensure the `activeFacet` property is correctly set. But this generates a `.../feed/...` URL and we want a `.../search...` URL, so then we replace the href with what `annotator.search_url` builds before adding the facet to the OPDS feed.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
More manual testing and verifying the search OPDS feed for the active facet is set through `  +@opds:activeFacet: "true"`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
