### PR TITLE
Sma 523 add open access until date

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -1,4 +1,5 @@
 import urllib.request, urllib.parse, urllib.error
+from datetime import timedelta, datetime
 import copy
 import logging
 from flask import url_for
@@ -425,6 +426,7 @@ class CirculationManagerAnnotator(Annotator):
         always_available = OPDSFeed.makeelement(
             "{%s}availability" % OPDSFeed.OPDS_NS, status="available"
         )
+
         link_tag.append(always_available)
         return link_tag
 
@@ -1130,7 +1132,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             active_loan=active_loan
         )
 
-        children = AcquisitionFeed.license_tags(license_pool, active_loan, None)
+        children = AcquisitionFeed.license_tags(license_pool, active_loan, None, rel=rel, library=self.library)
         link_tag.extend(children)
 
         children = self.drm_device_registration_tags(

--- a/api/opds.py
+++ b/api/opds.py
@@ -1,5 +1,4 @@
 import urllib.request, urllib.parse, urllib.error
-from datetime import timedelta, datetime
 import copy
 import logging
 from flask import url_for

--- a/core/opds.py
+++ b/core/opds.py
@@ -1650,7 +1650,7 @@ class AcquisitionFeed(OPDSFeed):
         return top_level_parent
 
     @classmethod
-    def license_tags(cls, license_pool, loan, hold):
+    def license_tags(cls, license_pool, loan, hold, rel=None, library=None):
         # Generate a list of licensing tags. These should be inserted
         # into a <link> tag.
         tags = []
@@ -1688,10 +1688,16 @@ class AcquisitionFeed(OPDSFeed):
             else:
                 status = 'reserved'
                 since = hold.start
-        elif (license_pool.open_access or license_pool.unlimited_access or license_pool.self_hosted or (
+        elif (license_pool.open_access or rel == OPDSFeed.OPEN_ACCESS_REL):
+            status = 'available'
+
+            default_loan_period = collection.default_loan_period(library) if library else collection.STANDARD_DEFAULT_LOAN_PERIOD
+
+            since = license_pool.availability_time
+            until = datetime.datetime.utcnow() + datetime.timedelta(days=default_loan_period)
+        elif (license_pool.unlimited_access or license_pool.self_hosted or (
                 license_pool.licenses_available > 0 and
-                license_pool.licenses_owned > 0)
-          ):
+                license_pool.licenses_owned > 0)):
             status = 'available'
         else:
             status='unavailable'

--- a/core/tests/test_opds.py
+++ b/core/tests/test_opds.py
@@ -1625,6 +1625,33 @@ class TestAcquisitionFeed(DatabaseTest):
         assert 'status' in tags[0].attrib
         assert 'available' == tags[0].attrib['status']
 
+    def test_license_tags_open_access(self):
+        # Arrange
+        edition, pool = self._edition(with_license_pool=True)
+        pool.open_access = True
+        pool.self_hosted = False
+        pool.unlimited_access = False
+        creation_time = datetime.datetime.utcnow()
+
+        # Act
+        tags = AcquisitionFeed.license_tags(
+            pool, None, None
+        )
+
+        # Assert
+        assert 1 == len(tags)
+
+        [tag] = tags
+
+        assert ('status' in tag.attrib) == True
+        assert 'available' == tag.attrib['status']
+        assert 'since' in tag.attrib
+        assert tag.attrib['since'] == pool.availability_time.strftime('%Y-%m-%dT%H:%M:%S+00:00')
+        assert 'until' in tag.attrib
+        assert tag.attrib['until'] == (creation_time + datetime.timedelta(days=21)).strftime('%Y-%m-%dT%H:%M:%SZ')
+        assert ('holds' in tag.attrib) == False
+        assert ('copies' in tag.attrib) == False
+
     def test_single_entry(self):
 
         # Here's a Work with two LicensePools.


### PR DESCRIPTION
## Description

This adds `opds:since` and `opds:until` parameters to the availability object for open source materials

## Motivation and Context

This allows client applications to create "loan-like" behavior for open source materials without generating loan objects internally. These can have loan length configured at the collection/library level and help support several projects involving the Circulation Manager

## How Has This Been Tested?

I have run this code locally with open source material and added an applicable unit test

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
