### PR TITLE
NOREF Move 5th grade to early grades category

### DIFF
--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -58,7 +58,7 @@ CLEVER_GRADE_TO_EXTERNAL_TYPE_MAP = {
     "2": "E",
     "3": "E",
     "4": "E",                           # Middle
-    "5": "M",
+    "5": "E",
     "6": "M",
     "7": "M",
     "8": "M",
@@ -71,7 +71,6 @@ CLEVER_GRADE_TO_EXTERNAL_TYPE_MAP = {
     "Other": None,                      # Indeterminate
     "Ungraded": None,
 }
-
 
 def external_type_from_clever_grade(grade):
     """Maps a 'grade' value returned by the Clever API for student users to an external_type"""

--- a/api/clever/__init__.py
+++ b/api/clever/__init__.py
@@ -57,9 +57,9 @@ CLEVER_GRADE_TO_EXTERNAL_TYPE_MAP = {
     "1": "E",
     "2": "E",
     "3": "E",
-    "4": "E",                           # Middle
+    "4": "E",
     "5": "E",
-    "6": "M",
+    "6": "M",                           # Middle
     "7": "M",
     "8": "M",
     "9": "H",                           # High

--- a/tests/clever/test_clever.py
+++ b/tests/clever/test_clever.py
@@ -46,11 +46,12 @@ class TestClever:
         THEN:  The matching external_type value should be returned, or None if the match fails
         """
         for e_grade in [
-            "InfantToddler", "Preschool", "PreKindergarten", "TransitionalKindergarten", "Kindergarten", "1", "2", "3", "4"
+            "InfantToddler", "Preschool", "PreKindergarten", "TransitionalKindergarten",
+            "Kindergarten", "1", "2", "3", "4", "5"
         ]:
             assert external_type_from_clever_grade(e_grade) == "E"
 
-        for m_grade in ["5", "6", "7", "8"]:
+        for m_grade in ["6", "7", "8"]:
             assert external_type_from_clever_grade(m_grade) == "M"
 
         for h_grade in ["9", "10", "11", "12", "13", "PostGraduate"]:


### PR DESCRIPTION
## Description

This moves 5th grade from the Middle to Early category to reflect standard groupings

## Motivation and Context

This is to properly align the reading experience for schools using the Clever integration with Open eBooks

## How Has This Been Tested?

The appropriate unit tests have been updated

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
